### PR TITLE
refactor: make CredentialHash/AddrKeyHash aliases of Blake2b224

### DIFF
--- a/ledger/common/address.go
+++ b/ledger/common/address.go
@@ -51,7 +51,7 @@ const (
 	ByronAddressTypeRedeem = 2
 )
 
-type AddrKeyHash Blake2b224
+type AddrKeyHash = Blake2b224
 
 type Address struct {
 	addressType      uint8

--- a/ledger/common/credentials.go
+++ b/ledger/common/credentials.go
@@ -27,7 +27,7 @@ const (
 	CredentialTypeScriptHash  = 1
 )
 
-type CredentialHash Blake2b224
+type CredentialHash = Blake2b224
 
 type Credential struct {
 	cbor.StructAsArray


### PR DESCRIPTION
This makes the types interchangeable with Blake2b224 for convenience. It also allows using the Bytes() function when using the more specific types