### PR TITLE
refactor: use CBOR set tags when encoding TX body fields

### DIFF
--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -172,8 +172,8 @@ type AlonzoTransactionBody struct {
 	TxValidityIntervalStart uint64                                        `cbor:"8,keyasint,omitempty"`
 	TxMint                  *common.MultiAsset[common.MultiAssetTypeMint] `cbor:"9,keyasint,omitempty"`
 	TxScriptDataHash        *common.Blake2b256                            `cbor:"11,keyasint,omitempty"`
-	TxCollateral            []shelley.ShelleyTransactionInput             `cbor:"13,keyasint,omitempty"`
-	TxRequiredSigners       []common.Blake2b224                           `cbor:"14,keyasint,omitempty"`
+	TxCollateral            cbor.SetType[shelley.ShelleyTransactionInput] `cbor:"13,keyasint,omitempty,omitzero"`
+	TxRequiredSigners       cbor.SetType[common.Blake2b224]               `cbor:"14,keyasint,omitempty,omitzero"`
 	NetworkId               uint8                                         `cbor:"15,keyasint,omitempty"`
 }
 
@@ -246,14 +246,14 @@ func (b *AlonzoTransactionBody) AssetMint() *common.MultiAsset[common.MultiAsset
 
 func (b *AlonzoTransactionBody) Collateral() []common.TransactionInput {
 	ret := []common.TransactionInput{}
-	for _, collateral := range b.TxCollateral {
+	for _, collateral := range b.TxCollateral.Items() {
 		ret = append(ret, collateral)
 	}
 	return ret
 }
 
 func (b *AlonzoTransactionBody) RequiredSigners() []common.Blake2b224 {
-	return b.TxRequiredSigners[:]
+	return b.TxRequiredSigners.Items()
 }
 
 func (b *AlonzoTransactionBody) ScriptDataHash() *common.Blake2b256 {

--- a/ledger/alonzo/rules_test.go
+++ b/ledger/alonzo/rules_test.go
@@ -997,9 +997,12 @@ func TestUtxoValidateInsufficientCollateral(t *testing.T) {
 	t.Run(
 		"insufficient collateral",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+				},
+				false,
+			)
 			err := alonzo.UtxoValidateInsufficientCollateral(
 				testTx,
 				testSlot,
@@ -1027,10 +1030,13 @@ func TestUtxoValidateInsufficientCollateral(t *testing.T) {
 	t.Run(
 		"sufficient collateral",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-				shelley.NewShelleyTransactionInput(testInputTxId, 1),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+					shelley.NewShelleyTransactionInput(testInputTxId, 1),
+				},
+				false,
+			)
 			err := alonzo.UtxoValidateInsufficientCollateral(
 				testTx,
 				testSlot,
@@ -1087,10 +1093,13 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 	t.Run(
 		"coin and assets",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-				shelley.NewShelleyTransactionInput(testInputTxId, 1),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+					shelley.NewShelleyTransactionInput(testInputTxId, 1),
+				},
+				false,
+			)
 			err := alonzo.UtxoValidateCollateralContainsNonAda(
 				testTx,
 				testSlot,
@@ -1118,9 +1127,12 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 	t.Run(
 		"coin only",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+				},
+				false,
+			)
 			err := alonzo.UtxoValidateCollateralContainsNonAda(
 				testTx,
 				testSlot,
@@ -1192,9 +1204,12 @@ func TestUtxoValidateNoCollateralInputs(t *testing.T) {
 	t.Run(
 		"collateral",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+				},
+				false,
+			)
 			err := alonzo.UtxoValidateNoCollateralInputs(
 				testTx,
 				testSlot,

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -245,12 +245,12 @@ type BabbageTransactionBody struct {
 	TxValidityIntervalStart uint64                                        `cbor:"8,keyasint,omitempty"`
 	TxMint                  *common.MultiAsset[common.MultiAssetTypeMint] `cbor:"9,keyasint,omitempty"`
 	TxScriptDataHash        *common.Blake2b256                            `cbor:"11,keyasint,omitempty"`
-	TxCollateral            []shelley.ShelleyTransactionInput             `cbor:"13,keyasint,omitempty"`
-	TxRequiredSigners       []common.Blake2b224                           `cbor:"14,keyasint,omitempty"`
+	TxCollateral            cbor.SetType[shelley.ShelleyTransactionInput] `cbor:"13,keyasint,omitempty,omitzero"`
+	TxRequiredSigners       cbor.SetType[common.Blake2b224]               `cbor:"14,keyasint,omitempty,omitzero"`
 	NetworkId               uint8                                         `cbor:"15,keyasint,omitempty"`
 	TxCollateralReturn      *BabbageTransactionOutput                     `cbor:"16,keyasint,omitempty"`
 	TxTotalCollateral       uint64                                        `cbor:"17,keyasint,omitempty"`
-	TxReferenceInputs       []shelley.ShelleyTransactionInput             `cbor:"18,keyasint,omitempty"`
+	TxReferenceInputs       cbor.SetType[shelley.ShelleyTransactionInput] `cbor:"18,keyasint,omitempty,omitzero"`
 }
 
 func (b *BabbageTransactionBody) UnmarshalCBOR(cborData []byte) error {
@@ -322,14 +322,14 @@ func (b *BabbageTransactionBody) AssetMint() *common.MultiAsset[common.MultiAsse
 
 func (b *BabbageTransactionBody) Collateral() []common.TransactionInput {
 	ret := []common.TransactionInput{}
-	for _, collateral := range b.TxCollateral {
+	for _, collateral := range b.TxCollateral.Items() {
 		ret = append(ret, collateral)
 	}
 	return ret
 }
 
 func (b *BabbageTransactionBody) RequiredSigners() []common.Blake2b224 {
-	return b.TxRequiredSigners[:]
+	return b.TxRequiredSigners.Items()
 }
 
 func (b *BabbageTransactionBody) ScriptDataHash() *common.Blake2b256 {
@@ -338,7 +338,7 @@ func (b *BabbageTransactionBody) ScriptDataHash() *common.Blake2b256 {
 
 func (b *BabbageTransactionBody) ReferenceInputs() []common.TransactionInput {
 	ret := []common.TransactionInput{}
-	for _, input := range b.TxReferenceInputs {
+	for _, input := range b.TxReferenceInputs.Items() {
 		ret = append(ret, &input)
 	}
 	return ret

--- a/ledger/babbage/rules_test.go
+++ b/ledger/babbage/rules_test.go
@@ -998,9 +998,12 @@ func TestUtxoValidateInsufficientCollateral(t *testing.T) {
 	t.Run(
 		"insufficient collateral",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+				},
+				false,
+			)
 			err := babbage.UtxoValidateInsufficientCollateral(
 				testTx,
 				testSlot,
@@ -1028,10 +1031,13 @@ func TestUtxoValidateInsufficientCollateral(t *testing.T) {
 	t.Run(
 		"sufficient collateral",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-				shelley.NewShelleyTransactionInput(testInputTxId, 1),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+					shelley.NewShelleyTransactionInput(testInputTxId, 1),
+				},
+				false,
+			)
 			err := babbage.UtxoValidateInsufficientCollateral(
 				testTx,
 				testSlot,
@@ -1110,10 +1116,13 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 	t.Run(
 		"coin and assets",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-				shelley.NewShelleyTransactionInput(testInputTxId, 1),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+					shelley.NewShelleyTransactionInput(testInputTxId, 1),
+				},
+				false,
+			)
 			err := babbage.UtxoValidateCollateralContainsNonAda(
 				testTx,
 				testSlot,
@@ -1141,9 +1150,12 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 	t.Run(
 		"coin only",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+				},
+				false,
+			)
 			err := babbage.UtxoValidateCollateralContainsNonAda(
 				testTx,
 				testSlot,
@@ -1162,10 +1174,13 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 	t.Run(
 		"coin and assets with return",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-				shelley.NewShelleyTransactionInput(testInputTxId, 1),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+					shelley.NewShelleyTransactionInput(testInputTxId, 1),
+				},
+				false,
+			)
 			testTx.Body.TxCollateralReturn = &babbage.BabbageTransactionOutput{
 				OutputAmount: mary.MaryTransactionOutputValue{
 					Amount: testCollateralAmount,
@@ -1190,9 +1205,12 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 	t.Run(
 		"coin and zero assets with return",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 2),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 2),
+				},
+				false,
+			)
 			testTx.Body.TxCollateralReturn = &babbage.BabbageTransactionOutput{
 				OutputAmount: mary.MaryTransactionOutputValue{
 					Amount: testCollateralAmount,
@@ -1269,9 +1287,12 @@ func TestUtxoValidateNoCollateralInputs(t *testing.T) {
 	t.Run(
 		"collateral",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+				},
+				false,
+			)
 			err := babbage.UtxoValidateNoCollateralInputs(
 				testTx,
 				testSlot,
@@ -1374,9 +1395,12 @@ func TestUtxoValidateCollateralEqBalance(t *testing.T) {
 	testTx := &babbage.BabbageTransaction{
 		Body: babbage.BabbageTransactionBody{
 			TxTotalCollateral: testTotalCollateral,
-			TxCollateral: []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-			},
+			TxCollateral: cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+				},
+				false,
+			),
 		},
 	}
 	testLedgerState := test.MockLedgerState{
@@ -1492,10 +1516,13 @@ func TestUtxoValidateTooManyCollateralInputs(t *testing.T) {
 	t.Run(
 		"too many collateral inputs",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-				shelley.NewShelleyTransactionInput(testInputTxId, 1),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+					shelley.NewShelleyTransactionInput(testInputTxId, 1),
+				},
+				false,
+			)
 			err := babbage.UtxoValidateTooManyCollateralInputs(
 				testTx,
 				testSlot,
@@ -1523,9 +1550,12 @@ func TestUtxoValidateTooManyCollateralInputs(t *testing.T) {
 	t.Run(
 		"single collateral input",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+				},
+				false,
+			)
 			err := babbage.UtxoValidateTooManyCollateralInputs(
 				testTx,
 				testSlot,

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -350,12 +350,12 @@ type ConwayTransactionBody struct {
 	TxValidityIntervalStart uint64                                        `cbor:"8,keyasint,omitempty"`
 	TxMint                  *common.MultiAsset[common.MultiAssetTypeMint] `cbor:"9,keyasint,omitempty"`
 	TxScriptDataHash        *common.Blake2b256                            `cbor:"11,keyasint,omitempty"`
-	TxCollateral            []shelley.ShelleyTransactionInput             `cbor:"13,keyasint,omitempty"`
-	TxRequiredSigners       []common.Blake2b224                           `cbor:"14,keyasint,omitempty"`
+	TxCollateral            cbor.SetType[shelley.ShelleyTransactionInput] `cbor:"13,keyasint,omitempty,omitzero"`
+	TxRequiredSigners       cbor.SetType[common.Blake2b224]               `cbor:"14,keyasint,omitempty,omitzero"`
 	NetworkId               uint8                                         `cbor:"15,keyasint,omitempty"`
 	TxCollateralReturn      *babbage.BabbageTransactionOutput             `cbor:"16,keyasint,omitempty"`
 	TxTotalCollateral       uint64                                        `cbor:"17,keyasint,omitempty"`
-	TxReferenceInputs       []shelley.ShelleyTransactionInput             `cbor:"18,keyasint,omitempty"`
+	TxReferenceInputs       cbor.SetType[shelley.ShelleyTransactionInput] `cbor:"18,keyasint,omitempty,omitzero"`
 	TxVotingProcedures      common.VotingProcedures                       `cbor:"19,keyasint,omitempty"`
 	TxProposalProcedures    []common.ProposalProcedure                    `cbor:"20,keyasint,omitempty"`
 	TxCurrentTreasuryValue  int64                                         `cbor:"21,keyasint,omitempty"`
@@ -431,14 +431,14 @@ func (b *ConwayTransactionBody) AssetMint() *common.MultiAsset[common.MultiAsset
 
 func (b *ConwayTransactionBody) Collateral() []common.TransactionInput {
 	ret := []common.TransactionInput{}
-	for _, collateral := range b.TxCollateral {
+	for _, collateral := range b.TxCollateral.Items() {
 		ret = append(ret, collateral)
 	}
 	return ret
 }
 
 func (b *ConwayTransactionBody) RequiredSigners() []common.Blake2b224 {
-	return b.TxRequiredSigners[:]
+	return b.TxRequiredSigners.Items()
 }
 
 func (b *ConwayTransactionBody) ScriptDataHash() *common.Blake2b256 {
@@ -447,7 +447,7 @@ func (b *ConwayTransactionBody) ScriptDataHash() *common.Blake2b256 {
 
 func (b *ConwayTransactionBody) ReferenceInputs() []common.TransactionInput {
 	ret := []common.TransactionInput{}
-	for _, input := range b.TxReferenceInputs {
+	for _, input := range b.TxReferenceInputs.Items() {
 		ret = append(ret, &input)
 	}
 	return ret

--- a/ledger/conway/pparams_test.go
+++ b/ledger/conway/pparams_test.go
@@ -619,14 +619,23 @@ func TestConwayTransactionBody_Utxorpc(t *testing.T) {
 		OutputAddress: address,
 		OutputAmount:  mary.MaryTransactionOutputValue{Amount: 5000},
 	}
-	txCollateral := []shelley.ShelleyTransactionInput{input}
+	txCollateral := cbor.NewSetType[shelley.ShelleyTransactionInput](
+		[]shelley.ShelleyTransactionInput{input},
+		false,
+	)
 	txTotalCollateral := uint64(200)
-	txReferenceInputs := []shelley.ShelleyTransactionInput{input}
+	txReferenceInputs := cbor.NewSetType[shelley.ShelleyTransactionInput](
+		[]shelley.ShelleyTransactionInput{input},
+		false,
+	)
 	txAuxDataHash := &common.Blake2b256{0xde, 0xad, 0xbe, 0xef}
 	txValidityIntervalStart := uint64(4000)
 	var signer common.Blake2b224
 	copy(signer[:], []byte{0xab, 0xcd, 0xef})
-	txRequiredSigners := []common.Blake2b224{signer}
+	txRequiredSigners := cbor.NewSetType[common.Blake2b224](
+		[]common.Blake2b224{signer},
+		false,
+	)
 	txScriptDataHash := &common.Blake2b256{0xba, 0xad, 0xf0, 0x0d}
 	txMint := &common.MultiAsset[common.MultiAssetTypeMint]{}
 
@@ -682,14 +691,23 @@ func TestConwayTransaction_Utxorpc(t *testing.T) {
 		OutputAmount:  mary.MaryTransactionOutputValue{Amount: 5000},
 	}
 
-	txCollateral := []shelley.ShelleyTransactionInput{input}
+	txCollateral := cbor.NewSetType[shelley.ShelleyTransactionInput](
+		[]shelley.ShelleyTransactionInput{input},
+		false,
+	)
 	txTotalCollateral := uint64(200)
-	txReferenceInputs := []shelley.ShelleyTransactionInput{input}
+	txReferenceInputs := cbor.NewSetType[shelley.ShelleyTransactionInput](
+		[]shelley.ShelleyTransactionInput{input},
+		false,
+	)
 	txAuxDataHash := &common.Blake2b256{0xde, 0xad, 0xbe, 0xef}
 	txValidityIntervalStart := uint64(4000)
 	var signer common.Blake2b224
 	copy(signer[:], []byte{0xab, 0xcd, 0xef})
-	txRequiredSigners := []common.Blake2b224{signer}
+	txRequiredSigners := cbor.NewSetType[common.Blake2b224](
+		[]common.Blake2b224{signer},
+		false,
+	)
 	txScriptDataHash := &common.Blake2b256{0xba, 0xad, 0xf0, 0x0d}
 	txMint := &common.MultiAsset[common.MultiAssetTypeMint]{}
 

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -998,9 +998,12 @@ func TestUtxoValidateInsufficientCollateral(t *testing.T) {
 	t.Run(
 		"insufficient collateral",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+				},
+				false,
+			)
 			err := conway.UtxoValidateInsufficientCollateral(
 				testTx,
 				testSlot,
@@ -1028,10 +1031,13 @@ func TestUtxoValidateInsufficientCollateral(t *testing.T) {
 	t.Run(
 		"sufficient collateral",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-				shelley.NewShelleyTransactionInput(testInputTxId, 1),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+					shelley.NewShelleyTransactionInput(testInputTxId, 1),
+				},
+				false,
+			)
 			err := conway.UtxoValidateInsufficientCollateral(
 				testTx,
 				testSlot,
@@ -1112,10 +1118,13 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 	t.Run(
 		"coin and assets",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-				shelley.NewShelleyTransactionInput(testInputTxId, 1),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+					shelley.NewShelleyTransactionInput(testInputTxId, 1),
+				},
+				false,
+			)
 			err := conway.UtxoValidateCollateralContainsNonAda(
 				testTx,
 				testSlot,
@@ -1143,9 +1152,12 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 	t.Run(
 		"coin only",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+				},
+				false,
+			)
 			err := conway.UtxoValidateCollateralContainsNonAda(
 				testTx,
 				testSlot,
@@ -1164,10 +1176,13 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 	t.Run(
 		"coin and assets with return",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-				shelley.NewShelleyTransactionInput(testInputTxId, 1),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+					shelley.NewShelleyTransactionInput(testInputTxId, 1),
+				},
+				false,
+			)
 			testTx.Body.TxCollateralReturn = &babbage.BabbageTransactionOutput{
 				OutputAmount: mary.MaryTransactionOutputValue{
 					Amount: testCollateralAmount,
@@ -1192,9 +1207,12 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 	t.Run(
 		"coin and zero assets with return",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 2),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 2),
+				},
+				false,
+			)
 			testTx.Body.TxCollateralReturn = &babbage.BabbageTransactionOutput{
 				OutputAmount: mary.MaryTransactionOutputValue{
 					Amount: testCollateralAmount,
@@ -1273,9 +1291,12 @@ func TestUtxoValidateNoCollateralInputs(t *testing.T) {
 	t.Run(
 		"collateral",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+				},
+				false,
+			)
 			err := conway.UtxoValidateNoCollateralInputs(
 				testTx,
 				testSlot,
@@ -1390,9 +1411,12 @@ func TestUtxoValidateDisjointRefInputs(t *testing.T) {
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 				},
 			)
-			testTx.Body.TxReferenceInputs = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-			}
+			testTx.Body.TxReferenceInputs = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+				},
+				false,
+			)
 			err := conway.UtxoValidateDisjointRefInputs(
 				testTx,
 				testSlot,
@@ -1425,9 +1449,12 @@ func TestUtxoValidateDisjointRefInputs(t *testing.T) {
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 				},
 			)
-			testTx.Body.TxReferenceInputs = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 1),
-			}
+			testTx.Body.TxReferenceInputs = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 1),
+				},
+				false,
+			)
 			err := conway.UtxoValidateDisjointRefInputs(
 				testTx,
 				testSlot,
@@ -1453,9 +1480,12 @@ func TestUtxoValidateCollateralEqBalance(t *testing.T) {
 	testTx := &conway.ConwayTransaction{
 		Body: conway.ConwayTransactionBody{
 			TxTotalCollateral: testTotalCollateral,
-			TxCollateral: []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-			},
+			TxCollateral: cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+				},
+				false,
+			),
 		},
 	}
 	testLedgerState := test.MockLedgerState{
@@ -1544,10 +1574,13 @@ func TestUtxoValidateTooManyCollateralInputs(t *testing.T) {
 	t.Run(
 		"too many collateral inputs",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-				shelley.NewShelleyTransactionInput(testInputTxId, 1),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+					shelley.NewShelleyTransactionInput(testInputTxId, 1),
+				},
+				false,
+			)
 			err := conway.UtxoValidateTooManyCollateralInputs(
 				testTx,
 				testSlot,
@@ -1575,9 +1608,12 @@ func TestUtxoValidateTooManyCollateralInputs(t *testing.T) {
 	t.Run(
 		"single collateral input",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = []shelley.ShelleyTransactionInput{
-				shelley.NewShelleyTransactionInput(testInputTxId, 0),
-			}
+			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+				[]shelley.ShelleyTransactionInput{
+					shelley.NewShelleyTransactionInput(testInputTxId, 0),
+				},
+				false,
+			)
 			err := conway.UtxoValidateTooManyCollateralInputs(
 				testTx,
 				testSlot,


### PR DESCRIPTION
This creates a generic CBOR set type wrapper that supports the optional encoding format for various transaction body attributes

Fixes #1063
Fixes #1064
Fixes #1065