### PR TITLE
fix: parse Byron transaction as array

### DIFF
--- a/ledger/byron.go
+++ b/ledger/byron.go
@@ -101,6 +101,7 @@ func (h *ByronMainBlockHeader) Era() Era {
 }
 
 type ByronTransaction struct {
+	cbor.StructAsArray
 	cbor.DecodeStoreCbor
 	// TODO: flesh these out
 	TxInputs   []any


### PR DESCRIPTION
Fixes #379