### PR TITLE
refactor: allow easier iteration of redeemers

### DIFF
--- a/ledger/alonzo/alonzo_test.go
+++ b/ledger/alonzo/alonzo_test.go
@@ -164,3 +164,84 @@ func TestAlonzoTransactionOutputToPlutusDataCoinAssets(t *testing.T) {
 		t.Fatalf("did not get expected PlutusData\n     got: %#v\n  wanted: %#v", tmpData, expectedData)
 	}
 }
+
+func TestAlonzoRedeemersIter(t *testing.T) {
+	testRedeemers := AlonzoRedeemers{
+		{
+			Tag:   common.RedeemerTagMint,
+			Index: 2,
+			ExUnits: common.ExUnits{
+				Memory: 1111,
+				Steps:  2222,
+			},
+		},
+		{
+			Tag:   common.RedeemerTagMint,
+			Index: 0,
+			ExUnits: common.ExUnits{
+				Memory: 1111,
+				Steps:  0,
+			},
+		},
+		{
+			Tag:   common.RedeemerTagSpend,
+			Index: 4,
+			ExUnits: common.ExUnits{
+				Memory: 0,
+				Steps:  4444,
+			},
+		},
+	}
+	expectedOrder := []struct {
+		Key   common.RedeemerKey
+		Value common.RedeemerValue
+	}{
+		{
+			Key: common.RedeemerKey{
+				Tag:   common.RedeemerTagSpend,
+				Index: 4,
+			},
+			Value: common.RedeemerValue{
+				ExUnits: common.ExUnits{
+					Memory: 0,
+					Steps:  4444,
+				},
+			},
+		},
+		{
+			Key: common.RedeemerKey{
+				Tag:   common.RedeemerTagMint,
+				Index: 0,
+			},
+			Value: common.RedeemerValue{
+				ExUnits: common.ExUnits{
+					Memory: 1111,
+					Steps:  0,
+				},
+			},
+		},
+		{
+			Key: common.RedeemerKey{
+				Tag:   common.RedeemerTagMint,
+				Index: 2,
+			},
+			Value: common.RedeemerValue{
+				ExUnits: common.ExUnits{
+					Memory: 1111,
+					Steps:  2222,
+				},
+			},
+		},
+	}
+	iterIdx := 0
+	for key, val := range testRedeemers.Iter() {
+		expected := expectedOrder[iterIdx]
+		if !reflect.DeepEqual(key, expected.Key) {
+			t.Fatalf("did not get expected key: got %#v, wanted %#v", key, expected.Key)
+		}
+		if !reflect.DeepEqual(val, expected.Value) {
+			t.Fatalf("did not get expected value: got %#v, wanted %#v", val, expected.Value)
+		}
+		iterIdx++
+	}
+}

--- a/ledger/common/redeemer.go
+++ b/ledger/common/redeemer.go
@@ -18,16 +18,25 @@ import (
 	"github.com/blinklabs-io/gouroboros/cbor"
 )
 
