### PR TITLE
fix: Byron address CBOR encoding

### DIFF
--- a/ledger/byron/genesis.go
+++ b/ledger/byron/genesis.go
@@ -22,7 +22,6 @@ import (
 	"slices"
 	"strconv"
 
-	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
@@ -123,7 +122,7 @@ func (g *ByronGenesis) avvmUtxos() ([]common.Utxo, error) {
 		if err != nil {
 			return nil, err
 		}
-		addrBytes, err := cbor.Encode(tmpAddr)
+		addrBytes, err := tmpAddr.Bytes()
 		if err != nil {
 			return nil, err
 		}
@@ -155,7 +154,7 @@ func (g *ByronGenesis) nonAvvmUtxos() ([]common.Utxo, error) {
 		if err != nil {
 			return nil, err
 		}
-		addrBytes, err := cbor.Encode(tmpAddr)
+		addrBytes, err := tmpAddr.Bytes()
 		if err != nil {
 			return nil, err
 		}

--- a/ledger/common/address.go
+++ b/ledger/common/address.go
@@ -282,10 +282,6 @@ func (a *Address) MarshalCBOR() ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get address bytes: %w", err)
 	}
-
-	if a.addressType == AddressTypeByron {
-		return addrBytes, nil
-	}
 	return cbor.Encode(addrBytes)
 }
 


### PR DESCRIPTION
This makes Byron address bytes wrapped in a bytestring for CBOR, the same as Shelley addresses. It also switches the Byron genesis UTxO code to explicitly use address bytes rather than use the CBOR representation

Fixes #1066