### PR TITLE
Shutdown finished channel

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -60,7 +60,7 @@ type Connection struct {
 	protoErrorChan        chan error
 	handshakeFinishedChan chan interface{}
 	doneChan              chan interface{}
-	shutdownFinishedChan  chan struct{}
+	shutdownFinishedChan  chan interface{}
 	waitGroup             sync.WaitGroup
 	onceClose             sync.Once
 	sendKeepAlives        bool
@@ -94,7 +94,7 @@ func NewConnection(options ...ConnectionOptionFunc) (*Connection, error) {
 		protoErrorChan:        make(chan error, 10),
 		handshakeFinishedChan: make(chan interface{}),
 		doneChan:              make(chan interface{}),
-		shutdownFinishedChan:  make(chan struct{}),
+		shutdownFinishedChan:  make(chan interface{}),
 	}
 	// Apply provided options functions
 	for _, option := range options {
@@ -126,7 +126,7 @@ func (c *Connection) ErrorChan() chan error {
 	return c.errorChan
 }
 
-func (c *Connection) ShutdownFinishedChan() <-chan struct{} {
+func (c *Connection) ShutdownFinishedChan() <-chan interface{} {
 	return c.shutdownFinishedChan
 }
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -17,6 +17,7 @@ package ouroboros_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/internal/test/ouroboros_mock"
@@ -70,5 +71,15 @@ func TestDoubleClose(t *testing.T) {
 			"unexpected error when closing Connection object again: %s",
 			err,
 		)
+	}
+
+	// after shutdown is completed oConn.ShutdownCh() should be closed
+	timeout := time.NewTimer(time.Second * 10)
+	defer timeout.Stop()
+
+	select {
+	case <-oConn.ShutdownFinishedChan():
+	case <-timeout.C:
+		t.Fatalf("timeout for shutdown")
 	}
 }


### PR DESCRIPTION
This pull request introduces a wait mechanism to accurately determine when the connection close process is completed.
Connection close is initiated as it was before with `connecion.Close()` and after `<-oConn.ShutdownFinishedCh()` we can be sure that the whole process of closing has been finished