### PR TITLE
feat: account for stake deregistration in validation rules

### DIFF
--- a/ledger/allegra/rules_test.go
+++ b/ledger/allegra/rules_test.go
@@ -505,8 +505,6 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 	var testInputAmount uint64 = 555666777
 	var testFee uint64 = 123456
 	var testStakeDeposit uint64 = 2_000_000
-	var testStakeCred1 = []byte{0x01, 0x23, 0x45}
-	var testStakeCred2 = []byte{0xab, 0xcd, 0xef}
 	testOutputExactAmount := testInputAmount - testFee
 	testOutputUnderAmount := testOutputExactAmount - 999
 	testOutputOverAmount := testOutputExactAmount + 999
@@ -532,13 +530,6 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 				Id: shelley.NewShelleyTransactionInput(testInputTxId, 0),
 				Output: shelley.ShelleyTransactionOutput{
 					OutputAmount: testInputAmount,
-				},
-			},
-		},
-		MockStakeRegistration: []common.StakeRegistrationCertificate{
-			{
-				StakeRegistration: common.StakeCredential{
-					Credential: testStakeCred2,
 				},
 			},
 		},
@@ -568,18 +559,16 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 			}
 		},
 	)
-	// First stake registration
+	// Stake registration
 	t.Run(
-		"first stake registration",
+		"stake registration",
 		func(t *testing.T) {
 			testTx.Body.TxOutputs[0].OutputAmount = testOutputExactAmount - testStakeDeposit
 			testTx.Body.TxCertificates = []common.CertificateWrapper{
 				{
 					Type: common.CertificateTypeStakeRegistration,
 					Certificate: &common.StakeRegistrationCertificate{
-						StakeRegistration: common.StakeCredential{
-							Credential: testStakeCred1,
-						},
+						StakeRegistration: common.StakeCredential{},
 					},
 				},
 			}
@@ -597,18 +586,16 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 			}
 		},
 	)
-	// Second stake registration
+	// Stake deregistration
 	t.Run(
-		"second stake registration",
+		"stake deregistration",
 		func(t *testing.T) {
-			testTx.Body.TxOutputs[0].OutputAmount = testOutputExactAmount
+			testTx.Body.TxOutputs[0].OutputAmount = testOutputExactAmount + testStakeDeposit
 			testTx.Body.TxCertificates = []common.CertificateWrapper{
 				{
 					Type: common.CertificateTypeStakeRegistration,
-					Certificate: &common.StakeRegistrationCertificate{
-						StakeRegistration: common.StakeCredential{
-							Credential: testStakeCred2,
-						},
+					Certificate: &common.StakeDeregistrationCertificate{
+						StakeDeregistration: common.StakeCredential{},
 					},
 				},
 			}

--- a/ledger/alonzo/rules_test.go
+++ b/ledger/alonzo/rules_test.go
@@ -520,8 +520,6 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 	var testInputAmount uint64 = 555666777
 	var testFee uint64 = 123456
 	var testStakeDeposit uint64 = 2_000_000
-	var testStakeCred1 = []byte{0x01, 0x23, 0x45}
-	var testStakeCred2 = []byte{0xab, 0xcd, 0xef}
 	testOutputExactAmount := testInputAmount - testFee
 	testOutputUnderAmount := testOutputExactAmount - 999
 	testOutputOverAmount := testOutputExactAmount + 999
@@ -551,13 +549,6 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 				Id: shelley.NewShelleyTransactionInput(testInputTxId, 0),
 				Output: shelley.ShelleyTransactionOutput{
 					OutputAmount: testInputAmount,
-				},
-			},
-		},
-		MockStakeRegistration: []common.StakeRegistrationCertificate{
-			{
-				StakeRegistration: common.StakeCredential{
-					Credential: testStakeCred2,
 				},
 			},
 		},
@@ -591,18 +582,16 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 			}
 		},
 	)
