### PR TITLE
refactor: merge genesis big.Rat types

### DIFF
--- a/ledger/alonzo/genesis.go
+++ b/ledger/alonzo/genesis.go
@@ -19,9 +19,10 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"math/big"
 	"os"
 	"strconv"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
 type AlonzoGenesis struct {
@@ -156,22 +157,6 @@ type AlonzoGenesisExUnits struct {
 }
 
 type AlonzoGenesisExecutionPrices struct {
-	Steps *AlonzoGenesisExecutionPricesRat `json:"prSteps"`
-	Mem   *AlonzoGenesisExecutionPricesRat `json:"prMem"`
-}
-
-type AlonzoGenesisExecutionPricesRat struct {
-	*big.Rat
-}
-
-func (r *AlonzoGenesisExecutionPricesRat) UnmarshalJSON(data []byte) error {
-	var tmpData struct {
-		Numerator   int64 `json:"numerator"`
-		Denominator int64 `json:"denominator"`
-	}
-	if err := json.Unmarshal(data, &tmpData); err != nil {
-		return err
-	}
-	r.Rat = big.NewRat(tmpData.Numerator, tmpData.Denominator)
-	return nil
+	Steps *common.GenesisRat `json:"prSteps"`
+	Mem   *common.GenesisRat `json:"prMem"`
 }

--- a/ledger/alonzo/genesis_test.go
+++ b/ledger/alonzo/genesis_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
 const alonzoGenesisConfig = `
@@ -228,10 +229,10 @@ var expectedGenesisObj = alonzo.AlonzoGenesis{
 	CollateralPercentage: 150,
 	MaxCollateralInputs:  3,
 	ExecutionPrices: alonzo.AlonzoGenesisExecutionPrices{
-		Mem: &alonzo.AlonzoGenesisExecutionPricesRat{
+		Mem: &common.GenesisRat{
 			Rat: big.NewRat(577, 10000),
 		},
-		Steps: &alonzo.AlonzoGenesisExecutionPricesRat{
+		Steps: &common.GenesisRat{
 			Rat: big.NewRat(721, 10000000),
 		},
 	},

--- a/ledger/common/genesis.go
+++ b/ledger/common/genesis.go
@@ -15,6 +15,7 @@
 package common
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 )
@@ -25,6 +26,16 @@ type GenesisRat struct {
 }
 
 func (r *GenesisRat) UnmarshalJSON(data []byte) error {
+	// Try as ratio
+	var tmpData struct {
+		Numerator   int64 `json:"numerator"`
+		Denominator int64 `json:"denominator"`
+	}
+	if err := json.Unmarshal(data, &tmpData); err == nil {
+		r.Rat = big.NewRat(tmpData.Numerator, tmpData.Denominator)
+		return nil
+	}
+	// Try as decimal value
 	r.Rat = new(big.Rat)
 	if _, ok := r.SetString(string(data)); !ok {
 		return fmt.Errorf("math/big: cannot unmarshal %q into a *big.Rat", data)

--- a/ledger/common/genesis_test.go
+++ b/ledger/common/genesis_test.go
@@ -1,0 +1,51 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common_test
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+func TestGenesisRatNumDenom(t *testing.T) {
+	jsonData := `{"testRat": { "numerator": 721, "denominator": 10000 }}`
+	expectedRat := big.NewRat(721, 10000)
+	var testData struct {
+		TestRat common.GenesisRat `json:"testRat"`
+	}
+	if err := json.Unmarshal([]byte(jsonData), &testData); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if testData.TestRat.Cmp(expectedRat) != 0 {
+		t.Errorf("did not get expected value: got %s, wanted %s", testData.TestRat.String(), expectedRat.String())
+	}
+}
+
+func TestGenesisRatFloat(t *testing.T) {
+	jsonData := `{"testRat": 0.0721}`
+	expectedRat := big.NewRat(721, 10000)
+	var testData struct {
+		TestRat common.GenesisRat `json:"testRat"`
+	}
+	if err := json.Unmarshal([]byte(jsonData), &testData); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if testData.TestRat.Cmp(expectedRat) != 0 {
+		t.Errorf("did not get expected value: got %s, wanted %s", testData.TestRat.String(), expectedRat.String())
+	}
+}


### PR DESCRIPTION
This adds the functionality from alonzo.AlonzoGenesisExecutionPricesRat to common.Rat and removes the former type

Fixes #1124