### PR TITLE
fix(chainsync): Handle error in chainsync.NewWrappedHeader

### DIFF
--- a/protocol/chainsync/messages.go
+++ b/protocol/chainsync/messages.go
@@ -184,18 +184,19 @@ func NewMsgRollForwardNtN(
 	byronType uint,
 	blockCbor []byte,
 	tip Tip,
-) *MsgRollForwardNtN {
+) (*MsgRollForwardNtN, error) {
 	m := &MsgRollForwardNtN{
 		MessageBase: protocol.MessageBase{
 			MessageType: MessageTypeRollForward,
 		},
 		Tip: tip,
 	}
-	wrappedHeader := NewWrappedHeader(era, byronType, blockCbor)
-	if wrappedHeader != nil {
-		m.WrappedHeader = *wrappedHeader
+	wrappedHeader, err := NewWrappedHeader(era, byronType, blockCbor)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create wrapped header: %w", err)
 	}
-	return m
+	m.WrappedHeader = *wrappedHeader
+	return m, nil
 }
 
 type MsgRollBackward struct {

--- a/protocol/chainsync/server.go
+++ b/protocol/chainsync/server.go
@@ -126,12 +126,15 @@ func (s *Server) RollForward(blockType uint, blockData []byte, tip Tip) error {
 		)
 	if s.Mode() == protocol.ProtocolModeNodeToNode {
 		eraId := ledger.BlockToBlockHeaderTypeMap[blockType]
-		msg := NewMsgRollForwardNtN(
+		msg, err := NewMsgRollForwardNtN(
 			eraId,
 			0,
 			blockData,
 			tip,
 		)
+		if err != nil {
+			return fmt.Errorf("failed to create roll forward message: %w", err)
+		}
 		return s.SendMessage(msg)
 	} else {
 		msg := NewMsgRollForwardNtC(

--- a/protocol/chainsync/wrappers.go
+++ b/protocol/chainsync/wrappers.go
@@ -15,6 +15,8 @@
 package chainsync
 
 import (
+	"fmt"
+
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
 )
@@ -51,7 +53,7 @@ func NewWrappedHeader(
 	era uint,
 	byronType uint,
 	blockCbor []byte,
-) *WrappedHeader {
+) (*WrappedHeader, error) {
 	w := &WrappedHeader{
 		Era:       era,
 		byronType: byronType,
@@ -64,12 +66,14 @@ func NewWrappedHeader(
 	}
 	// Parse block and extract header
 	tmp := []cbor.RawMessage{}
-	// TODO: figure out a better way to handle an error (#856)
 	if _, err := cbor.Decode(blockCbor, &tmp); err != nil {
-		return nil
+		return nil, fmt.Errorf("CBOR decode failed in NewWrappedHeader: %w", err)
+	}
+	if len(tmp) == 0 {
+		return nil, fmt.Errorf("decoded CBOR header is empty")
 	}
 	w.headerCbor = tmp[0]
-	return w
+	return w, nil
 }
 
 func (w *WrappedHeader) UnmarshalCBOR(data []byte) error {

--- a/protocol/chainsync/wrappers.go
+++ b/protocol/chainsync/wrappers.go
@@ -15,6 +15,7 @@
 package chainsync
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -70,7 +71,7 @@ func NewWrappedHeader(
 		return nil, fmt.Errorf("CBOR decode failed in NewWrappedHeader: %w", err)
 	}
 	if len(tmp) == 0 {
-		return nil, fmt.Errorf("decoded CBOR header is empty")
+		return nil, errors.New("decoded CBOR header is empty")
 	}
 	w.headerCbor = tmp[0]
 	return w, nil


### PR DESCRIPTION
1. Updated NewWrappedHeader to return an error when CBOR decoding fails.
2. Modified NewMsgRollForwardNtN to return the wrapped header error.
3. Added unit test for NewMsgRollForwardNtN to verify error propagation from NewWrappedHeader with corrupted CBOR.
4. Modified existing test case of NewMsgRollForwardNtN function.

Closes #856 