### PR TITLE
Not returning on connection close for chainsync, block-fetch and tx-submission protocol

### DIFF
--- a/protocol/blockfetch/blockfetch.go
+++ b/protocol/blockfetch/blockfetch.go
@@ -79,8 +79,7 @@ var StateMap = protocol.StateMap{
 		},
 	},
 	StateDone: protocol.StateMapEntry{
-		Agency:      protocol.AgencyNone,
-		Transitions: []protocol.StateTransition{},
+		Agency: protocol.AgencyNone,
 	},
 }
 

--- a/protocol/blockfetch/blockfetch_test.go
+++ b/protocol/blockfetch/blockfetch_test.go
@@ -1,0 +1,171 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package blockfetch
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/muxer"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+)
+
+// testAddr implements net.Addr for testing
+type testAddr struct{}
+
+func (a testAddr) Network() string { return "test" }
+func (a testAddr) String() string  { return "test-addr" }
+
+// testConn implements net.Conn for testing with buffered writes
+type testConn struct {
+	writeChan chan []byte
+}
+
+func (c *testConn) Read(b []byte) (n int, err error) { return 0, nil }
+func (c *testConn) Write(b []byte) (n int, err error) {
+	c.writeChan <- b
+	return len(b), nil
+}
+func (c *testConn) Close() error                       { return nil }
+func (c *testConn) LocalAddr() net.Addr                { return testAddr{} }
+func (c *testConn) RemoteAddr() net.Addr               { return testAddr{} }
+func (c *testConn) SetDeadline(t time.Time) error      { return nil }
+func (c *testConn) SetReadDeadline(t time.Time) error  { return nil }
+func (c *testConn) SetWriteDeadline(t time.Time) error { return nil }
+
+func getTestProtocolOptions(conn net.Conn) protocol.ProtocolOptions {
+	mux := muxer.New(conn)
+	return protocol.ProtocolOptions{
+		ConnectionId: connection.ConnectionId{
+			LocalAddr:  testAddr{},
+			RemoteAddr: testAddr{},
+		},
+		Muxer:  mux,
+		Logger: slog.Default(),
+	}
+}
+
+func TestNewBlockFetch(t *testing.T) {
+	conn := &testConn{writeChan: make(chan []byte, 1)}
+	cfg := NewConfig()
+	bf := New(getTestProtocolOptions(conn), &cfg)
+	assert.NotNil(t, bf.Client)
+	assert.NotNil(t, bf.Server)
+}
+
+func TestConfigOptions(t *testing.T) {
+	t.Run("Default config", func(t *testing.T) {
+		cfg := NewConfig()
+		assert.Equal(t, 5*time.Second, cfg.BatchStartTimeout)
+		assert.Equal(t, 60*time.Second, cfg.BlockTimeout)
+	})
+
+	t.Run("Custom config", func(t *testing.T) {
+		cfg := NewConfig(
+			WithBatchStartTimeout(10*time.Second),
+			WithBlockTimeout(30*time.Second),
+			WithRecvQueueSize(100),
+		)
+		assert.Equal(t, 10*time.Second, cfg.BatchStartTimeout)
+		assert.Equal(t, 30*time.Second, cfg.BlockTimeout)
+		assert.Equal(t, 100, cfg.RecvQueueSize)
+	})
+}
+
+func TestConnectionErrorHandling(t *testing.T) {
+	conn := &testConn{writeChan: make(chan []byte, 1)}
+	cfg := NewConfig()
+	bf := New(getTestProtocolOptions(conn), &cfg)
+
+	t.Run("Non-EOF error when not done", func(t *testing.T) {
+		err := bf.HandleConnectionError(errors.New("test error"))
+		assert.Error(t, err)
+	})
+
+	t.Run("EOF error when not done", func(t *testing.T) {
+		err := bf.HandleConnectionError(io.EOF)
+		assert.Error(t, err)
+	})
+
+	t.Run("Connection reset error", func(t *testing.T) {
+		err := bf.HandleConnectionError(errors.New("connection reset by peer"))
+		assert.Error(t, err)
+	})
+}
+
+func TestCallbackRegistration(t *testing.T) {
+	conn := &testConn{writeChan: make(chan []byte, 1)}
+
+	t.Run("Block callback registration", func(t *testing.T) {
+		blockFunc := func(ctx CallbackContext, slot uint, block ledger.Block) error {
+			return nil
+		}
+		cfg := NewConfig(WithBlockFunc(blockFunc))
+		client := NewClient(getTestProtocolOptions(conn), &cfg)
+		assert.NotNil(t, client)
+		assert.NotNil(t, cfg.BlockFunc)
+	})
+
+	t.Run("RequestRange callback registration", func(t *testing.T) {
+		requestRangeFunc := func(ctx CallbackContext, start, end common.Point) error {
+			return nil
+		}
+		cfg := NewConfig(WithRequestRangeFunc(requestRangeFunc))
+		server := NewServer(getTestProtocolOptions(conn), &cfg)
+		assert.NotNil(t, server)
+		assert.NotNil(t, cfg.RequestRangeFunc)
+	})
+}
+
+func TestClientMessageSending(t *testing.T) {
+	conn := &testConn{writeChan: make(chan []byte, 1)}
+	cfg := NewConfig()
+	client := NewClient(getTestProtocolOptions(conn), &cfg)
+
+	t.Run("Client can send messages", func(t *testing.T) {
+		// Start the client protocol
+		client.Start()
+
+		// Send a done message
+		err := client.Protocol.SendMessage(NewMsgClientDone())
+		assert.NoError(t, err)
+
+		// Verify message was written to connection
+		select {
+		case <-conn.writeChan:
+			// Message was sent successfully
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("timeout waiting for message send")
+		}
+	})
+}
+
+func TestServerMessageHandling(t *testing.T) {
+	conn := &testConn{writeChan: make(chan []byte, 1)}
+	cfg := NewConfig()
+	server := NewServer(getTestProtocolOptions(conn), &cfg)
+
+	t.Run("Server can be started", func(t *testing.T) {
+		server.Start()
+
+	})
+}

