### PR TITLE
fix: use stored CBOR in TX validation rules

### DIFF
--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -456,6 +456,13 @@ func MinFeeTx(
 		return 0, errors.New("pparams are not expected type")
 	}
 	txBytes := tx.Cbor()
+	if len(txBytes) == 0 {
+		var err error
+		txBytes, err = cbor.Encode(tx)
+		if err != nil {
+			return 0, err
+		}
+	}
 	minFee := uint64(
 		(tmpPparams.MinFeeA * uint(len(txBytes))) + tmpPparams.MinFeeB,
 	)

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -457,6 +457,13 @@ func MinFeeTx(
 		return 0, errors.New("pparams are not expected type")
 	}
 	txBytes := tx.Cbor()
+	if len(txBytes) == 0 {
+		var err error
+		txBytes, err = cbor.Encode(tx)
+		if err != nil {
+			return 0, err
+		}
+	}
 	minFee := uint64(
 		(tmpPparams.MinFeeA * uint(len(txBytes))) + tmpPparams.MinFeeB,
 	)

--- a/ledger/shelley/rules.go
+++ b/ledger/shelley/rules.go
@@ -283,9 +283,13 @@ func UtxoValidateMaxTxSizeUtxo(
 	if !ok {
 		return errors.New("pparams are not expected type")
 	}
-	txBytes, err := cbor.Encode(tx)
-	if err != nil {
-		return err
+	txBytes := tx.Cbor()
+	if len(txBytes) == 0 {
+		var err error
+		txBytes, err = cbor.Encode(tx)
+		if err != nil {
+			return err
+		}
 	}
 	if uint(len(txBytes)) <= tmpPparams.MaxTxSize {
 		return nil
@@ -306,6 +310,13 @@ func MinFeeTx(
 		return 0, errors.New("pparams are not expected type")
 	}
 	txBytes := tx.Cbor()
+	if len(txBytes) == 0 {
+		var err error
+		txBytes, err = cbor.Encode(tx)
+		if err != nil {
+			return 0, err
+		}
+	}
 	minFee := uint64(
 		(tmpPparams.MinFeeA * uint(len(txBytes))) + tmpPparams.MinFeeB,
 	)


### PR DESCRIPTION
We fall back to encoding to CBOR ourselves if there is no stored CBOR