### PR TITLE
feat!: provide context object for callback functions

### DIFF
--- a/cmd/gouroboros/chainsync.go
+++ b/cmd/gouroboros/chainsync.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -256,12 +256,13 @@ func testChainSync(f *globalFlags) {
 	select {}
 }
 
-func chainSyncRollBackwardHandler(point common.Point, tip chainsync.Tip) error {
+func chainSyncRollBackwardHandler(ctx chainsync.CallbackContext, point common.Point, tip chainsync.Tip) error {
 	fmt.Printf("roll backward: point = %#v, tip = %#v\n", point, tip)
 	return nil
 }
 
 func chainSyncRollForwardHandler(
+	ctx chainsync.CallbackContext,
 	blockType uint,
 	blockData interface{},
 	tip chainsync.Tip,
@@ -312,7 +313,7 @@ func chainSyncRollForwardHandler(
 	return nil
 }
 
-func blockFetchBlockHandler(blockData ledger.Block) error {
+func blockFetchBlockHandler(ctx blockfetch.CallbackContext, blockData ledger.Block) error {
 	switch block := blockData.(type) {
 	case *ledger.ByronEpochBoundaryBlock:
 		fmt.Printf("era = Byron (EBB), epoch = %d, slot = %d, id = %s\n", block.Header.ConsensusData.Epoch, block.SlotNumber(), block.Hash())

--- a/cmd/tx-submission/main.go
+++ b/cmd/tx-submission/main.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -145,6 +145,7 @@ func main() {
 }
 
 func handleRequestTxIds(
+	ctx txsubmission.CallbackContext,
 	blocking bool,
 	ack uint16,
 	req uint16,
@@ -167,6 +168,7 @@ func handleRequestTxIds(
 }
 
 func handleRequestTxs(
+	ctx txsubmission.CallbackContext,
 	txIds []txsubmission.TxId,
 ) ([]txsubmission.TxBody, error) {
 	ret := []txsubmission.TxBody{

--- a/connection/id.go
+++ b/connection/id.go
@@ -1,0 +1,33 @@
+// Copyright 2024 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connection
+
+import (
+	"fmt"
+	"net"
+)
+
+type ConnectionId struct {
+	LocalAddr  net.Addr
+	RemoteAddr net.Addr
+}
+
+func (c ConnectionId) String() string {
+	return fmt.Sprintf(
+		"%s<->%s",
+		c.LocalAddr.String(),
+		c.RemoteAddr.String(),
+	)
+}

--- a/protocol/blockfetch/blockfetch.go
+++ b/protocol/blockfetch/blockfetch.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package blockfetch
 import (
 	"time"
 
+	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	"github.com/blinklabs-io/gouroboros/protocol/common"
 
@@ -92,9 +93,16 @@ type Config struct {
 	BlockTimeout      time.Duration
 }
 
+// Callback context
+type CallbackContext struct {
+	ConnectionId connection.ConnectionId
+	Client       *Client
+	Server       *Server
+}
+
 // Callback function types
-type BlockFunc func(ledger.Block) error
-type RequestRangeFunc func(common.Point, common.Point) error
+type BlockFunc func(CallbackContext, ledger.Block) error
+type RequestRangeFunc func(CallbackContext, common.Point, common.Point) error
 
 func New(protoOptions protocol.ProtocolOptions, cfg *Config) *BlockFetch {
 	b := &BlockFetch{

--- a/protocol/blockfetch/server.go
+++ b/protocol/blockfetch/server.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,12 +23,17 @@ import (
 
 type Server struct {
 	*protocol.Protocol
-	config *Config
+	config          *Config
+	callbackContext CallbackContext
 }
 
 func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 	s := &Server{
 		config: cfg,
+	}
+	s.callbackContext = CallbackContext{
+		Server:       s,
+		ConnectionId: protoOptions.ConnectionId,
 	}
 	protoConfig := protocol.ProtocolConfig{
 		Name:                ProtocolName,
@@ -98,7 +103,7 @@ func (s *Server) handleRequestRange(msg protocol.Message) error {
 		)
 	}
 	msgRequestRange := msg.(*MsgRequestRange)
-	return s.config.RequestRangeFunc(msgRequestRange.Start, msgRequestRange.End)
+	return s.config.RequestRangeFunc(s.callbackContext, msgRequestRange.Start, msgRequestRange.End)
 }
 
 func (s *Server) handleClientDone() error {

--- a/protocol/chainsync/chainsync.go
+++ b/protocol/chainsync/chainsync.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package chainsync
 import (
 	"time"
 
+	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	"github.com/blinklabs-io/gouroboros/protocol/common"
 )
@@ -121,11 +122,18 @@ type Config struct {
 	PipelineLimit     int
 }
 
+// Callback context
+type CallbackContext struct {
+	ConnectionId connection.ConnectionId
+	Client       *Client
+	Server       *Server
+}
+
 // Callback function types
-type RollBackwardFunc func(common.Point, Tip) error
-type RollForwardFunc func(uint, interface{}, Tip) error
-type FindIntersectFunc func([]common.Point) (common.Point, Tip, error)
-type RequestNextFunc func() error
+type RollBackwardFunc func(CallbackContext, common.Point, Tip) error
+type RollForwardFunc func(CallbackContext, uint, interface{}, Tip) error
+type FindIntersectFunc func(CallbackContext, []common.Point) (common.Point, Tip, error)
+type RequestNextFunc func(CallbackContext) error
 
 // New returns a new ChainSync object
 func New(protoOptions protocol.ProtocolOptions, cfg *Config) *ChainSync {

--- a/protocol/chainsync/server.go
+++ b/protocol/chainsync/server.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,7 +25,8 @@ import (
 // Server implements the ChainSync server
 type Server struct {
 	*protocol.Protocol
-	config *Config
+	config          *Config
+	callbackContext CallbackContext
 }
 
 // NewServer returns a new ChainSync server object
@@ -40,6 +41,10 @@ func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 	}
 	s := &Server{
 		config: cfg,
+	}
+	s.callbackContext = CallbackContext{
+		Server:       s,
+		ConnectionId: protoOptions.ConnectionId,
 	}
 	protoConfig := protocol.ProtocolConfig{
 		Name:                ProtocolName,
@@ -112,7 +117,7 @@ func (s *Server) handleRequestNext(msg protocol.Message) error {
 			"received chain-sync RequestNext message but no callback function is defined",
 		)
 	}
-	return s.config.RequestNextFunc()
+	return s.config.RequestNextFunc(s.callbackContext)
 }
 
 func (s *Server) handleFindIntersect(msg protocol.Message) error {
@@ -122,7 +127,7 @@ func (s *Server) handleFindIntersect(msg protocol.Message) error {
 		)
 	}
 	msgFindIntersect := msg.(*MsgFindIntersect)
-	point, tip, err := s.config.FindIntersectFunc(msgFindIntersect.Points)
+	point, tip, err := s.config.FindIntersectFunc(s.callbackContext, msgFindIntersect.Points)
 	if err != nil {
 		if err == IntersectNotFoundError {
 			msgResp := NewMsgIntersectNotFound(tip)

--- a/protocol/handshake/client.go
+++ b/protocol/handshake/client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,8 +24,9 @@ import (
 // Client implements the Handshake client
 type Client struct {
 	*protocol.Protocol
-	config    *Config
-	onceStart sync.Once
+	config          *Config
+	callbackContext CallbackContext
+	onceStart       sync.Once
 }
 
 // NewClient returns a new Handshake client object
@@ -36,6 +37,10 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 	}
 	c := &Client{
 		config: cfg,
+	}
+	c.callbackContext = CallbackContext{
+		Client:       c,
+		ConnectionId: protoOptions.ConnectionId,
 	}
 	// Update state map with timeout
 	stateMap := StateMap.Copy()
@@ -99,7 +104,7 @@ func (c *Client) handleAcceptVersion(msg protocol.Message) error {
 	if err != nil {
 		return err
 	}
-	return c.config.FinishedFunc(msgAcceptVersion.Version, versionData)
+	return c.config.FinishedFunc(c.callbackContext, msgAcceptVersion.Version, versionData)
 }
 
 func (c *Client) handleRefuse(msgGeneric protocol.Message) error {

--- a/protocol/handshake/handshake.go
+++ b/protocol/handshake/handshake.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package handshake
 import (
 	"time"
 
+	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/protocol"
 )
 
@@ -75,8 +76,15 @@ type Config struct {
 	Timeout            time.Duration
 }
 
+// Callback context
+type CallbackContext struct {
+	ConnectionId connection.ConnectionId
+	Client       *Client
+	Server       *Server
+}
+
 // Callback function types
-type FinishedFunc func(uint16, protocol.VersionData) error
+type FinishedFunc func(CallbackContext, uint16, protocol.VersionData) error
 
 // New returns a new Handshake object
 func New(protoOptions protocol.ProtocolOptions, cfg *Config) *Handshake {

--- a/protocol/handshake/server.go
+++ b/protocol/handshake/server.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,13 +24,18 @@ import (
 // Server implements the Handshake server
 type Server struct {
 	*protocol.Protocol
-	config *Config
+	config          *Config
+	callbackContext CallbackContext
 }
 
 // NewServer returns a new Handshake server object
 func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 	s := &Server{
 		config: cfg,
+	}
+	s.callbackContext = CallbackContext{
+		Server:       s,
+		ConnectionId: protoOptions.ConnectionId,
 	}
 	protoConfig := protocol.ProtocolConfig{
 		Name:                ProtocolName,
@@ -153,5 +158,5 @@ func (s *Server) handleProposeVersions(msg protocol.Message) error {
 	if err := s.SendMessage(msgAcceptVersion); err != nil {
 		return err
 	}
-	return s.config.FinishedFunc(proposedVersion, proposedVersionData)
+	return s.config.FinishedFunc(s.callbackContext, proposedVersion, proposedVersionData)
 }

--- a/protocol/keepalive/keepalive.go
+++ b/protocol/keepalive/keepalive.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package keepalive
 import (
 	"time"
 
+	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/protocol"
 )
 
@@ -79,10 +80,17 @@ type Config struct {
 	Cookie                uint16
 }
 
+// Callback context
+type CallbackContext struct {
+	ConnectionId connection.ConnectionId
+	Client       *Client
+	Server       *Server
+}
+
 // Callback function types
-type KeepAliveFunc func(uint16) error
-type KeepAliveResponseFunc func(uint16) error
-type DoneFunc func() error
+type KeepAliveFunc func(CallbackContext, uint16) error
+type KeepAliveResponseFunc func(CallbackContext, uint16) error
+type DoneFunc func(CallbackContext) error
 
 func New(protoOptions protocol.ProtocolOptions, cfg *Config) *KeepAlive {
 	k := &KeepAlive{

--- a/protocol/localstatequery/client.go
+++ b/protocol/localstatequery/client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import (
 type Client struct {
 	*protocol.Protocol
 	config                        *Config
+	callbackContext               CallbackContext
 	enableGetChainBlockNo         bool
 	enableGetChainPoint           bool
 	enableGetRewardInfoPoolsBlock bool
@@ -51,6 +52,10 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 		acquireResultChan: make(chan error),
 		acquired:          false,
 		currentEra:        -1,
+	}
+	c.callbackContext = CallbackContext{
+		Client:       c,
+		ConnectionId: protoOptions.ConnectionId,
 	}
 	// Update state map with timeouts
 	stateMap := StateMap.Copy()

--- a/protocol/localstatequery/localstatequery.go
+++ b/protocol/localstatequery/localstatequery.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package localstatequery
 import (
 	"time"
 
+	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/protocol"
 )
 
@@ -119,13 +120,20 @@ type Config struct {
 	QueryTimeout   time.Duration
 }
 
+// Callback context
+type CallbackContext struct {
+	ConnectionId connection.ConnectionId
+	Client       *Client
+	Server       *Server
+}
+
 // Callback function types
 // TODO: update callbacks
-type AcquireFunc func(interface{}) error
-type QueryFunc func(interface{}) error
-type ReleaseFunc func() error
-type ReAcquireFunc func(interface{}) error
-type DoneFunc func() error
+type AcquireFunc func(CallbackContext, interface{}) error
+type QueryFunc func(CallbackContext, interface{}) error
+type ReleaseFunc func(CallbackContext) error
+type ReAcquireFunc func(CallbackContext, interface{}) error
+type DoneFunc func(CallbackContext) error
 
 // New returns a new LocalStateQuery object
 func New(protoOptions protocol.ProtocolOptions, cfg *Config) *LocalStateQuery {

--- a/protocol/localtxmonitor/client.go
+++ b/protocol/localtxmonitor/client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import (
 type Client struct {
 	*protocol.Protocol
 	config             *Config
+	callbackContext    CallbackContext
 	busyMutex          sync.Mutex
 	acquired           bool
 	acquiredSlot       uint64
@@ -48,6 +49,10 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 		hasTxResultChan:    make(chan bool),
 		nextTxResultChan:   make(chan []byte),
 		getSizesResultChan: make(chan MsgReplyGetSizesResult),
+	}
+	c.callbackContext = CallbackContext{
+		Client:       c,
+		ConnectionId: protoOptions.ConnectionId,
 	}
 	// Update state map with timeout
 	stateMap := StateMap.Copy()

--- a/protocol/localtxmonitor/localtxmonitor.go
+++ b/protocol/localtxmonitor/localtxmonitor.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package localtxmonitor
 import (
 	"time"
 
+	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/protocol"
 )
@@ -127,8 +128,15 @@ type TxAndEraId struct {
 	txObj ledger.Transaction
 }
 
+// Callback context
+type CallbackContext struct {
+	ConnectionId connection.ConnectionId
+	Client       *Client
+	Server       *Server
+}
+
 // Callback function types
-type GetMempoolFunc func() (uint64, uint32, []TxAndEraId, error)
+type GetMempoolFunc func(CallbackContext) (uint64, uint32, []TxAndEraId, error)
 
 // New returns a new LocalTxMonitor object
 func New(protoOptions protocol.ProtocolOptions, cfg *Config) *LocalTxMonitor {

--- a/protocol/localtxmonitor/server.go
+++ b/protocol/localtxmonitor/server.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import (
 type Server struct {
 	*protocol.Protocol
 	config           *Config
+	callbackContext  CallbackContext
 	mempoolCapacity  uint32
 	mempoolTxs       []TxAndEraId
 	mempoolNextTxIdx int
@@ -35,6 +36,10 @@ type Server struct {
 func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 	s := &Server{
 		config: cfg,
+	}
+	s.callbackContext = CallbackContext{
+		Server:       s,
+		ConnectionId: protoOptions.ConnectionId,
 	}
 	protoConfig := protocol.ProtocolConfig{
 		Name:                ProtocolName,
@@ -84,7 +89,7 @@ func (s *Server) handleAcquire() error {
 		)
 	}
 	// Call the user callback function to get mempool information
-	mempoolSlotNumber, mempoolCapacity, mempoolTxs, err := s.config.GetMempoolFunc()
+	mempoolSlotNumber, mempoolCapacity, mempoolTxs, err := s.config.GetMempoolFunc(s.callbackContext)
 	if err != nil {
 		return err
 	}

--- a/protocol/localtxsubmission/client.go
+++ b/protocol/localtxsubmission/client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import (
 type Client struct {
 	*protocol.Protocol
 	config           *Config
+	callbackContext  CallbackContext
 	busyMutex        sync.Mutex
 	submitResultChan chan error
 	onceStart        sync.Once
@@ -41,6 +42,10 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 	c := &Client{
 		config:           cfg,
 		submitResultChan: make(chan error),
+	}
+	c.callbackContext = CallbackContext{
+		Client:       c,
+		ConnectionId: protoOptions.ConnectionId,
 	}
 	// Update state map with timeout
 	stateMap := StateMap.Copy()

--- a/protocol/localtxsubmission/localtxsubmission.go
+++ b/protocol/localtxsubmission/localtxsubmission.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package localtxsubmission
 import (
 	"time"
 
+	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/protocol"
 )
 
@@ -74,8 +75,15 @@ type Config struct {
 	Timeout      time.Duration
 }
 
+// Callback context
+type CallbackContext struct {
+	ConnectionId connection.ConnectionId
+	Client       *Client
+	Server       *Server
+}
+
 // Callback function types
-type SubmitTxFunc func(interface{}) error
+type SubmitTxFunc func(CallbackContext, interface{}) error
 
 // New returns a new LocalTxSubmission object
 func New(

--- a/protocol/localtxsubmission/server.go
+++ b/protocol/localtxsubmission/server.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,13 +24,18 @@ import (
 // Server implements the LocalTxSubmission server
 type Server struct {
 	*protocol.Protocol
-	config *Config
+	config          *Config
+	callbackContext CallbackContext
 }
 
 // NewServer returns a new Server object
 func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 	s := &Server{
 		config: cfg,
+	}
+	s.callbackContext = CallbackContext{
+		Server:       s,
+		ConnectionId: protoOptions.ConnectionId,
 	}
 	protoConfig := protocol.ProtocolConfig{
 		Name:                ProtocolName,
@@ -73,7 +78,7 @@ func (s *Server) handleSubmitTx(msg protocol.Message) error {
 	}
 	msgSubmitTx := msg.(*MsgSubmitTx)
 	// Call the user callback function and send Accept/RejectTx based on result
-	err := s.config.SubmitTxFunc(msgSubmitTx.Transaction)
+	err := s.config.SubmitTxFunc(s.callbackContext, msgSubmitTx.Transaction)
 	if err == nil {
 		newMsg := NewMsgAcceptTx()
 		if err := s.SendMessage(newMsg); err != nil {

--- a/protocol/peersharing/client.go
+++ b/protocol/peersharing/client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,8 +23,9 @@ import (
 // Client implements the PeerSharing client
 type Client struct {
 	*protocol.Protocol
-	config         *Config
-	sharePeersChan chan []PeerAddress
+	config          *Config
+	callbackContext CallbackContext
+	sharePeersChan  chan []PeerAddress
 }
 
 // NewClient returns a new PeerSharing client object
@@ -36,6 +37,10 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 	c := &Client{
 		config:         cfg,
 		sharePeersChan: make(chan []PeerAddress),
+	}
+	c.callbackContext = CallbackContext{
+		Client:       c,
+		ConnectionId: protoOptions.ConnectionId,
 	}
 	// Update state map with timeout
 	stateMap := StateMap.Copy()

--- a/protocol/peersharing/peersharing.go
+++ b/protocol/peersharing/peersharing.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package peersharing
 import (
 	"time"
 
+	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/protocol"
 )
 
@@ -74,8 +75,15 @@ type Config struct {
 	Timeout          time.Duration
 }
 
+// Callback context
+type CallbackContext struct {
+	ConnectionId connection.ConnectionId
+	Client       *Client
+	Server       *Server
+}
+
 // Callback function types
-type ShareRequestFunc func(int) ([]PeerAddress, error)
+type ShareRequestFunc func(CallbackContext, int) ([]PeerAddress, error)
 
 // New returns a new PeerSharing object
 func New(protoOptions protocol.ProtocolOptions, cfg *Config) *PeerSharing {

--- a/protocol/peersharing/server.go
+++ b/protocol/peersharing/server.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,13 +23,18 @@ import (
 // Server implements the PeerSharing server
 type Server struct {
 	*protocol.Protocol
-	config *Config
+	config          *Config
+	callbackContext CallbackContext
 }
 
 // NewServer returns a new PeerSharing server object
 func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 	s := &Server{
 		config: cfg,
+	}
+	s.callbackContext = CallbackContext{
+		Server:       s,
+		ConnectionId: protoOptions.ConnectionId,
 	}
 	protoConfig := protocol.ProtocolConfig{
 		Name:                ProtocolName,
@@ -71,7 +76,7 @@ func (s *Server) handleShareRequest(msg protocol.Message) error {
 		)
 	}
 	msgShareRequest := msg.(*MsgShareRequest)
-	peers, err := s.config.ShareRequestFunc(int(msgShareRequest.Amount))
+	peers, err := s.config.ShareRequestFunc(s.callbackContext, int(msgShareRequest.Amount))
 	if err != nil {
 		return err
 	}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/muxer"
 	"github.com/blinklabs-io/gouroboros/utils"
 )
@@ -81,9 +82,10 @@ const (
 
 // ProtocolOptions provides common arguments for all mini-protocols
 type ProtocolOptions struct {
-	Muxer     *muxer.Muxer
-	ErrorChan chan error
-	Mode      ProtocolMode
+	ConnectionId connection.ConnectionId
+	Muxer        *muxer.Muxer
+	ErrorChan    chan error
+	Mode         ProtocolMode
 	// TODO: remove me
 	Role    ProtocolRole
 	Version uint16

--- a/protocol/txsubmission/server.go
+++ b/protocol/txsubmission/server.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import (
 type Server struct {
 	*protocol.Protocol
 	config                 *Config
+	callbackContext        CallbackContext
 	ackCount               int
 	stateDone              bool
 	requestTxIdsResultChan chan []TxIdAndSize
@@ -38,6 +39,10 @@ func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 		config:                 cfg,
 		requestTxIdsResultChan: make(chan []TxIdAndSize),
 		requestTxsResultChan:   make(chan []TxBody),
+	}
+	s.callbackContext = CallbackContext{
+		Server:       s,
+		ConnectionId: protoOptions.ConnectionId,
 	}
 	protoConfig := protocol.ProtocolConfig{
 		Name:                ProtocolName,
@@ -153,5 +158,5 @@ func (s *Server) handleInit() error {
 		)
 	}
 	// Call the user callback function
-	return s.config.InitFunc()
+	return s.config.InitFunc(s.callbackContext)
 }

--- a/protocol/txsubmission/txsubmission.go
+++ b/protocol/txsubmission/txsubmission.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package txsubmission
 import (
 	"time"
 
+	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/protocol"
 )
 
@@ -124,10 +125,17 @@ type Config struct {
 	IdleTimeout      time.Duration
 }
 
+// Callback context
+type CallbackContext struct {
+	ConnectionId connection.ConnectionId
+	Client       *Client
+	Server       *Server
+}
+
 // Callback function types
-type RequestTxIdsFunc func(bool, uint16, uint16) ([]TxIdAndSize, error)
-type RequestTxsFunc func([]TxId) ([]TxBody, error)
-type InitFunc func() error
+type RequestTxIdsFunc func(CallbackContext, bool, uint16, uint16) ([]TxIdAndSize, error)
+type RequestTxsFunc func(CallbackContext, []TxId) ([]TxBody, error)
+type InitFunc func(CallbackContext) error
 
 // New returns a new TxSubmission object
 func New(protoOptions protocol.ProtocolOptions, cfg *Config) *TxSubmission {


### PR DESCRIPTION
This provides a new protocol callback function parameter that provides the current client or server object and the connection ID. This allows easily identifying the connection that triggered a callback when using multiple connections and performing related operations within the protocol.

Fixes #578

BREAKING CHANGE: this changes the prototype for protocol callback functions