--- a/protocol/blockfetch/client.go
+++ b/protocol/blockfetch/client.go
@@ -35,6 +35,8 @@ type Client struct {
 	blockUseCallback     bool
 	onceStart            sync.Once
 	onceStop             sync.Once
+	currentState         protocol.State
+	stateMutex           sync.Mutex
 }
 
 func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
@@ -46,6 +48,7 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 		config:               cfg,
 		blockChan:            make(chan ledger.Block),
 		startBatchResultChan: make(chan error),
+		currentState:         StateIdle,
 	}
 	c.callbackContext = CallbackContext{
 		Client:       c,
@@ -82,6 +85,18 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 	return c
 }
 
+func (c *Client) IsDone() bool {
+	c.stateMutex.Lock()
+	defer c.stateMutex.Unlock()
+	return c.currentState.Id == StateDone.Id
+}
+
+func (c *Client) setState(newState protocol.State) {
+	c.stateMutex.Lock()
+	defer c.stateMutex.Unlock()
+	c.currentState = newState
+}
+
 func (c *Client) Start() {
 	c.onceStart.Do(func() {
 		c.Protocol.Logger().
@@ -110,7 +125,11 @@ func (c *Client) Stop() error {
 				"connection_id", c.callbackContext.ConnectionId.String(),
 			)
 		msg := NewMsgClientDone()
-		err = c.SendMessage(msg)
+		if sendErr := c.SendMessage(msg); sendErr != nil {
+			err = sendErr
+			return
+		}
+		c.setState(StateDone)
 	})
 	return err
 }
