### PR TITLE
perf: a little optimization for Transactions() methods

### DIFF
--- a/ledger/allegra.go
+++ b/ledger/allegra.go
@@ -71,14 +71,13 @@ func (b *AllegraBlock) Era() Era {
 }
 
 func (b *AllegraBlock) Transactions() []Transaction {
-	ret := []Transaction{}
+	ret := make([]Transaction, len(b.TransactionBodies))
 	for idx := range b.TransactionBodies {
-		tmpTransaction := AllegraTransaction{
+		ret[idx] = &AllegraTransaction{
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],
 			TxMetadata: b.TransactionMetadataSet[uint(idx)],
 		}
-		ret = append(ret, &tmpTransaction)
 	}
 	return ret
 }

--- a/ledger/alonzo.go
+++ b/ledger/alonzo.go
@@ -73,22 +73,19 @@ func (b *AlonzoBlock) Era() Era {
 }
 
 func (b *AlonzoBlock) Transactions() []Transaction {
-	ret := []Transaction{}
+	invalidTxMap := make(map[uint]bool, len(b.InvalidTransactions))
+	for _, invalidTxIdx := range b.InvalidTransactions {
+		invalidTxMap[invalidTxIdx] = true
+	}
+
+	ret := make([]Transaction, len(b.TransactionBodies))
 	for idx := range b.TransactionBodies {
-		tmpTransaction := AlonzoTransaction{
+		ret[idx] = &AlonzoTransaction{
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],
 			TxMetadata: b.TransactionMetadataSet[uint(idx)],
+			IsValid:    !invalidTxMap[uint(idx)],
 		}
-		isValid := true
-		for _, invalidTxIdx := range b.InvalidTransactions {
-			if invalidTxIdx == uint(idx) {
-				isValid = false
-				break
-			}
-		}
-		tmpTransaction.IsValid = isValid
-		ret = append(ret, &tmpTransaction)
 	}
 	return ret
 }

--- a/ledger/babbage.go
+++ b/ledger/babbage.go
@@ -73,22 +73,19 @@ func (b *BabbageBlock) Era() Era {
 }
 
 func (b *BabbageBlock) Transactions() []Transaction {
-	ret := []Transaction{}
+	invalidTxMap := make(map[uint]bool, len(b.InvalidTransactions))
+	for _, invalidTxIdx := range b.InvalidTransactions {
+		invalidTxMap[invalidTxIdx] = true
+	}
+
+	ret := make([]Transaction, len(b.TransactionBodies))
 	for idx := range b.TransactionBodies {
-		tmpTransaction := BabbageTransaction{
+		ret[idx] = &BabbageTransaction{
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],
 			TxMetadata: b.TransactionMetadataSet[uint(idx)],
+			IsValid:    !invalidTxMap[uint(idx)],
 		}
-		isValid := true
-		for _, invalidTxIdx := range b.InvalidTransactions {
-			if invalidTxIdx == uint(idx) {
-				isValid = false
-				break
-			}
-		}
-		tmpTransaction.IsValid = isValid
-		ret = append(ret, &tmpTransaction)
 	}
 	return ret
 }

