### PR TITLE
ci(golangci-lint): use bugs and performance presets

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,12 +12,12 @@ linters:
     - staticcheck
     - unused
     # Defaults above ours below
-    - bodyclose
-    - fatcontext
-    - gosec
-    - noctx
-    - perfsprint
-    - prealloc
+  disable:
+    - asasalint
+    - recvcheck
+  presets:
+    - bugs
+    - performance
 #linters-settings:
 #  errcheck:
 #    check-type-assertions: true


### PR DESCRIPTION
This disables the `asasalint` and `recvcheck` checks due to failing. There are open issues to resolve them, individually.