@@ -196,6 +215,8 @@ func (c *Client) messageHandler(msg protocol.Message) error {
 		err = c.handleBlock(msg)
 	case MessageTypeBatchDone:
 		err = c.handleBatchDone()
+	case MessageTypeClientDone:
+		c.setState(StateDone)
 	default:
 		err = fmt.Errorf(
 			"%s: received unexpected message type %d",

--- a/protocol/chainsync/chainsync_test.go
+++ b/protocol/chainsync/chainsync_test.go
@@ -1,0 +1,184 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package chainsync
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/muxer"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+)
+
+// testAddr implements net.Addr for testing
+type testAddr struct{}
+
+func (a testAddr) Network() string { return "test" }
+func (a testAddr) String() string  { return "test-addr" }
+
+// testConn implements net.Conn for testing with buffered writes
+type testConn struct {
+	writeChan chan []byte
+}
+
+func (c *testConn) Read(b []byte) (n int, err error) { return 0, nil }
+func (c *testConn) Write(b []byte) (n int, err error) {
+	c.writeChan <- b
+	return len(b), nil
+}
+func (c *testConn) Close() error                       { return nil }
+func (c *testConn) LocalAddr() net.Addr                { return testAddr{} }
+func (c *testConn) RemoteAddr() net.Addr               { return testAddr{} }
+func (c *testConn) SetDeadline(t time.Time) error      { return nil }
+func (c *testConn) SetReadDeadline(t time.Time) error  { return nil }
+func (c *testConn) SetWriteDeadline(t time.Time) error { return nil }
+
+func getTestProtocolOptions(conn net.Conn) protocol.ProtocolOptions {
+	mux := muxer.New(conn)
+	return protocol.ProtocolOptions{
+		ConnectionId: connection.ConnectionId{
+			LocalAddr:  testAddr{},
+			RemoteAddr: testAddr{},
+		},
+		Muxer:  mux,
+		Logger: slog.Default(),
+	}
+}
+
+func TestNewChainSync(t *testing.T) {
+	conn := &testConn{writeChan: make(chan []byte, 1)}
+	cfg := NewConfig()
+	cs := New(getTestProtocolOptions(conn), &cfg)
+	assert.NotNil(t, cs.Client)
+	assert.NotNil(t, cs.Server)
+}
+
+func TestConfigOptions(t *testing.T) {
+	t.Run("Default config", func(t *testing.T) {
+		cfg := NewConfig()
+		assert.Equal(t, 5*time.Second, cfg.IntersectTimeout)
+		assert.Equal(t, 300*time.Second, cfg.BlockTimeout)
+		assert.Equal(t, 0, cfg.PipelineLimit)
+	})
+
+	t.Run("Custom config", func(t *testing.T) {
+		cfg := NewConfig(
+			WithIntersectTimeout(10*time.Second),
+			WithBlockTimeout(30*time.Second),
+			WithPipelineLimit(100),
+			WithRecvQueueSize(50),
+		)
+		assert.Equal(t, 10*time.Second, cfg.IntersectTimeout)
+		assert.Equal(t, 30*time.Second, cfg.BlockTimeout)
+		assert.Equal(t, 100, cfg.PipelineLimit)
+		assert.Equal(t, 50, cfg.RecvQueueSize)
+	})
+}
+
+func TestConnectionErrorHandling(t *testing.T) {
+	conn := &testConn{writeChan: make(chan []byte, 1)}
+	cfg := NewConfig()
+	cs := New(getTestProtocolOptions(conn), &cfg)
+
+	t.Run("Non-EOF error when not done", func(t *testing.T) {
+		err := cs.HandleConnectionError(errors.New("test error"))
+		assert.Error(t, err)
+	})
+
+	t.Run("EOF error when not done", func(t *testing.T) {
+		err := cs.HandleConnectionError(io.EOF)
+		assert.Error(t, err)
+	})
+
+	t.Run("Connection reset error when not done", func(t *testing.T) {
+		err := cs.HandleConnectionError(errors.New("connection reset by peer"))
+		assert.Error(t, err)
+	})
+
+	t.Run("EOF error when done", func(t *testing.T) {
+		// Force done state
+		cs.currentState = stateDone
+		err := cs.HandleConnectionError(io.EOF)
+		assert.NoError(t, err)
+	})
+}
+
+func TestCallbackRegistration(t *testing.T) {
+	conn := &testConn{writeChan: make(chan []byte, 1)}
+
+	t.Run("RollForward callback registration", func(t *testing.T) {
+		rollForwardFunc := func(ctx CallbackContext, blockType uint, block any, tip Tip) error {
+			return nil
+		}
+		cfg := NewConfig(WithRollForwardFunc(rollForwardFunc))
+		client := NewClient(&StateContext{}, getTestProtocolOptions(conn), &cfg)
+		assert.NotNil(t, client)
+		assert.NotNil(t, cfg.RollForwardFunc)
+	})
+
+	t.Run("FindIntersect callback registration", func(t *testing.T) {
+		findIntersectFunc := func(ctx CallbackContext, points []common.Point) (common.Point, Tip, error) {
+			return common.Point{}, Tip{}, nil
+		}
+		cfg := NewConfig(WithFindIntersectFunc(findIntersectFunc))
+		server := NewServer(&StateContext{}, getTestProtocolOptions(conn), &cfg)
+		assert.NotNil(t, server)
+		assert.NotNil(t, cfg.FindIntersectFunc)
+	})
+}
+
+func TestClientMessageSending(t *testing.T) {
+	conn := &testConn{writeChan: make(chan []byte, 1)}
+	cfg := NewConfig()
+	client := NewClient(&StateContext{}, getTestProtocolOptions(conn), &cfg)
+
+	t.Run("Client can send messages", func(t *testing.T) {
+		// Start the client protocol
+		client.Start()
+
+		// Create proper Done message
+		doneMsg := &MsgDone{}
+
+		// Send a done message
+		err := client.Protocol.SendMessage(doneMsg)
+		assert.NoError(t, err)
+
+		// Verify message was written to connection
+		select {
+		case <-conn.writeChan:
+			// Message was sent successfully
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("timeout waiting for message send")
+		}
+	})
+}
+
+func TestServerMessageHandling(t *testing.T) {
+	conn := &testConn{writeChan: make(chan []byte, 1)}
+	cfg := NewConfig()
+	server := NewServer(&StateContext{}, getTestProtocolOptions(conn), &cfg)
+
+	t.Run("Server can be started", func(t *testing.T) {
+		server.Start()
+		// Simple test to verify server can be started without error
+		assert.NotNil(t, server)
+	})
+}

--- a/protocol/chainsync/server.go
+++ b/protocol/chainsync/server.go
@@ -187,7 +187,8 @@ func (s *Server) messageHandler(msg protocol.Message) error {
 		err = fmt.Errorf(
 			"%s: received unexpected message type %d",
 			ProtocolName,
-			msg.Type())
+			msg.Type(),
+		)
 	}
 	return err
 }

