### PR TITLE
refactor: use separate type for TX pparam update

### DIFF
--- a/ledger/allegra/allegra.go
+++ b/ledger/allegra/allegra.go
@@ -144,21 +144,23 @@ func (h *AllegraBlockHeader) Era() common.Era {
 	return EraAllegra
 }
 
+type AllegraTransactionPparamUpdate struct {
+	cbor.StructAsArray
+	ProtocolParamUpdates map[common.Blake2b224]AllegraProtocolParameterUpdate
+	Epoch                uint64
+}
+
 type AllegraTransactionBody struct {
 	common.TransactionBodyBase
-	TxInputs       shelley.ShelleyTransactionInputSet `cbor:"0,keyasint,omitempty"`
-	TxOutputs      []shelley.ShelleyTransactionOutput `cbor:"1,keyasint,omitempty"`
-	TxFee          uint64                             `cbor:"2,keyasint,omitempty"`
-	Ttl            uint64                             `cbor:"3,keyasint,omitempty"`
-	TxCertificates []common.CertificateWrapper        `cbor:"4,keyasint,omitempty"`
-	TxWithdrawals  map[*common.Address]uint64         `cbor:"5,keyasint,omitempty"`
-	Update         struct {
-		cbor.StructAsArray
-		ProtocolParamUpdates map[common.Blake2b224]AllegraProtocolParameterUpdate
-		Epoch                uint64
-	} `cbor:"6,keyasint,omitempty"`
-	TxAuxDataHash           *common.Blake2b256 `cbor:"7,keyasint,omitempty"`
-	TxValidityIntervalStart uint64             `cbor:"8,keyasint,omitempty"`
+	TxInputs                shelley.ShelleyTransactionInputSet `cbor:"0,keyasint,omitempty"`
+	TxOutputs               []shelley.ShelleyTransactionOutput `cbor:"1,keyasint,omitempty"`
+	TxFee                   uint64                             `cbor:"2,keyasint,omitempty"`
+	Ttl                     uint64                             `cbor:"3,keyasint,omitempty"`
+	TxCertificates          []common.CertificateWrapper        `cbor:"4,keyasint,omitempty"`
+	TxWithdrawals           map[*common.Address]uint64         `cbor:"5,keyasint,omitempty"`
+	Update                  *AllegraTransactionPparamUpdate    `cbor:"6,keyasint,omitempty"`
+	TxAuxDataHash           *common.Blake2b256                 `cbor:"7,keyasint,omitempty"`
+	TxValidityIntervalStart uint64                             `cbor:"8,keyasint,omitempty"`
 }
 
 func (b *AllegraTransactionBody) UnmarshalCBOR(cborData []byte) error {

--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -153,19 +153,21 @@ func (h *AlonzoBlockHeader) Era() common.Era {
 	return EraAlonzo
 }
 
+type AlonzoTransactionPparamUpdate struct {
+	cbor.StructAsArray
+	ProtocolParamUpdates map[common.Blake2b224]AlonzoProtocolParameterUpdate
+	Epoch                uint64
+}
+
 type AlonzoTransactionBody struct {
 	common.TransactionBodyBase
-	TxInputs       shelley.ShelleyTransactionInputSet `cbor:"0,keyasint,omitempty"`
-	TxOutputs      []AlonzoTransactionOutput          `cbor:"1,keyasint,omitempty"`
-	TxFee          uint64                             `cbor:"2,keyasint,omitempty"`
-	Ttl            uint64                             `cbor:"3,keyasint,omitempty"`
-	TxCertificates []common.CertificateWrapper        `cbor:"4,keyasint,omitempty"`
-	TxWithdrawals  map[*common.Address]uint64         `cbor:"5,keyasint,omitempty"`
-	Update         struct {
-		cbor.StructAsArray
-		ProtocolParamUpdates map[common.Blake2b224]AlonzoProtocolParameterUpdate
-		Epoch                uint64
-	} `cbor:"6,keyasint,omitempty"`
+	TxInputs                shelley.ShelleyTransactionInputSet            `cbor:"0,keyasint,omitempty"`
+	TxOutputs               []AlonzoTransactionOutput                     `cbor:"1,keyasint,omitempty"`
+	TxFee                   uint64                                        `cbor:"2,keyasint,omitempty"`
+	Ttl                     uint64                                        `cbor:"3,keyasint,omitempty"`
+	TxCertificates          []common.CertificateWrapper                   `cbor:"4,keyasint,omitempty"`
+	TxWithdrawals           map[*common.Address]uint64                    `cbor:"5,keyasint,omitempty"`
+	Update                  *AlonzoTransactionPparamUpdate                `cbor:"6,keyasint,omitempty"`
 	TxAuxDataHash           *common.Blake2b256                            `cbor:"7,keyasint,omitempty"`
 	TxValidityIntervalStart uint64                                        `cbor:"8,keyasint,omitempty"`
 	TxMint                  *common.MultiAsset[common.MultiAssetTypeMint] `cbor:"9,keyasint,omitempty"`

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -226,19 +226,21 @@ func (h *BabbageBlockHeader) Era() common.Era {
 	return EraBabbage
 }
 
+type BabbageTransactionPparamUpdate struct {
+	cbor.StructAsArray
+	ProtocolParamUpdates map[common.Blake2b224]BabbageProtocolParameterUpdate
+	Epoch                uint64
+}
+
 type BabbageTransactionBody struct {
 	common.TransactionBodyBase
-	TxInputs       shelley.ShelleyTransactionInputSet `cbor:"0,keyasint,omitempty"`
-	TxOutputs      []BabbageTransactionOutput         `cbor:"1,keyasint,omitempty"`
-	TxFee          uint64                             `cbor:"2,keyasint,omitempty"`
-	Ttl            uint64                             `cbor:"3,keyasint,omitempty"`
-	TxCertificates []common.CertificateWrapper        `cbor:"4,keyasint,omitempty"`
-	TxWithdrawals  map[*common.Address]uint64         `cbor:"5,keyasint,omitempty"`
-	Update         struct {
-		cbor.StructAsArray
-		ProtocolParamUpdates map[common.Blake2b224]BabbageProtocolParameterUpdate
-		Epoch                uint64
-	} `cbor:"6,keyasint,omitempty"`
+	TxInputs                shelley.ShelleyTransactionInputSet            `cbor:"0,keyasint,omitempty"`
+	TxOutputs               []BabbageTransactionOutput                    `cbor:"1,keyasint,omitempty"`
+	TxFee                   uint64                                        `cbor:"2,keyasint,omitempty"`
+	Ttl                     uint64                                        `cbor:"3,keyasint,omitempty"`
+	TxCertificates          []common.CertificateWrapper                   `cbor:"4,keyasint,omitempty"`
+	TxWithdrawals           map[*common.Address]uint64                    `cbor:"5,keyasint,omitempty"`
+	Update                  *BabbageTransactionPparamUpdate               `cbor:"6,keyasint,omitempty"`
 	TxAuxDataHash           *common.Blake2b256                            `cbor:"7,keyasint,omitempty"`
 	TxValidityIntervalStart uint64                                        `cbor:"8,keyasint,omitempty"`
 	TxMint                  *common.MultiAsset[common.MultiAssetTypeMint] `cbor:"9,keyasint,omitempty"`

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -308,19 +308,21 @@ func (s *ConwayTransactionInputSet) SetItems(
 	copy(s.items, items)
 }
 
+type ConwayTransactionPparamUpdate struct {
+	cbor.StructAsArray
+	ProtocolParamUpdates map[common.Blake2b224]babbage.BabbageProtocolParameterUpdate
+	Epoch                uint64
+}
+
 type ConwayTransactionBody struct {
 	common.TransactionBodyBase
-	TxInputs       ConwayTransactionInputSet          `cbor:"0,keyasint,omitempty"`
-	TxOutputs      []babbage.BabbageTransactionOutput `cbor:"1,keyasint,omitempty"`
-	TxFee          uint64                             `cbor:"2,keyasint,omitempty"`
-	Ttl            uint64                             `cbor:"3,keyasint,omitempty"`
-	TxCertificates []common.CertificateWrapper        `cbor:"4,keyasint,omitempty"`
-	TxWithdrawals  map[*common.Address]uint64         `cbor:"5,keyasint,omitempty"`
-	Update         struct {
-		cbor.StructAsArray
-		ProtocolParamUpdates map[common.Blake2b224]babbage.BabbageProtocolParameterUpdate
-		Epoch                uint64
-	} `cbor:"6,keyasint,omitempty"`
+	TxInputs                ConwayTransactionInputSet                     `cbor:"0,keyasint,omitempty"`
+	TxOutputs               []babbage.BabbageTransactionOutput            `cbor:"1,keyasint,omitempty"`
+	TxFee                   uint64                                        `cbor:"2,keyasint,omitempty"`
+	Ttl                     uint64                                        `cbor:"3,keyasint,omitempty"`
+	TxCertificates          []common.CertificateWrapper                   `cbor:"4,keyasint,omitempty"`
+	TxWithdrawals           map[*common.Address]uint64                    `cbor:"5,keyasint,omitempty"`
+	Update                  *ConwayTransactionPparamUpdate                `cbor:"6,keyasint,omitempty"`
 	TxAuxDataHash           *common.Blake2b256                            `cbor:"7,keyasint,omitempty"`
 	TxValidityIntervalStart uint64                                        `cbor:"8,keyasint,omitempty"`
 	TxMint                  *common.MultiAsset[common.MultiAssetTypeMint] `cbor:"9,keyasint,omitempty"`

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -145,19 +145,21 @@ func (h *MaryBlockHeader) Era() common.Era {
 	return EraMary
 }
 
+type MaryTransactionPparamUpdate struct {
+	cbor.StructAsArray
+	ProtocolParamUpdates map[common.Blake2b224]MaryProtocolParameterUpdate
+	Epoch                uint64
+}
+
 type MaryTransactionBody struct {
 	common.TransactionBodyBase
-	TxInputs       shelley.ShelleyTransactionInputSet `cbor:"0,keyasint,omitempty"`
-	TxOutputs      []MaryTransactionOutput            `cbor:"1,keyasint,omitempty"`
-	TxFee          uint64                             `cbor:"2,keyasint,omitempty"`
-	Ttl            uint64                             `cbor:"3,keyasint,omitempty"`
-	TxCertificates []common.CertificateWrapper        `cbor:"4,keyasint,omitempty"`
-	TxWithdrawals  map[*common.Address]uint64         `cbor:"5,keyasint,omitempty"`
-	Update         struct {
-		cbor.StructAsArray
-		ProtocolParamUpdates map[common.Blake2b224]MaryProtocolParameterUpdate
-		Epoch                uint64
-	} `cbor:"6,keyasint,omitempty"`
+	TxInputs                shelley.ShelleyTransactionInputSet            `cbor:"0,keyasint,omitempty"`
+	TxOutputs               []MaryTransactionOutput                       `cbor:"1,keyasint,omitempty"`
+	TxFee                   uint64                                        `cbor:"2,keyasint,omitempty"`
+	Ttl                     uint64                                        `cbor:"3,keyasint,omitempty"`
+	TxCertificates          []common.CertificateWrapper                   `cbor:"4,keyasint,omitempty"`
+	TxWithdrawals           map[*common.Address]uint64                    `cbor:"5,keyasint,omitempty"`
+	Update                  *MaryTransactionPparamUpdate                  `cbor:"6,keyasint,omitempty"`
 	TxAuxDataHash           *common.Blake2b256                            `cbor:"7,keyasint,omitempty"`
 	TxValidityIntervalStart uint64                                        `cbor:"8,keyasint,omitempty"`
 	TxMint                  *common.MultiAsset[common.MultiAssetTypeMint] `cbor:"9,keyasint,omitempty"`

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -207,20 +207,22 @@ func (h *ShelleyBlockHeader) Era() common.Era {
 	return EraShelley
 }
 
+type ShelleyTransactionPparamUpdate struct {
+	cbor.StructAsArray
+	ProtocolParamUpdates map[common.Blake2b224]ShelleyProtocolParameterUpdate
+	Epoch                uint64
+}
+
 type ShelleyTransactionBody struct {
 	common.TransactionBodyBase
-	TxInputs       ShelleyTransactionInputSet  `cbor:"0,keyasint,omitempty"`
-	TxOutputs      []ShelleyTransactionOutput  `cbor:"1,keyasint,omitempty"`
-	TxFee          uint64                      `cbor:"2,keyasint,omitempty"`
-	Ttl            uint64                      `cbor:"3,keyasint,omitempty"`
-	TxCertificates []common.CertificateWrapper `cbor:"4,keyasint,omitempty"`
-	TxWithdrawals  map[*common.Address]uint64  `cbor:"5,keyasint,omitempty"`
-	Update         struct {
-		cbor.StructAsArray
-		ProtocolParamUpdates map[common.Blake2b224]ShelleyProtocolParameterUpdate
-		Epoch                uint64
-	} `cbor:"6,keyasint,omitempty"`
-	TxAuxDataHash *common.Blake2b256 `cbor:"7,keyasint,omitempty"`
+	TxInputs       ShelleyTransactionInputSet      `cbor:"0,keyasint,omitempty"`
+	TxOutputs      []ShelleyTransactionOutput      `cbor:"1,keyasint,omitempty"`
+	TxFee          uint64                          `cbor:"2,keyasint,omitempty"`
+	Ttl            uint64                          `cbor:"3,keyasint,omitempty"`
+	TxCertificates []common.CertificateWrapper     `cbor:"4,keyasint,omitempty"`
+	TxWithdrawals  map[*common.Address]uint64      `cbor:"5,keyasint,omitempty"`
+	Update         *ShelleyTransactionPparamUpdate `cbor:"6,keyasint,omitempty"`
+	TxAuxDataHash  *common.Blake2b256              `cbor:"7,keyasint,omitempty"`
 }
 
 func (b *ShelleyTransactionBody) UnmarshalCBOR(cborData []byte) error {


### PR DESCRIPTION
We also switch to using a pointer to give us a more usable zero value for CBOR encoding

Fixes #1058