### PR TITLE
feat(ledger): Add a method to get the Certificate type to the interface

### DIFF
--- a/ledger/common/certs.go
+++ b/ledger/common/certs.go
@@ -117,6 +117,7 @@ type Certificate interface {
 	isCertificate()
 	Cbor() []byte
 	Utxorpc() *utxorpc.Certificate
+	Type() uint
 }
 
 const (
@@ -177,6 +178,10 @@ func (c *StakeRegistrationCertificate) Utxorpc() *utxorpc.Certificate {
 	}
 }
 
+func (c *StakeRegistrationCertificate) Type() uint {
+	return c.CertType
+}
+
 type StakeDeregistrationCertificate struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
@@ -196,6 +201,10 @@ func (c *StakeDeregistrationCertificate) Utxorpc() *utxorpc.Certificate {
 			StakeDeregistration: c.StakeDeregistration.Utxorpc(),
 		},
 	}
+}
+
+func (c *StakeDeregistrationCertificate) Type() uint {
+	return c.CertType
 }
 
 type StakeDelegationCertificate struct {
@@ -221,6 +230,10 @@ func (c *StakeDelegationCertificate) Utxorpc() *utxorpc.Certificate {
 			},
 		},
 	}
+}
+
+func (c *StakeDelegationCertificate) Type() uint {
+	return c.CertType
 }
 
 type (
@@ -373,6 +386,10 @@ func (c *PoolRegistrationCertificate) Utxorpc() *utxorpc.Certificate {
 	}
 }
 
+func (c *PoolRegistrationCertificate) Type() uint {
+	return c.CertType
+}
+
 type PoolRetirementCertificate struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
@@ -396,6 +413,10 @@ func (c *PoolRetirementCertificate) Utxorpc() *utxorpc.Certificate {
 			},
 		},
 	}
+}
+
+func (c *PoolRetirementCertificate) Type() uint {
+	return c.CertType
 }
 
 type GenesisKeyDelegationCertificate struct {
@@ -423,6 +444,10 @@ func (c *GenesisKeyDelegationCertificate) Utxorpc() *utxorpc.Certificate {
 			},
 		},
 	}
+}
+
+func (c *GenesisKeyDelegationCertificate) Type() uint {
+	return c.CertType
 }
 
 type MirSource int32
@@ -508,6 +533,10 @@ func (c *MoveInstantaneousRewardsCertificate) Utxorpc() *utxorpc.Certificate {
 	}
 }
 
+func (c *MoveInstantaneousRewardsCertificate) Type() uint {
+	return c.CertType
+}
+
 type RegistrationCertificate struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
