### PR TITLE
feat: CBOR encode support for indefinite-length bytestrings

### DIFF
--- a/cbor/encode.go
+++ b/cbor/encode.go
@@ -67,16 +67,14 @@ func EncodeGeneric(src interface{}) ([]byte, error) {
 	return cborData, nil
 }
 
-type IndefLengthList struct {
-	Items []any
-}
+type IndefLengthList []any
 
-func (i *IndefLengthList) MarshalCBOR() ([]byte, error) {
+func (i IndefLengthList) MarshalCBOR() ([]byte, error) {
 	ret := []byte{
 		// Start indefinite-length list
 		0x9f,
 	}
-	for _, item := range i.Items {
+	for _, item := range []any(i) {
 		data, err := Encode(&item)
 		if err != nil {
 			return nil, err
@@ -86,6 +84,28 @@ func (i *IndefLengthList) MarshalCBOR() ([]byte, error) {
 	ret = append(
 		ret,
 		// End indefinite length array
+		byte(0xff),
+	)
+	return ret, nil
+}
+
+type IndefLengthByteString []any
+
+func (i IndefLengthByteString) MarshalCBOR() ([]byte, error) {
+	ret := []byte{
+		// Start indefinite-length bytestring
+		0x5f,
+	}
+	for _, item := range []any(i) {
+		data, err := Encode(&item)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, data...)
+	}
+	ret = append(
+		ret,
+		// End indefinite length bytestring
 		byte(0xff),
 	)
 	return ret, nil

--- a/cbor/encode_test.go
+++ b/cbor/encode_test.go
@@ -50,3 +50,43 @@ func TestEncode(t *testing.T) {
 		}
 	}
 }
+
+func TestEncodeIndefLengthList(t *testing.T) {
+	expectedCborHex := "9f1904d219162eff"
+	tmpData := cbor.IndefLengthList{
+		1234,
+		5678,
+	}
+	cborData, err := cbor.Encode(tmpData)
+	if err != nil {
+		t.Fatalf("failed to encode object to CBOR: %s", err)
+	}
+	cborHex := hex.EncodeToString(cborData)
+	if cborHex != expectedCborHex {
+		t.Fatalf(
+			"object did not encode to expected CBOR\n  got %s\n  wanted: %s",
+			cborHex,
+			expectedCborHex,
+		)
+	}
+}
+
+func TestEncodeIndefLengthByteString(t *testing.T) {
+	expectedCborHex := "5f440102030443abcdefff"
+	tmpData := cbor.IndefLengthByteString{
+		[]byte{1, 2, 3, 4},
+		[]byte{0xab, 0xcd, 0xef},
+	}
+	cborData, err := cbor.Encode(tmpData)
+	if err != nil {
+		t.Fatalf("failed to encode object to CBOR: %s", err)
+	}
+	cborHex := hex.EncodeToString(cborData)
+	if cborHex != expectedCborHex {
+		t.Fatalf(
+			"object did not encode to expected CBOR\n  got %s\n  wanted: %s",
+			cborHex,
+			expectedCborHex,
+		)
+	}
+}

--- a/protocol/txsubmission/messages.go
+++ b/protocol/txsubmission/messages.go
@@ -93,9 +93,7 @@ func (m *MsgReplyTxIds) MarshalCBOR() ([]byte, error) {
 	}
 	tmp := []any{
 		MessageTypeReplyTxIds,
-		cbor.IndefLengthList{
-			Items: items,
-		},
+		cbor.IndefLengthList(items),
 	}
 	return cbor.Encode(tmp)
 }
@@ -122,9 +120,7 @@ func (m *MsgRequestTxs) MarshalCBOR() ([]byte, error) {
 	}
 	tmp := []any{
 		MessageTypeRequestTxs,
-		cbor.IndefLengthList{
-			Items: items,
-		},
+		cbor.IndefLengthList(items),
 	}
 	return cbor.Encode(tmp)
 }
@@ -151,9 +147,7 @@ func (m *MsgReplyTxs) MarshalCBOR() ([]byte, error) {
 	}
 	tmp := []any{
 		MessageTypeReplyTxs,
-		cbor.IndefLengthList{
-			Items: items,
-		},
+		cbor.IndefLengthList(items),
 	}
 	return cbor.Encode(tmp)
 }


### PR DESCRIPTION
This also slightly changes the way that indefinite-length lists work, as well as adds tests for indefinite-length lists

Fixes #659