-	// First stake registration
+	// Stake registration
 	t.Run(
-		"first stake registration",
+		"stake registration",
 		func(t *testing.T) {
 			testTx.Body.TxOutputs[0].OutputAmount.Amount = testOutputExactAmount - testStakeDeposit
 			testTx.Body.TxCertificates = []common.CertificateWrapper{
 				{
 					Type: common.CertificateTypeStakeRegistration,
 					Certificate: &common.StakeRegistrationCertificate{
-						StakeRegistration: common.StakeCredential{
-							Credential: testStakeCred1,
-						},
+						StakeRegistration: common.StakeCredential{},
 					},
 				},
 			}
@@ -620,18 +609,16 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 			}
 		},
 	)
-	// Second stake registration
+	// Stake deregistration
 	t.Run(
-		"second stake registration",
+		"stake deregistration",
 		func(t *testing.T) {
-			testTx.Body.TxOutputs[0].OutputAmount.Amount = testOutputExactAmount
+			testTx.Body.TxOutputs[0].OutputAmount.Amount = testOutputExactAmount + testStakeDeposit
 			testTx.Body.TxCertificates = []common.CertificateWrapper{
 				{
 					Type: common.CertificateTypeStakeRegistration,
-					Certificate: &common.StakeRegistrationCertificate{
-						StakeRegistration: common.StakeCredential{
-							Credential: testStakeCred2,
-						},
+					Certificate: &common.StakeDeregistrationCertificate{
+						StakeDeregistration: common.StakeCredential{},
 					},
 				},
 			}

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -182,7 +182,7 @@ func UtxoValidateValueNotConservedUtxo(tx common.Transaction, slot uint64, ls co
 		return errors.New("pparams are not expected type")
 	}
 	// Calculate consumed value
-	// consumed = value from input(s) + withdrawals + refunds(?)
+	// consumed = value from input(s) + withdrawals + refunds
 	var consumedValue uint64
 	for _, tmpInput := range tx.Inputs() {
 		tmpUtxo, err := ls.UtxoById(tmpInput)
@@ -194,6 +194,12 @@ func UtxoValidateValueNotConservedUtxo(tx common.Transaction, slot uint64, ls co
 	}
 	for _, tmpWithdrawalAmount := range tx.Withdrawals() {
 		consumedValue += tmpWithdrawalAmount
+	}
+	for _, cert := range tx.Certificates() {
+		switch cert.(type) {
+		case *common.StakeDeregistrationCertificate:
+			consumedValue += uint64(tmpPparams.KeyDeposit)
+		}
 	}
 	// Calculate produced value
 	// produced = value from output(s) + fee + deposits
@@ -213,13 +219,7 @@ func UtxoValidateValueNotConservedUtxo(tx common.Transaction, slot uint64, ls co
 				producedValue += uint64(tmpPparams.PoolDeposit)
 			}
 		case *common.StakeRegistrationCertificate:
-			certs, err := ls.StakeRegistration(tmpCert.StakeRegistration.Credential)
-			if err != nil {
-				return err
-			}
-			if len(certs) == 0 {
-				producedValue += uint64(tmpPparams.KeyDeposit)
-			}
+			producedValue += uint64(tmpPparams.KeyDeposit)
 		}
 	}
 	if consumedValue == producedValue {

--- a/ledger/babbage/rules_test.go
+++ b/ledger/babbage/rules_test.go
@@ -523,8 +523,6 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 	var testInputAmount uint64 = 555666777
 	var testFee uint64 = 123456
 	var testStakeDeposit uint64 = 2_000_000
-	var testStakeCred1 = []byte{0x01, 0x23, 0x45}
-	var testStakeCred2 = []byte{0xab, 0xcd, 0xef}
 	testOutputExactAmount := testInputAmount - testFee
 	testOutputUnderAmount := testOutputExactAmount - 999
 	testOutputOverAmount := testOutputExactAmount + 999
@@ -559,13 +557,6 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 				},
 			},
 		},
