### PR TITLE
fix: use LazyValue for metadata to avoid decoding issues

### DIFF
--- a/ledger/allegra.go
+++ b/ledger/allegra.go
@@ -39,7 +39,7 @@ type AllegraBlock struct {
 	Header                 *AllegraBlockHeader
 	TransactionBodies      []AllegraTransactionBody
 	TransactionWitnessSets []ShelleyTransactionWitnessSet
-	TransactionMetadataSet map[uint]*cbor.Value
+	TransactionMetadataSet map[uint]*cbor.LazyValue
 }
 
 func (b *AllegraBlock) UnmarshalCBOR(cborData []byte) error {
@@ -135,7 +135,7 @@ type AllegraTransaction struct {
 	cbor.DecodeStoreCbor
 	Body       AllegraTransactionBody
 	WitnessSet ShelleyTransactionWitnessSet
-	TxMetadata *cbor.Value
+	TxMetadata *cbor.LazyValue
 }
 
 func (t AllegraTransaction) Hash() string {
@@ -210,7 +210,7 @@ func (t AllegraTransaction) ProposalProcedures() []ProposalProcedure {
 	return t.Body.ProposalProcedures()
 }
 
-func (t AllegraTransaction) Metadata() *cbor.Value {
+func (t AllegraTransaction) Metadata() *cbor.LazyValue {
 	return t.TxMetadata
 }
 

--- a/ledger/alonzo.go
+++ b/ledger/alonzo.go
@@ -40,7 +40,7 @@ type AlonzoBlock struct {
 	Header                 *AlonzoBlockHeader
 	TransactionBodies      []AlonzoTransactionBody
 	TransactionWitnessSets []AlonzoTransactionWitnessSet
-	TransactionMetadataSet map[uint]*cbor.Value
+	TransactionMetadataSet map[uint]*cbor.LazyValue
 	InvalidTransactions    []uint
 }
 
@@ -249,7 +249,7 @@ type AlonzoTransaction struct {
 	Body       AlonzoTransactionBody
 	WitnessSet AlonzoTransactionWitnessSet
 	IsTxValid  bool
-	TxMetadata *cbor.Value
+	TxMetadata *cbor.LazyValue
 }
 
 func (t AlonzoTransaction) Hash() string {
@@ -324,7 +324,7 @@ func (t AlonzoTransaction) ProposalProcedures() []ProposalProcedure {
 	return t.Body.ProposalProcedures()
 }
 
-func (t AlonzoTransaction) Metadata() *cbor.Value {
+func (t AlonzoTransaction) Metadata() *cbor.LazyValue {
 	return t.TxMetadata
 }
 

--- a/ledger/babbage.go
+++ b/ledger/babbage.go
@@ -40,7 +40,7 @@ type BabbageBlock struct {
 	Header                 *BabbageBlockHeader
 	TransactionBodies      []BabbageTransactionBody
 	TransactionWitnessSets []BabbageTransactionWitnessSet
-	TransactionMetadataSet map[uint]*cbor.Value
+	TransactionMetadataSet map[uint]*cbor.LazyValue
 	InvalidTransactions    []uint
 }
 
@@ -417,7 +417,7 @@ type BabbageTransaction struct {
 	Body       BabbageTransactionBody
 	WitnessSet BabbageTransactionWitnessSet
 	IsTxValid  bool
-	TxMetadata *cbor.Value
+	TxMetadata *cbor.LazyValue
 }
 
 func (t BabbageTransaction) Hash() string {
@@ -492,7 +492,7 @@ func (t BabbageTransaction) ProposalProcedures() []ProposalProcedure {
 	return t.Body.ProposalProcedures()
 }
 
-func (t BabbageTransaction) Metadata() *cbor.Value {
+func (t BabbageTransaction) Metadata() *cbor.LazyValue {
 	return t.TxMetadata
 }
 

--- a/ledger/byron.go
+++ b/ledger/byron.go
@@ -126,7 +126,7 @@ type ByronTransaction struct {
 	hash       string
 	TxInputs   []ByronTransactionInput
 	TxOutputs  []ByronTransactionOutput
-	Attributes *cbor.Value
+	Attributes *cbor.LazyValue
 }
 
 func (t *ByronTransaction) UnmarshalCBOR(data []byte) error {
@@ -235,7 +235,7 @@ func (t *ByronTransaction) ProposalProcedures() []ProposalProcedure {
 	return nil
 }
 
-func (t *ByronTransaction) Metadata() *cbor.Value {
+func (t *ByronTransaction) Metadata() *cbor.LazyValue {
 	return t.Attributes
 }
 

--- a/ledger/conway.go
+++ b/ledger/conway.go
@@ -39,7 +39,7 @@ type ConwayBlock struct {
 	Header                 *ConwayBlockHeader
 	TransactionBodies      []ConwayTransactionBody
 	TransactionWitnessSets []BabbageTransactionWitnessSet
-	TransactionMetadataSet map[uint]*cbor.Value
+	TransactionMetadataSet map[uint]*cbor.LazyValue
 	InvalidTransactions    []uint
 }
 
@@ -322,7 +322,7 @@ type ConwayTransaction struct {
 	Body       ConwayTransactionBody
 	WitnessSet BabbageTransactionWitnessSet
 	IsTxValid  bool
-	TxMetadata *cbor.Value
+	TxMetadata *cbor.LazyValue
 }
 
 func (t ConwayTransaction) Hash() string {
@@ -397,7 +397,7 @@ func (t ConwayTransaction) ProposalProcedures() []ProposalProcedure {
 	return t.Body.ProposalProcedures()
 }
 
-func (t ConwayTransaction) Metadata() *cbor.Value {
+func (t ConwayTransaction) Metadata() *cbor.LazyValue {
 	return t.TxMetadata
 }
 

--- a/ledger/mary.go
+++ b/ledger/mary.go
@@ -40,7 +40,7 @@ type MaryBlock struct {
 	Header                 *MaryBlockHeader
 	TransactionBodies      []MaryTransactionBody
 	TransactionWitnessSets []MaryTransactionWitnessSet
-	TransactionMetadataSet map[uint]*cbor.Value
+	TransactionMetadataSet map[uint]*cbor.LazyValue
 }
 
 func (b *MaryBlock) UnmarshalCBOR(cborData []byte) error {
@@ -146,7 +146,7 @@ type MaryTransaction struct {
 	cbor.DecodeStoreCbor
 	Body       MaryTransactionBody
 	WitnessSet MaryTransactionWitnessSet
-	TxMetadata *cbor.Value
+	TxMetadata *cbor.LazyValue
 }
 
 type MaryTransactionWitnessSet struct {
@@ -227,7 +227,7 @@ func (t MaryTransaction) ProposalProcedures() []ProposalProcedure {
 	return t.Body.ProposalProcedures()
 }
 
-func (t MaryTransaction) Metadata() *cbor.Value {
+func (t MaryTransaction) Metadata() *cbor.LazyValue {
 	return t.TxMetadata
 }
 

--- a/ledger/shelley.go
+++ b/ledger/shelley.go
@@ -39,7 +39,7 @@ type ShelleyBlock struct {
 	Header                 *ShelleyBlockHeader
 	TransactionBodies      []ShelleyTransactionBody
 	TransactionWitnessSets []ShelleyTransactionWitnessSet
-	TransactionMetadataSet map[uint]*cbor.Value
+	TransactionMetadataSet map[uint]*cbor.LazyValue
 }
 
 func (b *ShelleyBlock) UnmarshalCBOR(cborData []byte) error {
@@ -389,7 +389,7 @@ type ShelleyTransaction struct {
 	cbor.DecodeStoreCbor
 	Body       ShelleyTransactionBody
 	WitnessSet ShelleyTransactionWitnessSet
-	TxMetadata *cbor.Value
+	TxMetadata *cbor.LazyValue
 }
 
 func (t ShelleyTransaction) Hash() string {
@@ -464,7 +464,7 @@ func (t ShelleyTransaction) ProposalProcedures() []ProposalProcedure {
 	return t.Body.ProposalProcedures()
 }
 
-func (t ShelleyTransaction) Metadata() *cbor.Value {
+func (t ShelleyTransaction) Metadata() *cbor.LazyValue {
 	return t.TxMetadata
 }
 

--- a/ledger/tx.go
+++ b/ledger/tx.go
@@ -26,7 +26,7 @@ import (
 
 type Transaction interface {
 	TransactionBody
-	Metadata() *cbor.Value
+	Metadata() *cbor.LazyValue
 	IsValid() bool
 	Consumed() []TransactionInput
 	Produced() []TransactionOutput


### PR DESCRIPTION
The TX metadata isn't guaranteed to be well-formed, so we don't decode it immediately