### PR TITLE
Refactor protocol state machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A Go client implementation of the Cardano Ouroboros network protocol
 
 This is loosely based on the [official Haskell implementation](https://github.com/input-output-hk/ouroboros-network)
 
+NOTE: this library is under heavily development, and the interface should not be considered stable until it reaches `v1.0.0`
+
 ## Implementation status
 
 The Ouroboros protocol consists of a simple multiplexer protocol and various mini-protocols that run on top of it.

--- a/protocol/state.go
+++ b/protocol/state.go
@@ -1,0 +1,35 @@
+package protocol
+
+const (
+	AGENCY_NONE   uint = 0
+	AGENCY_CLIENT uint = 1
+	AGENCY_SERVER uint = 2
+)
+
+type State struct {
+	Id   uint
+	Name string
+}
+
+func NewState(id uint, name string) State {
+	return State{
+		Id:   id,
+		Name: name,
+	}
+}
+
+func (s State) String() string {
+	return s.Name
+}
+
+type StateTransition struct {
+	MsgType  uint8
+	NewState State
+}
+
+type StateMapEntry struct {
+	Agency      uint
+	Transitions []StateTransition
+}
+
+type StateMap map[State]StateMapEntry


### PR DESCRIPTION
* move state checking/management into Protocol object
* define state maps for each mini-protocol
* create separate ProtocolConfig struct instead of passing a long list
  params to protocol.New()
* add tracking/checks for protocol agency

Fixes #25 