### PR TITLE
chore: remove positive logging in tests

### DIFF
--- a/ledger/alonzo/genesis_test.go
+++ b/ledger/alonzo/genesis_test.go
@@ -462,8 +462,6 @@ func TestNewAlonzoGenesisFromReader(t *testing.T) {
 			"Expected LovelacePerUtxoWord 34482, got %d",
 			result.LovelacePerUtxoWord,
 		)
-	} else {
-		t.Logf("LovelacePerUtxoWord is correct: %d", result.LovelacePerUtxoWord)
 	}
 
 	if result.ExecutionPrices.Steps.Rat.Cmp(big.NewRat(721, 10000)) != 0 {
@@ -471,8 +469,6 @@ func TestNewAlonzoGenesisFromReader(t *testing.T) {
 			"Unexpected prSteps: got %v, expected 721/10000",
 			result.ExecutionPrices.Steps.Rat,
 		)
-	} else {
-		t.Logf("prSteps is correct: %v", result.ExecutionPrices.Steps.Rat)
 	}
 
 	if result.ExecutionPrices.Mem.Rat.Cmp(big.NewRat(577, 10000)) != 0 {
@@ -480,8 +476,6 @@ func TestNewAlonzoGenesisFromReader(t *testing.T) {
 			"Unexpected prMem: got %v, expected 577/10000",
 			result.ExecutionPrices.Mem.Rat,
 		)
-	} else {
-		t.Logf("prMem is correct: %v", result.ExecutionPrices.Mem.Rat)
 	}
 
 	expectedCostModels := map[string]map[string]int{
@@ -496,9 +490,5 @@ func TestNewAlonzoGenesisFromReader(t *testing.T) {
 			result.CostModels,
 			expectedCostModels,
 		)
-	} else {
-		t.Logf("CostModels are correct")
 	}
-
-	t.Logf("AlonzoGenesis JSON decoding test completed successfully.")
 }

--- a/ledger/byron/genesis_test.go
+++ b/ledger/byron/genesis_test.go
@@ -429,7 +429,5 @@ func TestNewByronGenesisFromReader(t *testing.T) {
 			result,
 			expected,
 		)
-	} else {
-		t.Logf("ByronGenesis decoded correctly")
 	}
 }

--- a/ledger/common/common_test.go
+++ b/ledger/common/common_test.go
@@ -385,8 +385,6 @@ func TestCertificateTypeMethods(t *testing.T) {
 					got,
 					tt.expected,
 				)
-			} else {
-				t.Logf("PASS: %s -> Type() = %d, expected = %d \n", tt.name, got, tt.expected)
 			}
 		})
 	}

--- a/ledger/conway/genesis_test.go
+++ b/ledger/conway/genesis_test.go
@@ -466,7 +466,5 @@ func TestNewConwayGenesisFromReader(t *testing.T) {
 			expected,
 			actual,
 		)
-	} else {
-		t.Logf("ConwayGenesis decoded correctly and matches expected structure")
 	}
 }


### PR DESCRIPTION
We only want tests to log when there's a failure to keep the output clean