### PR TITLE
Potential fix for code scanning alert no. 13: Potentially unsafe quoting

### DIFF
--- a/cbor/value.go
+++ b/cbor/value.go
@@ -231,14 +231,15 @@ func generateAstJsonMap[T map[any]any | Map](v T) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		// NOTE: Github CodeQL hates this due to "potentially unsafe quoting", but it
-		// won't happen in practice since both values injected are auto-generated
-		tmpJson := fmt.Sprintf(
-			`{"k":%s,"v":%s}`,
-			keyAstJson,
-			valAstJson,
-		)
-		tmpItems = append(tmpItems, tmpJson)
+		tmpJsonMap := map[string]json.RawMessage{
+			"k": keyAstJson,
+			"v": valAstJson,
+		}
+		tmpJson, err := json.Marshal(tmpJsonMap)
+		if err != nil {
+			return nil, err
+		}
+		tmpItems = append(tmpItems, string(tmpJson))
 	}
 	// We naively sort the rendered map items to give consistent ordering
 	sort.Strings(tmpItems)


### PR DESCRIPTION
Potential fix for [https://github.com/blinklabs-io/gouroboros/security/code-scanning/13](https://github.com/blinklabs-io/gouroboros/security/code-scanning/13)

To fix the problem, we should avoid manually constructing JSON strings and instead use a structured API that handles quoting and escaping automatically. This can be achieved by using the `json.Marshal` function to serialize the key-value pairs into JSON format.

- Replace the manual string construction with `json.Marshal` to ensure proper escaping of quotes and other special characters.
- Update the `generateAstJsonMap` function to use `json.Marshal` for constructing the JSON string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
