### PR TITLE
fix: allocate map before assignment when decoding Conway redeemers

### DIFF
--- a/ledger/conway.go
+++ b/ledger/conway.go
@@ -141,6 +141,7 @@ func (r *ConwayRedeemers) UnmarshalCBOR(cborData []byte) error {
 	var tmpRedeemers []AlonzoRedeemer
 	if _, err := cbor.Decode(cborData, &tmpRedeemers); err == nil {
 		// Copy data from legacy redeemer type
+		r.Redeemers = make(map[ConwayRedeemerKey]ConwayRedeemerValue)
 		for _, redeemer := range tmpRedeemers {
 			tmpKey := ConwayRedeemerKey{
 				Tag:   redeemer.Tag,


### PR DESCRIPTION
Fixes #680