-		MockStakeRegistration: []common.StakeRegistrationCertificate{
-			{
-				StakeRegistration: common.StakeCredential{
-					Credential: testStakeCred2,
-				},
-			},
-		},
 	}
 	testSlot := uint64(0)
 	testProtocolParams := &babbage.BabbageProtocolParameters{
@@ -590,18 +581,16 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 			}
 		},
 	)
-	// First stake registration
+	// Stake registration
 	t.Run(
-		"first stake registration",
+		"stake registration",
 		func(t *testing.T) {
 			testTx.Body.TxOutputs[0].OutputAmount.Amount = testOutputExactAmount - testStakeDeposit
 			testTx.Body.TxCertificates = []common.CertificateWrapper{
 				{
 					Type: common.CertificateTypeStakeRegistration,
 					Certificate: &common.StakeRegistrationCertificate{
-						StakeRegistration: common.StakeCredential{
-							Credential: testStakeCred1,
-						},
+						StakeRegistration: common.StakeCredential{},
 					},
 				},
 			}
@@ -619,18 +608,16 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 			}
 		},
 	)
-	// Second stake registration
+	// Stake deregistration
 	t.Run(
-		"second stake registration",
+		"stake deregistration",
 		func(t *testing.T) {
-			testTx.Body.TxOutputs[0].OutputAmount.Amount = testOutputExactAmount
+			testTx.Body.TxOutputs[0].OutputAmount.Amount = testOutputExactAmount + testStakeDeposit
 			testTx.Body.TxCertificates = []common.CertificateWrapper{
 				{
 					Type: common.CertificateTypeStakeRegistration,
-					Certificate: &common.StakeRegistrationCertificate{
-						StakeRegistration: common.StakeCredential{
-							Credential: testStakeCred2,
-						},
+					Certificate: &common.StakeDeregistrationCertificate{
+						StakeDeregistration: common.StakeCredential{},
 					},
 				},
 			}

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -524,8 +524,6 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 	var testInputAmount uint64 = 555666777
 	var testFee uint64 = 123456
 	var testStakeDeposit uint64 = 2_000_000
-	var testStakeCred1 = []byte{0x01, 0x23, 0x45}
-	var testStakeCred2 = []byte{0xab, 0xcd, 0xef}
 	testOutputExactAmount := testInputAmount - testFee
 	testOutputUnderAmount := testOutputExactAmount - 999
 	testOutputOverAmount := testOutputExactAmount + 999
@@ -562,13 +560,6 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 				},
 			},
 		},
-		MockStakeRegistration: []common.StakeRegistrationCertificate{
-			{
-				StakeRegistration: common.StakeCredential{
-					Credential: testStakeCred2,
-				},
-			},
-		},
 	}
 	testSlot := uint64(0)
 	testProtocolParams := &conway.ConwayProtocolParameters{
@@ -593,18 +584,16 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 			}
 		},
 	)
-	// First stake registration
+	// Stake registration
 	t.Run(
-		"first stake registration",
+		"stake registration",
 		func(t *testing.T) {
 			testTx.Body.TxOutputs[0].OutputAmount.Amount = testOutputExactAmount - testStakeDeposit
 			testTx.Body.TxCertificates = []common.CertificateWrapper{
 				{
 					Type: common.CertificateTypeStakeRegistration,
 					Certificate: &common.StakeRegistrationCertificate{
-						StakeRegistration: common.StakeCredential{
-							Credential: testStakeCred1,
-						},
+						StakeRegistration: common.StakeCredential{},
 					},
 				},
 			}
@@ -622,18 +611,16 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 			}
 		},
 	)
