### PR TITLE
feat: devnet network

### DIFF
--- a/networks.go
+++ b/networks.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Blink Labs Software
+// Copyright 2025 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -70,6 +70,11 @@ var (
 			},
 		},
 	}
+	NetworkDevnet = Network{
+		Id:           common.AddressNetworkTestnet,
+		Name:         "devnet",
+		NetworkMagic: 42,
+	}
 )
 
 // List of valid networks for use in lookup functions
@@ -78,6 +83,7 @@ var networks = []Network{
 	NetworkPreprod,
 	NetworkPreview,
 	NetworkSancho,
+	NetworkDevnet,
 }
 
 // NetworkByName returns a predefined network by name


### PR DESCRIPTION
This introduces a `devnet` network with the magic number of 42, which is used in local testing.