### PR TITLE
feat:add Allegra protocol parameters support

### DIFF
--- a/ledger/allegra.go
+++ b/ledger/allegra.go
@@ -114,6 +114,11 @@ func (h *AllegraBlockHeader) Era() Era {
 
 type AllegraTransactionBody struct {
 	ShelleyTransactionBody
+	Update struct {
+		cbor.StructAsArray
+		ProtocolParamUpdates map[Blake2b224]AllegraProtocolParameterUpdate
+		Epoch                uint64
+	} `cbor:"6,keyasint,omitempty"`
 	ValidityIntervalStart uint64 `cbor:"8,keyasint,omitempty"`
 }
 
@@ -189,6 +194,14 @@ func (t *AllegraTransaction) Cbor() []byte {
 	// This should never fail, since we're only encoding a list and a bool value
 	cborData, _ = cbor.Encode(&tmpObj)
 	return cborData
+}
+
+type AllegraProtocolParameters struct {
+	ShelleyProtocolParameters
+}
+
+type AllegraProtocolParameterUpdate struct {
+	ShelleyProtocolParameterUpdate
 }
 
 func NewAllegraBlockFromCbor(data []byte) (*AllegraBlock, error) {

--- a/protocol/localstatequery/client.go
+++ b/protocol/localstatequery/client.go
@@ -354,6 +354,12 @@ func (c *Client) GetCurrentProtocolParams() (CurrentProtocolParamsResult, error)
 			return nil, err
 		}
 		return result[0], nil
+	case ledger.EraIdAllegra:
+		result := []ledger.AllegraProtocolParameters{}
+		if err := c.runQuery(query, &result); err != nil {
+			return nil, err
+		}
+		return result[0], nil
 	case ledger.EraIdShelley:
 		result := []ledger.ShelleyProtocolParameters{}
 		if err := c.runQuery(query, &result); err != nil {


### PR DESCRIPTION
Test
```
era = Allegra, slot = 23068725, block_no = 5406744, id = e1a6bd60b491446a17f9696a5414e087e763cc6c0c6ccf3359ce5b755dca8abe
era = Allegra, slot = 23068772, block_no = 5406745, id = bac3854978e827644a6e711aae574f4e0353bfcec9c6960eaa08c923ae1704c8
era = Allegra, slot = 23068793, block_no = 5406746, id = 69c44ac1dda2ec74646e4223bc804d9126f719b1c245dadc2ad65e8de1b276d7
era = Mary, slot = 23068800, block_no = 5406747, id = a650a3f398ba4a9427ec8c293e9f7156d81fd2f7ca849014d8d2c1156c359b3a
era = Mary, slot = 23068966, block_no = 5406748, id = 6ba25afbbaf2c6c6d65f64987fb15ea7a86ce0e6414357d7b95e6df7d573539b
```

Closes #325 