### PR TITLE
chore: remove unused isResponse param in message handlers

### DIFF
--- a/protocol/blockfetch/client.go
+++ b/protocol/blockfetch/client.go
@@ -124,7 +124,7 @@ func (c *Client) GetBlock(point common.Point) (ledger.Block, error) {
 	return block, nil
 }
 
-func (c *Client) messageHandler(msg protocol.Message, isResponse bool) error {
+func (c *Client) messageHandler(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeStartBatch:

--- a/protocol/blockfetch/server.go
+++ b/protocol/blockfetch/server.go
@@ -44,7 +44,7 @@ func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 	return s
 }
 
-func (s *Server) messageHandler(msg protocol.Message, isResponse bool) error {
+func (s *Server) messageHandler(msg protocol.Message) error {
 	var err error
 	// TODO: add cases for messages from client
 	switch msg.Type() {

--- a/protocol/chainsync/client.go
+++ b/protocol/chainsync/client.go
@@ -96,7 +96,7 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 	return c
 }
 
-func (c *Client) messageHandler(msg protocol.Message, isResponse bool) error {
+func (c *Client) messageHandler(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeAwaitReply:

--- a/protocol/chainsync/server.go
+++ b/protocol/chainsync/server.go
@@ -54,7 +54,7 @@ func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 	return s
 }
 
-func (s *Server) messageHandler(msg protocol.Message, isResponse bool) error {
+func (s *Server) messageHandler(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeRequestNext:

--- a/protocol/handshake/client.go
+++ b/protocol/handshake/client.go
@@ -70,7 +70,7 @@ func (c *Client) Start() {
 	})
 }
 
-func (c *Client) handleMessage(msg protocol.Message, isResponse bool) error {
+func (c *Client) handleMessage(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeAcceptVersion:

--- a/protocol/handshake/server.go
+++ b/protocol/handshake/server.go
@@ -47,7 +47,7 @@ func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 	return s
 }
 
-func (s *Server) handleMessage(msg protocol.Message, isResponse bool) error {
+func (s *Server) handleMessage(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeProposeVersions:

--- a/protocol/keepalive/client.go
+++ b/protocol/keepalive/client.go
@@ -86,7 +86,7 @@ func (c *Client) startTimer() {
 	})
 }
 
-func (c *Client) messageHandler(msg protocol.Message, isResponse bool) error {
+func (c *Client) messageHandler(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeKeepAliveResponse:

--- a/protocol/keepalive/server.go
+++ b/protocol/keepalive/server.go
@@ -44,7 +44,7 @@ func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 	return s
 }
 
-func (s *Server) messageHandler(msg protocol.Message, isResponse bool) error {
+func (s *Server) messageHandler(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeKeepAlive:

--- a/protocol/localstatequery/client.go
+++ b/protocol/localstatequery/client.go
@@ -91,7 +91,7 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 	return c
 }
 
-func (c *Client) messageHandler(msg protocol.Message, isResponse bool) error {
+func (c *Client) messageHandler(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeAcquired:

--- a/protocol/localstatequery/server.go
+++ b/protocol/localstatequery/server.go
@@ -58,7 +58,7 @@ func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 	return s
 }
 
-func (s *Server) messageHandler(msg protocol.Message, isResponse bool) error {
+func (s *Server) messageHandler(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeAcquire:

--- a/protocol/localtxmonitor/client.go
+++ b/protocol/localtxmonitor/client.go
@@ -83,7 +83,7 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 	return c
 }
 
-func (c *Client) messageHandler(msg protocol.Message, isResponse bool) error {
+func (c *Client) messageHandler(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeAcquired:

--- a/protocol/localtxmonitor/server.go
+++ b/protocol/localtxmonitor/server.go
@@ -52,7 +52,7 @@ func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 	return s
 }
 
-func (s *Server) messageHandler(msg protocol.Message, isResponse bool) error {
+func (s *Server) messageHandler(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeAcquire:

--- a/protocol/localtxsubmission/client.go
+++ b/protocol/localtxsubmission/client.go
@@ -69,7 +69,7 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 	return c
 }
 
-func (c *Client) messageHandler(msg protocol.Message, isResponse bool) error {
+func (c *Client) messageHandler(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeAcceptTx:

--- a/protocol/localtxsubmission/server.go
+++ b/protocol/localtxsubmission/server.go
@@ -48,7 +48,7 @@ func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 	return s
 }
 
-func (s *Server) messageHandler(msg protocol.Message, isResponse bool) error {
+func (s *Server) messageHandler(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeSubmitTx:

--- a/protocol/peersharing/client.go
+++ b/protocol/peersharing/client.go
@@ -69,7 +69,7 @@ func (c *Client) GetPeers(amount uint8) ([]interface{}, error) {
 	return peers, nil
 }
 
-func (c *Client) handleMessage(msg protocol.Message, isResponse bool) error {
+func (c *Client) handleMessage(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeSharePeers:

--- a/protocol/peersharing/server.go
+++ b/protocol/peersharing/server.go
@@ -47,7 +47,7 @@ func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 	return s
 }
 
-func (s *Server) handleMessage(msg protocol.Message, isResponse bool) error {
+func (s *Server) handleMessage(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeShareRequest:

--- a/protocol/txsubmission/client.go
+++ b/protocol/txsubmission/client.go
@@ -67,7 +67,7 @@ func (c *Client) Init() {
 	})
 }
 
-func (c *Client) messageHandler(msg protocol.Message, isResponse bool) error {
+func (c *Client) messageHandler(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeRequestTxIds:

--- a/protocol/txsubmission/server.go
+++ b/protocol/txsubmission/server.go
@@ -57,7 +57,7 @@ func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 	return s
 }
 
-func (s *Server) messageHandler(msg protocol.Message, isResponse bool) error {
+func (s *Server) messageHandler(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeReplyTxIds:


### PR DESCRIPTION
This information was useful in the past, but improvements in protocol handling and the muxer have made is unnecessary