--- a/ledger/babbage_test.go
+++ b/ledger/babbage_test.go
@@ -1,0 +1,64 @@
+package ledger
+
+import (
+	"testing"
+)
+
+func TestBabbageBlockTransactions(t *testing.T) {
+	b := &BabbageBlock{}
+
+	t.Run("empty", func(t *testing.T) {
+		if lenTxs := len(b.Transactions()); lenTxs != 0 {
+			t.Fatalf("expected number of transactions is 0 but it was %d", lenTxs)
+		}
+	})
+
+	txsCount := 7
+	b.TransactionBodies = make([]BabbageTransactionBody, txsCount)
+	b.TransactionWitnessSets = make([]BabbageTransactionWitnessSet, txsCount)
+
+	for i := 0; i < txsCount; i++ {
+		b.TransactionBodies[i] = BabbageTransactionBody{
+			TotalCollateral: 1 << i,
+		}
+		b.TransactionWitnessSets[i] = BabbageTransactionWitnessSet{
+			AlonzoTransactionWitnessSet: AlonzoTransactionWitnessSet{
+				ShelleyTransactionWitnessSet: ShelleyTransactionWitnessSet{
+					VkeyWitnesses: []interface{}{
+						append(make([]byte, 95), 1<<i),
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("no invalid", func(t *testing.T) {
+		txs := b.Transactions()
+
+		if lenTxs := len(txs); lenTxs != txsCount {
+			t.Fatalf("expected number of transactions is %d but it was %d", txsCount, lenTxs)
+		}
+
+		for i, tx := range txs {
+			if btx := tx.(*BabbageTransaction); !btx.IsValid {
+				t.Fatalf("expected transaction number %d IsValid is %v but is was %v", i, true, btx.IsValid)
+			}
+		}
+	})
+
+	t.Run("with invalid", func(t *testing.T) {
+		b.InvalidTransactions = []uint{2, 4, 5}
+		txs := b.Transactions()
+
+		if lenTxs := len(txs); lenTxs != txsCount {
+			t.Fatalf("expected number of transactions is %d but it was %d", txsCount, lenTxs)
+		}
+
+		for i, tx := range txs {
+			expected := i != 2 && i != 4 && i != 5
+			if btx := tx.(*BabbageTransaction); btx.IsValid != expected {
+				t.Fatalf("expected transaction number %d IsValid is %v but is was %v", i, expected, btx.IsValid)
+			}
+		}
+	})
+}

--- a/ledger/conway.go
+++ b/ledger/conway.go
@@ -72,22 +72,19 @@ func (b *ConwayBlock) Era() Era {
 }
 
 func (b *ConwayBlock) Transactions() []Transaction {
-	ret := []Transaction{}
+	invalidTxMap := make(map[uint]bool, len(b.InvalidTransactions))
+	for _, invalidTxIdx := range b.InvalidTransactions {
+		invalidTxMap[invalidTxIdx] = true
+	}
+
+	ret := make([]Transaction, len(b.TransactionBodies))
 	for idx := range b.TransactionBodies {
-		tmpTransaction := ConwayTransaction{
+		ret[idx] = &ConwayTransaction{
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],
 			TxMetadata: b.TransactionMetadataSet[uint(idx)],
+			IsValid:    !invalidTxMap[uint(idx)],
 		}
-		isValid := true
-		for _, invalidTxIdx := range b.InvalidTransactions {
-			if invalidTxIdx == uint(idx) {
-				isValid = false
-				break
-			}
-		}
-		tmpTransaction.IsValid = isValid
-		ret = append(ret, &tmpTransaction)
 	}
 	return ret
 }

--- a/ledger/mary.go
+++ b/ledger/mary.go
@@ -72,14 +72,13 @@ func (b *MaryBlock) Era() Era {
 }
 
 func (b *MaryBlock) Transactions() []Transaction {
-	ret := []Transaction{}
+	ret := make([]Transaction, len(b.TransactionBodies))
 	for idx := range b.TransactionBodies {
-		tmpTransaction := MaryTransaction{
+		ret[idx] = &MaryTransaction{
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],
 			TxMetadata: b.TransactionMetadataSet[uint(idx)],
 		}
-		ret = append(ret, &tmpTransaction)
 	}
 	return ret
 }

--- a/ledger/shelley.go
+++ b/ledger/shelley.go
@@ -71,14 +71,13 @@ func (b *ShelleyBlock) Era() Era {
 }
 
 func (b *ShelleyBlock) Transactions() []Transaction {
-	ret := []Transaction{}
+	ret := make([]Transaction, len(b.TransactionBodies))
 	for idx := range b.TransactionBodies {
-		tmpTransaction := ShelleyTransaction{
+		ret[idx] = &ShelleyTransaction{
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],
 			TxMetadata: b.TransactionMetadataSet[uint(idx)],
 		}
-		ret = append(ret, &tmpTransaction)
 	}
 	return ret
 }


### PR DESCRIPTION
Changes inside `Transactions() []Transaction` methods:
- in advance allocate memory for returning slice of Transactions (size of slice is known)
- use map to mark invalid transactions replacing the previous loop through an invalid slice.

Additionally, a `cachedTransactions` slice can be introduced within each struct, allowing for immediate return from the method when the slice is not nil, if you ok with that?