### PR TITLE
fix: close connection on muxer stop

### DIFF
--- a/internal/test/ouroboros_mock/connection.go
+++ b/internal/test/ouroboros_mock/connection.go
@@ -70,6 +70,7 @@ func (c *Connection) Write(b []byte) (n int, err error) {
 
 // Close closes both sides of the connection. This is needed to satisfy the net.Conn interface
 func (c *Connection) Close() error {
+	c.muxer.Stop()
 	if err := c.conn.Close(); err != nil {
 		return err
 	}

--- a/muxer/muxer.go
+++ b/muxer/muxer.go
@@ -88,6 +88,9 @@ func (m *Muxer) Stop() {
 	m.onceStop.Do(func() {
 		// Close doneChan to signify that we're shutting down
 		close(m.doneChan)
+		// Close underlying connection
+		// We must do this to break out of pending Read() calls to shut down cleanly
+		_ = m.conn.Close()
 		// Wait for other goroutines to shutdown
 		m.waitGroup.Wait()
 		// Close protocol receive channels

--- a/ouroboros.go
+++ b/ouroboros.go
@@ -138,12 +138,6 @@ func (o *Ouroboros) Close() error {
 		if o.muxer != nil {
 			o.muxer.Stop()
 		}
-		// Close the underlying connection
-		if o.conn != nil {
-			if err = o.conn.Close(); err != nil {
-				return
-			}
-		}
 		// Wait for other goroutines to finish
 		o.waitGroup.Wait()
 		// Close channels


### PR DESCRIPTION
This also stops the muxer on mock connection close

Fixes https://github.com/blinklabs-io/gouroboros/issues/257