### PR TITLE
fix: better handling for arbitrary CBOR data structures

### DIFF
--- a/cbor/value_test.go
+++ b/cbor/value_test.go
@@ -46,13 +46,6 @@ var testDefs = []struct {
 		expectedObject:      nil,
 		expectedDecodeError: io.ErrUnexpectedEOF,
 	},
-	// Invalid map key type
-	{
-		cborHex: "A1810000",
-		expectedDecodeError: fmt.Errorf(
-			"decode failure, probably due to type unsupported by Go: runtime error: hash of unhashable type []interface {}",
-		),
-	},
 	// [1, 2, 3]
 	{
 		cborHex:         "83010203",


### PR DESCRIPTION
* use a pointer for map keys for non-comparable types in cbor.Value
* allow arbitrary tag types for cbor.Value

Signed-off-by: Aurora Gaffney <aurora@blinklabs.io>