### PR TITLE
fix(muxer): Return better error message when the peer closes the connection

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -286,8 +286,8 @@ func (c *Connection) setupConnection() error {
 				return
 			}
 			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
-				// Return a bare io.EOF error if error is EOF/ErrUnexpectedEOF
-				c.errorChan <- io.EOF
+				// Preserve the original wrapped error with friendly message
+				c.errorChan <- err
 			} else {
 				// Wrap error message to denote it comes from the muxer
 				c.errorChan <- fmt.Errorf("muxer error: %w", err)
@@ -354,7 +354,7 @@ func (c *Connection) setupConnection() error {
 	select {
 	case <-c.doneChan:
 		// Return an error if we're shutting down
-		return io.EOF
+		return fmt.Errorf("connection shutdown initiated: %w", io.EOF)
 	case err := <-c.protoErrorChan:
 		// Shutdown the connection and return the error
 		c.Close()

--- a/connection.go
+++ b/connection.go
@@ -285,8 +285,9 @@ func (c *Connection) setupConnection() error {
 			if !ok {
 				return
 			}
-			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
-				// Preserve the original wrapped error with friendly message
+			var connErr *muxer.ConnectionClosedError
+			if errors.As(err, &connErr) {
+				// Pass through ConnectionClosedError from muxer
 				c.errorChan <- err
 			} else {
 				// Wrap error message to denote it comes from the muxer


### PR DESCRIPTION
1. Replaced plain io.EOF with descriptive wrapped errors like peer closed the connection while reading header: EOF
in Muxer.readLoop(). 
2. Updated downstream handling in setupConnection() function and muxer error forwarding to preserve
the wrapped errors.

Closes #518 