### PR TITLE
feat(ledger/babbage): Integer underflow issue in babbage.UtxoValidateCollateralEqBalance

### DIFF
--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -193,13 +193,10 @@ func UtxoValidateCollateralEqBalance(
 
 	// Subtract collateral return amount with underflow protection
 	collReturn := tx.CollateralReturn()
-	if collReturn != nil {
-		returnAmt := collReturn.Amount()
-		if collBalance < returnAmt {
-			return errors.New("collateral return amount exceeds collateral input balance")
-		}
-		collBalance -= returnAmt
+	if collReturn != nil && collBalance >= collReturn.Amount() {
+		collBalance -= collReturn.Amount()
 	}
+
 	if totalCollateral == collBalance {
 		return nil
 	}

--- a/ledger/babbage/rules_test.go
+++ b/ledger/babbage/rules_test.go
@@ -1449,6 +1449,27 @@ func TestUtxoValidateCollateralEqBalance(t *testing.T) {
 			}
 		},
 	)
+	// no valid collateral UTxO, should skip and not underflow
+	t.Run("no valid collateral UTxO, should skip and not underflow", func(t *testing.T) {
+		// Ledger state with NO matching UTxO
+		missingUtxoLedgerState := test.MockLedgerState{
+			MockUtxos: []common.Utxo{}, // empty
+		}
+		testTx.Body.TxCollateralReturn = &babbage.BabbageTransactionOutput{
+			OutputAmount: mary.MaryTransactionOutputValue{
+				Amount: testCollateralReturnAmountBad,
+			},
+		}
+		err := babbage.UtxoValidateCollateralEqBalance(
+			testTx,
+			testSlot,
+			missingUtxoLedgerState,
+			testProtocolParams,
+		)
+		if err != nil {
+			t.Errorf("Should skip collateral return validation if collBalance == 0. Got error: %v", err)
+		}
+	})
 }
 
 func TestUtxoValidateTooManyCollateralInputs(t *testing.T) {


### PR DESCRIPTION
1. Fixed an uint underflow in UtxoValidateCollateralEqBalance by skipping validation when no valid collateral UTxOs are found.  
2. Added a unit test to ensure collateral return subtraction is skipped when collBalance is zero, avoiding invalid balance validation.

Closes #1000 