### PR TITLE
feat: generic custom CBOR tag handling

### DIFF
--- a/cbor/cbor.go
+++ b/cbor/cbor.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,20 +30,6 @@ const (
 
 	// Max value able to be stored in a single byte without type prefix
 	CborMaxUintSimple uint8 = 0x17
-
-	// Useful tag numbers
-	CborTagCbor     = 24
-	CborTagRational = 30
-	CborTagSet      = 258
-	CborTagMap      = 259
-
-	// Tag ranges for "alternatives"
-	// https://www.ietf.org/archive/id/draft-bormann-cbor-notable-tags-07.html#name-enumerated-alternative-data
-	CborTagAlternative1Min = 121
-	CborTagAlternative1Max = 127
-	CborTagAlternative2Min = 1280
-	CborTagAlternative2Max = 1400
-	CborTagAlternative3    = 101
 )
 
 // Create an alias for RawMessage for convenience

--- a/cbor/decode.go
+++ b/cbor/decode.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ func Decode(dataBytes []byte, dest interface{}) (int, error) {
 		// This defaults to 32, but there are blocks in the wild using >64 nested levels
 		MaxNestedLevels: 256,
 	}
-	decMode, err := decOptions.DecMode()
+	decMode, err := decOptions.DecModeWithTags(customTagSet)
 	if err != nil {
 		return 0, err
 	}

