### PR TITLE
fix: adjust UTxO by Txin query field type

### DIFF
--- a/protocol/localstatequery/queries.go
+++ b/protocol/localstatequery/queries.go
@@ -307,7 +307,7 @@ type ShelleyRewardProvenanceQuery struct {
 type ShelleyUtxoByTxinQuery struct {
 	cbor.StructAsArray
 	Type  int
-	TxIns []ledger.TransactionInput
+	TxIns []ledger.ShelleyTransactionInput
 }
 
 type ShelleyStakePoolsQuery struct {


### PR DESCRIPTION
We need a concrete type rather than an interface for decoding