### PR TITLE
feat: changes to support cost models while updating Alonzo protocols through genesis config

### DIFF
--- a/ledger/alonzo/genesis.go
+++ b/ledger/alonzo/genesis.go
@@ -16,6 +16,7 @@ package alonzo
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"math/big"
 	"os"
@@ -29,7 +30,7 @@ type AlonzoGenesis struct {
 	ExecutionPrices      AlonzoGenesisExecutionPrices `json:"executionPrices"`
 	MaxTxExUnits         AlonzoGenesisExUnits         `json:"maxTxExUnits"`
 	MaxBlockExUnits      AlonzoGenesisExUnits         `json:"maxBlockExUnits"`
-	CostModels           map[string]map[string]int    `json:"costModels"`
+	CostModels           map[string]interface{}       `json:"costModels"`
 }
 
 func NewAlonzoGenesisFromReader(r io.Reader) (AlonzoGenesis, error) {
@@ -37,6 +38,9 @@ func NewAlonzoGenesisFromReader(r io.Reader) (AlonzoGenesis, error) {
 	dec := json.NewDecoder(r)
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&ret); err != nil {
+		return ret, err
+	}
+	if err := ret.NormalizeCostModels(); err != nil {
 		return ret, err
 	}
 	return ret, nil
@@ -74,5 +78,44 @@ func (r *AlonzoGenesisExecutionPricesRat) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	r.Rat = big.NewRat(tmpData.Numerator, tmpData.Denominator)
+	return nil
+}
+
+func (a *AlonzoGenesis) NormalizeCostModels() error {
+	if a.CostModels == nil {
+		return nil
+	}
+
+	normalized := make(map[string]map[string]int)
+	for version, model := range a.CostModels {
+		if modelMap, ok := model.(map[string]interface{}); ok {
+			versionMap := make(map[string]int)
+			for k, v := range modelMap {
+				switch val := v.(type) {
+				case float64:
+					versionMap[k] = int(val)
+				case int:
+					versionMap[k] = val
+				case json.Number:
+					intVal, err := val.Int64()
+					if err != nil {
+						floatVal, err := val.Float64()
+						if err != nil {
+							return fmt.Errorf("invalid number in cost model: %v", val)
+						}
+						intVal = int64(floatVal)
+					}
+					versionMap[k] = int(intVal)
+				default:
+					return fmt.Errorf("invalid cost model value type: %T", v)
+				}
+			}
+			normalized[version] = versionMap
+		}
+	}
+	a.CostModels = make(map[string]interface{})
+	for k, v := range normalized {
+		a.CostModels[k] = v
+	}
 	return nil
 }

--- a/ledger/alonzo/genesis_test.go
+++ b/ledger/alonzo/genesis_test.go
@@ -243,8 +243,8 @@ var expectedGenesisObj = alonzo.AlonzoGenesis{
 		Mem:   50000000,
 		Steps: 40000000000,
 	},
