### PR TITLE
fix(ledger): use a named type for credential hash

### DIFF
--- a/internal/test/ledger/ledger.go
+++ b/internal/test/ledger/ledger.go
@@ -51,7 +51,11 @@ func (ls MockLedgerState) StakeRegistration(
 ) ([]common.StakeRegistrationCertificate, error) {
 	ret := []common.StakeRegistrationCertificate{}
 	for _, cert := range ls.MockStakeRegistration {
-		if string(cert.StakeRegistration.Credential) == string(stakingKey) {
+		if string(
+			common.Blake2b224(cert.StakeRegistration.Credential).Bytes(),
+		) == string(
+			stakingKey,
+		) {
 			ret = append(ret, cert)
 		}
 	}

--- a/ledger/common/credentials.go
+++ b/ledger/common/credentials.go
@@ -27,11 +27,13 @@ const (
 	CredentialTypeScriptHash  = 1
 )
 
+type CredentialHash Blake2b224
+
 type Credential struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
 	CredType   uint
-	Credential []byte
+	Credential CredentialHash
 }
 
 func (c *Credential) UnmarshalCBOR(data []byte) error {


### PR DESCRIPTION
This makes it more like other hashes where we have defined which hash type it should be underneath.