### PR TITLE
fix: prevent Conway TX inputs from being decoded as Shelley TX input

### DIFF
--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -199,6 +199,28 @@ func (t *ConwayTransactionWitnessSet) UnmarshalCBOR(cborData []byte) error {
 	return t.UnmarshalCbor(cborData, t)
 }
 
+type ConwayTransactionInput struct {
+	shelley.ShelleyTransactionInput
+}
+
+func NewConwayTransactionInput(hash string, idx int) ConwayTransactionInput {
+	tmpHash, err := hex.DecodeString(hash)
+	if err != nil {
+		panic(fmt.Sprintf("failed to decode transaction hash: %s", err))
+	}
+	return ConwayTransactionInput{
+		ShelleyTransactionInput: shelley.ShelleyTransactionInput{
+			TxId:        common.Blake2b256(tmpHash),
+			OutputIndex: uint32(idx),
+		},
+	}
+}
+
+func (i *ConwayTransactionInput) UnmarshalCBOR(data []byte) error {
+	// We override the unmarshal function from ShelleyTransactionInput
+	return cbor.DecodeGeneric(data, &i.ShelleyTransactionInput)
+}
+
 type ConwayTransactionBody struct {
 	babbage.BabbageTransactionBody
 	TxVotingProcedures     common.VotingProcedures    `cbor:"19,keyasint,omitempty"`

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -386,13 +386,21 @@ func (i ShelleyTransactionInput) Utxorpc() *utxorpc.TxInput {
 	return &utxorpc.TxInput{
 		TxHash:      i.TxId.Bytes(),
 		OutputIndex: i.OutputIndex,
-		// AsOutput: i.AsOutput,
-		// Redeemer: i.Redeemer,
 	}
 }
 
 func (i ShelleyTransactionInput) String() string {
 	return fmt.Sprintf("%s#%d", i.TxId, i.OutputIndex)
+}
+
+func (i *ShelleyTransactionInput) UnmarshalCBOR(data []byte) error {
+	// Make sure this isn't a tag-wrapped set
+	// This is needed to prevent Conway+ TXs from being decoded as an earlier type
+	var tmpTag cbor.RawTag
+	if _, err := cbor.Decode(data, &tmpTag); err == nil {
+		return fmt.Errorf("did not expect CBOR tag")
+	}
+	return cbor.DecodeGeneric(data, i)
 }
 
 func (i ShelleyTransactionInput) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Conway-era TX inputs using CBOR tag 258 (sets) could be implicitly decoded by earlier eras, but this doesn't match the behavior of cardano-node. We explicitly prevent this from happening to allow proper identification of TX types