### PR TITLE
test(protocol): localstatequery using cardano blueprint tests

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cardano-blueprint"]
+	path = cardano-blueprint
+	url = git@github.com:cardano-scaling/cardano-blueprint

--- a/cmd/gouroboros/query.go
+++ b/cmd/gouroboros/query.go
@@ -124,7 +124,9 @@ func testQuery(f *globalFlags) {
 			os.Exit(1)
 		}
 		fmt.Printf(
-			"system-start: year = %d, day = %d, picoseconds = %d\n",
+			// REVIEW: %d should work for big/Int, but warns and produces output
+			// like {%!d(bool=false) [2025]}
+			"system-start: year = %v, day = %d, picoseconds = %v\n",
 			systemStart.Year,
 			systemStart.Day,
 			systemStart.Picoseconds,

--- a/protocol/localstatequery/client_test.go
+++ b/protocol/localstatequery/client_test.go
@@ -17,6 +17,7 @@ package localstatequery_test
 import (
 	"encoding/json"
 	"fmt"
+	"math/big"
 	"reflect"
 	"testing"
 	"time"
@@ -290,9 +291,9 @@ func TestGetUTxOByAddress(t *testing.T) {
 func TestGenesisConfigJSON(t *testing.T) {
 	genesisConfig := localstatequery.GenesisConfigResult{
 		Start: localstatequery.SystemStartResult{
-			Year:        2024,
+			Year:        *big.NewInt(2024),
 			Day:         35,
-			Picoseconds: 1234567890123456,
+			Picoseconds: *big.NewInt(1234567890123456),
 		},
 		NetworkMagic:      764824073,
 		NetworkId:         1,

--- a/protocol/localstatequery/queries.go
+++ b/protocol/localstatequery/queries.go
@@ -15,7 +15,9 @@
 package localstatequery
 
 import (
+	"encoding/json"
 	"fmt"
+	"math/big"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
@@ -416,9 +418,40 @@ type SystemStartQuery struct {
 type SystemStartResult struct {
 	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
 	_           struct{} `cbor:",toarray"`
-	Year        int
+	Year        big.Int
 	Day         int
-	Picoseconds uint64
+	Picoseconds big.Int
+}
+
+func (s SystemStartResult) String() string {
+	return fmt.Sprintf("SystemStart %s %d %s", s.Year.String(), s.Day, s.Picoseconds.String())
+}
+
+func (s SystemStartResult) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Year        string `json:"year"`
+		Day         int    `json:"day"`
+		Picoseconds string `json:"picoseconds"`
+	}{
+		Year:        s.Year.String(),
+		Day:         s.Day,
+		Picoseconds: s.Picoseconds.String(),
+	})
+}
+
+func (s *SystemStartResult) UnmarshalJSON(data []byte) error {
+	var tmp struct {
+		Year        string `json:"year"`
+		Day         int    `json:"day"`
+		Picoseconds string `json:"picoseconds"`
+	}
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	s.Year.SetString(tmp.Year, 10)
+	s.Day = tmp.Day
+	s.Picoseconds.SetString(tmp.Picoseconds, 10)
+	return nil
 }
 
 type ChainBlockNoQuery struct {


### PR DESCRIPTION
Adds cardano-blueprint submodule that contains first examples of local state query query and result data.

The included getSystemStart result example was generated using the actual data type used by the haskell server implementation. To make the example roundtrip, big integers (> int64) must be supported.

Closes #992 