--- a/protocol/txsubmission/txsubmission_test.go
+++ b/protocol/txsubmission/txsubmission_test.go
@@ -1,0 +1,209 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package txsubmission
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/muxer"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/stretchr/testify/assert"
+)
+
+// testAddr implements net.Addr for testing
+type testAddr struct{}
+
+func (a testAddr) Network() string { return "test" }
+func (a testAddr) String() string  { return "test-addr" }
+
+// testConn implements net.Conn for testing with buffered writes
+type testConn struct {
+	writeChan chan []byte
+}
+
+func (c *testConn) Read(b []byte) (n int, err error) { return 0, nil }
+func (c *testConn) Write(b []byte) (n int, err error) {
+	c.writeChan <- b
+	return len(b), nil
+}
+func (c *testConn) Close() error                       { return nil }
+func (c *testConn) LocalAddr() net.Addr                { return testAddr{} }
+func (c *testConn) RemoteAddr() net.Addr               { return testAddr{} }
+func (c *testConn) SetDeadline(t time.Time) error      { return nil }
+func (c *testConn) SetReadDeadline(t time.Time) error  { return nil }
+func (c *testConn) SetWriteDeadline(t time.Time) error { return nil }
+
+func getTestProtocolOptions(conn net.Conn) protocol.ProtocolOptions {
+	mux := muxer.New(conn)
+	return protocol.ProtocolOptions{
+		ConnectionId: connection.ConnectionId{
+			LocalAddr:  testAddr{},
+			RemoteAddr: testAddr{},
+		},
+		Muxer:  mux,
+		Logger: slog.Default(),
+	}
+}
+
+func TestNewTxSubmission(t *testing.T) {
+	conn := &testConn{writeChan: make(chan []byte, 1)}
+	cfg := NewConfig()
+	ts := New(getTestProtocolOptions(conn), &cfg)
+	assert.NotNil(t, ts.Client)
+	assert.NotNil(t, ts.Server)
+}
+
+func TestConfigOptions(t *testing.T) {
+	t.Run("Default config", func(t *testing.T) {
+		cfg := NewConfig()
+		assert.Equal(t, 300*time.Second, cfg.IdleTimeout)
+	})
+
+	t.Run("Custom config", func(t *testing.T) {
+		cfg := NewConfig(
+			WithIdleTimeout(60*time.Second),
+			WithRequestTxIdsFunc(func(ctx CallbackContext, blocking bool, ack, req uint16) ([]TxIdAndSize, error) {
+				return nil, nil
+			}),
+			WithRequestTxsFunc(func(ctx CallbackContext, txIds []TxId) ([]TxBody, error) {
+				return nil, nil
+			}),
+		)
+		assert.Equal(t, 60*time.Second, cfg.IdleTimeout)
+		assert.NotNil(t, cfg.RequestTxIdsFunc)
+		assert.NotNil(t, cfg.RequestTxsFunc)
+	})
+}
+
+func TestConnectionErrorHandling(t *testing.T) {
+	conn := &testConn{writeChan: make(chan []byte, 1)}
+	cfg := NewConfig()
+	ts := New(getTestProtocolOptions(conn), &cfg)
+
+	t.Run("Non-EOF error when not done", func(t *testing.T) {
+		err := ts.HandleConnectionError(errors.New("test error"))
+		assert.Error(t, err)
+	})
+
+	t.Run("EOF error when not done", func(t *testing.T) {
+		err := ts.HandleConnectionError(io.EOF)
+		assert.Error(t, err)
+	})
+
+	t.Run("Connection reset error when not done", func(t *testing.T) {
+		err := ts.HandleConnectionError(errors.New("connection reset by peer"))
+		assert.Error(t, err)
+	})
+
+	t.Run("EOF error when done", func(t *testing.T) {
+		ts.currentState = stateDone
+		err := ts.HandleConnectionError(io.EOF)
+		assert.NoError(t, err)
+	})
+}
+
+func TestCallbackRegistration(t *testing.T) {
+	conn := &testConn{writeChan: make(chan []byte, 1)}
+
+	t.Run("RequestTxIds callback registration", func(t *testing.T) {
+		requestTxIdsFunc := func(ctx CallbackContext, blocking bool, ack, req uint16) ([]TxIdAndSize, error) {
+			return nil, nil
+		}
+		cfg := NewConfig(WithRequestTxIdsFunc(requestTxIdsFunc))
+		server := NewServer(getTestProtocolOptions(conn), &cfg)
+		assert.NotNil(t, server)
+		assert.NotNil(t, cfg.RequestTxIdsFunc)
+	})
+
+	t.Run("RequestTxs callback registration", func(t *testing.T) {
+		requestTxsFunc := func(ctx CallbackContext, txIds []TxId) ([]TxBody, error) {
+			return nil, nil
+		}
+		cfg := NewConfig(WithRequestTxsFunc(requestTxsFunc))
+		server := NewServer(getTestProtocolOptions(conn), &cfg)
+		assert.NotNil(t, server)
+		assert.NotNil(t, cfg.RequestTxsFunc)
+	})
+}
+
+func TestClientMessageSending(t *testing.T) {
+	conn := &testConn{writeChan: make(chan []byte, 1)}
+	cfg := NewConfig()
+	client := NewClient(getTestProtocolOptions(conn), &cfg)
+
+	t.Run("Client can send messages", func(t *testing.T) {
+		// Start the client protocol
+		client.Start()
+
+		// Send an init message
+		initMsg := NewMsgInit()
+		err := client.Protocol.SendMessage(initMsg)
+		assert.NoError(t, err)
+
+		// Verify message was written to connection
+		select {
+		case <-conn.writeChan:
+			// Message was sent successfully
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("timeout waiting for message send")
+		}
+	})
+}
+
+func TestServerMessageHandling(t *testing.T) {
+	conn := &testConn{writeChan: make(chan []byte, 1)}
+	cfg := NewConfig()
+	server := NewServer(getTestProtocolOptions(conn), &cfg)
+
+	t.Run("Server can be started", func(t *testing.T) {
+		server.Start()
+		assert.NotNil(t, server)
+	})
+}
+
+func TestIsConnectionReset(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "connection reset",
+			err:      errors.New("connection reset by peer"),
+			expected: true,
+		},
+		{
+			name:     "broken pipe",
+			err:      errors.New("broken pipe"),
+			expected: true,
+		},
+		{
+			name:     "other error",
+			err:      errors.New("other error"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isConnectionReset(tt.err))
+		})
+	}
+}


### PR DESCRIPTION
1. Added changes to not return error while closing the connection for chainsync, block-fetch and tx-submission protocol- made changes in client,server and respective protocol files.
2. Added unit tests to test the change.