-	// Second stake registration
+	// Stake deregistration
 	t.Run(
-		"second stake registration",
+		"stake deregistration",
 		func(t *testing.T) {
-			testTx.Body.TxOutputs[0].OutputAmount.Amount = testOutputExactAmount
+			testTx.Body.TxOutputs[0].OutputAmount.Amount = testOutputExactAmount + testStakeDeposit
 			testTx.Body.TxCertificates = []common.CertificateWrapper{
 				{
 					Type: common.CertificateTypeStakeRegistration,
-					Certificate: &common.StakeRegistrationCertificate{
-						StakeRegistration: common.StakeCredential{
-							Credential: testStakeCred2,
-						},
+					Certificate: &common.StakeDeregistrationCertificate{
+						StakeDeregistration: common.StakeCredential{},
 					},
 				},
 			}

--- a/ledger/mary/rules_test.go
+++ b/ledger/mary/rules_test.go
@@ -517,8 +517,6 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 	var testInputAmount uint64 = 555666777
 	var testFee uint64 = 123456
 	var testStakeDeposit uint64 = 2_000_000
-	var testStakeCred1 = []byte{0x01, 0x23, 0x45}
-	var testStakeCred2 = []byte{0xab, 0xcd, 0xef}
 	testOutputExactAmount := testInputAmount - testFee
 	testOutputUnderAmount := testOutputExactAmount - 999
 	testOutputOverAmount := testOutputExactAmount + 999
@@ -552,13 +550,6 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 				},
 			},
 		},
-		MockStakeRegistration: []common.StakeRegistrationCertificate{
-			{
-				StakeRegistration: common.StakeCredential{
-					Credential: testStakeCred2,
-				},
-			},
-		},
 	}
 	testSlot := uint64(0)
 	testProtocolParams := &mary.MaryProtocolParameters{
@@ -587,18 +578,16 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 			}
 		},
 	)
-	// First stake registration
+	// Stake registration
 	t.Run(
-		"first stake registration",
+		"stake registration",
 		func(t *testing.T) {
 			testTx.Body.TxOutputs[0].OutputAmount.Amount = testOutputExactAmount - testStakeDeposit
 			testTx.Body.TxCertificates = []common.CertificateWrapper{
 				{
 					Type: common.CertificateTypeStakeRegistration,
 					Certificate: &common.StakeRegistrationCertificate{
-						StakeRegistration: common.StakeCredential{
-							Credential: testStakeCred1,
-						},
+						StakeRegistration: common.StakeCredential{},
 					},
 				},
 			}
@@ -616,18 +605,16 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 			}
 		},
 	)
