### PR TITLE
feat(ledger): Added ToPlutusData() function to gov proposal related types

### DIFF
--- a/ledger/common/gov.go
+++ b/ledger/common/gov.go
@@ -140,7 +140,7 @@ type ProposalProcedure struct {
 
 func (p *ProposalProcedure) ToPlutusData() data.PlutusData {
 	return data.NewConstr(0,
-		data.NewInteger(big.NewInt(int64(p.Deposit))),
+		data.NewInteger(new(big.Int).SetUint64(p.Deposit)),
 		p.RewardAccount.ToPlutusData(),
 		p.GovAction.ToPlutusData(),
 	)
@@ -242,8 +242,8 @@ func (a *HardForkInitiationGovAction) ToPlutusData() data.PlutusData {
 	return data.NewConstr(1,
 		a.ActionId.ToPlutusData(),
 		data.NewConstr(0,
-			data.NewInteger(big.NewInt(int64(a.ProtocolVersion.Major))),
-			data.NewInteger(big.NewInt(int64(a.ProtocolVersion.Minor))),
+			data.NewInteger(new(big.Int).SetUint64(uint64(a.ProtocolVersion.Major))),
+			data.NewInteger(new(big.Int).SetUint64(uint64(a.ProtocolVersion.Minor))),
 		),
 	)
 }
@@ -262,7 +262,7 @@ func (a *TreasuryWithdrawalGovAction) ToPlutusData() data.PlutusData {
 	for addr, amount := range a.Withdrawals {
 		pairs = append(pairs, [2]data.PlutusData{
 			data.NewConstr(0, addr.ToPlutusData()),
-			data.NewInteger(big.NewInt(int64(amount))),
+			data.NewInteger(new(big.Int).SetUint64(amount)),
 		})
 	}
 	return data.NewConstr(2,
@@ -306,7 +306,7 @@ func (a *UpdateCommitteeGovAction) ToPlutusData() data.PlutusData {
 	for cred, epoch := range a.CredEpochs {
 		addedPairs = append(addedPairs, [2]data.PlutusData{
 			cred.ToPlutusData(),
-			data.NewInteger(big.NewInt(int64(epoch))),
+			data.NewInteger(new(big.Int).SetUint64(uint64(epoch))),
 		})
 	}
 

--- a/ledger/common/gov.go
+++ b/ledger/common/gov.go
@@ -17,7 +17,6 @@ package common
 import (
 	"fmt"
 	"math/big"
-	"reflect"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/plutigo/pkg/data"
@@ -293,7 +292,7 @@ type UpdateCommitteeGovAction struct {
 	ActionId    *GovActionId
 	Credentials []Credential
 	CredEpochs  map[*Credential]uint
-	Unknown     cbor.Rat
+	Quorum      cbor.Rat
 }
 
 func (a *UpdateCommitteeGovAction) ToPlutusData() data.PlutusData {
@@ -310,26 +309,13 @@ func (a *UpdateCommitteeGovAction) ToPlutusData() data.PlutusData {
 		})
 	}
 
-	// Safe handling of Unknown Rat
+	// Get numerator and denominator using Rat methods
 	var num, den *big.Int
-	if rat := a.Unknown; rat != (cbor.Rat{}) {
-		val := reflect.ValueOf(rat)
-		numField := val.FieldByName("num")
-		denField := val.FieldByName("den")
-
-		if numField.IsValid() && !numField.IsNil() {
-			num = numField.Interface().(*big.Int)
-		}
-		if denField.IsValid() && !denField.IsNil() {
-			den = denField.Interface().(*big.Int)
-		}
-	}
-
-	// Default values if still nil
-	if num == nil {
+	if a.Quorum != (cbor.Rat{}) {
+		num = a.Quorum.Num()
+		den = a.Quorum.Denom()
+	} else {
 		num = big.NewInt(0)
-	}
-	if den == nil {
 		den = big.NewInt(1)
 	}
 

--- a/ledger/common/gov_test.go
+++ b/ledger/common/gov_test.go
@@ -291,7 +291,7 @@ func TestUpdateCommitteeGovActionToPlutusData(t *testing.T) {
 			ActionId:    &GovActionId{},
 			Credentials: creds,
 			CredEpochs:  credEpochs,
-			Unknown:     cbor.Rat{}, // Zero value
+			Quorum:      cbor.Rat{}, // Zero value
 		}
 
 		pd := action.ToPlutusData()


### PR DESCRIPTION
1. Implemented ToPlutusData() for GovAnchor, GovActionId, ProposalProcedure, GovActionWrapper, ParameterChangeGovAction, HardForkInitiationGovAction, TreasuryWithdrawalGovAction, NoConfidenceGovAction, UpdateCommitteeGovAction, NewConstitutionGovAction, InfoGovAction
2. Added unit tests for all the ToPlutusData() implemented above.

Closes #1106 