### PR TITLE
feat: ledger support for Byron TX inputs/outputs

### DIFF
--- a/ledger/common.go
+++ b/ledger/common.go
@@ -336,14 +336,18 @@ func (a *Address) populateFromBytes(data []byte) error {
 }
 
 func (a *Address) UnmarshalCBOR(data []byte) error {
-	// Decode bytes from CBOR
+	// Try to unwrap as bytestring (Shelley and forward)
 	tmpData := []byte{}
-	if _, err := cbor.Decode(data, &tmpData); err != nil {
-		return err
-	}
-	err := a.populateFromBytes(tmpData)
-	if err != nil {
-		return err
+	if _, err := cbor.Decode(data, &tmpData); err == nil {
+		err := a.populateFromBytes(tmpData)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Probably a Byron address
+		if err := a.populateFromBytes(data); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/ledger/common_test.go
+++ b/ledger/common_test.go
@@ -139,6 +139,11 @@ func TestAddressFromBytes(t *testing.T) {
 			addressBytesHex: "015bad085057ac10ecc7060f7ac41edd6f63068d8963ef7d86ca58669e5ecf2d283418a60be5a848a2380eb721000da1e0bbf39733134beca4cb57afb0b35fc89c63061c9914e055001a518c7516",
 			expectedAddress: "addr1q9d66zzs27kppmx8qc8h43q7m4hkxp5d39377lvxefvxd8j7eukjsdqc5c97t2zg5guqadepqqx6rc9m7wtnxy6tajjvk4a0kze4ljyuvvrpexg5up2sqxj33363v35gtew",
 		},
+		// Byron address
+		{
+			addressBytesHex: "82d818584283581caf56de241bcca83d72c51e74d18487aa5bc68b45e2caa170fa329d3aa101581e581cea1425ccdd649b25af5deb7e6335da2eb8167353a55e77925122e95f001a3a858621",
+			expectedAddress: "DdzFFzCqrht2ii4Vc7KRchSkVvQtCqdGkQt4nF4Yxg1NpsubFBity2Tpt2eSEGrxBH1eva8qCFKM2Y5QkwM1SFBizRwZgz1N452WYvgG",
+		},
 	}
 	for _, testDef := range testDefs {
 		addr := Address{}


### PR DESCRIPTION
This adds support for decoding Byron transaction inputs and outputs, as well as enhances the Address type for Byron addresses

Fixes #285