### PR TITLE
refactor: remove reflection when storing CBOR on decode

### DIFF
--- a/ledger/allegra/allegra.go
+++ b/ledger/allegra/allegra.go
@@ -53,7 +53,14 @@ type AllegraBlock struct {
 }
 
 func (b *AllegraBlock) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCbor(cborData, b)
+	type tAllegraBlock AllegraBlock
+	var tmp tAllegraBlock
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*b = AllegraBlock(tmp)
+	b.SetCbor(cborData)
+	return nil
 }
 
 func (AllegraBlock) Type() int {
@@ -152,7 +159,14 @@ type AllegraTransactionBody struct {
 }
 
 func (b *AllegraTransactionBody) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCbor(cborData, b)
+	type tAllegraTransactionBody AllegraTransactionBody
+	var tmp tAllegraTransactionBody
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*b = AllegraTransactionBody(tmp)
+	b.SetCbor(cborData)
+	return nil
 }
 
 func (b *AllegraTransactionBody) Inputs() []common.TransactionInput {
@@ -219,8 +233,15 @@ type AllegraTransaction struct {
 	TxMetadata *cbor.LazyValue
 }
 
-func (t *AllegraTransaction) UnmarshalCBOR(data []byte) error {
-	return t.UnmarshalCbor(data, t)
+func (t *AllegraTransaction) UnmarshalCBOR(cborData []byte) error {
+	type tAllegraTransaction AllegraTransaction
+	var tmp tAllegraTransaction
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*t = AllegraTransaction(tmp)
+	t.SetCbor(cborData)
+	return nil
 }
 
 func (AllegraTransaction) Type() int {

--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -56,7 +56,14 @@ type AlonzoBlock struct {
 }
 
 func (b *AlonzoBlock) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCbor(cborData, b)
+	type tAlonzoBlock AlonzoBlock
+	var tmp tAlonzoBlock
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*b = AlonzoBlock(tmp)
+	b.SetCbor(cborData)
+	return nil
 }
 
 func (AlonzoBlock) Type() int {
@@ -166,7 +173,14 @@ type AlonzoTransactionBody struct {
 }
 
 func (b *AlonzoTransactionBody) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCbor(cborData, b)
+	type tAlonzoTransactionBody AlonzoTransactionBody
+	var tmp tAlonzoTransactionBody
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*b = AlonzoTransactionBody(tmp)
+	b.SetCbor(cborData)
+	return nil
 }
 
 func (b *AlonzoTransactionBody) Inputs() []common.TransactionInput {
@@ -391,7 +405,14 @@ type AlonzoTransactionWitnessSet struct {
 }
 
 func (w *AlonzoTransactionWitnessSet) UnmarshalCBOR(cborData []byte) error {
-	return w.UnmarshalCbor(cborData, w)
+	type tAlonzoTransactionWitnessSet AlonzoTransactionWitnessSet
+	var tmp tAlonzoTransactionWitnessSet
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*w = AlonzoTransactionWitnessSet(tmp)
+	w.SetCbor(cborData)
+	return nil
 }
 
 func (w AlonzoTransactionWitnessSet) Vkey() []common.VkeyWitness {
@@ -437,8 +458,15 @@ type AlonzoTransaction struct {
 	TxMetadata *cbor.LazyValue
 }
 
-func (t *AlonzoTransaction) UnmarshalCBOR(data []byte) error {
-	return t.UnmarshalCbor(data, t)
+func (t *AlonzoTransaction) UnmarshalCBOR(cborData []byte) error {
+	type tAlonzoTransaction AlonzoTransaction
+	var tmp tAlonzoTransaction
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*t = AlonzoTransaction(tmp)
+	t.SetCbor(cborData)
+	return nil
 }
 
 func (AlonzoTransaction) Type() int {

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -58,7 +58,14 @@ type BabbageBlock struct {
 }
 
 func (b *BabbageBlock) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCbor(cborData, b)
+	type tBabbageBlock BabbageBlock
+	var tmp tBabbageBlock
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*b = BabbageBlock(tmp)
+	b.SetCbor(cborData)
+	return nil
 }
 
 func (BabbageBlock) Type() int {
@@ -174,7 +181,14 @@ type BabbageProtoVersion struct {
 }
 
 func (h *BabbageBlockHeader) UnmarshalCBOR(cborData []byte) error {
-	return h.UnmarshalCbor(cborData, h)
+	type tBabbageBlockHeader BabbageBlockHeader
+	var tmp tBabbageBlockHeader
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*h = BabbageBlockHeader(tmp)
+	h.SetCbor(cborData)
+	return nil
 }
 
 func (h *BabbageBlockHeader) Hash() common.Blake2b256 {
@@ -235,7 +249,14 @@ type BabbageTransactionBody struct {
 }
 
 func (b *BabbageTransactionBody) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCbor(cborData, b)
+	type tBabbageTransactionBody BabbageTransactionBody
+	var tmp tBabbageTransactionBody
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*b = BabbageTransactionBody(tmp)
+	b.SetCbor(cborData)
+	return nil
 }
 
 func (b *BabbageTransactionBody) Inputs() []common.TransactionInput {
@@ -537,7 +558,14 @@ type BabbageTransactionWitnessSet struct {
 }
 
 func (w *BabbageTransactionWitnessSet) UnmarshalCBOR(cborData []byte) error {
-	return w.UnmarshalCbor(cborData, w)
+	type tBabbageTransactionWitnessSet BabbageTransactionWitnessSet
+	var tmp tBabbageTransactionWitnessSet
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*w = BabbageTransactionWitnessSet(tmp)
+	w.SetCbor(cborData)
+	return nil
 }
 
 func (w BabbageTransactionWitnessSet) Vkey() []common.VkeyWitness {
@@ -582,8 +610,15 @@ type BabbageTransaction struct {
 	TxMetadata *cbor.LazyValue
 }
 
-func (t *BabbageTransaction) UnmarshalCBOR(data []byte) error {
-	return t.UnmarshalCbor(data, t)
+func (t *BabbageTransaction) UnmarshalCBOR(cborData []byte) error {
+	type tBabbageTransaction BabbageTransaction
+	var tmp tBabbageTransaction
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*t = BabbageTransaction(tmp)
+	t.SetCbor(cborData)
+	return nil
 }
 
 func (BabbageTransaction) Type() int {

--- a/ledger/byron/byron.go
+++ b/ledger/byron/byron.go
@@ -80,8 +80,14 @@ type ByronMainBlockHeader struct {
 }
 
 func (h *ByronMainBlockHeader) UnmarshalCBOR(cborData []byte) error {
-	// Decode generically and store original CBOR
-	return h.UnmarshalCbor(cborData, h)
+	type tByronMainBlockHeader ByronMainBlockHeader
+	var tmp tByronMainBlockHeader
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*h = ByronMainBlockHeader(tmp)
+	h.SetCbor(cborData)
+	return nil
 }
 
 func (h *ByronMainBlockHeader) Hash() common.Blake2b256 {
@@ -137,9 +143,15 @@ type ByronTransaction struct {
 	Attributes *cbor.LazyValue
 }
 
-func (t *ByronTransaction) UnmarshalCBOR(data []byte) error {
-	// Decode generically and store original CBOR
-	return t.UnmarshalCbor(data, t)
+func (t *ByronTransaction) UnmarshalCBOR(cborData []byte) error {
+	type tByronTransaction ByronTransaction
+	var tmp tByronTransaction
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*t = ByronTransaction(tmp)
+	t.SetCbor(cborData)
+	return nil
 }
 
 func (ByronTransaction) Type() int {
@@ -451,8 +463,15 @@ type ByronUpdateProposal struct {
 	Signature       []byte
 }
 
-func (p *ByronUpdateProposal) UnmarshalCBOR(data []byte) error {
-	return p.UnmarshalCbor(data, p)
+func (p *ByronUpdateProposal) UnmarshalCBOR(cborData []byte) error {
+	type tByronUpdateProposal ByronUpdateProposal
+	var tmp tByronUpdateProposal
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*p = ByronUpdateProposal(tmp)
+	p.SetCbor(cborData)
+	return nil
 }
 
 type ByronUpdateProposalBlockVersionMod struct {
@@ -488,9 +507,15 @@ type ByronMainBlockBody struct {
 	UpdPayload ByronUpdatePayload
 }
 
-func (b *ByronMainBlockBody) UnmarshalCBOR(data []byte) error {
-	// Decode generically and store original CBOR
-	return b.UnmarshalCbor(data, b)
+func (b *ByronMainBlockBody) UnmarshalCBOR(cborData []byte) error {
+	type tByronMainBlockBody ByronMainBlockBody
+	var tmp tByronMainBlockBody
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*b = ByronMainBlockBody(tmp)
+	b.SetCbor(cborData)
+	return nil
 }
 
 type ByronEpochBoundaryBlockHeader struct {
@@ -512,8 +537,14 @@ type ByronEpochBoundaryBlockHeader struct {
 }
 
 func (h *ByronEpochBoundaryBlockHeader) UnmarshalCBOR(cborData []byte) error {
-	// Decode generically and store original CBOR
-	return h.UnmarshalCbor(cborData, h)
+	type tByronEpochBoundaryBlockHeader ByronEpochBoundaryBlockHeader
+	var tmp tByronEpochBoundaryBlockHeader
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*h = ByronEpochBoundaryBlockHeader(tmp)
+	h.SetCbor(cborData)
+	return nil
 }
 
 func (h *ByronEpochBoundaryBlockHeader) Hash() common.Blake2b256 {
@@ -567,8 +598,14 @@ type ByronMainBlock struct {
 }
 
 func (b *ByronMainBlock) UnmarshalCBOR(cborData []byte) error {
-	// Decode generically and store original CBOR
-	return b.UnmarshalCbor(cborData, b)
+	type tByronMainBlock ByronMainBlock
+	var tmp tByronMainBlock
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*b = ByronMainBlock(tmp)
+	b.SetCbor(cborData)
+	return nil
 }
 
 func (ByronMainBlock) Type() int {
@@ -628,8 +665,14 @@ type ByronEpochBoundaryBlock struct {
 }
 
 func (b *ByronEpochBoundaryBlock) UnmarshalCBOR(cborData []byte) error {
-	// Decode generically and store original CBOR
-	return b.UnmarshalCbor(cborData, b)
+	type tByronEpochBoundaryBlock ByronEpochBoundaryBlock
+	var tmp tByronEpochBoundaryBlock
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*b = ByronEpochBoundaryBlock(tmp)
+	b.SetCbor(cborData)
+	return nil
 }
 
 func (ByronEpochBoundaryBlock) Type() int {

--- a/ledger/common/certs.go
+++ b/ledger/common/certs.go
@@ -167,7 +167,14 @@ type StakeRegistrationCertificate struct {
 func (c StakeRegistrationCertificate) isCertificate() {}
 
 func (c *StakeRegistrationCertificate) UnmarshalCBOR(cborData []byte) error {
-	return c.UnmarshalCbor(cborData, c)
+	type tStakeRegistrationCertificate StakeRegistrationCertificate
+	var tmp tStakeRegistrationCertificate
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*c = StakeRegistrationCertificate(tmp)
+	c.SetCbor(cborData)
+	return nil
 }
 
 func (c *StakeRegistrationCertificate) Utxorpc() *utxorpc.Certificate {
@@ -192,7 +199,14 @@ type StakeDeregistrationCertificate struct {
 func (c StakeDeregistrationCertificate) isCertificate() {}
 
 func (c *StakeDeregistrationCertificate) UnmarshalCBOR(cborData []byte) error {
-	return c.UnmarshalCbor(cborData, c)
+	type tStakeDeregistrationCertificate StakeDeregistrationCertificate
+	var tmp tStakeDeregistrationCertificate
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*c = StakeDeregistrationCertificate(tmp)
+	c.SetCbor(cborData)
+	return nil
 }
 
 func (c *StakeDeregistrationCertificate) Utxorpc() *utxorpc.Certificate {
@@ -218,7 +232,14 @@ type StakeDelegationCertificate struct {
 func (c StakeDelegationCertificate) isCertificate() {}
 
 func (c *StakeDelegationCertificate) UnmarshalCBOR(cborData []byte) error {
-	return c.UnmarshalCbor(cborData, c)
+	type tStakeDelegationCertificate StakeDelegationCertificate
+	var tmp tStakeDelegationCertificate
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*c = StakeDelegationCertificate(tmp)
+	c.SetCbor(cborData)
+	return nil
 }
 
 func (c *StakeDelegationCertificate) Utxorpc() *utxorpc.Certificate {
@@ -353,7 +374,14 @@ type PoolRegistrationCertificate struct {
 func (c PoolRegistrationCertificate) isCertificate() {}
 
 func (c *PoolRegistrationCertificate) UnmarshalCBOR(cborData []byte) error {
-	return c.UnmarshalCbor(cborData, c)
+	type tPoolRegistrationCertificate PoolRegistrationCertificate
+	var tmp tPoolRegistrationCertificate
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*c = PoolRegistrationCertificate(tmp)
+	c.SetCbor(cborData)
+	return nil
 }
 
 func (c *PoolRegistrationCertificate) Utxorpc() *utxorpc.Certificate {
@@ -401,7 +429,14 @@ type PoolRetirementCertificate struct {
 func (c PoolRetirementCertificate) isCertificate() {}
 
 func (c *PoolRetirementCertificate) UnmarshalCBOR(cborData []byte) error {
-	return c.UnmarshalCbor(cborData, c)
+	type tPoolRetirementCertificate PoolRetirementCertificate
+	var tmp tPoolRetirementCertificate
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*c = PoolRetirementCertificate(tmp)
+	c.SetCbor(cborData)
+	return nil
 }
 
 func (c *PoolRetirementCertificate) Utxorpc() *utxorpc.Certificate {
@@ -431,7 +466,14 @@ type GenesisKeyDelegationCertificate struct {
 func (c GenesisKeyDelegationCertificate) isCertificate() {}
 
 func (c *GenesisKeyDelegationCertificate) UnmarshalCBOR(cborData []byte) error {
-	return c.UnmarshalCbor(cborData, c)
+	type tGenesisKeyDelegationCertificate GenesisKeyDelegationCertificate
+	var tmp tGenesisKeyDelegationCertificate
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*c = GenesisKeyDelegationCertificate(tmp)
+	c.SetCbor(cborData)
+	return nil
 }
 
 func (c *GenesisKeyDelegationCertificate) Utxorpc() *utxorpc.Certificate {
@@ -504,7 +546,14 @@ func (c MoveInstantaneousRewardsCertificate) isCertificate() {}
 func (c *MoveInstantaneousRewardsCertificate) UnmarshalCBOR(
 	cborData []byte,
 ) error {
-	return c.UnmarshalCbor(cborData, c)
+	type tMoveInstantaneousRewardsCertificate MoveInstantaneousRewardsCertificate
+	var tmp tMoveInstantaneousRewardsCertificate
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*c = MoveInstantaneousRewardsCertificate(tmp)
+	c.SetCbor(cborData)
+	return nil
 }
 
 func (c *MoveInstantaneousRewardsCertificate) Utxorpc() *utxorpc.Certificate {
@@ -550,7 +599,14 @@ func (c RegistrationCertificate) isCertificate() {}
 func (c *RegistrationCertificate) UnmarshalCBOR(
 	cborData []byte,
 ) error {
-	return c.UnmarshalCbor(cborData, c)
+	type tRegistrationCertificate RegistrationCertificate
+	var tmp tRegistrationCertificate
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*c = RegistrationCertificate(tmp)
+	c.SetCbor(cborData)
+	return nil
 }
 
 func (c *RegistrationCertificate) Utxorpc() *utxorpc.Certificate {
@@ -575,7 +631,14 @@ func (c DeregistrationCertificate) isCertificate() {}
 func (c *DeregistrationCertificate) UnmarshalCBOR(
 	cborData []byte,
 ) error {
-	return c.UnmarshalCbor(cborData, c)
+	type tDeregistrationCertificate DeregistrationCertificate
+	var tmp tDeregistrationCertificate
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*c = DeregistrationCertificate(tmp)
+	c.SetCbor(cborData)
+	return nil
 }
 
 func (c *DeregistrationCertificate) Utxorpc() *utxorpc.Certificate {
@@ -600,7 +663,14 @@ func (c VoteDelegationCertificate) isCertificate() {}
 func (c *VoteDelegationCertificate) UnmarshalCBOR(
 	cborData []byte,
 ) error {
-	return c.UnmarshalCbor(cborData, c)
+	type tVoteDelegationCertificate VoteDelegationCertificate
+	var tmp tVoteDelegationCertificate
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*c = VoteDelegationCertificate(tmp)
+	c.SetCbor(cborData)
+	return nil
 }
 
 func (c *VoteDelegationCertificate) Utxorpc() *utxorpc.Certificate {
@@ -626,7 +696,14 @@ func (c StakeVoteDelegationCertificate) isCertificate() {}
 func (c *StakeVoteDelegationCertificate) UnmarshalCBOR(
 	cborData []byte,
 ) error {
-	return c.UnmarshalCbor(cborData, c)
+	type tStakeVoteDelegationCertificate StakeVoteDelegationCertificate
+	var tmp tStakeVoteDelegationCertificate
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*c = StakeVoteDelegationCertificate(tmp)
+	c.SetCbor(cborData)
+	return nil
 }
 
 func (c *StakeVoteDelegationCertificate) Utxorpc() *utxorpc.Certificate {
@@ -652,7 +729,14 @@ func (c StakeRegistrationDelegationCertificate) isCertificate() {}
 func (c *StakeRegistrationDelegationCertificate) UnmarshalCBOR(
 	cborData []byte,
 ) error {
-	return c.UnmarshalCbor(cborData, c)
+	type tStakeRegistrationDelegationCertificate StakeRegistrationDelegationCertificate
+	var tmp tStakeRegistrationDelegationCertificate
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*c = StakeRegistrationDelegationCertificate(tmp)
+	c.SetCbor(cborData)
+	return nil
 }
 
 func (c *StakeRegistrationDelegationCertificate) Utxorpc() *utxorpc.Certificate {
@@ -678,7 +762,14 @@ func (c VoteRegistrationDelegationCertificate) isCertificate() {}
 func (c *VoteRegistrationDelegationCertificate) UnmarshalCBOR(
 	cborData []byte,
 ) error {
-	return c.UnmarshalCbor(cborData, c)
+	type tVoteRegistrationDelegationCertificate VoteRegistrationDelegationCertificate
+	var tmp tVoteRegistrationDelegationCertificate
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*c = VoteRegistrationDelegationCertificate(tmp)
+	c.SetCbor(cborData)
+	return nil
 }
 
 func (c *VoteRegistrationDelegationCertificate) Utxorpc() *utxorpc.Certificate {
@@ -705,7 +796,14 @@ func (c StakeVoteRegistrationDelegationCertificate) isCertificate() {}
 func (c *StakeVoteRegistrationDelegationCertificate) UnmarshalCBOR(
 	cborData []byte,
 ) error {
-	return c.UnmarshalCbor(cborData, c)
+	type tStakeVoteRegistrationDelegationCertificate StakeVoteRegistrationDelegationCertificate
+	var tmp tStakeVoteRegistrationDelegationCertificate
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*c = StakeVoteRegistrationDelegationCertificate(tmp)
+	c.SetCbor(cborData)
+	return nil
 }
 
 func (c *StakeVoteRegistrationDelegationCertificate) Utxorpc() *utxorpc.Certificate {
@@ -730,7 +828,14 @@ func (c AuthCommitteeHotCertificate) isCertificate() {}
 func (c *AuthCommitteeHotCertificate) UnmarshalCBOR(
 	cborData []byte,
 ) error {
-	return c.UnmarshalCbor(cborData, c)
+	type tAuthCommitteeHotCertificate AuthCommitteeHotCertificate
+	var tmp tAuthCommitteeHotCertificate
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*c = AuthCommitteeHotCertificate(tmp)
+	c.SetCbor(cborData)
+	return nil
 }
 
 func (c *AuthCommitteeHotCertificate) Utxorpc() *utxorpc.Certificate {
@@ -755,7 +860,14 @@ func (c ResignCommitteeColdCertificate) isCertificate() {}
 func (c *ResignCommitteeColdCertificate) UnmarshalCBOR(
 	cborData []byte,
 ) error {
-	return c.UnmarshalCbor(cborData, c)
+	type tResignCommitteeColdCertificate ResignCommitteeColdCertificate
+	var tmp tResignCommitteeColdCertificate
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*c = ResignCommitteeColdCertificate(tmp)
+	c.SetCbor(cborData)
+	return nil
 }
 
 func (c *ResignCommitteeColdCertificate) Utxorpc() *utxorpc.Certificate {
@@ -781,7 +893,14 @@ func (c RegistrationDrepCertificate) isCertificate() {}
 func (c *RegistrationDrepCertificate) UnmarshalCBOR(
 	cborData []byte,
 ) error {
-	return c.UnmarshalCbor(cborData, c)
+	type tRegistrationDrepCertificate RegistrationDrepCertificate
+	var tmp tRegistrationDrepCertificate
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*c = RegistrationDrepCertificate(tmp)
+	c.SetCbor(cborData)
+	return nil
 }
 
 func (c *RegistrationDrepCertificate) Utxorpc() *utxorpc.Certificate {
@@ -806,7 +925,14 @@ func (c DeregistrationDrepCertificate) isCertificate() {}
 func (c *DeregistrationDrepCertificate) UnmarshalCBOR(
 	cborData []byte,
 ) error {
-	return c.UnmarshalCbor(cborData, c)
+	type tDeregistrationDrepCertificate DeregistrationDrepCertificate
+	var tmp tDeregistrationDrepCertificate
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*c = DeregistrationDrepCertificate(tmp)
+	c.SetCbor(cborData)
+	return nil
 }
 
 func (c *DeregistrationDrepCertificate) Utxorpc() *utxorpc.Certificate {
@@ -831,7 +957,14 @@ func (c UpdateDrepCertificate) isCertificate() {}
 func (c *UpdateDrepCertificate) UnmarshalCBOR(
 	cborData []byte,
 ) error {
-	return c.UnmarshalCbor(cborData, c)
+	type tUpdateDrepCertificate UpdateDrepCertificate
+	var tmp tUpdateDrepCertificate
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*c = UpdateDrepCertificate(tmp)
+	c.SetCbor(cborData)
+	return nil
 }
 
 func (c *UpdateDrepCertificate) Utxorpc() *utxorpc.Certificate {

--- a/ledger/common/credentials.go
+++ b/ledger/common/credentials.go
@@ -36,8 +36,15 @@ type Credential struct {
 	Credential CredentialHash
 }
 
-func (c *Credential) UnmarshalCBOR(data []byte) error {
-	return c.UnmarshalCbor(data, c)
+func (c *Credential) UnmarshalCBOR(cborData []byte) error {
+	type tCredential Credential
+	var tmp tCredential
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*c = Credential(tmp)
+	c.SetCbor(cborData)
+	return nil
 }
 
 func (c *Credential) Hash() Blake2b224 {

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -56,7 +56,14 @@ type ConwayBlock struct {
 }
 
 func (b *ConwayBlock) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCbor(cborData, b)
+	type tConwayBlock ConwayBlock
+	var tmp tConwayBlock
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*b = ConwayBlock(tmp)
+	b.SetCbor(cborData)
+	return nil
 }
 
 func (ConwayBlock) Type() int {
@@ -222,7 +229,14 @@ type ConwayTransactionWitnessSet struct {
 }
 
 func (w *ConwayTransactionWitnessSet) UnmarshalCBOR(cborData []byte) error {
-	return w.UnmarshalCbor(cborData, w)
+	type tConwayTransactionWitnessSet ConwayTransactionWitnessSet
+	var tmp tConwayTransactionWitnessSet
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*w = ConwayTransactionWitnessSet(tmp)
+	w.SetCbor(cborData)
+	return nil
 }
 
 func (w ConwayTransactionWitnessSet) Vkey() []common.VkeyWitness {
@@ -321,7 +335,14 @@ type ConwayTransactionBody struct {
 }
 
 func (b *ConwayTransactionBody) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCbor(cborData, b)
+	type tConwayTransactionBody ConwayTransactionBody
+	var tmp tConwayTransactionBody
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*b = ConwayTransactionBody(tmp)
+	b.SetCbor(cborData)
+	return nil
 }
 
 func (b *ConwayTransactionBody) Inputs() []common.TransactionInput {
@@ -447,8 +468,15 @@ type ConwayTransaction struct {
 	TxMetadata *cbor.LazyValue
 }
 
-func (t *ConwayTransaction) UnmarshalCBOR(data []byte) error {
-	return t.UnmarshalCbor(data, t)
+func (t *ConwayTransaction) UnmarshalCBOR(cborData []byte) error {
+	type tConwayTransaction ConwayTransaction
+	var tmp tConwayTransaction
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*t = ConwayTransaction(tmp)
+	t.SetCbor(cborData)
+	return nil
 }
 
 func (ConwayTransaction) Type() int {

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -54,7 +54,14 @@ type MaryBlock struct {
 }
 
 func (b *MaryBlock) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCbor(cborData, b)
+	type tMaryBlock MaryBlock
+	var tmp tMaryBlock
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*b = MaryBlock(tmp)
+	b.SetCbor(cborData)
+	return nil
 }
 
 func (MaryBlock) Type() int {
@@ -154,7 +161,14 @@ type MaryTransactionBody struct {
 }
 
 func (b *MaryTransactionBody) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCbor(cborData, b)
+	type tMaryTransactionBody MaryTransactionBody
+	var tmp tMaryTransactionBody
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*b = MaryTransactionBody(tmp)
+	b.SetCbor(cborData)
+	return nil
 }
 
 func (b *MaryTransactionBody) Inputs() []common.TransactionInput {
@@ -225,8 +239,15 @@ type MaryTransaction struct {
 	TxMetadata *cbor.LazyValue
 }
 
-func (t *MaryTransaction) UnmarshalCBOR(data []byte) error {
-	return t.UnmarshalCbor(data, t)
+func (t *MaryTransaction) UnmarshalCBOR(cborData []byte) error {
+	type tMaryTransaction MaryTransaction
+	var tmp tMaryTransaction
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*t = MaryTransaction(tmp)
+	t.SetCbor(cborData)
+	return nil
 }
 
 func (MaryTransaction) Type() int {
@@ -390,8 +411,15 @@ type MaryTransactionOutput struct {
 	OutputAmount  MaryTransactionOutputValue
 }
 
-func (o *MaryTransactionOutput) UnmarshalCBOR(data []byte) error {
-	return o.UnmarshalCbor(data, o)
+func (o *MaryTransactionOutput) UnmarshalCBOR(cborData []byte) error {
+	type tMaryTransactionOutput MaryTransactionOutput
+	var tmp tMaryTransactionOutput
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*o = MaryTransactionOutput(tmp)
+	o.SetCbor(cborData)
+	return nil
 }
 
 func (o MaryTransactionOutput) MarshalJSON() ([]byte, error) {

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -55,7 +55,14 @@ type ShelleyBlock struct {
 }
 
 func (b *ShelleyBlock) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCbor(cborData, b)
+	type tShelleyBlock ShelleyBlock
+	var tmp tShelleyBlock
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*b = ShelleyBlock(tmp)
+	b.SetCbor(cborData)
+	return nil
 }
 
 func (ShelleyBlock) Type() int {
@@ -155,7 +162,14 @@ type ShelleyBlockHeaderBody struct {
 }
 
 func (h *ShelleyBlockHeader) UnmarshalCBOR(cborData []byte) error {
-	return h.UnmarshalCbor(cborData, h)
+	type tShelleyBlockHeader ShelleyBlockHeader
+	var tmp tShelleyBlockHeader
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*h = ShelleyBlockHeader(tmp)
+	h.SetCbor(cborData)
+	return nil
 }
 
 func (h *ShelleyBlockHeader) Hash() common.Blake2b256 {
@@ -207,7 +221,14 @@ type ShelleyTransactionBody struct {
 }
 
 func (b *ShelleyTransactionBody) UnmarshalCBOR(cborData []byte) error {
-	return b.UnmarshalCbor(cborData, b)
+	type tShelleyTransactionBody ShelleyTransactionBody
+	var tmp tShelleyTransactionBody
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*b = ShelleyTransactionBody(tmp)
+	b.SetCbor(cborData)
+	return nil
 }
 
 func (b *ShelleyTransactionBody) Inputs() []common.TransactionInput {
@@ -349,8 +370,15 @@ type ShelleyTransactionOutput struct {
 	OutputAmount  uint64         `json:"amount"`
 }
 
-func (o *ShelleyTransactionOutput) UnmarshalCBOR(data []byte) error {
-	return o.UnmarshalCbor(data, o)
+func (o *ShelleyTransactionOutput) UnmarshalCBOR(cborData []byte) error {
+	type tShelleyTransactionOutput ShelleyTransactionOutput
+	var tmp tShelleyTransactionOutput
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*o = ShelleyTransactionOutput(tmp)
+	o.SetCbor(cborData)
+	return nil
 }
 
 func (o ShelleyTransactionOutput) Address() common.Address {
@@ -387,8 +415,15 @@ type ShelleyTransactionWitnessSet struct {
 	BootstrapWitnesses []common.BootstrapWitness `cbor:"2,keyasint,omitempty"`
 }
 
-func (t *ShelleyTransactionWitnessSet) UnmarshalCBOR(cborData []byte) error {
-	return t.UnmarshalCbor(cborData, t)
+func (w *ShelleyTransactionWitnessSet) UnmarshalCBOR(cborData []byte) error {
+	type tShelleyTransactionWitnessSet ShelleyTransactionWitnessSet
+	var tmp tShelleyTransactionWitnessSet
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*w = ShelleyTransactionWitnessSet(tmp)
+	w.SetCbor(cborData)
+	return nil
 }
 
 func (w ShelleyTransactionWitnessSet) Vkey() []common.VkeyWitness {
@@ -436,8 +471,15 @@ type ShelleyTransaction struct {
 	TxMetadata *cbor.LazyValue
 }
 
-func (t *ShelleyTransaction) UnmarshalCBOR(data []byte) error {
-	return t.UnmarshalCbor(data, t)
+func (t *ShelleyTransaction) UnmarshalCBOR(cborData []byte) error {
+	type tShelleyTransaction ShelleyTransaction
+	var tmp tShelleyTransaction
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*t = ShelleyTransaction(tmp)
+	t.SetCbor(cborData)
+	return nil
 }
 
 func (ShelleyTransaction) Type() int {


### PR DESCRIPTION
This removes multiple uses of reflection during decoding by creating a static type of the same shape in UnmarshalCBOR. This works because the UnmarshalCBOR function from the original type does not follow to the new type, so generic decoding behavior is used instead.

This was only possible after removing embedding in any of the types that we want to capture the original CBOR on. The promoted UnmarshalCBOR function from the embedded type(s) were being called otherwise, which did not produce the desired result.