### PR TITLE
feat: Support getting ScriptRef from TransactionOutput interface

### DIFF
--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -324,6 +324,10 @@ func (o AlonzoTransactionOutput) Address() common.Address {
 	return o.OutputAddress
 }
 
+func (o AlonzoTransactionOutput) GetScriptRef() *cbor.LazyValue {
+	return nil
+}
+
 func (o AlonzoTransactionOutput) Amount() uint64 {
 	return o.OutputAmount.Amount
 }

--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -324,7 +324,7 @@ func (o AlonzoTransactionOutput) Address() common.Address {
 	return o.OutputAddress
 }
 
-func (o AlonzoTransactionOutput) GetScriptRef() *cbor.LazyValue {
+func (o AlonzoTransactionOutput) ScriptRef() *cbor.LazyValue {
 	return nil
 }
 

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -423,7 +423,7 @@ type BabbageTransactionOutput struct {
 	OutputAddress common.Address                       `cbor:"0,keyasint,omitempty"`
 	OutputAmount  mary.MaryTransactionOutputValue      `cbor:"1,keyasint,omitempty"`
 	DatumOption   *BabbageTransactionOutputDatumOption `cbor:"2,keyasint,omitempty"`
-	ScriptRef     *cbor.Tag                            `cbor:"3,keyasint,omitempty"`
+	TxScriptRef   *cbor.Tag                            `cbor:"3,keyasint,omitempty"`
 	legacyOutput  bool
 }
 
@@ -486,11 +486,11 @@ func (o BabbageTransactionOutput) Address() common.Address {
 	return o.OutputAddress
 }
 
-func (o BabbageTransactionOutput) GetScriptRef() *cbor.LazyValue {
-	if o.ScriptRef == nil {
+func (o BabbageTransactionOutput) ScriptRef() *cbor.LazyValue {
+	if o.TxScriptRef == nil {
 		return nil
 	}
-	if lazyVal, ok := o.ScriptRef.Content.(*cbor.LazyValue); ok {
+	if lazyVal, ok := o.TxScriptRef.Content.(*cbor.LazyValue); ok {
 		return lazyVal
 	}
 	return nil

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -486,6 +486,16 @@ func (o BabbageTransactionOutput) Address() common.Address {
 	return o.OutputAddress
 }
 
+func (o BabbageTransactionOutput) GetScriptRef() *cbor.LazyValue {
+	if o.ScriptRef == nil {
+		return nil
+	}
+	if lazyVal, ok := o.ScriptRef.Content.(*cbor.LazyValue); ok {
+		return lazyVal
+	}
+	return nil
+}
+
 func (o BabbageTransactionOutput) Amount() uint64 {
 	return o.OutputAmount.Amount
 }

--- a/ledger/byron/byron.go
+++ b/ledger/byron/byron.go
@@ -414,7 +414,7 @@ func (o ByronTransactionOutput) Address() common.Address {
 	return o.OutputAddress
 }
 
-func (o ByronTransactionOutput) GetScriptRef() *cbor.LazyValue {
+func (o ByronTransactionOutput) ScriptRef() *cbor.LazyValue {
 	return nil
 }
 

--- a/ledger/byron/byron.go
+++ b/ledger/byron/byron.go
@@ -414,6 +414,10 @@ func (o ByronTransactionOutput) Address() common.Address {
 	return o.OutputAddress
 }
 
+func (o ByronTransactionOutput) GetScriptRef() *cbor.LazyValue {
+	return nil
+}
+
 func (o ByronTransactionOutput) Amount() uint64 {
 	return o.OutputAmount
 }

--- a/ledger/common/tx.go
+++ b/ledger/common/tx.go
@@ -71,6 +71,7 @@ type TransactionOutput interface {
 	DatumHash() *Blake2b256
 	Cbor() []byte
 	Utxorpc() (*utxorpc.TxOutput, error)
+	GetScriptRef() *cbor.LazyValue
 }
 
 type TransactionWitnessSet interface {

--- a/ledger/common/tx.go
+++ b/ledger/common/tx.go
@@ -71,7 +71,7 @@ type TransactionOutput interface {
 	DatumHash() *Blake2b256
 	Cbor() []byte
 	Utxorpc() (*utxorpc.TxOutput, error)
-	GetScriptRef() *cbor.LazyValue
+	ScriptRef() *cbor.LazyValue
 }
 
 type TransactionWitnessSet interface {

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -446,6 +446,10 @@ func (o MaryTransactionOutput) Address() common.Address {
 	return o.OutputAddress
 }
 
+func (txo MaryTransactionOutput) GetScriptRef() *cbor.LazyValue {
+	return nil
+}
+
 func (o MaryTransactionOutput) Amount() uint64 {
 	return o.OutputAmount.Amount
 }

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -446,7 +446,7 @@ func (o MaryTransactionOutput) Address() common.Address {
 	return o.OutputAddress
 }
 
-func (txo MaryTransactionOutput) GetScriptRef() *cbor.LazyValue {
+func (txo MaryTransactionOutput) ScriptRef() *cbor.LazyValue {
 	return nil
 }
 

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -388,7 +388,7 @@ func (o ShelleyTransactionOutput) Address() common.Address {
 	return o.OutputAddress
 }
 
-func (o ShelleyTransactionOutput) GetScriptRef() *cbor.LazyValue {
+func (o ShelleyTransactionOutput) ScriptRef() *cbor.LazyValue {
 	return nil
 }
 

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -388,6 +388,10 @@ func (o ShelleyTransactionOutput) Address() common.Address {
 	return o.OutputAddress
 }
 
+func (o ShelleyTransactionOutput) GetScriptRef() *cbor.LazyValue {
+	return nil
+}
+
 func (o ShelleyTransactionOutput) Amount() uint64 {
 	return o.OutputAmount
 }


### PR DESCRIPTION
1. Extended common.TransactionOutput interface with GetScriptRef() method
2. Implemented GetScriptRef() in BabbageTransactionOutput to return actual ScriptRef (CBOR.LazyValue)
3. Added stub GetScriptRef() implementations returning nil in other eras such as Shelley, Mary, Alonzo, and Byron

Closes #1044 