-type VkeyWitness struct {
+type RedeemerTag uint8
+
+const (
+	RedeemerTagSpend     RedeemerTag = 0
+	RedeemerTagMint      RedeemerTag = 1
+	RedeemerTagCert      RedeemerTag = 2
+	RedeemerTagReward    RedeemerTag = 3
+	RedeemerTagVoting    RedeemerTag = 4
+	RedeemerTagProposing RedeemerTag = 5
+)
+
+type RedeemerKey struct {
 	cbor.StructAsArray
-	Vkey      []byte
-	Signature []byte
+	Tag   RedeemerTag
+	Index uint32
 }
 
-type BootstrapWitness struct {
+type RedeemerValue struct {
 	cbor.StructAsArray
-	PublicKey  []byte
-	Signature  []byte
-	ChainCode  []byte
-	Attributes []byte
+	Data    cbor.LazyValue
+	ExUnits ExUnits
 }

--- a/ledger/common/tx.go
+++ b/ledger/common/tx.go
@@ -15,6 +15,8 @@
 package common
 
 import (
+	"iter"
+
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/plutigo/data"
 	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
@@ -90,7 +92,8 @@ type TransactionWitnessSet interface {
 
 type TransactionWitnessRedeemers interface {
 	Indexes(RedeemerTag) []uint
-	Value(uint, RedeemerTag) (cbor.LazyValue, ExUnits)
+	Value(uint, RedeemerTag) RedeemerValue
+	Iter() iter.Seq2[RedeemerKey, RedeemerValue]
 }
 
 type Utxo struct {

--- a/ledger/conway/conway_test.go
+++ b/ledger/conway/conway_test.go
@@ -1,0 +1,108 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conway
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+func TestConwayRedeemersIter(t *testing.T) {
+	testRedeemers := ConwayRedeemers{
+		Redeemers: map[common.RedeemerKey]common.RedeemerValue{
+			{
+				Tag:   common.RedeemerTagMint,
+				Index: 2,
+			}: {
+				ExUnits: common.ExUnits{
+					Memory: 1111,
+					Steps:  2222,
+				},
+			},
+			{
+				Tag:   common.RedeemerTagMint,
+				Index: 0,
+			}: {
+				ExUnits: common.ExUnits{
+					Memory: 1111,
+					Steps:  0,
+				},
+			},
+			{
+				Tag:   common.RedeemerTagSpend,
+				Index: 4,
+			}: {
+				ExUnits: common.ExUnits{
+					Memory: 0,
+					Steps:  4444,
+				},
+			},
+		},
+	}
+	expectedOrder := []struct {
+		Key   common.RedeemerKey
+		Value common.RedeemerValue
+	}{
+		{
+			Key: common.RedeemerKey{
+				Tag:   common.RedeemerTagSpend,
+				Index: 4,
+			},
+			Value: common.RedeemerValue{
+				ExUnits: common.ExUnits{
+					Memory: 0,
+					Steps:  4444,
+				},
+			},
+		},
+		{
+			Key: common.RedeemerKey{
+				Tag:   common.RedeemerTagMint,
+				Index: 0,
+			},
+			Value: common.RedeemerValue{
+				ExUnits: common.ExUnits{
+					Memory: 1111,
+					Steps:  0,
+				},
+			},
+		},
+		{
+			Key: common.RedeemerKey{
+				Tag:   common.RedeemerTagMint,
+				Index: 2,
+			},
+			Value: common.RedeemerValue{
+				ExUnits: common.ExUnits{
+					Memory: 1111,
+					Steps:  2222,
+				},
+			},
+		},
+	}
+	iterIdx := 0
+	for key, val := range testRedeemers.Iter() {
+		expected := expectedOrder[iterIdx]
+		if !reflect.DeepEqual(key, expected.Key) {
+			t.Fatalf("did not get expected key: got %#v, wanted %#v", key, expected.Key)
+		}
+		if !reflect.DeepEqual(val, expected.Value) {
+			t.Fatalf("did not get expected value: got %#v, wanted %#v", val, expected.Value)
+		}
+		iterIdx++
+	}
+}

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -967,7 +967,7 @@ func TestUtxoValidateInsufficientCollateral(t *testing.T) {
 		},
 		WitnessSet: conway.ConwayTransactionWitnessSet{
 			WsRedeemers: conway.ConwayRedeemers{
-				Redeemers: map[conway.ConwayRedeemerKey]conway.ConwayRedeemerValue{
+				Redeemers: map[common.RedeemerKey]common.RedeemerValue{
 					// Placeholder entry
 					{}: {},
 				},
@@ -1063,7 +1063,7 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 		},
 		WitnessSet: conway.ConwayTransactionWitnessSet{
 			WsRedeemers: conway.ConwayRedeemers{
-				Redeemers: map[conway.ConwayRedeemerKey]conway.ConwayRedeemerValue{
+				Redeemers: map[common.RedeemerKey]common.RedeemerValue{
 					// Placeholder entry
 					{}: {},
 				},
@@ -1241,7 +1241,7 @@ func TestUtxoValidateNoCollateralInputs(t *testing.T) {
 		Body: conway.ConwayTransactionBody{},
 		WitnessSet: conway.ConwayTransactionWitnessSet{
 			WsRedeemers: conway.ConwayRedeemers{
-				Redeemers: map[conway.ConwayRedeemerKey]conway.ConwayRedeemerValue{
+				Redeemers: map[common.RedeemerKey]common.RedeemerValue{
 					// Placeholder entry
 					{}: {},
 				},
@@ -1314,13 +1314,13 @@ func TestUtxoValidateNoCollateralInputs(t *testing.T) {
 }
 
 func TestUtxoValidateExUnitsTooBigUtxo(t *testing.T) {
-	testRedeemerSmall := conway.ConwayRedeemerValue{
+	testRedeemerSmall := common.RedeemerValue{
 		ExUnits: common.ExUnits{
 			Memory: 1_000_000,
 			Steps:  2_000,
 		},
 	}
-	testRedeemerLarge := conway.ConwayRedeemerValue{
+	testRedeemerLarge := common.RedeemerValue{
 		ExUnits: common.ExUnits{
 			Memory: 1_000_000_000,
 			Steps:  2_000_000,
@@ -1342,7 +1342,7 @@ func TestUtxoValidateExUnitsTooBigUtxo(t *testing.T) {
 		"ExUnits too large",
 		func(t *testing.T) {
 			testTx.WitnessSet.WsRedeemers = conway.ConwayRedeemers{
-				Redeemers: map[conway.ConwayRedeemerKey]conway.ConwayRedeemerValue{
+				Redeemers: map[common.RedeemerKey]common.RedeemerValue{
 					{}: testRedeemerLarge,
 				},
 			}
@@ -1374,7 +1374,7 @@ func TestUtxoValidateExUnitsTooBigUtxo(t *testing.T) {
 		"ExUnits under limit",
 		func(t *testing.T) {
 			testTx.WitnessSet.WsRedeemers = conway.ConwayRedeemers{
-				Redeemers: map[conway.ConwayRedeemerKey]conway.ConwayRedeemerValue{
+				Redeemers: map[common.RedeemerKey]common.RedeemerValue{
 					{}: testRedeemerSmall,
 				},
 			}


### PR DESCRIPTION
This also moves the Conway redeemer key/value types to common so they can be reused for iteration

Fixes #1126