### PR TITLE
fix: Goroutine leak in handshake server on version mismatch refusal #535

### DIFF
--- a/protocol/handshake/server_test.go
+++ b/protocol/handshake/server_test.go
@@ -88,8 +88,9 @@ func TestServerBasicHandshake(t *testing.T) {
 }
 
 func TestServerHandshakeRefuseVersionMismatch(t *testing.T) {
-	// TODO: fix leaking goroutines
-	//defer goleak.VerifyNone(t)
+	defer func() {
+		goleak.VerifyNone(t)
+	}()
 	expectedErr := fmt.Errorf("handshake failed: refused due to version mismatch")
 	mockConn := ouroboros_mock.NewConnection(
 		ouroboros_mock.ProtocolRoleServer,

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -14,3 +14,29 @@
 
 // Package utils provides random utility functions
 package utils
+
+import (
+	"sync"
+)
+
+// DoneSignal provides a thread-safe way to close a channel and allows other routines to listen to the channel
+type DoneSignal struct {
+	closeCh chan struct{}
+	once    sync.Once
+}
+
+func NewDoneSignal() *DoneSignal {
+	return &DoneSignal{
+		closeCh: make(chan struct{}),
+	}
+}
+
+func (cn *DoneSignal) Close() {
+	cn.once.Do(func() {
+		close(cn.closeCh)
+	})
+}
+
+func (cn *DoneSignal) GetCh() <-chan struct{} {
+	return cn.closeCh
+}


### PR DESCRIPTION
Fix for https://github.com/blinklabs-io/gouroboros/issues/535
The Thread-Safe `DoneSignal` is introduced with the following features:
- The `Close` method can be called multiple times, but it will only trigger once.
- The `GetCh()` method returns a listen-only channel and should be called by all routines that listen for the closing event.

If either the `recvLoop` or `sendLoop` routines exits, it will trigger the closing of the `DoneSignal`. Subsequently, this will lead to the shutdown of the other routine and the `stateLoop`. The `stateLoop` will be finally finished after both the `recvLoop` and `sendLoop` have shut down (`p.waitGroup.Wait()`)

This pr does not fix https://github.com/blinklabs-io/gouroboros/issues/530 only makes all the protocol routines gracefully shutdown