-	// Second stake registration
+	// Stake deregistration
 	t.Run(
-		"second stake registration",
+		"stake deregistration",
 		func(t *testing.T) {
-			testTx.Body.TxOutputs[0].OutputAmount.Amount = testOutputExactAmount
+			testTx.Body.TxOutputs[0].OutputAmount.Amount = testOutputExactAmount + testStakeDeposit
 			testTx.Body.TxCertificates = []common.CertificateWrapper{
 				{
 					Type: common.CertificateTypeStakeRegistration,
-					Certificate: &common.StakeRegistrationCertificate{
-						StakeRegistration: common.StakeCredential{
-							Credential: testStakeCred2,
-						},
+					Certificate: &common.StakeDeregistrationCertificate{
+						StakeDeregistration: common.StakeCredential{},
 					},
 				},
 			}

--- a/ledger/shelley/rules.go
+++ b/ledger/shelley/rules.go
@@ -167,7 +167,7 @@ func UtxoValidateValueNotConservedUtxo(
 		return errors.New("pparams are not expected type")
 	}
 	// Calculate consumed value
-	// consumed = value from input(s) + withdrawals + refunds(?)
+	// consumed = value from input(s) + withdrawals + refunds
 	var consumedValue uint64
 	for _, tmpInput := range tx.Inputs() {
 		tmpUtxo, err := ls.UtxoById(tmpInput)
@@ -179,6 +179,12 @@ func UtxoValidateValueNotConservedUtxo(
 	}
 	for _, tmpWithdrawalAmount := range tx.Withdrawals() {
 		consumedValue += tmpWithdrawalAmount
+	}
+	for _, cert := range tx.Certificates() {
+		switch cert.(type) {
+		case *common.StakeDeregistrationCertificate:
+			consumedValue += uint64(tmpPparams.KeyDeposit)
+		}
 	}
 	// Calculate produced value
 	// produced = value from output(s) + fee + deposits
@@ -198,13 +204,7 @@ func UtxoValidateValueNotConservedUtxo(
 				producedValue += uint64(tmpPparams.PoolDeposit)
 			}
 		case *common.StakeRegistrationCertificate:
-			certs, err := ls.StakeRegistration(tmpCert.StakeRegistration.Credential)
-			if err != nil {
-				return err
-			}
-			if len(certs) == 0 {
-				producedValue += uint64(tmpPparams.KeyDeposit)
-			}
+			producedValue += uint64(tmpPparams.KeyDeposit)
 		}
 	}
 	if consumedValue == producedValue {

--- a/ledger/shelley/rules_test.go
+++ b/ledger/shelley/rules_test.go
@@ -494,8 +494,6 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 	var testInputAmount uint64 = 555666777
 	var testFee uint64 = 123456
 	var testStakeDeposit uint64 = 2_000_000
-	var testStakeCred1 = []byte{0x01, 0x23, 0x45}
-	var testStakeCred2 = []byte{0xab, 0xcd, 0xef}
 	testOutputExactAmount := testInputAmount - testFee
 	testOutputUnderAmount := testOutputExactAmount - 999
 	testOutputOverAmount := testOutputExactAmount + 999
@@ -519,13 +517,6 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 				Id: shelley.NewShelleyTransactionInput(testInputTxId, 0),
 				Output: shelley.ShelleyTransactionOutput{
 					OutputAmount: testInputAmount,
-				},
-			},
-		},
-		MockStakeRegistration: []common.StakeRegistrationCertificate{
-			{
-				StakeRegistration: common.StakeCredential{
-					Credential: testStakeCred2,
 				},
 			},
 		},
@@ -553,18 +544,16 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 			}
 		},
 	)
-	// First stake registration
+	// Stake registration
 	t.Run(
-		"first stake registration",
+		"stake registration",
 		func(t *testing.T) {
 			testTx.Body.TxOutputs[0].OutputAmount = testOutputExactAmount - testStakeDeposit
 			testTx.Body.TxCertificates = []common.CertificateWrapper{
 				{
 					Type: common.CertificateTypeStakeRegistration,
 					Certificate: &common.StakeRegistrationCertificate{
-						StakeRegistration: common.StakeCredential{
-							Credential: testStakeCred1,
-						},
+						StakeRegistration: common.StakeCredential{},
 					},
 				},
 			}
@@ -582,18 +571,16 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 			}
 		},
 	)
-	// Second stake registration
+	// Stake deregistration
 	t.Run(
-		"second stake registration",
+		"stake deregistration",
 		func(t *testing.T) {
-			testTx.Body.TxOutputs[0].OutputAmount = testOutputExactAmount
+			testTx.Body.TxOutputs[0].OutputAmount = testOutputExactAmount + testStakeDeposit
 			testTx.Body.TxCertificates = []common.CertificateWrapper{
 				{
 					Type: common.CertificateTypeStakeRegistration,
-					Certificate: &common.StakeRegistrationCertificate{
-						StakeRegistration: common.StakeCredential{
-							Credential: testStakeCred2,
-						},
+					Certificate: &common.StakeDeregistrationCertificate{
+						StakeDeregistration: common.StakeCredential{},
 					},
 				},
 			}


### PR DESCRIPTION
Also, because you cannot re-register a registered stake key or de-register and unregistered stake key, we can always apply the key deposit/refund for one of those certs and do not need to query