### PR TITLE
fix: retain data on CBOR unmarshal of native script

### DIFF
--- a/ledger/common/script.go
+++ b/ledger/common/script.go
@@ -158,6 +158,7 @@ func (n *NativeScript) UnmarshalCBOR(data []byte) error {
 	if _, err := cbor.Decode(data, tmpData); err != nil {
 		return err
 	}
+	n.item = tmpData
 	return nil
 }
 

--- a/ledger/common/script_test.go
+++ b/ledger/common/script_test.go
@@ -41,6 +41,19 @@ func TestScriptRefDecode(t *testing.T) {
 	}
 }
 
+func TestNativeScriptHash(t *testing.T) {
+	testScriptBytes, _ := hex.DecodeString("820181830301838200581c058a5ab0c66647dcce82d7244f80bfea41ba76c7c9ccaf86a41b00fe8200581c45cbc234959cb619ef54e36c16e7719318592e627cdf1a39bd3d64398200581c85fd53e110449649b709ef0fa93e86d99535bdce5db306ce0e7418fc")
+	expectedScriptHash := "1c0053ec18e2c0f7bd4d007fe14243ca220563f9c124381f75c43704"
+	var testScript common.NativeScript
+	if err := testScript.UnmarshalCBOR(testScriptBytes); err != nil {
+		t.Fatalf("unexpected error decoding native script: %s", err)
+	}
+	tmpHash := testScript.Hash()
+	if tmpHash.String() != expectedScriptHash {
+		t.Errorf("did not get expected script hash, got %s, wanted %s", tmpHash.String(), expectedScriptHash)
+	}
+}
+
 func TestPlutusV3ScriptHash(t *testing.T) {
 	testScriptBytes, _ := hex.DecodeString("587f01010032323232323225333002323232323253330073370e900118041baa0011323232533300a3370e900018059baa00513232533300f301100214a22c6eb8c03c004c030dd50028b18069807001180600098049baa00116300a300b0023009001300900230070013004375400229309b2b2b9a5573aaae7955cfaba157441")
 	testScript := common.PlutusV3Script(testScriptBytes)


### PR DESCRIPTION
This also adds a test for generating the native script hash

Fixes #1139