### PR TITLE
chore: disable musttag linter on genesis structs

### DIFF
--- a/ledger/alonzo/genesis.go
+++ b/ledger/alonzo/genesis.go
@@ -36,6 +36,7 @@ func NewAlonzoGenesisFromReader(r io.Reader) (AlonzoGenesis, error) {
 	var ret AlonzoGenesis
 	dec := json.NewDecoder(r)
 	dec.DisallowUnknownFields()
+	//nolint:musttag
 	if err := dec.Decode(&ret); err != nil {
 		return ret, err
 	}

--- a/ledger/byron/genesis.go
+++ b/ledger/byron/genesis.go
@@ -180,6 +180,7 @@ func NewByronGenesisFromReader(r io.Reader) (ByronGenesis, error) {
 	var ret ByronGenesis
 	dec := json.NewDecoder(r)
 	dec.DisallowUnknownFields()
+	//nolint:musttag
 	if err := dec.Decode(&ret); err != nil {
 		return ret, err
 	}

--- a/ledger/conway/genesis.go
+++ b/ledger/conway/genesis.go
@@ -77,6 +77,7 @@ func NewConwayGenesisFromReader(r io.Reader) (ConwayGenesis, error) {
 	var ret ConwayGenesis
 	dec := json.NewDecoder(r)
 	dec.DisallowUnknownFields()
+	//nolint:musttag
 	if err := dec.Decode(&ret); err != nil {
 		return ret, err
 	}

--- a/ledger/shelley/genesis.go
+++ b/ledger/shelley/genesis.go
@@ -158,6 +158,7 @@ func NewShelleyGenesisFromReader(r io.Reader) (ShelleyGenesis, error) {
 	var ret ShelleyGenesis
 	dec := json.NewDecoder(r)
 	dec.DisallowUnknownFields()
+	//nolint:musttag
 	if err := dec.Decode(&ret); err != nil {
 		return ret, err
 	}


### PR DESCRIPTION
Disable until #926 is resolved which will remove these comments