### PR TITLE
refactor: return Blake2b256 for block and TX hash

### DIFF
--- a/cmd/gouroboros/chainsync.go
+++ b/cmd/gouroboros/chainsync.go
@@ -264,7 +264,7 @@ func chainSyncRollForwardHandler(
 		block = v
 	case ledger.BlockHeader:
 		blockSlot := v.SlotNumber()
-		blockHash, _ := hex.DecodeString(v.Hash())
+		blockHash := v.Hash().Bytes()
 		var err error
 		if oConn == nil {
 			return errors.New("empty ouroboros connection, aborting!")

--- a/ledger/allegra/allegra.go
+++ b/ledger/allegra/allegra.go
@@ -15,7 +15,6 @@
 package allegra
 
 import (
-	"encoding/hex"
 	"fmt"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -61,7 +60,7 @@ func (AllegraBlock) Type() int {
 	return BlockTypeAllegra
 }
 
-func (b *AllegraBlock) Hash() string {
+func (b *AllegraBlock) Hash() common.Blake2b256 {
 	return b.BlockHeader.Hash()
 }
 
@@ -69,7 +68,7 @@ func (b *AllegraBlock) Header() common.BlockHeader {
 	return b.BlockHeader
 }
 
-func (b *AllegraBlock) PrevHash() string {
+func (b *AllegraBlock) PrevHash() common.Blake2b256 {
 	return b.BlockHeader.PrevHash()
 }
 
@@ -108,7 +107,6 @@ func (b *AllegraBlock) Transactions() []common.Transaction {
 
 func (b *AllegraBlock) Utxorpc() *utxorpc.Block {
 	txs := []*utxorpc.Tx{}
-	tmpHash, _ := hex.DecodeString(b.Hash())
 	for _, t := range b.Transactions() {
 		tx := t.Utxorpc()
 		txs = append(txs, tx)
@@ -117,7 +115,7 @@ func (b *AllegraBlock) Utxorpc() *utxorpc.Block {
 		Tx: txs,
 	}
 	header := &utxorpc.BlockHeader{
-		Hash:   tmpHash,
+		Hash:   b.Hash().Bytes(),
 		Height: b.BlockNumber(),
 		Slot:   b.SlotNumber(),
 	}
@@ -178,7 +176,7 @@ func (AllegraTransaction) Type() int {
 	return TxTypeAllegra
 }
 
-func (t AllegraTransaction) Hash() string {
+func (t AllegraTransaction) Hash() common.Blake2b256 {
 	return t.Body.Hash()
 }
 
@@ -280,7 +278,7 @@ func (t AllegraTransaction) Produced() []common.Utxo {
 		ret = append(
 			ret,
 			common.Utxo{
-				Id:     shelley.NewShelleyTransactionInput(t.Hash(), idx),
+				Id:     shelley.NewShelleyTransactionInput(t.Hash().String(), idx),
 				Output: output,
 			},
 		)

--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -15,7 +15,6 @@
 package alonzo
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -64,7 +63,7 @@ func (AlonzoBlock) Type() int {
 	return BlockTypeAlonzo
 }
 
-func (b *AlonzoBlock) Hash() string {
+func (b *AlonzoBlock) Hash() common.Blake2b256 {
 	return b.BlockHeader.Hash()
 }
 
@@ -72,7 +71,7 @@ func (b *AlonzoBlock) Header() common.BlockHeader {
 	return b.BlockHeader
 }
 
-func (b *AlonzoBlock) PrevHash() string {
+func (b *AlonzoBlock) PrevHash() common.Blake2b256 {
 	return b.BlockHeader.PrevHash()
 }
 
@@ -117,7 +116,6 @@ func (b *AlonzoBlock) Transactions() []common.Transaction {
 
 func (b *AlonzoBlock) Utxorpc() *utxorpc.Block {
 	txs := []*utxorpc.Tx{}
-	tmpHash, _ := hex.DecodeString(b.Hash())
 	for _, t := range b.Transactions() {
 		tx := t.Utxorpc()
 		txs = append(txs, tx)
@@ -126,7 +124,7 @@ func (b *AlonzoBlock) Utxorpc() *utxorpc.Block {
 		Tx: txs,
 	}
 	header := &utxorpc.BlockHeader{
-		Hash:   tmpHash,
+		Hash:   b.Hash().Bytes(),
 		Height: b.BlockNumber(),
 		Slot:   b.SlotNumber(),
 	}
@@ -370,7 +368,7 @@ func (AlonzoTransaction) Type() int {
 	return TxTypeAlonzo
 }
 
-func (t AlonzoTransaction) Hash() string {
+func (t AlonzoTransaction) Hash() common.Blake2b256 {
 	return t.Body.Hash()
 }
 
@@ -477,7 +475,7 @@ func (t AlonzoTransaction) Produced() []common.Utxo {
 			ret = append(
 				ret,
 				common.Utxo{
-					Id:     shelley.NewShelleyTransactionInput(t.Hash(), idx),
+					Id:     shelley.NewShelleyTransactionInput(t.Hash().String(), idx),
 					Output: output,
 				},
 			)

--- a/ledger/babbage/babbage_test.go
+++ b/ledger/babbage/babbage_test.go
@@ -15,7 +15,6 @@
 package babbage
 
 import (
-	"encoding/hex"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
@@ -2747,8 +2746,7 @@ func TestBabbageBlock_Utxorpc(t *testing.T) {
 	assert.Equal(t, len(babbageBlock.TransactionBodies), len(utxoBlock.Body.Tx))
 
 	// Validate the header details
-	tmpHash, _ := hex.DecodeString(babbageBlock.Hash())
-	assert.Equal(t, tmpHash, utxoBlock.Header.Hash)
+	assert.Equal(t, babbageBlock.Hash().Bytes(), utxoBlock.Header.Hash)
 	assert.Equal(t, babbageBlock.BlockNumber(), utxoBlock.Header.Height)
 	assert.Equal(t, babbageBlock.SlotNumber(), utxoBlock.Header.Slot)
 

--- a/ledger/byron/byron.go
+++ b/ledger/byron/byron.go
@@ -51,7 +51,7 @@ func init() {
 type ByronMainBlockHeader struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
-	hash          string
+	hash          *common.Blake2b256
 	ProtocolMagic uint32
 	PrevBlock     common.Blake2b256
 	BodyProof     interface{}
@@ -84,8 +84,8 @@ func (h *ByronMainBlockHeader) UnmarshalCBOR(cborData []byte) error {
 	return h.UnmarshalCbor(cborData, h)
 }
 
-func (h *ByronMainBlockHeader) Hash() string {
-	if h.hash == "" {
+func (h *ByronMainBlockHeader) Hash() common.Blake2b256 {
+	if h.hash == nil {
 		// Prepend bytes for CBOR list wrapper
 		// The block hash is calculated with these extra bytes, so we have to add them to
 		// get the correct value
@@ -95,13 +95,13 @@ func (h *ByronMainBlockHeader) Hash() string {
 				h.Cbor()...,
 			),
 		)
-		h.hash = hex.EncodeToString(tmpHash.Bytes())
+		h.hash = &tmpHash
 	}
-	return h.hash
+	return *h.hash
 }
 
-func (h *ByronMainBlockHeader) PrevHash() string {
-	return h.PrevBlock.String()
+func (h *ByronMainBlockHeader) PrevHash() common.Blake2b256 {
+	return h.PrevBlock
 }
 
 func (h *ByronMainBlockHeader) BlockNumber() uint64 {
@@ -131,7 +131,7 @@ func (h *ByronMainBlockHeader) Era() common.Era {
 type ByronTransaction struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
-	hash       string
+	hash       *common.Blake2b256
 	TxInputs   []ByronTransactionInput
 	TxOutputs  []ByronTransactionOutput
 	Attributes *cbor.LazyValue
@@ -146,12 +146,12 @@ func (ByronTransaction) Type() int {
 	return TxTypeByron
 }
 
-func (t *ByronTransaction) Hash() string {
-	if t.hash == "" {
+func (t *ByronTransaction) Hash() common.Blake2b256 {
+	if t.hash == nil {
 		tmpHash := common.Blake2b256Hash(t.Cbor())
-		t.hash = hex.EncodeToString(tmpHash.Bytes())
+		t.hash = &tmpHash
 	}
-	return t.hash
+	return *t.hash
 }
 
 func (t *ByronTransaction) Inputs() []common.TransactionInput {
@@ -275,7 +275,7 @@ func (t *ByronTransaction) Produced() []common.Utxo {
 		ret = append(
 			ret,
 			common.Utxo{
-				Id:     NewByronTransactionInput(t.Hash(), idx),
+				Id:     NewByronTransactionInput(t.Hash().String(), idx),
 				Output: output,
 			},
 		)
@@ -496,7 +496,7 @@ func (b *ByronMainBlockBody) UnmarshalCBOR(data []byte) error {
 type ByronEpochBoundaryBlockHeader struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
-	hash          string
+	hash          *common.Blake2b256
 	ProtocolMagic uint32
 	PrevBlock     common.Blake2b256
 	BodyProof     interface{}
@@ -516,8 +516,8 @@ func (h *ByronEpochBoundaryBlockHeader) UnmarshalCBOR(cborData []byte) error {
 	return h.UnmarshalCbor(cborData, h)
 }
 
-func (h *ByronEpochBoundaryBlockHeader) Hash() string {
-	if h.hash == "" {
+func (h *ByronEpochBoundaryBlockHeader) Hash() common.Blake2b256 {
+	if h.hash == nil {
 		// Prepend bytes for CBOR list wrapper
 		// The block hash is calculated with these extra bytes, so we have to add them to
 		// get the correct value
@@ -527,13 +527,13 @@ func (h *ByronEpochBoundaryBlockHeader) Hash() string {
 				h.Cbor()...,
 			),
 		)
-		h.hash = hex.EncodeToString(tmpHash.Bytes())
+		h.hash = &tmpHash
 	}
-	return h.hash
+	return *h.hash
 }
 
-func (h *ByronEpochBoundaryBlockHeader) PrevHash() string {
-	return h.PrevBlock.String()
+func (h *ByronEpochBoundaryBlockHeader) PrevHash() common.Blake2b256 {
+	return h.PrevBlock
 }
 
 func (h *ByronEpochBoundaryBlockHeader) BlockNumber() uint64 {
@@ -575,7 +575,7 @@ func (ByronMainBlock) Type() int {
 	return BlockTypeByronMain
 }
 
-func (b *ByronMainBlock) Hash() string {
+func (b *ByronMainBlock) Hash() common.Blake2b256 {
 	return b.BlockHeader.Hash()
 }
 
@@ -583,7 +583,7 @@ func (b *ByronMainBlock) Header() common.BlockHeader {
 	return b.BlockHeader
 }
 
-func (b *ByronMainBlock) PrevHash() string {
+func (b *ByronMainBlock) PrevHash() common.Blake2b256 {
 	return b.BlockHeader.PrevHash()
 }
 
@@ -636,7 +636,7 @@ func (ByronEpochBoundaryBlock) Type() int {
 	return BlockTypeByronEbb
 }
 
-func (b *ByronEpochBoundaryBlock) Hash() string {
+func (b *ByronEpochBoundaryBlock) Hash() common.Blake2b256 {
 	return b.BlockHeader.Hash()
 }
 
@@ -644,7 +644,7 @@ func (b *ByronEpochBoundaryBlock) Header() common.BlockHeader {
 	return b.BlockHeader
 }
 
-func (b *ByronEpochBoundaryBlock) PrevHash() string {
+func (b *ByronEpochBoundaryBlock) PrevHash() common.Blake2b256 {
 	return b.BlockHeader.PrevHash()
 }
 

--- a/ledger/common/block.go
+++ b/ledger/common/block.go
@@ -11,8 +11,8 @@ type Block interface {
 }
 
 type BlockHeader interface {
-	Hash() string
-	PrevHash() string
+	Hash() Blake2b256
+	PrevHash() Blake2b256
 	BlockNumber() uint64
 	SlotNumber() uint64
 	IssuerVkey() IssuerVkey

--- a/ledger/common/tx.go
+++ b/ledger/common/tx.go
@@ -33,7 +33,7 @@ type Transaction interface {
 type TransactionBody interface {
 	Cbor() []byte
 	Fee() uint64
-	Hash() string
+	Hash() Blake2b256
 	Inputs() []TransactionInput
 	Outputs() []TransactionOutput
 	TTL() uint64

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -15,7 +15,6 @@
 package conway
 
 import (
-	"encoding/hex"
 	"fmt"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -64,7 +63,7 @@ func (ConwayBlock) Type() int {
 	return BlockTypeConway
 }
 
-func (b *ConwayBlock) Hash() string {
+func (b *ConwayBlock) Hash() common.Blake2b256 {
 	return b.BlockHeader.Hash()
 }
 
@@ -72,7 +71,7 @@ func (b *ConwayBlock) Header() common.BlockHeader {
 	return b.BlockHeader
 }
 
-func (b *ConwayBlock) PrevHash() string {
+func (b *ConwayBlock) PrevHash() common.Blake2b256 {
 	return b.BlockHeader.PrevHash()
 }
 
@@ -117,7 +116,6 @@ func (b *ConwayBlock) Transactions() []common.Transaction {
 
 func (b *ConwayBlock) Utxorpc() *utxorpc.Block {
 	txs := []*utxorpc.Tx{}
-	tmpHash, _ := hex.DecodeString(b.Hash())
 	for _, t := range b.Transactions() {
 		tx := t.Utxorpc()
 		txs = append(txs, tx)
@@ -126,7 +124,7 @@ func (b *ConwayBlock) Utxorpc() *utxorpc.Block {
 		Tx: txs,
 	}
 	header := &utxorpc.BlockHeader{
-		Hash:   tmpHash,
+		Hash:   b.Hash().Bytes(),
 		Height: b.BlockNumber(),
 		Slot:   b.SlotNumber(),
 	}
@@ -325,7 +323,7 @@ func (ConwayTransaction) Type() int {
 	return TxTypeConway
 }
 
-func (t ConwayTransaction) Hash() string {
+func (t ConwayTransaction) Hash() common.Blake2b256 {
 	return t.Body.Hash()
 }
 
@@ -432,7 +430,7 @@ func (t ConwayTransaction) Produced() []common.Utxo {
 			ret = append(
 				ret,
 				common.Utxo{
-					Id:     shelley.NewShelleyTransactionInput(t.Hash(), idx),
+					Id:     shelley.NewShelleyTransactionInput(t.Hash().String(), idx),
 					Output: output,
 				},
 			)
@@ -444,7 +442,7 @@ func (t ConwayTransaction) Produced() []common.Utxo {
 		}
 		return []common.Utxo{
 			{
-				Id:     shelley.NewShelleyTransactionInput(t.Hash(), len(t.Outputs())),
+				Id:     shelley.NewShelleyTransactionInput(t.Hash().String(), len(t.Outputs())),
 				Output: t.CollateralReturn(),
 			},
 		}

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -15,7 +15,6 @@
 package mary
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -63,7 +62,7 @@ func (MaryBlock) Type() int {
 	return BlockTypeMary
 }
 
-func (b *MaryBlock) Hash() string {
+func (b *MaryBlock) Hash() common.Blake2b256 {
 	return b.BlockHeader.Hash()
 }
 
@@ -71,7 +70,7 @@ func (b *MaryBlock) Header() common.BlockHeader {
 	return b.BlockHeader
 }
 
-func (b *MaryBlock) PrevHash() string {
+func (b *MaryBlock) PrevHash() common.Blake2b256 {
 	return b.BlockHeader.PrevHash()
 }
 
@@ -110,7 +109,6 @@ func (b *MaryBlock) Transactions() []common.Transaction {
 
 func (b *MaryBlock) Utxorpc() *utxorpc.Block {
 	txs := []*utxorpc.Tx{}
-	tmpHash, _ := hex.DecodeString(b.Hash())
 	for _, t := range b.Transactions() {
 		tx := t.Utxorpc()
 		txs = append(txs, tx)
@@ -119,7 +117,7 @@ func (b *MaryBlock) Utxorpc() *utxorpc.Block {
 		Tx: txs,
 	}
 	header := &utxorpc.BlockHeader{
-		Hash:   tmpHash,
+		Hash:   b.Hash().Bytes(),
 		Height: b.BlockNumber(),
 		Slot:   b.SlotNumber(),
 	}
@@ -189,7 +187,7 @@ func (MaryTransaction) Type() int {
 	return TxTypeMary
 }
 
-func (t MaryTransaction) Hash() string {
+func (t MaryTransaction) Hash() common.Blake2b256 {
 	return t.Body.Hash()
 }
 
@@ -291,7 +289,7 @@ func (t MaryTransaction) Produced() []common.Utxo {
 		ret = append(
 			ret,
 			common.Utxo{
-				Id:     shelley.NewShelleyTransactionInput(t.Hash(), idx),
+				Id:     shelley.NewShelleyTransactionInput(t.Hash().String(), idx),
 				Output: output,
 			},
 		)

--- a/ledger/verify_block_body.go
+++ b/ledger/verify_block_body.go
@@ -423,7 +423,7 @@ func GetBlockOutput(
 	var regisCerts []RegisCert
 	var deRegisCerts []DeRegisCert
 	for txIndex, tx := range txBodies {
-		txHash := tx.Hash()
+		txHash := tx.Hash().String()
 		txOutputs := tx.Outputs()
 		for outputIndex, txOutput := range txOutputs {
 			cborDatum := []byte{}

--- a/protocol/blockfetch/client_test.go
+++ b/protocol/blockfetch/client_test.go
@@ -118,7 +118,7 @@ func TestGetBlock(t *testing.T) {
 	if _, err := cbor.Decode(blockCbor, &testBlock); err != nil {
 		t.Fatalf("received unexpected error: %s", err)
 	}
-	testBlockHash := test.DecodeHexString(testBlock.Hash())
+	testBlockHash := testBlock.Hash().Bytes()
 	wrappedBlock := blockfetch.WrappedBlock{
 		Type:     ledger.BlockTypeBabbage,
 		RawBlock: cbor.RawMessage(blockCbor),

--- a/protocol/chainsync/client.go
+++ b/protocol/chainsync/client.go
@@ -15,7 +15,6 @@
 package chainsync
 
 import (
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"sync"
@@ -653,12 +652,7 @@ func (c *Client) handleRollForward(msgGeneric protocol.Message) error {
 				firstBlockChan <- clientPointResult{error: err}
 				return err
 			}
-			blockHash, err := hex.DecodeString(blockHeader.Hash())
-			if err != nil {
-				firstBlockChan <- clientPointResult{error: err}
-				return err
-			}
-			point := common.NewPoint(blockHeader.SlotNumber(), blockHash)
+			point := common.NewPoint(blockHeader.SlotNumber(), blockHeader.Hash().Bytes())
 			firstBlockChan <- clientPointResult{tip: msg.Tip, point: point}
 			return nil
 		}
@@ -700,12 +694,7 @@ func (c *Client) handleRollForward(msgGeneric protocol.Message) error {
 				firstBlockChan <- clientPointResult{error: err}
 				return err
 			}
-			blockHash, err := hex.DecodeString(block.Hash())
-			if err != nil {
-				firstBlockChan <- clientPointResult{error: err}
-				return err
-			}
-			point := common.NewPoint(block.SlotNumber(), blockHash)
+			point := common.NewPoint(block.SlotNumber(), block.Hash().Bytes())
 			firstBlockChan <- clientPointResult{tip: msg.Tip, point: point}
 			return nil
 		}

--- a/protocol/chainsync/client_test.go
+++ b/protocol/chainsync/client_test.go
@@ -205,7 +205,7 @@ func TestGetAvailableBlockRange(t *testing.T) {
 	}
 	expectedStart := ocommon.NewPoint(
 		testBlock.SlotNumber(),
-		test.DecodeHexString(testBlock.Hash()),
+		testBlock.Hash().Bytes(),
 	)
 	conversation := append(
 		conversationHandshakeFindIntersect,

--- a/protocol/localtxmonitor/server.go
+++ b/protocol/localtxmonitor/server.go
@@ -167,7 +167,7 @@ func (s *Server) handleHasTx(msg protocol.Message) error {
 	txId := hex.EncodeToString(msgHasTx.TxId)
 	hasTx := false
 	for _, tx := range s.mempoolTxs {
-		if tx.txObj.Hash() == txId {
+		if tx.txObj.Hash().String() == txId {
 			hasTx = true
 			break
 		}


### PR DESCRIPTION
This switches from returning the string representation of a block/TX hash to the underlying Blake2b256 type containing the hash bytes. Those bytes are used all over the place, and it's cumbersome to need to use hex.DecodeString() everywhere to convert back to bytes

BREAKING CHANGE: library consumers will need to convert from bytes to string before use