### PR TITLE
fix: use correct TX size calc for min-fee in Alonzo and later

### DIFF
--- a/ledger/allegra/allegra.go
+++ b/ledger/allegra/allegra.go
@@ -318,7 +318,10 @@ func (t *AllegraTransaction) Cbor() []byte {
 		tmpObj = append(tmpObj, nil)
 	}
 	// This should never fail, since we're only encoding a list and a bool value
-	cborData, _ = cbor.Encode(&tmpObj)
+	cborData, err := cbor.Encode(&tmpObj)
+	if err != nil {
+		panic("CBOR encoding that should never fail has failed: " + err.Error())
+	}
 	return cborData
 }
 

--- a/ledger/alonzo/rules_test.go
+++ b/ledger/alonzo/rules_test.go
@@ -208,7 +208,8 @@ func TestUtxoValidateFeeTooSmallUtxo(t *testing.T) {
 	var testExactFee uint64 = 74
 	var testBelowFee uint64 = 73
 	var testAboveFee uint64 = 75
-	testTxCbor, _ := hex.DecodeString("abcdef")
+	// NOTE: this is length 4, but 3 will be used in the calculations
+	testTxCbor, _ := hex.DecodeString("abcdef01")
 	testTx := &alonzo.AlonzoTransaction{
 		Body: alonzo.AlonzoTransactionBody{
 			MaryTransactionBody: mary.MaryTransactionBody{

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -111,7 +111,7 @@ func (b *BabbageBlock) Transactions() []common.Transaction {
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],
 			TxMetadata: b.TransactionMetadataSet[uint(idx)],
-			IsTxValid:  !invalidTxMap[uint(idx)],
+			TxIsValid:  !invalidTxMap[uint(idx)],
 		}
 	}
 	return ret
@@ -511,7 +511,7 @@ type BabbageTransaction struct {
 	cbor.DecodeStoreCbor
 	Body       BabbageTransactionBody
 	WitnessSet BabbageTransactionWitnessSet
-	IsTxValid  bool
+	TxIsValid  bool
 	TxMetadata *cbor.LazyValue
 }
 
@@ -612,7 +612,7 @@ func (t BabbageTransaction) Metadata() *cbor.LazyValue {
 }
 
 func (t BabbageTransaction) IsValid() bool {
-	return t.IsTxValid
+	return t.TxIsValid
 }
 
 func (t BabbageTransaction) Consumed() []common.TransactionInput {
@@ -668,7 +668,7 @@ func (t *BabbageTransaction) Cbor() []byte {
 	tmpObj := []any{
 		cbor.RawMessage(t.Body.Cbor()),
 		cbor.RawMessage(t.WitnessSet.Cbor()),
-		t.IsValid,
+		t.TxIsValid,
 	}
 	if t.TxMetadata != nil {
 		tmpObj = append(tmpObj, cbor.RawMessage(t.TxMetadata.Cbor()))
@@ -676,7 +676,10 @@ func (t *BabbageTransaction) Cbor() []byte {
 		tmpObj = append(tmpObj, nil)
 	}
 	// This should never fail, since we're only encoding a list and a bool value
-	cborData, _ = cbor.Encode(&tmpObj)
+	cborData, err := cbor.Encode(&tmpObj)
+	if err != nil {
+		panic("CBOR encoding that should never fail has failed: " + err.Error())
+	}
 	return cborData
 }
 

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -463,8 +463,14 @@ func MinFeeTx(
 			return 0, err
 		}
 	}
+	// We calculate fee based on the pre-Alonzo TX format, which does not include the 'valid' field
+	// Instead of having a separate helper to build the CBOR in the custom format, we subtract 1 since
+	// a boolean is always represented by a single byte in CBOR
+	txSize := max(0, len(txBytes)-1)
 	minFee := uint64(
-		(tmpPparams.MinFeeA * uint(len(txBytes))) + tmpPparams.MinFeeB,
+		// The TX size can never be negative, so casting to uint is safe
+		//nolint:gosec
+		(tmpPparams.MinFeeA * uint(txSize)) + tmpPparams.MinFeeB,
 	)
 	return minFee, nil
 }

--- a/ledger/babbage/rules_test.go
+++ b/ledger/babbage/rules_test.go
@@ -213,7 +213,8 @@ func TestUtxoValidateFeeTooSmallUtxo(t *testing.T) {
 	var testExactFee uint64 = 74
 	var testBelowFee uint64 = 73
 	var testAboveFee uint64 = 75
-	testTxCbor, _ := hex.DecodeString("abcdef")
+	// NOTE: this is length 4, but 3 will be used in the calculations
+	testTxCbor, _ := hex.DecodeString("abcdef01")
 	testTx := &babbage.BabbageTransaction{
 		Body: babbage.BabbageTransactionBody{
 			AlonzoTransactionBody: alonzo.AlonzoTransactionBody{

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -109,7 +109,7 @@ func (b *ConwayBlock) Transactions() []common.Transaction {
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],
 			TxMetadata: b.TransactionMetadataSet[uint(idx)],
-			IsTxValid:  !invalidTxMap[uint(idx)],
+			TxIsValid:  !invalidTxMap[uint(idx)],
 		}
 	}
 	return ret
@@ -313,7 +313,7 @@ type ConwayTransaction struct {
 	cbor.DecodeStoreCbor
 	Body       ConwayTransactionBody
 	WitnessSet ConwayTransactionWitnessSet
-	IsTxValid  bool
+	TxIsValid  bool
 	TxMetadata *cbor.LazyValue
 }
 
@@ -414,7 +414,7 @@ func (t ConwayTransaction) Metadata() *cbor.LazyValue {
 }
 
 func (t ConwayTransaction) IsValid() bool {
-	return t.IsTxValid
+	return t.TxIsValid
 }
 
 func (t ConwayTransaction) Consumed() []common.TransactionInput {
@@ -470,7 +470,7 @@ func (t *ConwayTransaction) Cbor() []byte {
 	tmpObj := []any{
 		cbor.RawMessage(t.Body.Cbor()),
 		cbor.RawMessage(t.WitnessSet.Cbor()),
-		t.IsValid,
+		t.TxIsValid,
 	}
 	if t.TxMetadata != nil {
 		tmpObj = append(tmpObj, cbor.RawMessage(t.TxMetadata.Cbor()))
@@ -478,7 +478,10 @@ func (t *ConwayTransaction) Cbor() []byte {
 		tmpObj = append(tmpObj, nil)
 	}
 	// This should never fail, since we're only encoding a list and a bool value
-	cborData, _ = cbor.Encode(&tmpObj)
+	cborData, err := cbor.Encode(&tmpObj)
+	if err != nil {
+		panic("CBOR encoding that should never fail has failed: " + err.Error())
+	}
 	return cborData
 }
 

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -464,8 +464,14 @@ func MinFeeTx(
 			return 0, err
 		}
 	}
+	// We calculate fee based on the pre-Alonzo TX format, which does not include the 'valid' field
+	// Instead of having a separate helper to build the CBOR in the custom format, we subtract 1 since
+	// a boolean is always represented by a single byte in CBOR
+	txSize := max(0, len(txBytes)-1)
 	minFee := uint64(
-		(tmpPparams.MinFeeA * uint(len(txBytes))) + tmpPparams.MinFeeB,
+		// The TX size can never be negative, so casting to uint is safe
+		//nolint:gosec
+		(tmpPparams.MinFeeA * uint(txSize)) + tmpPparams.MinFeeB,
 	)
 	return minFee, nil
 }

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -208,7 +208,8 @@ func TestUtxoValidateFeeTooSmallUtxo(t *testing.T) {
 	var testExactFee uint64 = 74
 	var testBelowFee uint64 = 73
 	var testAboveFee uint64 = 75
-	testTxCbor, _ := hex.DecodeString("abcdef")
+	// NOTE: this is length 4, but 3 will be used in the calculations
+	testTxCbor, _ := hex.DecodeString("abcdef01")
 	testTx := &conway.ConwayTransaction{
 		Body: conway.ConwayTransactionBody{
 			BabbageTransactionBody: babbage.BabbageTransactionBody{

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -325,7 +325,10 @@ func (t *MaryTransaction) Cbor() []byte {
 		tmpObj = append(tmpObj, nil)
 	}
 	// This should never fail, since we're only encoding a list and a bool value
-	cborData, _ = cbor.Encode(&tmpObj)
+	cborData, err := cbor.Encode(&tmpObj)
+	if err != nil {
+		panic("CBOR encoding that should never fail has failed: " + err.Error())
+	}
 	return cborData
 }
 

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -679,7 +679,10 @@ func (t *ShelleyTransaction) Cbor() []byte {
 		tmpObj = append(tmpObj, nil)
 	}
 	// This should never fail, since we're only encoding a list and a bool value
-	cborData, _ = cbor.Encode(&tmpObj)
+	cborData, err := cbor.Encode(&tmpObj)
+	if err != nil {
+		panic("CBOR encoding that should never fail has failed: " + err.Error())
+	}
 	return cborData
 }
 


### PR DESCRIPTION
* subtract 1 byte from TX size in Alonzo+ when calculating fee
* add error handling around CBOR encode that should "never fail"
* rename 'IsTxValid' to 'TxIsValid' for consistency
* change nil check to length check