-	CostModels: map[string]map[string]int{
-		"PlutusV1": {
+	CostModels: map[string]interface{}{
+		"PlutusV1": map[string]int{
 			"addInteger-cpu-arguments-intercept":                       197209,
 			"addInteger-cpu-arguments-slope":                           0,
 			"addInteger-memory-arguments-intercept":                    1,
@@ -484,8 +484,8 @@ func TestNewAlonzoGenesisFromReader(t *testing.T) {
 		t.Logf("prMem is correct: %v", result.ExecutionPrices.Mem.Rat)
 	}
 
-	expectedCostModels := map[string]map[string]int{
-		"PlutusV1": {
+	expectedCostModels := map[string]interface{}{
+		"PlutusV1": map[string]int{
 			"addInteger-cpu-arguments-intercept": 205665,
 			"addInteger-cpu-arguments-slope":     812,
 		},

--- a/ledger/alonzo/genesis_test.go
+++ b/ledger/alonzo/genesis_test.go
@@ -243,7 +243,7 @@ var expectedGenesisObj = alonzo.AlonzoGenesis{
 		Mem:   50000000,
 		Steps: 40000000000,
 	},
-	CostModels: map[string]interface{}{
+	CostModels: map[string]alonzo.CostModel{
 		"PlutusV1": map[string]int{
 			"addInteger-cpu-arguments-intercept":                       197209,
 			"addInteger-cpu-arguments-slope":                           0,
@@ -484,7 +484,7 @@ func TestNewAlonzoGenesisFromReader(t *testing.T) {
 		t.Logf("prMem is correct: %v", result.ExecutionPrices.Mem.Rat)
 	}
 
-	expectedCostModels := map[string]interface{}{
+	expectedCostModels := map[string]alonzo.CostModel{
 		"PlutusV1": map[string]int{
 			"addInteger-cpu-arguments-intercept": 205665,
 			"addInteger-cpu-arguments-slope":     812,

--- a/ledger/alonzo/pparams.go
+++ b/ledger/alonzo/pparams.go
@@ -241,20 +241,6 @@ func plutusVersionToKey(version string) (uint, bool) {
 	}
 }
 
-// Helper to convert key back to string
-func plutusKeyToVersion(key uint) string {
-	switch key {
-	case PlutusV1Key:
-		return "PlutusV1"
-	case PlutusV2Key:
-		return "PlutusV2"
-	case PlutusV3Key:
-		return "PlutusV3"
-	default:
-		return ""
-	}
-}
-
 type AlonzoProtocolParameterUpdate struct {
 	cbor.DecodeStoreCbor
 	MinFeeA              *uint                                     `cbor:"0,keyasint"`

--- a/ledger/alonzo/pparams.go
+++ b/ledger/alonzo/pparams.go
@@ -15,12 +15,9 @@
 package alonzo
 
 import (
-	//"encoding/json"
 	"fmt"
 	"math"
 	"sort"
-
-	//"strconv"
 	"strings"
 
 	"github.com/blinklabs-io/gouroboros/cbor"

--- a/ledger/alonzo/pparams.go
+++ b/ledger/alonzo/pparams.go
@@ -22,8 +22,6 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
-
-	//"github.com/blinklabs-io/gouroboros/ledger/mary"
 	cardano "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
 

--- a/ledger/alonzo/pparams_test.go
+++ b/ledger/alonzo/pparams_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package alonzo_test
 
 import (

--- a/ledger/alonzo/pparams_test.go
+++ b/ledger/alonzo/pparams_test.go
@@ -17,16 +17,18 @@ package alonzo_test
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+	cardano "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
 
-// Helper to create properly initialized base protocol parameters
 func newBaseProtocolParams() alonzo.AlonzoProtocolParameters {
 	return alonzo.AlonzoProtocolParameters{
 		MinFeeA:            44,
@@ -43,217 +45,8 @@ func newBaseProtocolParams() alonzo.AlonzoProtocolParameters {
 		Tau:                &cbor.Rat{Rat: big.NewRat(5, 6)},
 		ProtocolMajor:      8,
 		ProtocolMinor:      0,
-		// Initialize other required fields with zero values
-		MinPoolCost:    0,
-		AdaPerUtxoByte: 0,
-	}
-}
-
-func TestAlonzoProtocolParametersUpdate(t *testing.T) {
-	tests := []struct {
-		name        string
-		updateCbor  string
-		expected    alonzo.AlonzoProtocolParameters
-		expectError bool
-	}{
-		{
-			name:       "Update MinPoolCost",
-			updateCbor: "a1101903e8", // {16: 1000}
-			expected: func() alonzo.AlonzoProtocolParameters {
-				params := newBaseProtocolParams()
-				params.MinPoolCost = 1000
-				return params
-			}(),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			data, err := hex.DecodeString(tt.updateCbor)
-			if err != nil {
-				t.Fatalf("failed to decode CBOR: %v", err)
-			}
-
-			var update alonzo.AlonzoProtocolParameterUpdate
-			if _, err := cbor.Decode(data, &update); err != nil {
-				if !tt.expectError {
-					t.Fatalf("failed to decode update: %v", err)
-				}
-				return
-			}
-
-			params := newBaseProtocolParams()
-			params.Update(&update)
-
-			if !reflect.DeepEqual(params, tt.expected) {
-				t.Errorf("unexpected result:\ngot: %+v\nwant: %+v", params, tt.expected)
-			}
-		})
-	}
-}
-
-func TestAlonzoProtocolParametersUpdateFromGenesis(t *testing.T) {
-	tests := []struct {
-		name        string
-		genesisJSON string
-		validate    func(*alonzo.AlonzoProtocolParameters) bool
-	}{
-		{
-			name: "Basic Parameters",
-			genesisJSON: `{
-                "lovelacePerUTxOWord": 34482,
-                "maxValueSize": 5000,
-                "collateralPercentage": 150,
-                "maxCollateralInputs": 3,
-                "maxTxExUnits": {"mem": 10000000, "steps": 10000000000},
-                "maxBlockExUnits": {"mem": 50000000, "steps": 40000000000},
-                "executionPrices": {
-                    "mem": {"numerator": 577, "denominator": 10000},
-                    "steps": {"numerator": 721, "denominator": 10000000}
-                },
-                "costModels": {
-                    "PlutusV1": {
-                        "param0": 100,
-                        "param1": 200,
-                        "param2": 300
-                    }
-                }
-            }`,
-			validate: func(p *alonzo.AlonzoProtocolParameters) bool {
-				return p.AdaPerUtxoByte == 4310 && // 34482 / 8
-					p.MaxValueSize == 5000 &&
-					p.CollateralPercentage == 150 &&
-					p.MaxCollateralInputs == 3 &&
-					p.MaxTxExUnits.Memory == 10000000 &&
-					p.MaxTxExUnits.Steps == 10000000000 &&
-					p.ExecutionCosts.MemPrice.Rat.Cmp(big.NewRat(577, 10000)) == 0 &&
-					p.CostModels[alonzo.PlutusV1] != nil &&
-					len(p.CostModels[alonzo.PlutusV1].Order) == 3
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create a temporary struct with the exact JSON structure
-			type TempExecutionPrices struct {
-				Mem *struct {
-					Numerator   int64 `json:"numerator"`
-					Denominator int64 `json:"denominator"`
-				} `json:"mem"`
-				Steps *struct {
-					Numerator   int64 `json:"numerator"`
-					Denominator int64 `json:"denominator"`
-				} `json:"steps"`
-			}
-
-			type TempCostModels map[string]map[string]int
-
-			type TempGenesis struct {
-				LovelacePerUtxoWord  uint64 `json:"lovelacePerUTxOWord"`
-				MaxValueSize         uint   `json:"maxValueSize"`
-				CollateralPercentage uint   `json:"collateralPercentage"`
-				MaxCollateralInputs  uint   `json:"maxCollateralInputs"`
-				MaxTxExUnits         struct {
-					Mem   uint64 `json:"mem"`
-					Steps uint64 `json:"steps"`
-				} `json:"maxTxExUnits"`
-				MaxBlockExUnits struct {
-					Mem   uint64 `json:"mem"`
-					Steps uint64 `json:"steps"`
-				} `json:"maxBlockExUnits"`
-				ExecutionPrices TempExecutionPrices `json:"executionPrices"`
-				CostModels      TempCostModels      `json:"costModels"`
-			}
-
-			var tempGenesis TempGenesis
-			err := json.Unmarshal([]byte(tt.genesisJSON), &tempGenesis)
-			if err != nil {
-				t.Fatalf("failed to parse genesis: %v", err)
-			}
-
-			// Convert to the actual AlonzoGenesis type with proper type conversions
-			genesis := alonzo.AlonzoGenesis{
-				LovelacePerUtxoWord:  tempGenesis.LovelacePerUtxoWord,
-				MaxValueSize:         tempGenesis.MaxValueSize,
-				CollateralPercentage: tempGenesis.CollateralPercentage,
-				MaxCollateralInputs:  tempGenesis.MaxCollateralInputs,
-				MaxTxExUnits: alonzo.AlonzoGenesisExUnits{
-					Mem:   uint(tempGenesis.MaxTxExUnits.Mem),
-					Steps: uint(tempGenesis.MaxTxExUnits.Steps),
-				},
-				MaxBlockExUnits: alonzo.AlonzoGenesisExUnits{
-					Mem:   uint(tempGenesis.MaxBlockExUnits.Mem),
-					Steps: uint(tempGenesis.MaxBlockExUnits.Steps),
-				},
-				ExecutionPrices: alonzo.AlonzoGenesisExecutionPrices{
-					Mem:   convertToExecutionPricesRat(tempGenesis.ExecutionPrices.Mem),
-					Steps: convertToExecutionPricesRat(tempGenesis.ExecutionPrices.Steps),
-				},
-				CostModels: convertCostModels(tempGenesis.CostModels),
-			}
-
-			params := newBaseProtocolParams()
-			err = params.UpdateFromGenesis(&genesis)
-			if err != nil {
-				t.Fatalf("UpdateFromGenesis failed: %v", err)
-			}
-
-			if !tt.validate(&params) {
-				t.Errorf("validation failed for params: %+v", params)
-			}
-		})
-	}
-}
-
-func convertToExecutionPricesRat(r *struct {
-	Numerator   int64 `json:"numerator"`
-	Denominator int64 `json:"denominator"`
-}) *alonzo.AlonzoGenesisExecutionPricesRat {
-	if r == nil {
-		return nil
-	}
-	return &alonzo.AlonzoGenesisExecutionPricesRat{
-		Rat: big.NewRat(r.Numerator, r.Denominator),
-	}
-}
-
-func convertCostModels(tempModels map[string]map[string]int) map[string]map[string]int {
-	// Create a new map with the correct type
-	models := make(map[string]map[string]int)
-	for k, v := range tempModels {
-		// Create a new inner map
-		innerMap := make(map[string]int)
-		for k2, v2 := range v {
-			innerMap[k2] = v2
-		}
-		models[k] = innerMap
-	}
-	return models
-}
-
-func TestAlonzoProtocolParametersUtxorpc(t *testing.T) {
-	baseParams := newBaseProtocolParams()
-	params := alonzo.AlonzoProtocolParameters{
-		MinFeeA:              baseParams.MinFeeA,
-		MinFeeB:              baseParams.MinFeeB,
-		MaxBlockBodySize:     baseParams.MaxBlockBodySize,
-		MaxTxSize:            baseParams.MaxTxSize,
-		MaxBlockHeaderSize:   baseParams.MaxBlockHeaderSize,
-		KeyDeposit:           baseParams.KeyDeposit,
-		PoolDeposit:          baseParams.PoolDeposit,
-		MaxEpoch:             baseParams.MaxEpoch,
-		NOpt:                 baseParams.NOpt,
-		A0:                   baseParams.A0,
-		Rho:                  baseParams.Rho,
-		Tau:                  baseParams.Tau,
-		ProtocolMajor:        baseParams.ProtocolMajor,
-		ProtocolMinor:        baseParams.ProtocolMinor,
-		MinPoolCost:          340000000,
-		AdaPerUtxoByte:       4310,
-		MaxValueSize:         5000,
-		CollateralPercentage: 150,
-		MaxCollateralInputs:  3,
+		MinPoolCost:        0,
+		AdaPerUtxoByte:     4310,
 		ExecutionCosts: common.ExUnitPrice{
 			MemPrice:  &cbor.Rat{Rat: big.NewRat(577, 10000)},
 			StepPrice: &cbor.Rat{Rat: big.NewRat(721, 10000000)},
@@ -266,70 +59,449 @@ func TestAlonzoProtocolParametersUtxorpc(t *testing.T) {
 			Memory: 50000000,
 			Steps:  40000000000,
 		},
-		CostModels: map[alonzo.PlutusVersion]*alonzo.CostModel{
-			alonzo.PlutusV1: {
-				Parameters: map[string]int64{"param0": 100, "param1": 200, "param2": 300},
-				Order:      []string{"param0", "param1", "param2"},
-			},
+		MaxValueSize:         5000,
+		CollateralPercentage: 150,
+		MaxCollateralInputs:  3,
+		CostModels: map[uint][]int64{
+			0: completeCostModel(166), // PlutusV1 with exactly 166 parameters
+			1: completeCostModel(175), // PlutusV2 with exactly 175 parameters
 		},
-	}
-
-	result := params.Utxorpc()
-	if result == nil {
-		t.Fatal("Utxorpc() returned nil")
-	}
-
-	// Verify cost models
-	if result.CostModels == nil {
-		t.Fatal("CostModels should not be nil")
-	}
-	if result.CostModels.PlutusV1 == nil {
-		t.Fatal("PlutusV1 cost model should not be nil")
-	}
-	if len(result.CostModels.PlutusV1.Values) != 3 {
-		t.Errorf("expected 3 cost model values, got %d", len(result.CostModels.PlutusV1.Values))
-	}
-
-	// Verify other parameters
-	if result.MaxTxSize != uint64(params.MaxTxSize) {
-		t.Errorf("incorrect MaxTxSize conversion")
-	}
-	if result.MinPoolCost != params.MinPoolCost {
-		t.Errorf("incorrect MinPoolCost conversion")
-	}
-	if result.CoinsPerUtxoByte != params.AdaPerUtxoByte {
-		t.Errorf("incorrect AdaPerUtxoByte conversion")
 	}
 }
 
-func TestCostModelConversions(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    map[alonzo.PlutusVersion]*alonzo.CostModel
-		expected map[uint][]int64
+// Helper function to create complete cost models
+func completeCostModel(size int) []int64 {
+	model := make([]int64, size)
+	for i := range model {
+		model[i] = int64(i + 1) // Fill with sequential values
+	}
+	return model
+}
+
+func TestAlonzoProtocolParamsUpdate(t *testing.T) {
+	testDefs := []struct {
+		startParams    alonzo.AlonzoProtocolParameters
+		updateCbor     string
+		expectedParams alonzo.AlonzoProtocolParameters
 	}{
 		{
-			name: "Single Version",
-			input: map[alonzo.PlutusVersion]*alonzo.CostModel{
-				alonzo.PlutusV1: {
-					Parameters: map[string]int64{"param0": 1, "param1": 2},
-					Order:      []string{"param0", "param1"},
+			startParams: alonzo.AlonzoProtocolParameters{
+				Decentralization: &cbor.Rat{
+					Rat: new(big.Rat).SetInt64(1),
 				},
 			},
-			expected: map[uint][]int64{
-				0: {1, 2},
+			updateCbor: "a10cd81e82090a",
+			expectedParams: alonzo.AlonzoProtocolParameters{
+				Decentralization: &cbor.Rat{Rat: big.NewRat(9, 10)},
 			},
+		},
+		{
+			startParams: alonzo.AlonzoProtocolParameters{
+				ProtocolMajor: 5,
+			},
+			updateCbor: "a10e820600",
+			expectedParams: alonzo.AlonzoProtocolParameters{
+				ProtocolMajor: 6,
+			},
+		},
+		{
+			startParams: alonzo.AlonzoProtocolParameters{
+				MaxBlockBodySize: 1,
+				MaxTxExUnits: common.ExUnits{
+					Memory: 1,
+					Steps:  1,
+				},
+			},
+			updateCbor: "a2021a0001200014821a00aba9501b00000002540be400",
+			expectedParams: alonzo.AlonzoProtocolParameters{
+				MaxBlockBodySize: 73728,
+				MaxTxExUnits: common.ExUnits{
+					Memory: 11250000,
+					Steps:  10000000000,
+				},
+			},
+		},
+	}
+	for _, testDef := range testDefs {
+		cborBytes, err := hex.DecodeString(testDef.updateCbor)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		var tmpUpdate alonzo.AlonzoProtocolParameterUpdate
+		if _, err := cbor.Decode(cborBytes, &tmpUpdate); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		tmpParams := testDef.startParams
+		tmpParams.Update(&tmpUpdate)
+		if !reflect.DeepEqual(tmpParams, testDef.expectedParams) {
+			t.Fatalf(
+				"did not get expected params:\n     got: %#v\n  wanted: %#v",
+				tmpParams,
+				testDef.expectedParams,
+			)
+		}
+	}
+}
+
+func TestAlonzoProtocolParametersUpdateFromGenesis(t *testing.T) {
+	// Create cost models in the format the UpdateFromGenesis expects
+	plutusV1CostModel := make(map[string]interface{})
+	for i := 1; i <= 166; i++ {
+		plutusV1CostModel[fmt.Sprintf("param%d", i)] = i
+	}
+
+	plutusV2CostModel := make(map[string]interface{})
+	for i := 1; i <= 175; i++ {
+		plutusV2CostModel[fmt.Sprintf("param%d", i)] = i
+	}
+
+	tests := []struct {
+		name        string
+		genesisJSON string
+	}{
+		{
+			name: "Basic Parameters",
+			genesisJSON: `{
+                "lovelacePerUTxOWord": 34482,
+                "maxValueSize": 5000,
+                "collateralPercentage": 150,
+                "maxCollateralInputs": 3,
+                "maxTxExUnits": {"mem": 10000000, "steps": 10000000000},
+                "maxBlockExUnits": {"mem": 50000000, "steps": 40000000000},
+                "executionPrices": {
+                    "prMem": {"numerator": 577, "denominator": 10000},
+                    "prSteps": {"numerator": 721, "denominator": 10000000}
+                },
+                "costModels": {
+                    "PlutusV1": ` + toJSON(plutusV1CostModel) + `,
+                    "PlutusV2": ` + toJSON(plutusV2CostModel) + `
+                }
+            }`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var genesis alonzo.AlonzoGenesis
+			if err := json.Unmarshal([]byte(tt.genesisJSON), &genesis); err != nil {
+				t.Fatalf("failed to parse genesis: %v", err)
+			}
+
 			params := newBaseProtocolParams()
-			params.CostModels = tt.input
-			result := params.ToLegacyCostModels()
-			if !reflect.DeepEqual(result, tt.expected) {
-				t.Errorf("unexpected result:\ngot: %v\nwant: %v", result, tt.expected)
+			if err := params.UpdateFromGenesis(&genesis); err != nil {
+				t.Fatalf("UpdateFromGenesis failed: %v", err)
+			}
+
+			if len(params.CostModels[0]) != 166 {
+				t.Errorf("expected 166 PlutusV1 parameters, got %d", len(params.CostModels[0]))
+			}
+			if len(params.CostModels[1]) != 175 {
+				t.Errorf("expected 175 PlutusV2 parameters, got %d", len(params.CostModels[1]))
 			}
 		})
 	}
+}
+
+func TestCostModelArrayFormat(t *testing.T) {
+	// Create a PlutusV1 cost model as an array
+	plutusV1Array := make([]int, 166)
+	for i := range plutusV1Array {
+		plutusV1Array[i] = i + 1
+	}
+
+	genesisJSON := fmt.Sprintf(`{
+		"lovelacePerUTxOWord": 34482,
+		"maxValueSize": 5000,
+		"collateralPercentage": 150,
+		"maxCollateralInputs": 3,
+		"executionPrices": {
+			"prMem": {"numerator": 577, "denominator": 10000},
+			"prSteps": {"numerator": 721, "denominator": 10000000}
+		},
+		"maxTxExUnits": {"mem": 10000000, "steps": 10000000000},
+		"maxBlockExUnits": {"mem": 50000000, "steps": 40000000000},
+		"costModels": {
+			"PlutusV1": %s
+		}
+	}`, toJSON(plutusV1Array))
+
+	var genesis alonzo.AlonzoGenesis
+	if err := json.Unmarshal([]byte(genesisJSON), &genesis); err != nil {
+		t.Fatalf("failed to unmarshal genesis JSON: %v", err)
+	}
+
+	params := alonzo.AlonzoProtocolParameters{}
+	if err := params.UpdateFromGenesis(&genesis); err != nil {
+		t.Fatalf("UpdateFromGenesis failed: %v", err)
+	}
+
+	if len(params.CostModels[alonzo.PlutusV1Key]) != 166 {
+		t.Errorf("expected 166 parameters, got %d", len(params.CostModels[alonzo.PlutusV1Key]))
+	}
+
+	// Verify first and last values
+	if params.CostModels[alonzo.PlutusV1Key][0] != 1 {
+		t.Errorf("expected first parameter to be 1, got %d", params.CostModels[alonzo.PlutusV1Key][0])
+	}
+	if params.CostModels[alonzo.PlutusV1Key][165] != 166 {
+		t.Errorf("expected last parameter to be 166, got %d", params.CostModels[alonzo.PlutusV1Key][165])
+	}
+}
+
+func TestScientificNotationInCostModels(t *testing.T) {
+	// Create a full cost model with 166 parameters, using scientific notation for some
+	costModel := make(map[string]interface{})
+	for i := 1; i <= 166; i++ {
+		switch i {
+		case 1:
+			costModel[fmt.Sprintf("param%d", i)] = 2.477736e+06
+		case 2:
+			costModel[fmt.Sprintf("param%d", i)] = 1.5e6
+		case 3:
+			costModel[fmt.Sprintf("param%d", i)] = 1000000
+		default:
+			costModel[fmt.Sprintf("param%d", i)] = i * 1000
+		}
+	}
+
+	genesisJSON := fmt.Sprintf(`{
+        "lovelacePerUTxOWord": 34482,
+        "maxValueSize": 5000,
+        "collateralPercentage": 150,
+        "maxCollateralInputs": 3,
+        "executionPrices": {
+            "prMem": {"numerator": 577, "denominator": 10000},
+            "prSteps": {"numerator": 721, "denominator": 10000000}
+        },
+        "maxTxExUnits": {"mem": 10000000, "steps": 10000000000},
+        "maxBlockExUnits": {"mem": 50000000, "steps": 40000000000},
+        "costModels": {
+            "PlutusV1": %s
+        }
+    }`, toJSON(costModel))
+
+	var genesis alonzo.AlonzoGenesis
+	if err := json.Unmarshal([]byte(genesisJSON), &genesis); err != nil {
+		t.Fatalf("failed to unmarshal genesis: %v", err)
+	}
+
+	params := alonzo.AlonzoProtocolParameters{}
+	if err := params.UpdateFromGenesis(&genesis); err != nil {
+		t.Fatalf("UpdateFromGenesis failed: %v", err)
+	}
+
+	// Verify the scientific notation conversions
+	expected := []int64{2477736, 1500000, 1000000}
+	for i := 0; i < 3; i++ {
+		if params.CostModels[alonzo.PlutusV1Key][i] != expected[i] {
+			t.Errorf("parameter %d conversion failed: got %d, want %d",
+				i+1, params.CostModels[alonzo.PlutusV1Key][i], expected[i])
+		}
+	}
+
+	// Verify we have all 166 parameters
+	if len(params.CostModels[alonzo.PlutusV1Key]) != 166 {
+		t.Errorf("expected 166 parameters, got %d", len(params.CostModels[alonzo.PlutusV1Key]))
+	}
+}
+
+func TestInvalidCostModelFormats(t *testing.T) {
+	baseJSON := `{
+        "lovelacePerUTxOWord": 34482,
+        "maxValueSize": 5000,
+        "collateralPercentage": 150,
+        "maxCollateralInputs": 3,
+        "executionPrices": {
+            "prMem": {"numerator": 577, "denominator": 10000},
+            "prSteps": {"numerator": 721, "denominator": 10000000}
+        },
+        "maxTxExUnits": {"mem": 10000000, "steps": 10000000000},
+        "maxBlockExUnits": {"mem": 50000000, "steps": 40000000000},
+        %s
+    }`
+
+	tests := []struct {
+		name        string
+		costModels  string
+		expectError string
+	}{
+		{
+			name: "InvalidType",
+			costModels: `"costModels": {
+                "PlutusV1": "invalid"
+            }`,
+			expectError: "invalid cost model format",
+		},
+		{
+			name: "ShortArray",
+			costModels: `"costModels": {
+                "PlutusV1": [1, 2, 3]
+            }`,
+			expectError: "expected 166, got 3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fullJSON := fmt.Sprintf(baseJSON, tt.costModels)
+
+			var genesis alonzo.AlonzoGenesis
+			if err := json.Unmarshal([]byte(fullJSON), &genesis); err != nil {
+				t.Fatalf("failed to unmarshal genesis: %v", err)
+			}
+
+			params := alonzo.AlonzoProtocolParameters{}
+			err := params.UpdateFromGenesis(&genesis)
+			if err == nil {
+				t.Fatal("expected error but got none")
+			}
+			if !strings.Contains(err.Error(), tt.expectError) {
+				t.Errorf("expected error containing %q, got %v", tt.expectError, err)
+			}
+		})
+	}
+}
+
+func TestAlonzoUtxorpc(t *testing.T) {
+	inputParams := alonzo.AlonzoProtocolParameters{
+		MaxTxSize:            16384,
+		MinFeeA:              500,
+		MinFeeB:              2,
+		MaxBlockBodySize:     65536,
+		MaxBlockHeaderSize:   1024,
+		KeyDeposit:           2000,
+		PoolDeposit:          500000,
+		MaxEpoch:             2160,
+		NOpt:                 100,
+		A0:                   &cbor.Rat{Rat: big.NewRat(1, 2)},
+		Rho:                  &cbor.Rat{Rat: big.NewRat(3, 4)},
+		Tau:                  &cbor.Rat{Rat: big.NewRat(5, 6)},
+		ProtocolMajor:        8,
+		ProtocolMinor:        0,
+		AdaPerUtxoByte:       44 / 8,
+		MinPoolCost:          340000000,
+		MaxValueSize:         1024,
+		CollateralPercentage: 150,
+		MaxCollateralInputs:  5,
+		ExecutionCosts: common.ExUnitPrice{
+			MemPrice:  &cbor.Rat{Rat: big.NewRat(1, 2)},
+			StepPrice: &cbor.Rat{Rat: big.NewRat(2, 3)},
+		},
+		MaxTxExUnits: common.ExUnits{
+			Memory: 1000000,
+			Steps:  200000,
+		},
+		MaxBlockExUnits: common.ExUnits{
+			Memory: 5000000,
+			Steps:  1000000,
+		},
+		CostModels: map[uint][]int64{
+			1: {100, 200, 300},
+			2: {400, 500, 600},
+			3: {700, 800, 900},
+		},
+	}
+
+	expectedUtxorpc := &cardano.PParams{
+		CoinsPerUtxoByte:         44 / 8,
+		MaxTxSize:                16384,
+		MinFeeCoefficient:        500,
+		MinFeeConstant:           2,
+		MaxBlockBodySize:         65536,
+		MaxBlockHeaderSize:       1024,
+		StakeKeyDeposit:          2000,
+		PoolDeposit:              500000,
+		PoolRetirementEpochBound: 2160,
+		DesiredNumberOfPools:     100,
+		PoolInfluence: &cardano.RationalNumber{
+			Numerator:   int32(1),
+			Denominator: uint32(2),
+		},
+		MonetaryExpansion: &cardano.RationalNumber{
+			Numerator:   int32(3),
+			Denominator: uint32(4),
+		},
+		TreasuryExpansion: &cardano.RationalNumber{
+			Numerator:   int32(5),
+			Denominator: uint32(6),
+		},
+		MinPoolCost: 340000000,
+		ProtocolVersion: &cardano.ProtocolVersion{
+			Major: 8,
+			Minor: 0,
+		},
+		MaxValueSize:         1024,
+		CollateralPercentage: 150,
+		MaxCollateralInputs:  5,
+		CostModels: &cardano.CostModels{
+			PlutusV1: &cardano.CostModel{
+				Values: []int64{100, 200, 300},
+			},
+			PlutusV2: &cardano.CostModel{
+				Values: []int64{400, 500, 600},
+			},
+			PlutusV3: &cardano.CostModel{
+				Values: []int64{700, 800, 900},
+			},
+		},
+		Prices: &cardano.ExPrices{
+			Memory: &cardano.RationalNumber{
+				Numerator:   int32(1),
+				Denominator: uint32(2),
+			},
+			Steps: &cardano.RationalNumber{
+				Numerator:   int32(2),
+				Denominator: uint32(3),
+			},
+		},
+		MaxExecutionUnitsPerTransaction: &cardano.ExUnits{
+			Memory: 1000000,
+			Steps:  200000,
+		},
+		MaxExecutionUnitsPerBlock: &cardano.ExUnits{
+			Memory: 5000000,
+			Steps:  1000000,
+		},
+	}
+
+	result := inputParams.Utxorpc()
+
+	if !reflect.DeepEqual(result, expectedUtxorpc) {
+		t.Fatalf(
+			"Utxorpc() test failed for Alonzo:\nExpected: %#v\nGot: %#v",
+			expectedUtxorpc,
+			result,
+		)
+	}
+}
+
+func toJSON(v interface{}) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal JSON: %v", err))
+	}
+	return string(b)
+}
+
+func verifyCostModel(t *testing.T, models map[string]interface{}, name string, expectedCount int) {
+	cm, ok := models[name].(map[string]interface{})
+	if !ok {
+		t.Fatalf("%s cost model not found or wrong type", name)
+	}
+	if len(cm) != expectedCount {
+		t.Fatalf("%s parameter count mismatch: got %d, want %d", name, len(cm), expectedCount)
+	}
+}
+
+func mustMarshalJSON(v interface{}) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal JSON: %v", err))
+	}
+	return string(b)
+}
+
+func jsonStringFromMap(m map[string]int64) string {
+	b, _ := json.Marshal(m)
+	return string(b)
 }

--- a/ledger/alonzo/pparams_test.go
+++ b/ledger/alonzo/pparams_test.go
@@ -1,24 +1,12 @@
-// Copyright 2024 Blink Labs Software
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package alonzo_test
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"math/big"
 	"reflect"
-	"strings"
+
+	//"strings"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -27,335 +15,304 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
-	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+	//"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
 
-func TestAlonzoProtocolParamsUpdate(t *testing.T) {
-	testDefs := []struct {
-		startParams    alonzo.AlonzoProtocolParameters
-		updateCbor     string
-		expectedParams alonzo.AlonzoProtocolParameters
-	}{
-		{
-			startParams: alonzo.AlonzoProtocolParameters{
-				MaryProtocolParameters: mary.MaryProtocolParameters{
-					AllegraProtocolParameters: allegra.AllegraProtocolParameters{
-						ShelleyProtocolParameters: shelley.ShelleyProtocolParameters{
-							Decentralization: &cbor.Rat{
-								Rat: new(big.Rat).SetInt64(1),
-							},
-						},
-					},
-				},
-			},
-			updateCbor: "a10cd81e82090a",
-			expectedParams: alonzo.AlonzoProtocolParameters{
-				MaryProtocolParameters: mary.MaryProtocolParameters{
-					AllegraProtocolParameters: allegra.AllegraProtocolParameters{
-						ShelleyProtocolParameters: shelley.ShelleyProtocolParameters{
-							Decentralization: &cbor.Rat{Rat: big.NewRat(9, 10)},
-						},
-					},
-				},
+// Helper to create properly initialized base protocol parameters
+func newBaseProtocolParams() mary.MaryProtocolParameters {
+	return mary.MaryProtocolParameters{
+		AllegraProtocolParameters: allegra.AllegraProtocolParameters{
+			ShelleyProtocolParameters: shelley.ShelleyProtocolParameters{
+				MinFeeA:            44,
+				MinFeeB:            155381,
+				MaxBlockBodySize:   65536,
+				MaxTxSize:          16384,
+				MaxBlockHeaderSize: 1100,
+				KeyDeposit:         2000000,
+				PoolDeposit:        500000000,
+				MaxEpoch:           18,
+				NOpt:               500,
+				A0:                 &cbor.Rat{Rat: big.NewRat(1, 2)},
+				Rho:                &cbor.Rat{Rat: big.NewRat(3, 4)},
+				Tau:                &cbor.Rat{Rat: big.NewRat(5, 6)},
+				ProtocolMajor:      8,
+				ProtocolMinor:      0,
 			},
 		},
-		{
-			startParams: alonzo.AlonzoProtocolParameters{
-				MaryProtocolParameters: mary.MaryProtocolParameters{
-					AllegraProtocolParameters: allegra.AllegraProtocolParameters{
-						ShelleyProtocolParameters: shelley.ShelleyProtocolParameters{
-							ProtocolMajor: 5,
-						},
-					},
-				},
-			},
-			updateCbor: "a10e820600",
-			expectedParams: alonzo.AlonzoProtocolParameters{
-				MaryProtocolParameters: mary.MaryProtocolParameters{
-					AllegraProtocolParameters: allegra.AllegraProtocolParameters{
-						ShelleyProtocolParameters: shelley.ShelleyProtocolParameters{
-							ProtocolMajor: 6,
-						},
-					},
-				},
-			},
-		},
-		{
-			startParams: alonzo.AlonzoProtocolParameters{
-				MaryProtocolParameters: mary.MaryProtocolParameters{
-					AllegraProtocolParameters: allegra.AllegraProtocolParameters{
-						ShelleyProtocolParameters: shelley.ShelleyProtocolParameters{
-							MaxBlockBodySize: 1,
-						},
-					},
-				},
-				MaxTxExUnits: common.ExUnits{
-					Memory: 1,
-					Steps:  1,
-				},
-			},
-			updateCbor: "a2021a0001200014821a00aba9501b00000002540be400",
-			expectedParams: alonzo.AlonzoProtocolParameters{
-				MaryProtocolParameters: mary.MaryProtocolParameters{
-					AllegraProtocolParameters: allegra.AllegraProtocolParameters{
-						ShelleyProtocolParameters: shelley.ShelleyProtocolParameters{
-							MaxBlockBodySize: 73728,
-						},
-					},
-				},
-				MaxTxExUnits: common.ExUnits{
-					Memory: 11250000,
-					Steps:  10000000000,
-				},
-			},
-		},
-	}
-	for _, testDef := range testDefs {
-		cborBytes, err := hex.DecodeString(testDef.updateCbor)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-		var tmpUpdate alonzo.AlonzoProtocolParameterUpdate
-		if _, err := cbor.Decode(cborBytes, &tmpUpdate); err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-		tmpParams := testDef.startParams
-		tmpParams.Update(&tmpUpdate)
-		if !reflect.DeepEqual(tmpParams, testDef.expectedParams) {
-			t.Fatalf(
-				"did not get expected params:\n     got: %#v\n  wanted: %#v",
-				tmpParams,
-				testDef.expectedParams,
-			)
-		}
 	}
 }
 
-func TestAlonzoProtocolParamsUpdateFromGenesis(t *testing.T) {
-	testDefs := []struct {
-		startParams    alonzo.AlonzoProtocolParameters
-		genesisJson    string
-		expectedParams alonzo.AlonzoProtocolParameters
+func TestAlonzoProtocolParametersUpdate(t *testing.T) {
+	tests := []struct {
+		name        string
+		updateCbor  string
+		expected    alonzo.AlonzoProtocolParameters
+		expectError bool
 	}{
 		{
-			startParams: alonzo.AlonzoProtocolParameters{
-				MaryProtocolParameters: mary.MaryProtocolParameters{
-					AllegraProtocolParameters: allegra.AllegraProtocolParameters{
-						ShelleyProtocolParameters: shelley.ShelleyProtocolParameters{
-							Decentralization: &cbor.Rat{
-								Rat: new(big.Rat).SetInt64(1),
-							},
-						},
-					},
-				},
-			},
-			genesisJson: `{"lovelacePerUTxOWord": 34482}`,
-			expectedParams: alonzo.AlonzoProtocolParameters{
-				MaryProtocolParameters: mary.MaryProtocolParameters{
-					AllegraProtocolParameters: allegra.AllegraProtocolParameters{
-						ShelleyProtocolParameters: shelley.ShelleyProtocolParameters{
-							Decentralization: &cbor.Rat{
-								Rat: new(big.Rat).SetInt64(1),
-							},
-						},
-					},
-				},
-				AdaPerUtxoByte: 34482 / 8,
-			},
-		},
-		{
-			startParams: alonzo.AlonzoProtocolParameters{},
-			genesisJson: `{
-				"lovelacePerUTxOWord": 34482,
-				"costModels": {
-					"plutus:v1": {
-						"addInteger-cpu-arguments-intercept": 10,
-						"subtractInteger-cpu-arguments-intercept": 30,
-						"multiplyInteger-cpu-arguments-intercept": 20
-					},
-					"plutus:v2": {
-						"appendByteString-cpu-arguments-slope": 5,
-						"consByteString-cpu-arguments-intercept": 2
-					},
-					"plutus:v3": {
-						"unknown-op": 999
-					}
-				}
-			}`,
-			expectedParams: alonzo.AlonzoProtocolParameters{
-				AdaPerUtxoByte: 34482 / 8,
-				CostModels: map[uint][]int64{
-					0: {
-						10, // addInteger-cpu-arguments-intercept
-						20, // multiplyInteger-cpu-arguments-intercept
-						30, // subtractInteger-cpu-arguments-intercept
-					},
-					1: {
-						5, // appendByteString-cpu-arguments-slope
-						2, // consByteString-cpu-arguments-intercept
-					},
-				},
-			},
-		},
-		{
-			//out of order keys
-			startParams: alonzo.AlonzoProtocolParameters{},
-			genesisJson: `{
-				"lovelacePerUTxOWord": 34482,
-				"costModels": {
-					"plutus:v1": {
-						"zzz": 3,
-						"aaa": 1,
-						"mmm": 2
-					}
-				}
-			}`,
-			expectedParams: alonzo.AlonzoProtocolParameters{
-				AdaPerUtxoByte: 34482 / 8,
-				CostModels: map[uint][]int64{
-					0: {
-						1, // "aaa"
-						2, // "mmm"
-						3, // "zzz"
-					},
-				},
+			name:       "Update MinPoolCost",
+			updateCbor: "a1101903e8", // {16: 1000}
+			expected: alonzo.AlonzoProtocolParameters{
+				MaryProtocolParameters: newBaseProtocolParams(),
+				MinPoolCost:            1000,
 			},
 		},
 	}
-	for _, testDef := range testDefs {
-		tmpGenesis, err := alonzo.NewAlonzoGenesisFromReader(
-			strings.NewReader(testDef.genesisJson),
-		)
-		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-		tmpParams := testDef.startParams
-		tmpParams.UpdateFromGenesis(&tmpGenesis)
-		if !reflect.DeepEqual(tmpParams, testDef.expectedParams) {
-			t.Fatalf(
-				"did not get expected params:\n     got: %#v\n  wanted: %#v",
-				tmpParams,
-				testDef.expectedParams,
-			)
-		}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := hex.DecodeString(tt.updateCbor)
+			if err != nil {
+				t.Fatalf("failed to decode CBOR: %v", err)
+			}
+
+			var update alonzo.AlonzoProtocolParameterUpdate
+			if _, err := cbor.Decode(data, &update); err != nil {
+				if !tt.expectError {
+					t.Fatalf("failed to decode update: %v", err)
+				}
+				return
+			}
+
+			params := alonzo.AlonzoProtocolParameters{
+				MaryProtocolParameters: newBaseProtocolParams(),
+			}
+			params.Update(&update)
+
+			if !reflect.DeepEqual(params, tt.expected) {
+				t.Errorf("unexpected result:\ngot: %+v\nwant: %+v", params, tt.expected)
+			}
+		})
+	}
+}
+func TestAlonzoProtocolParametersUpdateFromGenesis(t *testing.T) {
+	tests := []struct {
+		name        string
+		genesisJSON string
+		validate    func(*alonzo.AlonzoProtocolParameters) bool
+	}{
+		{
+			name: "Basic Parameters",
+			genesisJSON: `{
+                "lovelacePerUTxOWord": 34482,
+                "maxValueSize": 5000,
+                "collateralPercentage": 150,
+                "maxCollateralInputs": 3,
+                "maxTxExUnits": {"mem": 10000000, "steps": 10000000000},
+                "maxBlockExUnits": {"mem": 50000000, "steps": 40000000000},
+                "executionPrices": {
+                    "mem": {"numerator": 577, "denominator": 10000},
+                    "steps": {"numerator": 721, "denominator": 10000000}
+                },
+                "costModels": {
+                    "PlutusV1": {
+                        "param0": 100,
+                        "param1": 200,
+                        "param2": 300
+                    }
+                }
+            }`,
+			validate: func(p *alonzo.AlonzoProtocolParameters) bool {
+				return p.AdaPerUtxoByte == 4310 && // 34482 / 8
+					p.MaxValueSize == 5000 &&
+					p.CollateralPercentage == 150 &&
+					p.MaxCollateralInputs == 3 &&
+					p.MaxTxExUnits.Memory == 10000000 &&
+					p.MaxTxExUnits.Steps == 10000000000 &&
+					p.ExecutionCosts.MemPrice.Rat.Cmp(big.NewRat(577, 10000)) == 0 &&
+					p.CostModels[alonzo.PlutusV1] != nil &&
+					len(p.CostModels[alonzo.PlutusV1].Order) == 3
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temporary struct with the exact JSON structure
+			type TempExecutionPrices struct {
+				Mem *struct {
+					Numerator   int64 `json:"numerator"`
+					Denominator int64 `json:"denominator"`
+				} `json:"mem"`
+				Steps *struct {
+					Numerator   int64 `json:"numerator"`
+					Denominator int64 `json:"denominator"`
+				} `json:"steps"`
+			}
+
+			type TempCostModels map[string]map[string]int
+
+			type TempGenesis struct {
+				LovelacePerUtxoWord  uint64 `json:"lovelacePerUTxOWord"`
+				MaxValueSize         uint   `json:"maxValueSize"`
+				CollateralPercentage uint   `json:"collateralPercentage"`
+				MaxCollateralInputs  uint   `json:"maxCollateralInputs"`
+				MaxTxExUnits         struct {
+					Mem   uint64 `json:"mem"`
+					Steps uint64 `json:"steps"`
+				} `json:"maxTxExUnits"`
+				MaxBlockExUnits struct {
+					Mem   uint64 `json:"mem"`
+					Steps uint64 `json:"steps"`
+				} `json:"maxBlockExUnits"`
+				ExecutionPrices TempExecutionPrices `json:"executionPrices"`
+				CostModels      TempCostModels      `json:"costModels"`
+			}
+
+			var tempGenesis TempGenesis
+			err := json.Unmarshal([]byte(tt.genesisJSON), &tempGenesis)
+			if err != nil {
+				t.Fatalf("failed to parse genesis: %v", err)
+			}
+
+			// Convert to the actual AlonzoGenesis type with proper type conversions
+			genesis := alonzo.AlonzoGenesis{
+				LovelacePerUtxoWord:  tempGenesis.LovelacePerUtxoWord,
+				MaxValueSize:         tempGenesis.MaxValueSize,
+				CollateralPercentage: tempGenesis.CollateralPercentage,
+				MaxCollateralInputs:  tempGenesis.MaxCollateralInputs,
+				MaxTxExUnits: alonzo.AlonzoGenesisExUnits{
+					Mem:   uint(tempGenesis.MaxTxExUnits.Mem),
+					Steps: uint(tempGenesis.MaxTxExUnits.Steps),
+				},
+				MaxBlockExUnits: alonzo.AlonzoGenesisExUnits{
+					Mem:   uint(tempGenesis.MaxBlockExUnits.Mem),
+					Steps: uint(tempGenesis.MaxBlockExUnits.Steps),
+				},
+				ExecutionPrices: alonzo.AlonzoGenesisExecutionPrices{
+					Mem:   convertToExecutionPricesRat(tempGenesis.ExecutionPrices.Mem),
+					Steps: convertToExecutionPricesRat(tempGenesis.ExecutionPrices.Steps),
+				},
+				CostModels: convertCostModels(tempGenesis.CostModels),
+			}
+
+			params := alonzo.AlonzoProtocolParameters{
+				MaryProtocolParameters: newBaseProtocolParams(),
+			}
+			err = params.UpdateFromGenesis(&genesis)
+			if err != nil {
+				t.Fatalf("UpdateFromGenesis failed: %v", err)
+			}
+
+			if !tt.validate(&params) {
+				t.Errorf("validation failed for params: %+v", params)
+			}
+		})
 	}
 }
 
-func TestAlonzoUtxorpc(t *testing.T) {
-	inputParams := alonzo.AlonzoProtocolParameters{
-		MaryProtocolParameters: mary.MaryProtocolParameters{
-			AllegraProtocolParameters: allegra.AllegraProtocolParameters{
-				ShelleyProtocolParameters: shelley.ShelleyProtocolParameters{
-					MaxTxSize:          16384,
-					MinFeeA:            500,
-					MinFeeB:            2,
-					MaxBlockBodySize:   65536,
-					MaxBlockHeaderSize: 1024,
-					KeyDeposit:         2000,
-					PoolDeposit:        500000,
-					MaxEpoch:           2160,
-					NOpt:               100,
-					A0:                 &cbor.Rat{Rat: big.NewRat(1, 2)},
-					Rho:                &cbor.Rat{Rat: big.NewRat(3, 4)},
-					Tau:                &cbor.Rat{Rat: big.NewRat(5, 6)},
-					ProtocolMajor:      8,
-					ProtocolMinor:      0,
-				},
-			},
-		},
-		AdaPerUtxoByte:       44 / 8,
-		MinPoolCost:          340000000,
-		MaxValueSize:         1024,
-		CollateralPercentage: 150,
-		MaxCollateralInputs:  5,
+func convertToExecutionPricesRat(r *struct {
+	Numerator   int64 `json:"numerator"`
+	Denominator int64 `json:"denominator"`
+}) *alonzo.AlonzoGenesisExecutionPricesRat {
+	if r == nil {
+		return nil
+	}
+	return &alonzo.AlonzoGenesisExecutionPricesRat{
+		Rat: big.NewRat(r.Numerator, r.Denominator),
+	}
+}
+
+func convertCostModels(tempModels map[string]map[string]int) map[string]map[string]int {
+	// Create a new map with the correct type
+	models := make(map[string]map[string]int)
+	for k, v := range tempModels {
+		// Create a new inner map
+		innerMap := make(map[string]int)
+		for k2, v2 := range v {
+			innerMap[k2] = v2
+		}
+		models[k] = innerMap
+	}
+	return models
+}
+
+func TestAlonzoProtocolParametersUtxorpc(t *testing.T) {
+	params := alonzo.AlonzoProtocolParameters{
+		MaryProtocolParameters: newBaseProtocolParams(),
+		MinPoolCost:            340000000,
+		AdaPerUtxoByte:         4310,
+		MaxValueSize:           5000,
+		CollateralPercentage:   150,
+		MaxCollateralInputs:    3,
 		ExecutionCosts: common.ExUnitPrice{
-			MemPrice:  &cbor.Rat{Rat: big.NewRat(1, 2)},
-			StepPrice: &cbor.Rat{Rat: big.NewRat(2, 3)},
+			MemPrice:  &cbor.Rat{Rat: big.NewRat(577, 10000)},
+			StepPrice: &cbor.Rat{Rat: big.NewRat(721, 10000000)},
 		},
 		MaxTxExUnits: common.ExUnits{
-			Memory: 1000000,
-			Steps:  200000,
+			Memory: 10000000,
+			Steps:  10000000000,
 		},
 		MaxBlockExUnits: common.ExUnits{
-			Memory: 5000000,
-			Steps:  1000000,
+			Memory: 50000000,
+			Steps:  40000000000,
 		},
-		CostModels: map[uint][]int64{
-			1: {100, 200, 300},
-			2: {400, 500, 600},
-			3: {700, 800, 900},
+		CostModels: map[alonzo.PlutusVersion]*alonzo.CostModel{
+			alonzo.PlutusV1: {
+				Parameters: map[string]int64{"param0": 100, "param1": 200, "param2": 300},
+				Order:      []string{"param0", "param1", "param2"},
+			},
 		},
 	}
 
-	expectedUtxorpc := &cardano.PParams{
-		CoinsPerUtxoByte:         44 / 8,
-		MaxTxSize:                16384,
-		MinFeeCoefficient:        500,
-		MinFeeConstant:           2,
-		MaxBlockBodySize:         65536,
-		MaxBlockHeaderSize:       1024,
-		StakeKeyDeposit:          2000,
-		PoolDeposit:              500000,
-		PoolRetirementEpochBound: 2160,
-		DesiredNumberOfPools:     100,
-		PoolInfluence: &cardano.RationalNumber{
-			Numerator:   int32(1),
-			Denominator: uint32(2),
-		},
-		MonetaryExpansion: &cardano.RationalNumber{
-			Numerator:   int32(3),
-			Denominator: uint32(4),
-		},
-		TreasuryExpansion: &cardano.RationalNumber{
-			Numerator:   int32(5),
-			Denominator: uint32(6),
-		},
-		MinPoolCost: 340000000,
-		ProtocolVersion: &cardano.ProtocolVersion{
-			Major: 8,
-			Minor: 0,
-		},
-		MaxValueSize:         1024,
-		CollateralPercentage: 150,
-		MaxCollateralInputs:  5,
-		CostModels: &cardano.CostModels{
-			PlutusV1: &cardano.CostModel{
-				Values: []int64{100, 200, 300},
+	result := params.Utxorpc()
+	if result == nil {
+		t.Fatal("Utxorpc() returned nil")
+	}
+
+	// Verify cost models
+	if result.CostModels == nil {
+		t.Fatal("CostModels should not be nil")
+	}
+	if result.CostModels.PlutusV1 == nil {
+		t.Fatal("PlutusV1 cost model should not be nil")
+	}
+	if len(result.CostModels.PlutusV1.Values) != 3 {
+		t.Errorf("expected 3 cost model values, got %d", len(result.CostModels.PlutusV1.Values))
+	}
+
+	// Verify other parameters
+	if result.MaxTxSize != uint64(params.MaxTxSize) {
+		t.Errorf("incorrect MaxTxSize conversion")
+	}
+	if result.MinPoolCost != params.MinPoolCost {
+		t.Errorf("incorrect MinPoolCost conversion")
+	}
+	if result.CoinsPerUtxoByte != params.AdaPerUtxoByte {
+		t.Errorf("incorrect AdaPerUtxoByte conversion")
+	}
+}
+
+func TestCostModelConversions(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[alonzo.PlutusVersion]*alonzo.CostModel
+		expected map[uint][]int64
+	}{
+		{
+			name: "Single Version",
+			input: map[alonzo.PlutusVersion]*alonzo.CostModel{
+				alonzo.PlutusV1: {
+					Parameters: map[string]int64{"param0": 1, "param1": 2},
+					Order:      []string{"param0", "param1"},
+				},
 			},
-			PlutusV2: &cardano.CostModel{
-				Values: []int64{400, 500, 600},
+			expected: map[uint][]int64{
+				0: {1, 2},
 			},
-			PlutusV3: &cardano.CostModel{
-				Values: []int64{700, 800, 900},
-			},
-		},
-		Prices: &cardano.ExPrices{
-			Memory: &cardano.RationalNumber{
-				Numerator:   int32(1),
-				Denominator: uint32(2),
-			},
-			Steps: &cardano.RationalNumber{
-				Numerator:   int32(2),
-				Denominator: uint32(3),
-			},
-		},
-		MaxExecutionUnitsPerTransaction: &cardano.ExUnits{
-			Memory: 1000000,
-			Steps:  200000,
-		},
-		MaxExecutionUnitsPerBlock: &cardano.ExUnits{
-			Memory: 5000000,
-			Steps:  1000000,
 		},
 	}
 
-	result := inputParams.Utxorpc()
-
-	if !reflect.DeepEqual(result, expectedUtxorpc) {
-		t.Fatalf(
-			"Utxorpc() test failed for Alonzo:\nExpected: %#v\nGot: %#v",
-			expectedUtxorpc,
-			result,
-		)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := alonzo.AlonzoProtocolParameters{
+				MaryProtocolParameters: newBaseProtocolParams(),
+				CostModels:             tt.input,
+			}
+			result := params.ToLegacyCostModels()
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("unexpected result:\ngot: %v\nwant: %v", result, tt.expected)
+			}
+		})
 	}
 }

--- a/ledger/babbage/pparams.go
+++ b/ledger/babbage/pparams.go
@@ -258,7 +258,7 @@ func UpgradePParams(
 		ProtocolMinor:        prevPParams.ProtocolMinor,
 		MinPoolCost:          prevPParams.MinPoolCost,
 		AdaPerUtxoByte:       prevPParams.AdaPerUtxoByte,
-		CostModels:           prevPParams.CostModels,
+		CostModels:           prevPParams.ToLegacyCostModels(),
 		ExecutionCosts:       prevPParams.ExecutionCosts,
 		MaxTxExUnits:         prevPParams.MaxTxExUnits,
 		MaxBlockExUnits:      prevPParams.MaxBlockExUnits,

--- a/ledger/babbage/pparams.go
+++ b/ledger/babbage/pparams.go
@@ -265,7 +265,7 @@ func UpgradePParams(
 		ProtocolMinor:        prevPParams.ProtocolMinor,
 		MinPoolCost:          prevPParams.MinPoolCost,
 		AdaPerUtxoByte:       prevPParams.AdaPerUtxoByte,
-		CostModels:           prevPParams.ToLegacyCostModels(),
+		CostModels:           prevPParams.CostModels,
 		ExecutionCosts:       prevPParams.ExecutionCosts,
 		MaxTxExUnits:         prevPParams.MaxTxExUnits,
 		MaxBlockExUnits:      prevPParams.MaxBlockExUnits,


### PR DESCRIPTION
1. Changes added to support cost models when updating Alonzo protocol params from genesis config - mapped string keys to numeric indexes
2. Changes to support both array and map from genesis files
3. Added unit tests for the changes

Closes #852 
Closes #963 