@@ -527,6 +556,10 @@ func (c *RegistrationCertificate) UnmarshalCBOR(
 func (c *RegistrationCertificate) Utxorpc() *utxorpc.Certificate {
 	// TODO (#850)
 	return nil
+}
+
+func (c *RegistrationCertificate) Type() uint {
+	return c.CertType
 }
 
 type DeregistrationCertificate struct {
@@ -550,6 +583,10 @@ func (c *DeregistrationCertificate) Utxorpc() *utxorpc.Certificate {
 	return nil
 }
 
+func (c *DeregistrationCertificate) Type() uint {
+	return c.CertType
+}
+
 type VoteDelegationCertificate struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
@@ -569,6 +606,10 @@ func (c *VoteDelegationCertificate) UnmarshalCBOR(
 func (c *VoteDelegationCertificate) Utxorpc() *utxorpc.Certificate {
 	// TODO (#850)
 	return nil
+}
+
+func (c *VoteDelegationCertificate) Type() uint {
+	return c.CertType
 }
 
 type StakeVoteDelegationCertificate struct {
@@ -593,6 +634,10 @@ func (c *StakeVoteDelegationCertificate) Utxorpc() *utxorpc.Certificate {
 	return nil
 }
 
+func (c *StakeVoteDelegationCertificate) Type() uint {
+	return c.CertType
+}
+
 type StakeRegistrationDelegationCertificate struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
@@ -615,6 +660,10 @@ func (c *StakeRegistrationDelegationCertificate) Utxorpc() *utxorpc.Certificate 
 	return nil
 }
 
+func (c *StakeRegistrationDelegationCertificate) Type() uint {
+	return c.CertType
+}
+
 type VoteRegistrationDelegationCertificate struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
@@ -635,6 +684,10 @@ func (c *VoteRegistrationDelegationCertificate) UnmarshalCBOR(
 func (c *VoteRegistrationDelegationCertificate) Utxorpc() *utxorpc.Certificate {
 	// TODO (#850)
 	return nil
+}
+
+func (c *VoteRegistrationDelegationCertificate) Type() uint {
+	return c.CertType
 }
 
 type StakeVoteRegistrationDelegationCertificate struct {
@@ -660,6 +713,10 @@ func (c *StakeVoteRegistrationDelegationCertificate) Utxorpc() *utxorpc.Certific
 	return nil
 }
 
+func (c *StakeVoteRegistrationDelegationCertificate) Type() uint {
+	return c.CertType
+}
+
 type AuthCommitteeHotCertificate struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
@@ -681,6 +738,10 @@ func (c *AuthCommitteeHotCertificate) Utxorpc() *utxorpc.Certificate {
 	return nil
 }
 
+func (c *AuthCommitteeHotCertificate) Type() uint {
+	return c.CertType
+}
+
 type ResignCommitteeColdCertificate struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
@@ -700,6 +761,10 @@ func (c *ResignCommitteeColdCertificate) UnmarshalCBOR(
 func (c *ResignCommitteeColdCertificate) Utxorpc() *utxorpc.Certificate {
 	// TODO (#850)
 	return nil
+}
+
+func (c *ResignCommitteeColdCertificate) Type() uint {
+	return c.CertType
 }
 
 type RegistrationDrepCertificate struct {
@@ -724,6 +789,10 @@ func (c *RegistrationDrepCertificate) Utxorpc() *utxorpc.Certificate {
 	return nil
 }
 
+func (c *RegistrationDrepCertificate) Type() uint {
+	return c.CertType
+}
+
 type DeregistrationDrepCertificate struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
@@ -745,6 +814,10 @@ func (c *DeregistrationDrepCertificate) Utxorpc() *utxorpc.Certificate {
 	return nil
 }
 
+func (c *DeregistrationDrepCertificate) Type() uint {
+	return c.CertType
+}
+
 type UpdateDrepCertificate struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
@@ -764,4 +837,8 @@ func (c *UpdateDrepCertificate) UnmarshalCBOR(
 func (c *UpdateDrepCertificate) Utxorpc() *utxorpc.Certificate {
 	// TODO (#850)
 	return nil
+}
+
+func (c *UpdateDrepCertificate) Type() uint {
+	return c.CertType
 }

--- a/ledger/common/common_test.go
+++ b/ledger/common/common_test.go
@@ -243,3 +243,51 @@ func TestBlake2b224_String(t *testing.T) {
 		t.Errorf("expected %s but got %s", expected, hash.String())
 	}
 }
+
+func TestCertificateTypeMethods(t *testing.T) {
+	tests := []struct {
+		name     string
+		cert     Certificate
+		expected uint
+	}{
+		{"StakeRegistration", &StakeRegistrationCertificate{CertType: CertificateTypeStakeRegistration}, CertificateTypeStakeRegistration},
+		{"StakeDeregistration", &StakeDeregistrationCertificate{CertType: CertificateTypeStakeDeregistration}, CertificateTypeStakeDeregistration},
+		{"StakeDelegation", &StakeDelegationCertificate{CertType: CertificateTypeStakeDelegation}, CertificateTypeStakeDelegation},
+		{"PoolRegistration", &PoolRegistrationCertificate{CertType: CertificateTypePoolRegistration}, CertificateTypePoolRegistration},
+		{"PoolRetirement", &PoolRetirementCertificate{CertType: CertificateTypePoolRetirement}, CertificateTypePoolRetirement},
+		{"GenesisKeyDelegation", &GenesisKeyDelegationCertificate{CertType: CertificateTypeGenesisKeyDelegation}, CertificateTypeGenesisKeyDelegation},
+		{"MoveInstantaneousRewards", &MoveInstantaneousRewardsCertificate{CertType: CertificateTypeMoveInstantaneousRewards}, CertificateTypeMoveInstantaneousRewards},
+		{"Registration", &RegistrationCertificate{CertType: CertificateTypeRegistration}, CertificateTypeRegistration},
+		{"Deregistration", &DeregistrationCertificate{CertType: CertificateTypeDeregistration}, CertificateTypeDeregistration},
+		{"VoteDelegation", &VoteDelegationCertificate{CertType: CertificateTypeVoteDelegation}, CertificateTypeVoteDelegation},
+		{"StakeVoteDelegation", &StakeVoteDelegationCertificate{CertType: CertificateTypeStakeVoteDelegation}, CertificateTypeStakeVoteDelegation},
+		{"StakeRegistrationDelegation", &StakeRegistrationDelegationCertificate{CertType: CertificateTypeStakeRegistrationDelegation}, CertificateTypeStakeRegistrationDelegation},
+		{"VoteRegistrationDelegation", &VoteRegistrationDelegationCertificate{CertType: CertificateTypeVoteRegistrationDelegation}, CertificateTypeVoteRegistrationDelegation},
+		{"StakeVoteRegistrationDelegation", &StakeVoteRegistrationDelegationCertificate{CertType: CertificateTypeStakeVoteRegistrationDelegation}, CertificateTypeStakeVoteRegistrationDelegation},
+		{"AuthCommitteeHot", &AuthCommitteeHotCertificate{CertType: CertificateTypeAuthCommitteeHot}, CertificateTypeAuthCommitteeHot},
+		{"ResignCommitteeCold", &ResignCommitteeColdCertificate{CertType: CertificateTypeResignCommitteeCold}, CertificateTypeResignCommitteeCold},
+		{"RegistrationDrep", &RegistrationDrepCertificate{CertType: CertificateTypeRegistrationDrep}, CertificateTypeRegistrationDrep},
+		{"DeregistrationDrep", &DeregistrationDrepCertificate{CertType: CertificateTypeDeregistrationDrep}, CertificateTypeDeregistrationDrep},
+		{"UpdateDrep", &UpdateDrepCertificate{CertType: CertificateTypeUpdateDrep}, CertificateTypeUpdateDrep},
+	}
+
+	allPassed := true
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cert.Type()
+			if got != tt.expected {
+				allPassed = false
+				t.Errorf("FAIL: %s -> Type() = %d, expected = %d", tt.name, got, tt.expected)
+			} else {
+				t.Logf("PASS: %s -> Type() = %d, expected = %d \n", tt.name, got, tt.expected)
+			}
+		})
+	}
+
+	if allPassed {
+		t.Logf("\n ALL CERTIFICATE TYPE TESTS PASSED SUCCESSFULLY")
+	} else {
+		t.Logf("\n SOME CERTIFICATE TYPE TESTS FAILED ")
+	}
+}

--- a/ledger/common/common_test.go
+++ b/ledger/common/common_test.go
@@ -271,23 +271,14 @@ func TestCertificateTypeMethods(t *testing.T) {
 		{"UpdateDrep", &UpdateDrepCertificate{CertType: CertificateTypeUpdateDrep}, CertificateTypeUpdateDrep},
 	}
 
-	allPassed := true
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.cert.Type()
 			if got != tt.expected {
-				allPassed = false
 				t.Errorf("FAIL: %s -> Type() = %d, expected = %d", tt.name, got, tt.expected)
 			} else {
 				t.Logf("PASS: %s -> Type() = %d, expected = %d \n", tt.name, got, tt.expected)
 			}
 		})
-	}
-
-	if allPassed {
-		t.Logf("\n ALL CERTIFICATE TYPE TESTS PASSED SUCCESSFULLY")
-	} else {
-		t.Logf("\n SOME CERTIFICATE TYPE TESTS FAILED ")
 	}
 }


### PR DESCRIPTION
1. Added a new Type() uint method to the Certificate interface.
2. Added this method for all 19 certificate types using the existing CertType field. 
3. Added a test function to validate the method Type() returns the expected values.

Closes #636 