### PR TITLE
chore: move era registry to sub-package

### DIFF
--- a/ledger/allegra.go
+++ b/ledger/allegra.go
@@ -18,14 +18,15 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
-
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
 
 const (
-	EraIdAllegra = 2
+	EraIdAllegra   = 2
+	EraNameAllegra = "Allegra"
 
 	BlockTypeAllegra = 3
 
@@ -33,6 +34,17 @@ const (
 
 	TxTypeAllegra = 2
 )
+
+var (
+	EraAllegra = common.Era{
+		Id:   EraIdAllegra,
+		Name: EraNameAllegra,
+	}
+)
+
+func init() {
+	common.RegisterEra(EraAllegra)
+}
 
 type AllegraBlock struct {
 	cbor.StructAsArray
@@ -68,7 +80,7 @@ func (b *AllegraBlock) BlockBodySize() uint64 {
 }
 
 func (b *AllegraBlock) Era() Era {
-	return eras[EraIdAllegra]
+	return EraAllegra
 }
 
 func (b *AllegraBlock) Transactions() []Transaction {
@@ -110,7 +122,7 @@ type AllegraBlockHeader struct {
 }
 
 func (h *AllegraBlockHeader) Era() Era {
-	return eras[EraIdAllegra]
+	return EraAllegra
 }
 
 type AllegraTransactionBody struct {

--- a/ledger/alonzo.go
+++ b/ledger/alonzo.go
@@ -19,14 +19,15 @@ import (
 	"encoding/json"
 	"fmt"
 
-	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
-
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
 
 const (
-	EraIdAlonzo = 4
+	EraIdAlonzo   = 4
+	EraNameAlonzo = "Alonzo"
 
 	BlockTypeAlonzo = 5
 
@@ -34,6 +35,17 @@ const (
 
 	TxTypeAlonzo = 4
 )
+
+var (
+	EraAlonzo = common.Era{
+		Id:   EraIdAlonzo,
+		Name: EraNameAlonzo,
+	}
+)
+
+func init() {
+	common.RegisterEra(EraAlonzo)
+}
 
 type AlonzoBlock struct {
 	cbor.StructAsArray
@@ -70,7 +82,7 @@ func (b *AlonzoBlock) BlockBodySize() uint64 {
 }
 
 func (b *AlonzoBlock) Era() Era {
-	return eras[EraIdAlonzo]
+	return EraAlonzo
 }
 
 func (b *AlonzoBlock) Transactions() []Transaction {
@@ -118,7 +130,7 @@ type AlonzoBlockHeader struct {
 }
 
 func (h *AlonzoBlockHeader) Era() Era {
-	return eras[EraIdAlonzo]
+	return EraAlonzo
 }
 
 type AlonzoTransactionBody struct {

--- a/ledger/babbage.go
+++ b/ledger/babbage.go
@@ -19,14 +19,15 @@ import (
 	"encoding/json"
 	"fmt"
 
-	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
-
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
 
 const (
-	EraIdBabbage = 5
+	EraIdBabbage   = 5
+	EraNameBabbage = "Babbage"
 
 	BlockTypeBabbage = 6
 
@@ -34,6 +35,17 @@ const (
 
 	TxTypeBabbage = 5
 )
+
+var (
+	EraBabbage = common.Era{
+		Id:   EraIdBabbage,
+		Name: EraNameBabbage,
+	}
+)
+
+func init() {
+	common.RegisterEra(EraBabbage)
+}
 
 type BabbageBlock struct {
 	cbor.StructAsArray
@@ -70,7 +82,7 @@ func (b *BabbageBlock) BlockBodySize() uint64 {
 }
 
 func (b *BabbageBlock) Era() Era {
-	return eras[EraIdBabbage]
+	return EraBabbage
 }
 
 func (b *BabbageBlock) Transactions() []Transaction {
@@ -171,7 +183,7 @@ func (h *BabbageBlockHeader) BlockBodySize() uint64 {
 }
 
 func (h *BabbageBlockHeader) Era() Era {
-	return eras[EraIdBabbage]
+	return EraBabbage
 }
 
 type BabbageTransactionBody struct {

--- a/ledger/byron.go
+++ b/ledger/byron.go
@@ -18,14 +18,15 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
-
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
 
 const (
-	EraIdByron = 0
+	EraIdByron   = 0
+	EraNameByron = "Byron"
 
 	BlockTypeByronEbb  = 0
 	BlockTypeByronMain = 1
@@ -36,6 +37,17 @@ const (
 
 	ByronSlotsPerEpoch = 21600
 )
+
+var (
+	EraByron = common.Era{
+		Id:   EraIdByron,
+		Name: EraNameByron,
+	}
+)
+
+func init() {
+	common.RegisterEra(EraByron)
+}
 
 type ByronMainBlockHeader struct {
 	cbor.StructAsArray
@@ -119,7 +131,7 @@ func (h *ByronMainBlockHeader) BlockBodySize() uint64 {
 }
 
 func (h *ByronMainBlockHeader) Era() Era {
-	return eras[EraIdByron]
+	return EraByron
 }
 
 type ByronTransaction struct {
@@ -481,7 +493,7 @@ func (h *ByronEpochBoundaryBlockHeader) BlockBodySize() uint64 {
 }
 
 func (h *ByronEpochBoundaryBlockHeader) Era() Era {
-	return eras[EraIdByron]
+	return EraByron
 }
 
 type ByronMainBlock struct {

--- a/ledger/common/era.go
+++ b/ledger/common/era.go
@@ -1,0 +1,42 @@
+// Copyright 2024 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+type Era struct {
+	Id   uint8
+	Name string
+}
+
+var EraInvalid = Era{
+	Id:   0,
+	Name: "invalid",
+}
+
+var eras map[uint8]Era
+
+func RegisterEra(era Era) {
+	if eras == nil {
+		eras = make(map[uint8]Era)
+	}
+	eras[era.Id] = era
+}
+
+func EraById(eraId uint8) Era {
+	era, ok := eras[eraId]
+	if !ok {
+		return EraInvalid
+	}
+	return era
+}

--- a/ledger/common/era_test.go
+++ b/ledger/common/era_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ledger_test
+package common_test
 
 import (
-	"github.com/blinklabs-io/gouroboros/ledger"
 	"testing"
+
+	_ "github.com/blinklabs-io/gouroboros/ledger" // This is needed to get the eras registered
+	"github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
 type getEraByIdTestDefinition struct {
@@ -50,6 +52,10 @@ var getEraByIdTests = []getEraByIdTestDefinition{
 		Name: "Babbage",
 	},
 	{
+		Id:   6,
+		Name: "Conway",
+	},
+	{
 		Id:   99,
 		Name: "invalid",
 	},
@@ -57,8 +63,8 @@ var getEraByIdTests = []getEraByIdTestDefinition{
 
 func TestGetEraById(t *testing.T) {
 	for _, test := range getEraByIdTests {
-		era := ledger.GetEraById(test.Id)
-		if era == ledger.EraInvalid {
+		era := common.EraById(test.Id)
+		if era == common.EraInvalid {
 			if test.Name != "invalid" {
 				t.Fatalf("got unexpected EraInvalid, wanted %s", test.Name)
 			}

--- a/ledger/conway.go
+++ b/ledger/conway.go
@@ -18,14 +18,15 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
-
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
 
 const (
-	EraIdConway = 6
+	EraIdConway   = 6
+	EraNameConway = "Conway"
 
 	BlockTypeConway = 7
 
@@ -33,6 +34,17 @@ const (
 
 	TxTypeConway = 6
 )
+
+var (
+	EraConway = common.Era{
+		Id:   EraIdConway,
+		Name: EraNameConway,
+	}
+)
+
+func init() {
+	common.RegisterEra(EraConway)
+}
 
 type ConwayBlock struct {
 	cbor.StructAsArray
@@ -69,7 +81,7 @@ func (b *ConwayBlock) BlockBodySize() uint64 {
 }
 
 func (b *ConwayBlock) Era() Era {
-	return eras[EraIdConway]
+	return EraConway
 }
 
 func (b *ConwayBlock) Transactions() []Transaction {
@@ -117,7 +129,7 @@ type ConwayBlockHeader struct {
 }
 
 func (h *ConwayBlockHeader) Era() Era {
-	return eras[EraIdConway]
+	return EraConway
 }
 
 type ConwayRedeemerKey struct {

--- a/ledger/era.go
+++ b/ledger/era.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2024 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,53 +14,16 @@
 
 package ledger
 
-type Era struct {
-	Id   uint8
-	Name string
-}
+import (
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
 
-var eras = map[uint8]Era{
-	EraIdByron: Era{
-		Id:   EraIdByron,
-		Name: "Byron",
-	},
-	EraIdShelley: Era{
-		Id:   EraIdShelley,
-		Name: "Shelley",
-	},
-	EraIdAllegra: Era{
-		Id:   EraIdAllegra,
-		Name: "Allegra",
-	},
-	EraIdMary: Era{
-		Id:   EraIdMary,
-		Name: "Mary",
-	},
-	EraIdAlonzo: Era{
-		Id:   EraIdAlonzo,
-		Name: "Alonzo",
-	},
-	EraIdBabbage: Era{
-		Id:   EraIdBabbage,
-		Name: "Babbage",
-	},
-	EraIdConway: Era{
-		Id:   EraIdConway,
-		Name: "Conway",
-	},
-}
+type Era = common.Era
 
-var EraInvalid = Era{
-	Id:   0,
-	Name: "invalid",
-}
+var EraInvalid = common.EraInvalid
 
 func GetEraById(eraId uint8) Era {
-	era, ok := eras[eraId]
-	if !ok {
-		return EraInvalid
-	}
-	return era
+	return common.EraById(eraId)
 }
 
 // BlockHeaderToBlockTypeMap is a mapping of NtN chainsync block header types

--- a/ledger/mary.go
+++ b/ledger/mary.go
@@ -19,14 +19,15 @@ import (
 	"encoding/json"
 	"fmt"
 
-	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
-
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
 
 const (
-	EraIdMary = 3
+	EraIdMary   = 3
+	EraNameMary = "Mary"
 
 	BlockTypeMary = 4
 
@@ -34,6 +35,17 @@ const (
 
 	TxTypeMary = 3
 )
+
+var (
+	EraMary = common.Era{
+		Id:   EraIdMary,
+		Name: EraNameMary,
+	}
+)
+
+func init() {
+	common.RegisterEra(EraMary)
+}
 
 type MaryBlock struct {
 	cbor.StructAsArray
@@ -69,7 +81,7 @@ func (b *MaryBlock) BlockBodySize() uint64 {
 }
 
 func (b *MaryBlock) Era() Era {
-	return eras[EraIdMary]
+	return EraMary
 }
 
 func (b *MaryBlock) Transactions() []Transaction {
@@ -111,7 +123,7 @@ type MaryBlockHeader struct {
 }
 
 func (h *MaryBlockHeader) Era() Era {
-	return eras[EraIdMary]
+	return EraMary
 }
 
 type MaryTransactionBody struct {

--- a/ledger/shelley.go
+++ b/ledger/shelley.go
@@ -25,7 +25,8 @@ import (
 )
 
 const (
-	EraIdShelley = 1
+	EraIdShelley   = 1
+	EraNameShelley = "Shelley"
 
 	BlockTypeShelley = 2
 
@@ -33,6 +34,17 @@ const (
 
 	TxTypeShelley = 1
 )
+
+var (
+	EraShelley = common.Era{
+		Id:   EraIdShelley,
+		Name: EraNameShelley,
+	}
+)
+
+func init() {
+	common.RegisterEra(EraShelley)
+}
 
 type ShelleyBlock struct {
 	cbor.StructAsArray
@@ -68,7 +80,7 @@ func (b *ShelleyBlock) BlockBodySize() uint64 {
 }
 
 func (b *ShelleyBlock) Era() Era {
-	return eras[EraIdShelley]
+	return EraShelley
 }
 
 func (b *ShelleyBlock) Transactions() []Transaction {
@@ -158,7 +170,7 @@ func (h *ShelleyBlockHeader) BlockBodySize() uint64 {
 }
 
 func (h *ShelleyBlockHeader) Era() Era {
-	return eras[EraIdShelley]
+	return EraShelley
 }
 
 type ShelleyTransactionBody struct {


### PR DESCRIPTION
This also moves to a registration model for eras to avoid import cycles