### PR TITLE
feat: add IsValid method to Transaction interface

### DIFF
--- a/ledger/allegra.go
+++ b/ledger/allegra.go
@@ -157,6 +157,10 @@ func (t AllegraTransaction) Utxorpc() *utxorpc.Tx {
 	return t.Body.Utxorpc()
 }
 
+func (t AllegraTransaction) IsValid() bool {
+	return true
+}
+
 func (t *AllegraTransaction) Cbor() []byte {
 	// Return stored CBOR if we have any
 	cborData := t.DecodeStoreCbor.Cbor()

--- a/ledger/alonzo.go
+++ b/ledger/alonzo.go
@@ -84,7 +84,7 @@ func (b *AlonzoBlock) Transactions() []Transaction {
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],
 			TxMetadata: b.TransactionMetadataSet[uint(idx)],
-			IsValid:    !invalidTxMap[uint(idx)],
+			IsTxValid:  !invalidTxMap[uint(idx)],
 		}
 	}
 	return ret
@@ -227,7 +227,7 @@ type AlonzoTransaction struct {
 	cbor.DecodeStoreCbor
 	Body       AlonzoTransactionBody
 	WitnessSet AlonzoTransactionWitnessSet
-	IsValid    bool
+	IsTxValid  bool
 	TxMetadata *cbor.Value
 }
 
@@ -253,6 +253,10 @@ func (t AlonzoTransaction) TTL() uint64 {
 
 func (t AlonzoTransaction) Metadata() *cbor.Value {
 	return t.TxMetadata
+}
+
+func (t AlonzoTransaction) IsValid() bool {
+	return t.IsTxValid
 }
 
 func (t *AlonzoTransaction) Cbor() []byte {

--- a/ledger/babbage.go
+++ b/ledger/babbage.go
@@ -84,7 +84,7 @@ func (b *BabbageBlock) Transactions() []Transaction {
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],
 			TxMetadata: b.TransactionMetadataSet[uint(idx)],
-			IsValid:    !invalidTxMap[uint(idx)],
+			IsTxValid:  !invalidTxMap[uint(idx)],
 		}
 	}
 	return ret
@@ -351,7 +351,7 @@ type BabbageTransaction struct {
 	cbor.DecodeStoreCbor
 	Body       BabbageTransactionBody
 	WitnessSet BabbageTransactionWitnessSet
-	IsValid    bool
+	IsTxValid  bool
 	TxMetadata *cbor.Value
 }
 
@@ -377,6 +377,10 @@ func (t BabbageTransaction) TTL() uint64 {
 
 func (t BabbageTransaction) Metadata() *cbor.Value {
 	return t.TxMetadata
+}
+
+func (t BabbageTransaction) IsValid() bool {
+	return t.IsTxValid
 }
 
 func (t *BabbageTransaction) Cbor() []byte {

--- a/ledger/babbage_test.go
+++ b/ledger/babbage_test.go
@@ -40,8 +40,8 @@ func TestBabbageBlockTransactions(t *testing.T) {
 		}
 
 		for i, tx := range txs {
-			if btx := tx.(*BabbageTransaction); !btx.IsValid {
-				t.Fatalf("expected transaction number %d IsValid is %v but is was %v", i, true, btx.IsValid)
+			if btx := tx.(*BabbageTransaction); !btx.IsValid() {
+				t.Fatalf("expected transaction number %d IsValid is %v but is was %v", i, true, btx.IsValid())
 			}
 		}
 	})
@@ -56,8 +56,8 @@ func TestBabbageBlockTransactions(t *testing.T) {
 
 		for i, tx := range txs {
 			expected := i != 2 && i != 4 && i != 5
-			if btx := tx.(*BabbageTransaction); btx.IsValid != expected {
-				t.Fatalf("expected transaction number %d IsValid is %v but is was %v", i, expected, btx.IsValid)
+			if btx := tx.(*BabbageTransaction); btx.IsValid() != expected {
+				t.Fatalf("expected transaction number %d IsValid is %v but is was %v", i, expected, btx.IsValid())
 			}
 		}
 	})

--- a/ledger/byron.go
+++ b/ledger/byron.go
@@ -157,6 +157,10 @@ func (t *ByronTransaction) Metadata() *cbor.Value {
 	return t.Attributes
 }
 
+func (t *ByronTransaction) IsValid() bool {
+	return true
+}
+
 func (t *ByronTransaction) Utxorpc() *utxorpc.Tx {
 	return &utxorpc.Tx{}
 }

--- a/ledger/conway.go
+++ b/ledger/conway.go
@@ -83,7 +83,7 @@ func (b *ConwayBlock) Transactions() []Transaction {
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],
 			TxMetadata: b.TransactionMetadataSet[uint(idx)],
-			IsValid:    !invalidTxMap[uint(idx)],
+			IsTxValid:  !invalidTxMap[uint(idx)],
 		}
 	}
 	return ret
@@ -136,7 +136,7 @@ type ConwayTransaction struct {
 	cbor.DecodeStoreCbor
 	Body       ConwayTransactionBody
 	WitnessSet BabbageTransactionWitnessSet
-	IsValid    bool
+	IsTxValid  bool
 	TxMetadata *cbor.Value
 }
 
@@ -162,6 +162,10 @@ func (t ConwayTransaction) TTL() uint64 {
 
 func (t ConwayTransaction) Metadata() *cbor.Value {
 	return t.TxMetadata
+}
+
+func (t ConwayTransaction) IsValid() bool {
+	return t.IsTxValid
 }
 
 func (t *ConwayTransaction) Cbor() []byte {

--- a/ledger/mary.go
+++ b/ledger/mary.go
@@ -164,6 +164,10 @@ func (t MaryTransaction) Metadata() *cbor.Value {
 	return t.TxMetadata
 }
 
+func (t MaryTransaction) IsValid() bool {
+	return true
+}
+
 func (t *MaryTransaction) Cbor() []byte {
 	// Return stored CBOR if we have any
 	cborData := t.DecodeStoreCbor.Cbor()

--- a/ledger/shelley.go
+++ b/ledger/shelley.go
@@ -355,6 +355,10 @@ func (t ShelleyTransaction) Metadata() *cbor.Value {
 	return t.TxMetadata
 }
 
+func (t ShelleyTransaction) IsValid() bool {
+	return true
+}
+
 func (t ShelleyTransaction) Utxorpc() *utxorpc.Tx {
 	return t.Body.Utxorpc()
 }

--- a/ledger/tx.go
+++ b/ledger/tx.go
@@ -27,6 +27,7 @@ import (
 type Transaction interface {
 	TransactionBody
 	Metadata() *cbor.Value
+	IsValid() bool
 }
 
 type TransactionBody interface {


### PR DESCRIPTION
To enhance usability, this commit introduces the `IsValid` method within the `Transaction` interface. This allows easy determination of a transaction's validity status without the need for casting.