### PR TITLE
refactor(cbor): move debug from utils to cbor package

### DIFF
--- a/cbor/debug.go
+++ b/cbor/debug.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package utils
+package cbor
 
 import (
 	"bytes"


### PR DESCRIPTION
The only function is CBOR-related, so moving it and getting rid of the `utils` package.