### PR TITLE
refactor: improve local-state-query callback interface

### DIFF
--- a/protocol/localstatequery/client.go
+++ b/protocol/localstatequery/client.go
@@ -908,9 +908,9 @@ func (c *Client) handleFailure(msg protocol.Message) error {
 	msgFailure := msg.(*MsgFailure)
 	switch msgFailure.Failure {
 	case AcquireFailurePointTooOld:
-		c.acquireResultChan <- AcquireFailurePointTooOldError{}
+		c.acquireResultChan <- ErrAcquireFailurePointTooOld
 	case AcquireFailurePointNotOnChain:
-		c.acquireResultChan <- AcquireFailurePointNotOnChainError{}
+		c.acquireResultChan <- ErrAcquireFailurePointNotOnChain
 	default:
 		return fmt.Errorf("unknown failure type: %d", msgFailure.Failure)
 	}

--- a/protocol/localstatequery/error.go
+++ b/protocol/localstatequery/error.go
@@ -14,18 +14,10 @@
 
 package localstatequery
 
-// AcquireFailurePointTooOldError indicates a failure to acquire a point due to it being too old
-type AcquireFailurePointTooOldError struct {
-}
+import "errors"
 
-func (e AcquireFailurePointTooOldError) Error() string {
-	return "acquire failure: point too old"
-}
+// ErrAcquireFailurePointTooOld indicates a failure to acquire a point due to it being too old
+var ErrAcquireFailurePointTooOld = errors.New("acquire failure: point too old")
 
-// AcquireFailurePointNotOnChainError indicates a failure to acquire a point due to it not being present on the chain
-type AcquireFailurePointNotOnChainError struct {
-}
-
-func (e AcquireFailurePointNotOnChainError) Error() string {
-	return "acquire failure: point not on chain"
-}
+// ErrAcquireFailurePointNotOnChain indicates a failure to acquire a point due to it not being present on the chain
+var ErrAcquireFailurePointNotOnChain = errors.New("acquire failure: point not on chain")

--- a/protocol/localstatequery/localstatequery.go
+++ b/protocol/localstatequery/localstatequery.go
@@ -123,8 +123,6 @@ type Config struct {
 	AcquireFunc    AcquireFunc
 	QueryFunc      QueryFunc
 	ReleaseFunc    ReleaseFunc
-	ReAcquireFunc  ReAcquireFunc
-	DoneFunc       DoneFunc
 	AcquireTimeout time.Duration
 	QueryTimeout   time.Duration
 }
@@ -156,11 +154,9 @@ type CallbackContext struct {
 }
 
 // Callback function types
-type AcquireFunc func(CallbackContext, AcquireTarget) error
-type QueryFunc func(CallbackContext, any) error
+type AcquireFunc func(CallbackContext, AcquireTarget, bool) error
+type QueryFunc func(CallbackContext, any) (any, error)
 type ReleaseFunc func(CallbackContext) error
-type ReAcquireFunc func(CallbackContext, AcquireTarget) error
-type DoneFunc func(CallbackContext) error
 
 // New returns a new LocalStateQuery object
 func New(protoOptions protocol.ProtocolOptions, cfg *Config) *LocalStateQuery {
@@ -205,20 +201,6 @@ func WithQueryFunc(queryFunc QueryFunc) LocalStateQueryOptionFunc {
 func WithReleaseFunc(releaseFunc ReleaseFunc) LocalStateQueryOptionFunc {
 	return func(c *Config) {
 		c.ReleaseFunc = releaseFunc
-	}
-}
-
-// WithReAcquireFunc specifies the ReAcquire callback function when acting as a server
-func WithReAcquireFunc(reAcquireFunc ReAcquireFunc) LocalStateQueryOptionFunc {
-	return func(c *Config) {
-		c.ReAcquireFunc = reAcquireFunc
-	}
-}
-
-// WithDoneFunc specifies the Done callback function when acting as a server
-func WithDoneFunc(doneFunc DoneFunc) LocalStateQueryOptionFunc {
-	return func(c *Config) {
-		c.DoneFunc = doneFunc
 	}
 }
 


### PR DESCRIPTION
* switch custom errors to vars instead of types
* merge Acquire/ReAcquire callbacks
* remove Done callback
* add ability to return result in Query callback
* automatically send acquire result response
* automatically send query result