### PR TITLE
refactor: use int64 for ExUnits

### DIFF
--- a/ledger/alonzo/pparams.go
+++ b/ledger/alonzo/pparams.go
@@ -165,12 +165,12 @@ func (p *AlonzoProtocolParameters) UpdateFromGenesis(
 	p.CollateralPercentage = genesis.CollateralPercentage
 	p.MaxCollateralInputs = genesis.MaxCollateralInputs
 	p.MaxTxExUnits = common.ExUnits{
-		Memory: uint64(genesis.MaxTxExUnits.Mem),
-		Steps:  uint64(genesis.MaxTxExUnits.Steps),
+		Memory: int64(genesis.MaxTxExUnits.Mem),   // nolint:gosec
+		Steps:  int64(genesis.MaxTxExUnits.Steps), // nolint:gosec
 	}
 	p.MaxBlockExUnits = common.ExUnits{
-		Memory: uint64(genesis.MaxBlockExUnits.Mem),
-		Steps:  uint64(genesis.MaxBlockExUnits.Steps),
+		Memory: int64(genesis.MaxBlockExUnits.Mem),   // nolint:gosec
+		Steps:  int64(genesis.MaxBlockExUnits.Steps), // nolint:gosec
 	}
 
 	if genesis.ExecutionPrices.Mem != nil &&
@@ -347,12 +347,12 @@ func (p *AlonzoProtocolParameters) Utxorpc() (*cardano.PParams, error) {
 			},
 		},
 		MaxExecutionUnitsPerTransaction: &cardano.ExUnits{
-			Memory: p.MaxTxExUnits.Memory,
-			Steps:  p.MaxTxExUnits.Steps,
+			Memory: uint64(p.MaxTxExUnits.Memory),
+			Steps:  uint64(p.MaxTxExUnits.Steps),
 		},
 		MaxExecutionUnitsPerBlock: &cardano.ExUnits{
-			Memory: p.MaxBlockExUnits.Memory,
-			Steps:  p.MaxBlockExUnits.Steps,
+			Memory: uint64(p.MaxBlockExUnits.Memory),
+			Steps:  uint64(p.MaxBlockExUnits.Steps),
 		},
 	}, nil
 }

--- a/ledger/alonzo/rules.go
+++ b/ledger/alonzo/rules.go
@@ -91,7 +91,7 @@ func UtxoValidateExUnitsTooBigUtxo(
 	if !ok {
 		return errors.New("transaction is not expected type")
 	}
-	var totalSteps, totalMemory uint64
+	var totalSteps, totalMemory int64
 	for _, redeemer := range tmpTx.WitnessSet.WsRedeemers {
 		totalSteps += redeemer.ExUnits.Steps
 		totalMemory += redeemer.ExUnits.Memory

--- a/ledger/babbage/pparams.go
+++ b/ledger/babbage/pparams.go
@@ -236,12 +236,12 @@ func (p *BabbageProtocolParameters) Utxorpc() (*cardano.PParams, error) {
 			},
 		},
 		MaxExecutionUnitsPerTransaction: &cardano.ExUnits{
-			Memory: p.MaxTxExUnits.Memory,
-			Steps:  p.MaxTxExUnits.Steps,
+			Memory: uint64(p.MaxTxExUnits.Memory),
+			Steps:  uint64(p.MaxTxExUnits.Steps),
 		},
 		MaxExecutionUnitsPerBlock: &cardano.ExUnits{
-			Memory: p.MaxBlockExUnits.Memory,
-			Steps:  p.MaxBlockExUnits.Steps,
+			Memory: uint64(p.MaxBlockExUnits.Memory),
+			Steps:  uint64(p.MaxBlockExUnits.Steps),
 		},
 	}, nil
 }

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -416,7 +416,7 @@ func UtxoValidateExUnitsTooBigUtxo(
 	if !ok {
 		return errors.New("transaction is not expected type")
 	}
-	var totalSteps, totalMemory uint64
+	var totalSteps, totalMemory int64
 	for _, redeemer := range tmpTx.WitnessSet.WsRedeemers {
 		totalSteps += redeemer.ExUnits.Steps
 		totalMemory += redeemer.ExUnits.Memory

--- a/ledger/common/common.go
+++ b/ledger/common/common.go
@@ -436,8 +436,8 @@ func (i IssuerVkey) PoolId() string {
 // ExUnits represents the steps and memory usage for script execution
 type ExUnits struct {
 	cbor.StructAsArray
-	Memory uint64
-	Steps  uint64
+	Memory int64
+	Steps  int64
 }
 
 // GenesisRat is a convenience type for cbor.Rat

--- a/ledger/common/script.go
+++ b/ledger/common/script.go
@@ -146,8 +146,8 @@ func (s PlutusV3Script) Evaluate(scriptContext data.PlutusData, budget ExUnits) 
 	machineBudget := cek.DefaultExBudget
 	if budget.Steps > 0 || budget.Memory > 0 {
 		machineBudget = cek.ExBudget{
-			Cpu: int64(budget.Steps),  // nolint: gosec
-			Mem: int64(budget.Memory), // nolint: gosec
+			Cpu: budget.Steps,
+			Mem: budget.Memory,
 		}
 	}
 	// Decode raw script as bytestring to get actual script bytes
@@ -178,8 +178,8 @@ func (s PlutusV3Script) Evaluate(scriptContext data.PlutusData, budget ExUnits) 
 		return usedExUnits, fmt.Errorf("execute script: %w", err)
 	}
 	consumedBudget := machineBudget.Sub(&machine.ExBudget)
-	usedExUnits.Memory = uint64(consumedBudget.Mem) // nolint:gosec
-	usedExUnits.Steps = uint64(consumedBudget.Cpu)  // nolint:gosec
+	usedExUnits.Memory = consumedBudget.Mem
+	usedExUnits.Steps = consumedBudget.Cpu
 	return usedExUnits, nil
 }
 

--- a/ledger/conway/pparams.go
+++ b/ledger/conway/pparams.go
@@ -132,12 +132,12 @@ func (p *ConwayProtocolParameters) Utxorpc() (*cardano.PParams, error) {
 			},
 		},
 		MaxExecutionUnitsPerTransaction: &cardano.ExUnits{
-			Memory: p.MaxTxExUnits.Memory,
-			Steps:  p.MaxTxExUnits.Steps,
+			Memory: uint64(p.MaxTxExUnits.Memory),
+			Steps:  uint64(p.MaxTxExUnits.Steps),
 		},
 		MaxExecutionUnitsPerBlock: &cardano.ExUnits{
-			Memory: p.MaxBlockExUnits.Memory,
-			Steps:  p.MaxBlockExUnits.Steps,
+			Memory: uint64(p.MaxBlockExUnits.Memory),
+			Steps:  uint64(p.MaxBlockExUnits.Steps),
 		},
 	}, nil
 }

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -426,7 +426,7 @@ func UtxoValidateExUnitsTooBigUtxo(
 	if !ok {
 		return errors.New("transaction is not expected type")
 	}
-	var totalSteps, totalMemory uint64
+	var totalSteps, totalMemory int64
 	for _, redeemer := range tmpTx.WitnessSet.WsRedeemers.Redeemers {
 		totalSteps += redeemer.ExUnits.Steps
 		totalMemory += redeemer.ExUnits.Memory


### PR DESCRIPTION
This allows us to store negative values, such as for budget overruns. This also matches the implementation in plutigo

Fixes #1155