### PR TITLE
fix: exclude empty datum hash from Alonzo TX output CBOR

### DIFF
--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -265,10 +265,10 @@ func (b *AlonzoTransactionBody) Utxorpc() (*utxorpc.Tx, error) {
 type AlonzoTransactionOutput struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
-	OutputAddress     common.Address
-	OutputAmount      mary.MaryTransactionOutputValue
-	TxOutputDatumHash *common.Blake2b256
-	legacyOutput      bool
+	OutputAddress   common.Address
+	OutputAmount    mary.MaryTransactionOutputValue
+	OutputDatumHash *common.Blake2b256
+	legacyOutput    bool
 }
 
 func (o *AlonzoTransactionOutput) UnmarshalCBOR(cborData []byte) error {
@@ -300,7 +300,14 @@ func (o *AlonzoTransactionOutput) MarshalCBOR() ([]byte, error) {
 		}
 		return cbor.Encode(&tmpOutput)
 	}
-	return cbor.EncodeGeneric(o)
+	tmpOutput := []any{
+		o.OutputAddress,
+		o.OutputAmount,
+	}
+	if o.OutputDatumHash != nil {
+		tmpOutput = append(tmpOutput, o.OutputDatumHash)
+	}
+	return cbor.Encode(tmpOutput)
 }
 
 func (o AlonzoTransactionOutput) MarshalJSON() ([]byte, error) {
@@ -314,8 +321,8 @@ func (o AlonzoTransactionOutput) MarshalJSON() ([]byte, error) {
 		Amount:  o.OutputAmount.Amount,
 		Assets:  o.OutputAmount.Assets,
 	}
-	if o.TxOutputDatumHash != nil {
-		tmpObj.DatumHash = o.TxOutputDatumHash.String()
+	if o.OutputDatumHash != nil {
+		tmpObj.DatumHash = o.OutputDatumHash.String()
 	}
 	return json.Marshal(&tmpObj)
 }
@@ -337,7 +344,7 @@ func (o AlonzoTransactionOutput) Assets() *common.MultiAsset[common.MultiAssetTy
 }
 
 func (o AlonzoTransactionOutput) DatumHash() *common.Blake2b256 {
-	return o.TxOutputDatumHash
+	return o.OutputDatumHash
 }
 
 func (o AlonzoTransactionOutput) Datum() *cbor.LazyValue {
@@ -374,7 +381,7 @@ func (o AlonzoTransactionOutput) Utxorpc() (*utxorpc.TxOutput, error) {
 			Coin:    o.Amount(),
 			Assets:  assets,
 			Datum: &utxorpc.Datum{
-				Hash: o.TxOutputDatumHash.Bytes(),
+				Hash: o.OutputDatumHash.Bytes(),
 			},
 		},
 		nil

--- a/ledger/alonzo/pparams_test.go
+++ b/ledger/alonzo/pparams_test.go
@@ -461,9 +461,9 @@ func TestAlonzoTransactionOutput_Utxorpc(t *testing.T) {
 
 	// Mock output
 	output := alonzo.AlonzoTransactionOutput{
-		OutputAddress:     address,
-		OutputAmount:      mary.MaryTransactionOutputValue{Amount: amount},
-		TxOutputDatumHash: &datumHash,
+		OutputAddress:   address,
+		OutputAmount:    mary.MaryTransactionOutputValue{Amount: amount},
+		OutputDatumHash: &datumHash,
 	}
 
 	got, err := output.Utxorpc()
@@ -503,9 +503,9 @@ func TestAlonzoTransactionBody_Utxorpc(t *testing.T) {
 	address := common.Address{}
 	datumHash := common.Blake2b256{1, 2, 3, 4}
 	output := alonzo.AlonzoTransactionOutput{
-		OutputAddress:     address,
-		OutputAmount:      mary.MaryTransactionOutputValue{Amount: 1000},
-		TxOutputDatumHash: &datumHash,
+		OutputAddress:   address,
+		OutputAmount:    mary.MaryTransactionOutputValue{Amount: 1000},
+		OutputDatumHash: &datumHash,
 	}
 
 	body := alonzo.AlonzoTransactionBody{
@@ -560,9 +560,9 @@ func TestAlonzoTransaction_Utxorpc(t *testing.T) {
 	address := common.Address{}
 	datumHash := &common.Blake2b256{0x11, 0x22, 0x33}
 	output := alonzo.AlonzoTransactionOutput{
-		OutputAddress:     address,
-		OutputAmount:      mary.MaryTransactionOutputValue{Amount: 2000},
-		TxOutputDatumHash: datumHash,
+		OutputAddress:   address,
+		OutputAmount:    mary.MaryTransactionOutputValue{Amount: 2000},
+		OutputDatumHash: datumHash,
 	}
 
 	body := alonzo.AlonzoTransactionBody{


### PR DESCRIPTION
This also renames the TX output datum hash struct field for consistency

Fixes #1059