### PR TITLE
fix(protocol/localstatequery): Added unit test function to validate GenesisConfigResult 

### DIFF
--- a/protocol/localstatequery/client_test.go
+++ b/protocol/localstatequery/client_test.go
@@ -304,7 +304,7 @@ func TestGenesisConfigJSON(t *testing.T) {
 		SlotLength:        1,
 		UpdateQuorum:      5,
 		MaxLovelaceSupply: 45000000000000000,
-		ProtocolParams: localstatequery.ProtocolParams{
+		ProtocolParams: localstatequery.GenesisConfigResultProtocolParameters{
 			MinFeeA:               44,
 			MinFeeB:               155381,
 			MaxBlockBodySize:      65536,

--- a/protocol/localstatequery/queries.go
+++ b/protocol/localstatequery/queries.go
@@ -585,14 +585,14 @@ type GenesisConfigResult struct {
 	SlotLength        int
 	UpdateQuorum      int
 	MaxLovelaceSupply int64
-	ProtocolParams    ProtocolParams
+	ProtocolParams    GenesisConfigResultProtocolParameters
 	// This value contains maps with bytestring keys, which we can't parse yet
 	GenDelegs cbor.RawMessage
 	Unknown1  interface{}
 	Unknown2  interface{}
 }
 
-type ProtocolParams struct {
+type GenesisConfigResultProtocolParameters struct {
 	_                     struct{} `cbor:",toarray"`
 	MinFeeA               int
 	MinFeeB               int


### PR DESCRIPTION
1. Added a unit test function to validate GenesisConfigResult in protocol/localstatequery.
2. Added marshal/unmarshal this GenesisConfigResult to/from JSON to ensure it's fixed.

Closes #584 