### PR TITLE
feat(ledger): Add Byron transaction output support to NewTransactionOutputFromCbor 

### DIFF
--- a/ledger/byron.go
+++ b/ledger/byron.go
@@ -47,4 +47,5 @@ var (
 	NewByronMainBlockHeaderFromCbor          = byron.NewByronMainBlockHeaderFromCbor
 	NewByronTransactionInput                 = byron.NewByronTransactionInput
 	NewByronTransactionFromCbor              = byron.NewByronTransactionFromCbor
+	NewByronTransactionOutputFromCbor        = byron.NewByronTransactionOutputFromCbor
 )

--- a/ledger/byron/byron.go
+++ b/ledger/byron/byron.go
@@ -771,3 +771,11 @@ func NewByronTransactionFromCbor(data []byte) (*ByronTransaction, error) {
 	}
 	return &byronTx, nil
 }
+
+func NewByronTransactionOutputFromCbor(data []byte) (*ByronTransactionOutput, error) {
+	var byronTxOutput ByronTransactionOutput
+	if _, err := cbor.Decode(data, &byronTxOutput); err != nil {
+		return nil, fmt.Errorf("decode Byron transaction output error: %w", err)
+	}
+	return &byronTxOutput, nil
+}

--- a/ledger/tx.go
+++ b/ledger/tx.go
@@ -76,7 +76,9 @@ func NewTransactionBodyFromCbor(
 // NewTransactionOutputFromCbor attempts to parse the provided arbitrary CBOR data as a transaction output from
 // each of the eras, returning the first one that we can successfully decode
 func NewTransactionOutputFromCbor(data []byte) (TransactionOutput, error) {
-	// TODO: add Byron transaction output support (#849)
+	if txOut, err := NewByronTransactionOutputFromCbor(data); err == nil {
+		return txOut, nil
+	}
 	if txOut, err := NewShelleyTransactionOutputFromCbor(data); err == nil {
 		return txOut, nil
 	}
@@ -93,13 +95,9 @@ func NewTransactionOutputFromCbor(data []byte) (TransactionOutput, error) {
 }
 
 func DetermineTransactionType(data []byte) (uint, error) {
-	// TODO: uncomment this once the following issue is resolved: (#849)
-	// https://github.com/blinklabs-io/gouroboros/issues/206
-	/*
-		if _, err := NewByronTransactionFromCbor(data); err == nil {
-			return TxTypeByron, nil
-		}
-	*/
+	if _, err := NewByronTransactionFromCbor(data); err == nil {
+		return TxTypeByron, nil
+	}
 	if _, err := NewShelleyTransactionFromCbor(data); err == nil {
 		return TxTypeShelley, nil
 	}

--- a/ledger/tx_test.go
+++ b/ledger/tx_test.go
@@ -23,12 +23,19 @@ import (
 
 func TestDetermineTransactionType(t *testing.T) {
 	testDefs := []struct {
+		name           string
 		txCborHex      string
 		expectedTxType uint
 	}{
 		{
+			name:           "ConwayTx",
 			txCborHex:      "84a500d9010281825820279184037d249e397d97293738370756da559718fcdefae9924834840046b37b01018282583900923d4b64e1d730a4baf3e6dc433a9686983940f458363f37aad7a1a9568b72f85522e4a17d44a45cd021b9741b55d7cbc635c911625b015e1a00a9867082583900923d4b64e1d730a4baf3e6dc433a9686983940f458363f37aad7a1a9568b72f85522e4a17d44a45cd021b9741b55d7cbc635c911625b015e1b00000001267d7b04021a0002938d031a04e304e70800a100d9010281825820b829480e5d5827d2e1bd7c89176a5ca125c30812e54be7dbdf5c47c835a17f3d5840b13a76e7f2b19cde216fcad55ceeeb489ebab3dcf63ef1539ac4f535dece00411ee55c9b8188ef04b4aa3c72586e4a0ec9b89949367d7270fdddad3b18731403f5f6",
 			expectedTxType: 6,
+		},
+		{
+			name:           "ByronTx",
+			txCborHex:      "839f8200d8185824825820a12a839c25a01fa5d118167db5acdbd9e38172ae8f00e5ac0a4997ef792a200700ff9f8282d818584283581c6c9982e7f2b6dcc5eaa880e8014568913c8868d9f0f86eb687b2633ca101581e581c010d876783fb2b4d0d17c86df29af8d35356ed3d1827bf4744f06700001a8dc672c11a000f4240ffa0",
+			expectedTxType: 0,
 		},
 	}
 	for _, testDef := range testDefs {
@@ -38,7 +45,7 @@ func TestDetermineTransactionType(t *testing.T) {
 		}
 		tmpTxType, err := ledger.DetermineTransactionType(txCbor)
 		if err != nil {
-			t.Fatalf("unexpected error: %s", err)
+			t.Fatalf("DetermineTransactionType failed with an unexpected error: %s", err)
 		}
 		if tmpTxType != testDef.expectedTxType {
 			t.Fatalf(
@@ -47,5 +54,6 @@ func TestDetermineTransactionType(t *testing.T) {
 				testDef.expectedTxType,
 			)
 		}
+		t.Logf("Test %s passed: correctly identified tx type %d", testDef.name, tmpTxType)
 	}
 }

--- a/ledger/tx_test.go
+++ b/ledger/tx_test.go
@@ -54,6 +54,5 @@ func TestDetermineTransactionType(t *testing.T) {
 				testDef.expectedTxType,
 			)
 		}
-		t.Logf("Test %s passed: correctly identified tx type %d", testDef.name, tmpTxType)
 	}
 }


### PR DESCRIPTION
1. Enabled support for decoding Byron transaction outputs in NewTransactionOutputFromCbor
2. Uncommented Byron handling in DetermineTransactionType to detect Byron transactions
3.  Added test cases for DetermineTransactionType with valid Byron CBOR.

Closes #849 