--- a/cbor/encode.go
+++ b/cbor/encode.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import (
 
 func Encode(data interface{}) ([]byte, error) {
 	buf := bytes.NewBuffer(nil)
-	em, err := _cbor.CoreDetEncOptions().EncMode()
+	em, err := _cbor.CoreDetEncOptions().EncModeWithTags(customTagSet)
 	if err != nil {
 		return nil, err
 	}

--- a/cbor/tags.go
+++ b/cbor/tags.go
@@ -1,0 +1,120 @@
+// Copyright 2024 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cbor
+
+import (
+	"math/big"
+	"reflect"
+
+	_cbor "github.com/fxamacker/cbor/v2"
+)
+
+const (
+	// Useful tag numbers
+	CborTagCbor     = 24
+	CborTagRational = 30
+	CborTagSet      = 258
+	CborTagMap      = 259
+
+	// Tag ranges for "alternatives"
+	// https://www.ietf.org/archive/id/draft-bormann-cbor-notable-tags-07.html#name-enumerated-alternative-data
+	CborTagAlternative1Min = 121
+	CborTagAlternative1Max = 127
+	CborTagAlternative2Min = 1280
+	CborTagAlternative2Max = 1400
+	CborTagAlternative3    = 101
+)
+
+var customTagSet _cbor.TagSet
+
+func init() {
+	// Build custom tagset
+	customTagSet = _cbor.NewTagSet()
+	tagOpts := _cbor.TagOptions{EncTag: _cbor.EncTagRequired, DecTag: _cbor.DecTagRequired}
+	// Wrapped CBOR
+	if err := customTagSet.Add(
+		tagOpts,
+		reflect.TypeOf(WrappedCbor{}),
+		CborTagCbor,
+	); err != nil {
+		panic(err)
+	}
+	// Rational numbers
+	if err := customTagSet.Add(
+		tagOpts,
+		reflect.TypeOf(Rat{}),
+		CborTagRational,
+	); err != nil {
+		panic(err)
+	}
+	// Sets
+	if err := customTagSet.Add(
+		tagOpts,
+		reflect.TypeOf(Set{}),
+		CborTagSet,
+	); err != nil {
+		panic(err)
+	}
+	// Maps
+	if err := customTagSet.Add(
+		tagOpts,
+		reflect.TypeOf(Map{}),
+		CborTagMap,
+	); err != nil {
+		panic(err)
+	}
+}
+
+// WrappedCbor corresponds to CBOR tag 24 and is used to encode nested CBOR data
+type WrappedCbor []byte
+
+func (w WrappedCbor) Bytes() []byte {
+	return w[:]
+}
+
+// Rat corresponds to CBOR tag 30 and is used to represent a rational number
+type Rat struct {
+	*big.Rat
+}
+
+func (r *Rat) UnmarshalCBOR(cborData []byte) error {
+	tmpRat := []int64{}
+	if _, err := Decode(cborData, &tmpRat); err != nil {
+		return err
+	}
+	r.Rat = big.NewRat(tmpRat[0], tmpRat[1])
+	return nil
+}
+
+func (r *Rat) MarshalCBOR() ([]byte, error) {
+	tmpData := _cbor.Tag{
+		Number: CborTagRational,
+		Content: []uint64{
+			r.Num().Uint64(),
+			r.Denom().Uint64(),
+		},
+	}
+	return Encode(&tmpData)
+}
+
+func (r *Rat) ToBigRat() *big.Rat {
+	return r.Rat
+}
+
+// Set corresponds to CBOR tag 258 and is used to represent a mathematical finite set
+type Set []any
+
+// Map corresponds to CBOR tag 259 and is used to represent a map with key/value operations
+type Map map[any]any

--- a/cbor/tags_test.go
+++ b/cbor/tags_test.go
@@ -1,0 +1,94 @@
+// Copyright 2024 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cbor_test
+
+import (
+	"encoding/hex"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+)
+
+var tagsTestDefs = []struct {
+	cborHex string
+	object  any
+}{
+	{
+		cborHex: "d81843abcdef",
+		object:  cbor.WrappedCbor([]byte{0xab, 0xcd, 0xef}),
+	},
+	{
+		cborHex: "d81e82031903e8",
+		object: cbor.Rat{
+			Rat: big.NewRat(3, 1000),
+		},
+	},
+	{
+		cborHex: "d9010283010203",
+		object: cbor.Set(
+			[]any{
+				uint64(1), uint64(2), uint64(3),
+			},
+		),
+	},
+	{
+		cborHex: "d90103a201020304",
+		object: cbor.Map(
+			map[any]any{
+				uint64(1): uint64(2),
+				uint64(3): uint64(4),
+			},
+		),
+	},
+}
+
+func TestTagsDecode(t *testing.T) {
+	for _, testDef := range tagsTestDefs {
+		cborData, err := hex.DecodeString(testDef.cborHex)
+		if err != nil {
+			t.Fatalf("failed to decode CBOR hex: %s", err)
+		}
+		var dest any
+		if _, err := cbor.Decode(cborData, &dest); err != nil {
+			t.Fatalf("failed to decode CBOR: %s", err)
+		}
+		if !reflect.DeepEqual(dest, testDef.object) {
+			t.Fatalf(
+				"CBOR did not decode to expected object\n  got: %#v\n  wanted: %#v",
+				dest,
+				testDef.object,
+			)
+		}
+	}
+}
+
+func TestTagsEncode(t *testing.T) {
+	for _, testDef := range tagsTestDefs {
+		cborData, err := cbor.Encode(testDef.object)
+		if err != nil {
+			t.Fatalf("failed to encode object to CBOR: %s", err)
+		}
+		cborHex := hex.EncodeToString(cborData)
+		if cborHex != testDef.cborHex {
+			t.Fatalf(
+				"object did not encode to expected CBOR\n  got: %s\n  wanted: %s",
+				cborHex,
+				testDef.cborHex,
+			)
+		}
+	}
+}

--- a/cbor/value_test.go
+++ b/cbor/value_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -86,6 +86,41 @@ var testDefs = []struct {
 		},
 		expectedAstJson: `{"list":[{"int":22318265904693663008365},{"int":8535038193994223137511702528}]}`,
 	},
+	// 24('abcdef')
+	{
+		cborHex:         "d81843abcdef",
+		expectedObject:  cbor.WrappedCbor([]byte{0xab, 0xcd, 0xef}),
+		expectedAstJson: `{"bytes":"abcdef"}`,
+	},
+	// 30([3, 1000])
+	{
+		cborHex: "d81e82031903e8",
+		expectedObject: cbor.Rat{
+			Rat: big.NewRat(3, 1000),
+		},
+		expectedAstJson: `{"list":[{"int":3},{"int":1000}]}`,
+	},
+	// 258([1, 2, 3])
+	{
+		cborHex: "d9010283010203",
+		expectedObject: cbor.Set(
+			[]any{
+				uint64(1), uint64(2), uint64(3),
+			},
+		),
+		expectedAstJson: `{"list":[{"int":1},{"int":2},{"int":3}]}`,
+	},
+	// 259({1: 2, 3: 4})
+	{
+		cborHex: "d90103a201020304",
+		expectedObject: cbor.Map(
+			map[any]any{
+				uint64(1): uint64(2),
+				uint64(3): uint64(4),
+			},
+		),
+		expectedAstJson: `{"map":[{"k":{"int":1},"v":{"int":2}},{"k":{"int":3},"v":{"int":4}}]}`,
+	},
 }
 
 func TestValueDecode(t *testing.T) {
@@ -99,7 +134,7 @@ func TestValueDecode(t *testing.T) {
 			if testDef.expectedDecodeError != nil {
 				if err.Error() != testDef.expectedDecodeError.Error() {
 					t.Fatalf(
-						"did not receive expected decode error, got: %s, wanted: %s",
+						"did not receive expected decode error, got:    %s, wanted: %s",
 						err,
 						testDef.expectedDecodeError,
 					)
@@ -116,7 +151,7 @@ func TestValueDecode(t *testing.T) {
 		newObj := tmpValue.Value()
 		if !reflect.DeepEqual(newObj, testDef.expectedObject) {
 			t.Fatalf(
-				"CBOR did not decode to expected object\n  got: %#v\n  wanted: %#v",
+				"CBOR did not decode to expected object\n  got:    %#v\n  wanted: %#v",
 				newObj,
 				testDef.expectedObject,
 			)
@@ -156,7 +191,7 @@ func TestValueMarshalJSON(t *testing.T) {
 		}
 		if !test.JsonStringsEqual(jsonData, []byte(fullExpectedJson)) {
 			t.Fatalf(
-				"CBOR did not marshal to expected JSON\n  got: %s\n  wanted: %s",
+				"CBOR did not marshal to expected JSON\n  got:    %s\n  wanted: %s",
 				jsonData,
 				fullExpectedJson,
 			)
@@ -175,7 +210,7 @@ func TestLazyValueDecode(t *testing.T) {
 			if testDef.expectedDecodeError != nil {
 				if err.Error() != testDef.expectedDecodeError.Error() {
 					t.Fatalf(
-						"did not receive expected decode error, got: %s, wanted: %s",
+						"did not receive expected decode error, got:    %s, wanted: %s",
 						err,
 						testDef.expectedDecodeError,
 					)
@@ -190,7 +225,7 @@ func TestLazyValueDecode(t *testing.T) {
 			if testDef.expectedDecodeError != nil {
 				if err.Error() != testDef.expectedDecodeError.Error() {
 					t.Fatalf(
-						"did not receive expected decode error, got: %s, wanted: %s",
+						"did not receive expected decode error, got:    %s, wanted: %s",
 						err,
 						testDef.expectedDecodeError,
 					)
@@ -206,7 +241,7 @@ func TestLazyValueDecode(t *testing.T) {
 		}
 		if !reflect.DeepEqual(newObj, testDef.expectedObject) {
 			t.Fatalf(
-				"CBOR did not decode to expected object\n  got: %#v\n  wanted: %#v",
+				"CBOR did not decode to expected object\n  got:    %#v\n  wanted: %#v",
 				newObj,
 				testDef.expectedObject,
 			)
@@ -246,7 +281,7 @@ func TestLazyValueMarshalJSON(t *testing.T) {
 		}
 		if !test.JsonStringsEqual(jsonData, []byte(fullExpectedJson)) {
 			t.Fatalf(
-				"CBOR did not marshal to expected JSON\n  got: %s\n  wanted: %s",
+				"CBOR did not marshal to expected JSON\n  got:    %s\n  wanted: %s",
 				jsonData,
 				fullExpectedJson,
 			)
@@ -303,7 +338,7 @@ func TestConstructorDecode(t *testing.T) {
 		}
 		if !reflect.DeepEqual(tmpConstr.Fields(), testDef.expectedObj.Fields()) {
 			t.Fatalf(
-				"did not decode to expected fields\n  got: %#v\n  wanted: %#v",
+				"did not decode to expected fields\n  got:    %#v\n  wanted: %#v",
 				tmpConstr.Fields(),
 				testDef.expectedObj.Fields(),
 			)
@@ -320,7 +355,7 @@ func TestConstructorEncode(t *testing.T) {
 		cborDataHex := hex.EncodeToString(cborData)
 		if cborDataHex != strings.ToLower(testDef.cborHex) {
 			t.Fatalf(
-				"did not encode to expected CBOR\n  got: %s\n  wanted: %s",
+				"did not encode to expected CBOR\n  got:    %s\n  wanted: %s",
 				cborDataHex,
 				strings.ToLower(testDef.cborHex),
 			)

--- a/protocol/localtxmonitor/messages.go
+++ b/protocol/localtxmonitor/messages.go
@@ -174,7 +174,7 @@ func (m *MsgReplyNextTx) UnmarshalCBOR(data []byte) error {
 		txWrapper := tmp[1].([]interface{})
 		m.Transaction = MsgReplyNextTxTransaction{
 			EraId: uint8(txWrapper[0].(uint64)),
-			Tx:    txWrapper[1].(cbor.Tag).Content.([]byte),
+			Tx:    txWrapper[1].(cbor.WrappedCbor).Bytes(),
 		}
 	}
 	return nil


### PR DESCRIPTION
This moves the handling for some custom CBOR tag types from cbor.Value to the generic encoder/decoder to make them more widely usable.

Fixes #548