### PR TITLE
fix: remove use of sync.Once to avoid deadlocks

### DIFF
--- a/protocol/handshake/server_test.go
+++ b/protocol/handshake/server_test.go
@@ -106,8 +106,15 @@ func TestServerHandshakeRefuseVersionMismatch(t *testing.T) {
 				InputMessageType: handshake.MessageTypeRefuse,
 				InputMessage: handshake.NewMsgRefuse(
 					[]any{
-						handshake.RefuseReasonVersionMismatch,
-						protocol.GetProtocolVersionsNtC(),
+						uint64(handshake.RefuseReasonVersionMismatch),
+						// Convert []uint16 to []any
+						func(in []uint16) []any {
+							var ret []any
+							for _, item := range in {
+								ret = append(ret, item)
+							}
+							return ret
+						}(protocol.GetProtocolVersionsNtC()),
 					},
 				),
 			},


### PR DESCRIPTION
Fixes #522