### PR TITLE
feat!: use connection ID in connection manager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.5
 
 require (
-	github.com/blinklabs-io/ouroboros-mock v0.2.0
+	github.com/blinklabs-io/ouroboros-mock v0.3.0
 	github.com/fxamacker/cbor/v2 v2.6.0
 	github.com/jinzhu/copier v0.4.0
 	github.com/utxorpc/go-codegen v0.4.4

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/blinklabs-io/ouroboros-mock v0.2.0 h1:Wff7mJiFUzktQ5tuWRN9vXNk38wR0ij2Q4bYHwJXaV4=
-github.com/blinklabs-io/ouroboros-mock v0.2.0/go.mod h1:t9eIDjmj339GJtfV7jandJnCqmj8WkZsFg2N1TR68io=
+github.com/blinklabs-io/ouroboros-mock v0.3.0 h1:6VRWyhAv0k7nQEgzFpuqhS/n8OM+OAaLN/sCT5K2Hbc=
+github.com/blinklabs-io/ouroboros-mock v0.3.0/go.mod h1:0dzTNEk/Kvqa7qYHDy7/Nn3OTt+EOosMknB37FRzI1k=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fxamacker/cbor/v2 v2.6.0 h1:sU6J2usfADwWlYDAFhZBQ6TnLFBHxgesMrQfQgk1tWA=


### PR DESCRIPTION
This updates the connection manager to use the new Connection ID instead of a user-provided int value.

Fixes #577

BREAKING CHANGE: the API interface for ConnectionManager is changing to use ConnectionId instead of an arbitrary user-provided value