### PR TITLE
fix: debug logging for node-to-node clients

### DIFF
--- a/protocol/handshake/client.go
+++ b/protocol/handshake/client.go
@@ -57,7 +57,7 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 		ErrorChan:           protoOptions.ErrorChan,
 		Mode:                protoOptions.Mode,
 		Role:                protocol.ProtocolRoleClient,
-		MessageHandlerFunc:  c.handleMessage,
+		MessageHandlerFunc:  c.messageHandler,
 		MessageFromCborFunc: NewMsgFromCbor,
 		StateMap:            stateMap,
 		InitialState:        statePropose,
@@ -70,7 +70,7 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 func (c *Client) Start() {
 	c.onceStart.Do(func() {
 		c.Protocol.Logger().
-			Debug(fmt.Sprintf("starting protocol: %s", ProtocolName))
+			Debug(fmt.Sprintf("%s: starting protocol for connection %+v", ProtocolName, c.callbackContext.ConnectionId.RemoteAddr))
 		c.Protocol.Start()
 		// Send our ProposeVersions message
 		msg := NewMsgProposeVersions(c.config.ProtocolVersionMap)
@@ -78,9 +78,7 @@ func (c *Client) Start() {
 	})
 }
 
-func (c *Client) handleMessage(msg protocol.Message) error {
-	c.Protocol.Logger().
-		Debug(fmt.Sprintf("handling client message for %s", ProtocolName))
+func (c *Client) messageHandler(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeAcceptVersion:
@@ -99,7 +97,7 @@ func (c *Client) handleMessage(msg protocol.Message) error {
 
 func (c *Client) handleAcceptVersion(msg protocol.Message) error {
 	c.Protocol.Logger().
-		Debug(fmt.Sprintf("handling client accept version for %s", ProtocolName))
+		Debug(fmt.Sprintf("%s: client accept version for %+v", ProtocolName, c.callbackContext.ConnectionId.RemoteAddr))
 	if c.config.FinishedFunc == nil {
 		return fmt.Errorf(
 			"received handshake AcceptVersion message but no callback function is defined",
@@ -122,7 +120,7 @@ func (c *Client) handleAcceptVersion(msg protocol.Message) error {
 
 func (c *Client) handleRefuse(msgGeneric protocol.Message) error {
 	c.Protocol.Logger().
-		Debug(fmt.Sprintf("handling client refuse for %s", ProtocolName))
+		Debug(fmt.Sprintf("%s: client refuse for %+v", ProtocolName, c.callbackContext.ConnectionId.RemoteAddr))
 	msg := msgGeneric.(*MsgRefuse)
 	var err error
 	switch msg.Reason[0].(uint64) {

--- a/protocol/keepalive/client.go
+++ b/protocol/keepalive/client.go
@@ -54,6 +54,7 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 		Name:                ProtocolName,
 		ProtocolId:          ProtocolId,
 		Muxer:               protoOptions.Muxer,
+		Logger:              protoOptions.Logger,
 		ErrorChan:           protoOptions.ErrorChan,
 		Mode:                protoOptions.Mode,
 		Role:                protocol.ProtocolRoleClient,
@@ -68,6 +69,8 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 
 func (c *Client) Start() {
 	c.onceStart.Do(func() {
+		c.Protocol.Logger().
+			Debug(fmt.Sprintf("%s: starting protocol for connection %+v", ProtocolName, c.callbackContext.ConnectionId.RemoteAddr))
 		c.Protocol.Start()
 		// Start goroutine to cleanup resources on protocol shutdown
 		go func() {
@@ -119,6 +122,8 @@ func (c *Client) messageHandler(msg protocol.Message) error {
 }
 
 func (c *Client) handleKeepAliveResponse(msgGeneric protocol.Message) error {
+	c.Protocol.Logger().
+		Debug(fmt.Sprintf("%s: client keepalive response for %+v", ProtocolName, c.callbackContext.ConnectionId.RemoteAddr))
 	msg := msgGeneric.(*MsgKeepAliveResponse)
 	if msg.Cookie != c.config.Cookie {
 		return fmt.Errorf(

--- a/protocol/peersharing/client.go
+++ b/protocol/peersharing/client.go
@@ -53,6 +53,7 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 		Name:                ProtocolName,
 		ProtocolId:          ProtocolId,
 		Muxer:               protoOptions.Muxer,
+		Logger:              protoOptions.Logger,
 		ErrorChan:           protoOptions.ErrorChan,
 		Mode:                protoOptions.Mode,
 		Role:                protocol.ProtocolRoleClient,
@@ -66,6 +67,8 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 }
 
 func (c *Client) GetPeers(amount uint8) ([]PeerAddress, error) {
+	c.Protocol.Logger().
+		Debug(fmt.Sprintf("%s: client %+v called GetPeers(amount: %d)", ProtocolName, c.callbackContext.ConnectionId.RemoteAddr, amount))
 	msg := NewMsgShareRequest(amount)
 	if err := c.SendMessage(msg); err != nil {
 		return nil, err
@@ -78,6 +81,8 @@ func (c *Client) GetPeers(amount uint8) ([]PeerAddress, error) {
 }
 
 func (c *Client) handleMessage(msg protocol.Message) error {
+	c.Protocol.Logger().
+		Debug(fmt.Sprintf("%s: client message for %+v", ProtocolName, c.callbackContext.ConnectionId.RemoteAddr))
 	var err error
 	switch msg.Type() {
 	case MessageTypeSharePeers:
@@ -93,6 +98,8 @@ func (c *Client) handleMessage(msg protocol.Message) error {
 }
 
 func (c *Client) handleSharePeers(msg protocol.Message) error {
+	c.Protocol.Logger().
+		Debug(fmt.Sprintf("%s: client share peers for %+v", ProtocolName, c.callbackContext.ConnectionId.RemoteAddr))
 	msgSharePeers := msg.(*MsgSharePeers)
 	c.sharePeersChan <- msgSharePeers.PeerAddresses
 	return nil

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -121,7 +121,6 @@ func New(config ProtocolConfig) *Protocol {
 func (p *Protocol) Start() {
 	p.onceStart.Do(func() {
 		// Register protocol with muxer
-		p.Logger().Debug("registering protocol with muxer")
 		muxerProtocolRole := muxer.ProtocolRoleInitiator
 		if p.config.Role == ProtocolRoleServer {
 			muxerProtocolRole = muxer.ProtocolRoleResponder
@@ -160,7 +159,6 @@ func (p *Protocol) Start() {
 func (p *Protocol) Stop() {
 	p.onceStop.Do(func() {
 		// Unregister protocol from muxer
-		p.Logger().Debug("unregistering protocol with muxer")
 		muxerProtocolRole := muxer.ProtocolRoleInitiator
 		if p.config.Role == ProtocolRoleServer {
 			muxerProtocolRole = muxer.ProtocolRoleResponder

--- a/protocol/txsubmission/client.go
+++ b/protocol/txsubmission/client.go
@@ -53,6 +53,7 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 		Name:                ProtocolName,
 		ProtocolId:          ProtocolId,
 		Muxer:               protoOptions.Muxer,
+		Logger:              protoOptions.Logger,
 		ErrorChan:           protoOptions.ErrorChan,
 		Mode:                protoOptions.Mode,
 		Role:                protocol.ProtocolRoleClient,
@@ -75,6 +76,8 @@ func (c *Client) Init() {
 }
 
 func (c *Client) messageHandler(msg protocol.Message) error {
+	c.Protocol.Logger().
+		Debug(fmt.Sprintf("%s: client message for %+v", ProtocolName, c.callbackContext.ConnectionId.RemoteAddr))
 	var err error
 	switch msg.Type() {
 	case MessageTypeRequestTxIds:
@@ -92,6 +95,8 @@ func (c *Client) messageHandler(msg protocol.Message) error {
 }
 
 func (c *Client) handleRequestTxIds(msg protocol.Message) error {
+	c.Protocol.Logger().
+		Debug(fmt.Sprintf("%s: client request tx ids for %+v", ProtocolName, c.callbackContext.ConnectionId.RemoteAddr))
 	if c.config.RequestTxIdsFunc == nil {
 		return fmt.Errorf(
 			"received tx-submission RequestTxIds message but no callback function is defined",
@@ -116,6 +121,8 @@ func (c *Client) handleRequestTxIds(msg protocol.Message) error {
 }
 
 func (c *Client) handleRequestTxs(msg protocol.Message) error {
+	c.Protocol.Logger().
+		Debug(fmt.Sprintf("%s: client request txs for %+v", ProtocolName, c.callbackContext.ConnectionId.RemoteAddr))
 	if c.config.RequestTxsFunc == nil {
 		return fmt.Errorf(
 			"received tx-submission RequestTxs message but no callback function is defined",


### PR DESCRIPTION
This helps with troubleshooting node-to-node connections from the client side. Log messages are prefixed with the appropriate subsystem.

```
{"time":"2024-10-04T17:04:12.703339621-04:00","level":"INFO","msg":"maxprocs: Leaving GOMAXPROCS=8: CPU quota undefined"}
{"time":"2024-10-04T17:04:12.703378997-04:00","level":"INFO","msg":"running: node version devel (commit 070c28f)"}
{"time":"2024-10-04T17:04:12.703505903-04:00","level":"DEBUG","msg":"config: &{BindAddr:0.0.0.0 CardanoConfig:./configs/cardano/preview/config.json Network:mainnet MetricsPort:12798 Port:3001 Topology:./custom-p2p-topology.json}"}
{"time":"2024-10-04T17:04:12.703520138-04:00","level":"DEBUG","msg":"topology: &{Producers:[] LocalRoots:[{AccessPoints:[] Advertise:false Trustable:false Valency:1}] PublicRoots:[{AccessPoints:[] Advertise:false Valency:0}] BootstrapPeers:[{Address:backbone.cardano.iog.io Port:3001}] UseLedgerAfterSlot:128908821}"}
{"time":"2024-10-04T17:04:12.703855119-04:00","level":"DEBUG","msg":"node: cardano node config: &{path:configs/cardano/preview AlonzoGenesisFile:alonzo-genesis.json AlonzoGenesisHash:7e94a15f55d1e82d10f09203fa1d40f8eede58fd8066542cf6566008068ed874 ByronGenesisFile:byron-genesis.json ByronGenesisHash:83de1d7302569ad56cf9139a41e2e11346d4cb4a31c00142557b6ab3fa550761 ConwayGenesisFile:conway-genesis.json ConwayGenesisHash:9cc5084f02e27210eacba47af0872e3dba8946ad9460b6072d793e1d2f3987ef ShelleyGenesisFile:shelley-genesis.json ShelleyGenesisHash:363498d1024f84bb39d3fa9593ce391483cb40d479b87233f868d6e57c3a400d}"}
{"time":"2024-10-04T17:04:12.703864097-04:00","level":"INFO","msg":"listener: ouroboros node-to-node connections on 0.0.0.0:3001"}
{"time":"2024-10-04T17:04:12.703921926-04:00","level":"INFO","msg":"metrics: prometheus metrics on 0.0.0.0:12798"}
{"time":"2024-10-04T17:04:12.708269756-04:00","level":"DEBUG","msg":"connmanager: adding host: {Address:backbone.cardano.iog.io Port:3001 Tags:map[HostBootstrapPeer:true]}"}
{"time":"2024-10-04T17:04:12.708287868-04:00","level":"DEBUG","msg":"outbound: starting connections"}
{"time":"2024-10-04T17:04:12.70829328-04:00","level":"DEBUG","msg":"outbound: adding bootstrap peer topology host: backbone.cardano.iog.io:3001"}
{"time":"2024-10-04T17:04:12.708304804-04:00","level":"DEBUG","msg":"outbound: establishing TCP connection to: backbone.cardano.iog.io:3001"}
{"time":"2024-10-04T17:04:12.793281321-04:00","level":"DEBUG","msg":"outbound: establishing ouroboros protocol to backbone.cardano.iog.io:3001"}
{"time":"2024-10-04T17:04:12.79347029-04:00","level":"DEBUG","msg":"handshake: starting protocol for connection [2600:1f13:117:4302:63f4:6cdb:f69c:3f58]:3001"}
{"time":"2024-10-04T17:04:12.872546705-04:00","level":"DEBUG","msg":"handshake: client accept version for [2600:1f13:117:4302:63f4:6cdb:f69c:3f58]:3001"}
{"time":"2024-10-04T17:04:12.87272316-04:00","level":"DEBUG","msg":"block-fetch: starting protocol for connection [2600:1f13:117:4302:63f4:6cdb:f69c:3f58]:3001"}
{"time":"2024-10-04T17:04:12.872772868-04:00","level":"DEBUG","msg":"chain-sync: starting protocol for connection [2600:1f13:117:4302:63f4:6cdb:f69c:3f58]:3001"}
{"time":"2024-10-04T17:04:12.872826402-04:00","level":"DEBUG","msg":"keep-alive: starting protocol for connection [2600:1f13:117:4302:63f4:6cdb:f69c:3f58]:3001"}
{"time":"2024-10-04T17:04:12.873001885-04:00","level":"INFO","msg":"outbound: connected ouroboros to backbone.cardano.iog.io:3001"}
{"time":"2024-10-04T17:04:12.873564844-04:00","level":"DEBUG","msg":"chain-sync: client [2600:1f13:117:4302:63f4:6cdb:f69c:3f58]:3001 called GetCurrentTip()"}
{"time":"2024-10-04T17:04:12.977060834-04:00","level":"DEBUG","msg":"chain-sync: client intersect not found for [2600:1f13:117:4302:63f4:6cdb:f69c:3f58]:3001"}
{"time":"2024-10-04T17:04:12.977087362-04:00","level":"DEBUG","msg":"keep-alive: client keepalive response for [2600:1f13:117:4302:63f4:6cdb:f69c:3f58]:3001"}
{"time":"2024-10-04T17:04:12.977120275-04:00","level":"DEBUG","msg":"chain-sync: returning tip results {Slot: 136509507, Hash: 379042d77ac0d9af5e1f0bbd5d6e84ef63a3275b6bb0ef8d637becdf7f7d2c9a, BlockNumber: 10920487} to [2600:1f13:117:4302:63f4:6cdb:f69c:3f58]:3001"}
{"time":"2024-10-04T17:04:12.977179248-04:00","level":"DEBUG","msg":"chain-sync: client [2600:1f13:117:4302:63f4:6cdb:f69c:3f58]:3001 called Sync(intersectPoints: []{Slot: 136509507, Hash: 379042d77ac0d9af5e1f0bbd5d6e84ef63a3275b6bb0ef8d637becdf7f7d2c9a})"}
{"time":"2024-10-04T17:04:13.055604131-04:00","level":"DEBUG","msg":"chain-sync: client intersect found for [2600:1f13:117:4302:63f4:6cdb:f69c:3f58]:3001"}
{"time":"2024-10-04T17:04:13.140122531-04:00","level":"DEBUG","msg":"chain-sync: client roll backward for [2600:1f13:117:4302:63f4:6cdb:f69c:3f58]:3001"}
{"time":"2024-10-04T17:04:13.141171154-04:00","level":"INFO","msg":"chain rolled back, new tip: 379042d77ac0d9af5e1f0bbd5d6e84ef63a3275b6bb0ef8d637becdf7f7d2c9a at slot 136509507"}
{"time":"2024-10-04T17:04:13.217705584-04:00","level":"DEBUG","msg":"chain-sync: client await reply for [2600:1f13:117:4302:63f4:6cdb:f69c:3f58]:3001"}
```