### PR TITLE
fix: require explicit muxer start before handshake

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -341,6 +341,7 @@ func (c *Connection) setupConnection() error {
 	} else {
 		c.handshake.Client.Start()
 	}
+	c.muxer.StartOnce()
 	// Wait for handshake completion or error
 	select {
 	case <-c.doneChan:


### PR DESCRIPTION
This removes a race condition that caused random failures when the remote peer sent a handshake message before we have registered the protocol