### PR TITLE
feat: TX collateral inputs support

### DIFF
--- a/ledger/allegra.go
+++ b/ledger/allegra.go
@@ -158,6 +158,10 @@ func (t AllegraTransaction) ReferenceInputs() []TransactionInput {
 	return t.Body.ReferenceInputs()
 }
 
+func (t AllegraTransaction) Collateral() []TransactionInput {
+	return t.Body.Collateral()
+}
+
 func (t AllegraTransaction) CollateralReturn() TransactionOutput {
 	return t.Body.CollateralReturn()
 }

--- a/ledger/alonzo.go
+++ b/ledger/alonzo.go
@@ -129,7 +129,7 @@ type AlonzoTransactionBody struct {
 		Epoch                uint64
 	} `cbor:"6,keyasint,omitempty"`
 	ScriptDataHash  Blake2b256                `cbor:"11,keyasint,omitempty"`
-	Collateral      []ShelleyTransactionInput `cbor:"13,keyasint,omitempty"`
+	TxCollateral    []ShelleyTransactionInput `cbor:"13,keyasint,omitempty"`
 	RequiredSigners []Blake2b224              `cbor:"14,keyasint,omitempty"`
 	NetworkId       uint8                     `cbor:"15,keyasint,omitempty"`
 }
@@ -143,6 +143,14 @@ func (b *AlonzoTransactionBody) Outputs() []TransactionOutput {
 	for _, output := range b.TxOutputs {
 		output := output
 		ret = append(ret, &output)
+	}
+	return ret
+}
+
+func (b *AlonzoTransactionBody) Collateral() []TransactionInput {
+	ret := []TransactionInput{}
+	for _, collateral := range b.TxCollateral {
+		ret = append(ret, collateral)
 	}
 	return ret
 }
@@ -258,6 +266,10 @@ func (t AlonzoTransaction) TTL() uint64 {
 
 func (t AlonzoTransaction) ReferenceInputs() []TransactionInput {
 	return t.Body.ReferenceInputs()
+}
+
+func (t AlonzoTransaction) Collateral() []TransactionInput {
+	return t.Body.Collateral()
 }
 
 func (t AlonzoTransaction) CollateralReturn() TransactionOutput {

--- a/ledger/babbage.go
+++ b/ledger/babbage.go
@@ -434,6 +434,10 @@ func (t BabbageTransaction) ReferenceInputs() []TransactionInput {
 	return t.Body.ReferenceInputs()
 }
 
+func (t BabbageTransaction) Collateral() []TransactionInput {
+	return t.Body.Collateral()
+}
+
 func (t BabbageTransaction) CollateralReturn() TransactionOutput {
 	return t.Body.CollateralReturn()
 }

--- a/ledger/byron.go
+++ b/ledger/byron.go
@@ -175,6 +175,11 @@ func (t *ByronTransaction) ReferenceInputs() []TransactionInput {
 	return nil
 }
 
+func (t *ByronTransaction) Collateral() []TransactionInput {
+	// No collateral in Byron
+	return nil
+}
+
 func (t *ByronTransaction) CollateralReturn() TransactionOutput {
 	// No collateral in Byron
 	return nil

--- a/ledger/conway.go
+++ b/ledger/conway.go
@@ -164,6 +164,10 @@ func (t ConwayTransaction) ReferenceInputs() []TransactionInput {
 	return t.Body.ReferenceInputs()
 }
 
+func (t ConwayTransaction) Collateral() []TransactionInput {
+	return t.Body.Collateral()
+}
+
 func (t ConwayTransaction) CollateralReturn() TransactionOutput {
 	return t.Body.CollateralReturn()
 }

--- a/ledger/mary.go
+++ b/ledger/mary.go
@@ -175,6 +175,10 @@ func (t MaryTransaction) ReferenceInputs() []TransactionInput {
 	return t.Body.ReferenceInputs()
 }
 
+func (t MaryTransaction) Collateral() []TransactionInput {
+	return t.Body.Collateral()
+}
+
 func (t MaryTransaction) CollateralReturn() TransactionOutput {
 	return t.Body.CollateralReturn()
 }

--- a/ledger/shelley.go
+++ b/ledger/shelley.go
@@ -221,6 +221,11 @@ func (b *ShelleyTransactionBody) ReferenceInputs() []TransactionInput {
 	return []TransactionInput{}
 }
 
+func (b *ShelleyTransactionBody) Collateral() []TransactionInput {
+	// No collateral in Shelley
+	return nil
+}
+
 func (b *ShelleyTransactionBody) CollateralReturn() TransactionOutput {
 	// No collateral in Shelley
 	return nil
@@ -362,6 +367,10 @@ func (t ShelleyTransaction) TTL() uint64 {
 
 func (t ShelleyTransaction) ReferenceInputs() []TransactionInput {
 	return t.Body.ReferenceInputs()
+}
+
+func (t ShelleyTransaction) Collateral() []TransactionInput {
+	return t.Body.Collateral()
 }
 
 func (t ShelleyTransaction) CollateralReturn() TransactionOutput {

--- a/ledger/tx.go
+++ b/ledger/tx.go
@@ -39,8 +39,9 @@ type TransactionBody interface {
 	Outputs() []TransactionOutput
 	TTL() uint64
 	ReferenceInputs() []TransactionInput
-	Utxorpc() *utxorpc.Tx
+	Collateral() []TransactionInput
 	CollateralReturn() TransactionOutput
+	Utxorpc() *utxorpc.Tx
 }
 
 type TransactionInput interface {


### PR DESCRIPTION
This adds support for returning the collateral inputs (if any) from a transaction body.

Fixes #338