### PR TITLE
fix: Random panic in handshake tests #530

### DIFF
--- a/protocol/handshake/messages.go
+++ b/protocol/handshake/messages.go
@@ -30,9 +30,9 @@ const (
 
 // Refusal reasons
 const (
-	RefuseReasonVersionMismatch = 0
-	RefuseReasonDecodeError     = 1
-	RefuseReasonRefused         = 2
+	RefuseReasonVersionMismatch uint64 = 0
+	RefuseReasonDecodeError     uint64 = 1
+	RefuseReasonRefused         uint64 = 2
 )
 
 // NewMsgFromCbor parses a Handshake message from CBOR

--- a/protocol/handshake/server.go
+++ b/protocol/handshake/server.go
@@ -16,6 +16,7 @@ package handshake
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/blinklabs-io/gouroboros/protocol"
 )
@@ -82,6 +83,12 @@ func (s *Server) handleProposeVersions(msg protocol.Message) error {
 		for supportedVersion := range s.config.ProtocolVersionMap {
 			supportedVersions = append(supportedVersions, supportedVersion)
 		}
+
+		// sort asending - iterating over map is not deterministic
+		sort.Slice(supportedVersions, func(i, j int) bool {
+			return supportedVersions[i] < supportedVersions[j]
+		})
+
 		msgRefuse := NewMsgRefuse(
 			[]any{
 				RefuseReasonVersionMismatch,

--- a/protocol/handshake/server_test.go
+++ b/protocol/handshake/server_test.go
@@ -117,12 +117,12 @@ func TestServerHandshakeRefuseVersionMismatch(t *testing.T) {
 				InputMessageType: handshake.MessageTypeRefuse,
 				InputMessage: handshake.NewMsgRefuse(
 					[]any{
-						uint64(handshake.RefuseReasonVersionMismatch),
+						handshake.RefuseReasonVersionMismatch,
 						// Convert []uint16 to []any
 						func(in []uint16) []any {
 							var ret []any
 							for _, item := range in {
-								ret = append(ret, item)
+								ret = append(ret, uint64(item))
 							}
 							return ret
 						}(protocol.GetProtocolVersionsNtC()),

--- a/protocol/versions.go
+++ b/protocol/versions.go
@@ -14,6 +14,8 @@
 
 package protocol
 
+import "sort"
+
 // The NtC protocol versions have the 15th bit set in the handshake
 const ProtocolVersionNtCOffset = 0x8000
 
@@ -258,6 +260,12 @@ func GetProtocolVersionsNtC() []uint16 {
 			versions = append(versions, key)
 		}
 	}
+
+	// sort asending - iterating over map is not deterministic
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i] < versions[j]
+	})
+
 	return versions
 }
 
@@ -269,6 +277,12 @@ func GetProtocolVersionsNtN() []uint16 {
 			versions = append(versions, key)
 		}
 	}
+
+	// sort asending - iterating over map is not deterministic
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i] < versions[j]
+	})
+
 	return versions
 }
 


### PR DESCRIPTION
This change should fix https://github.com/blinklabs-io/gouroboros/issues/530

Problem was happening because iterating through map is not deterministic.
Also there was uint64/uint16 differences

To test this fix, the only method available is to start the `func TestServerHandshakeRefuseVersionMismatch(t *testing.T)` test multiple times until line 211 in `internal/test/ouroboros_mock/connection.go` (`if !reflect.DeepEqual(msg, entry.InputMessage)`) is reached. Following these modifications, both messages should consistently match