### PR TITLE
refactor: Use common.Script types when returning Plutus scripts from witness set

### DIFF
--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -521,7 +521,7 @@ type AlonzoTransactionWitnessSet struct {
 	VkeyWitnesses      []common.VkeyWitness      `cbor:"0,keyasint,omitempty"`
 	WsNativeScripts    []common.NativeScript     `cbor:"1,keyasint,omitempty"`
 	BootstrapWitnesses []common.BootstrapWitness `cbor:"2,keyasint,omitempty"`
-	WsPlutusV1Scripts  [][]byte                  `cbor:"3,keyasint,omitempty"`
+	WsPlutusV1Scripts  []common.PlutusV1Script   `cbor:"3,keyasint,omitempty"`
 	WsPlutusData       []common.Datum            `cbor:"4,keyasint,omitempty"`
 	WsRedeemers        AlonzoRedeemers           `cbor:"5,keyasint,omitempty"`
 }
@@ -549,16 +549,16 @@ func (w AlonzoTransactionWitnessSet) NativeScripts() []common.NativeScript {
 	return w.WsNativeScripts
 }
 
-func (w AlonzoTransactionWitnessSet) PlutusV1Scripts() [][]byte {
+func (w AlonzoTransactionWitnessSet) PlutusV1Scripts() []common.PlutusV1Script {
 	return w.WsPlutusV1Scripts
 }
 
-func (w AlonzoTransactionWitnessSet) PlutusV2Scripts() [][]byte {
+func (w AlonzoTransactionWitnessSet) PlutusV2Scripts() []common.PlutusV2Script {
 	// No plutus v2 scripts in Alonzo
 	return nil
 }
 
-func (w AlonzoTransactionWitnessSet) PlutusV3Scripts() [][]byte {
+func (w AlonzoTransactionWitnessSet) PlutusV3Scripts() []common.PlutusV3Script {
 	// No plutus v3 scripts in Alonzo
 	return nil
 }

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -654,10 +654,10 @@ type BabbageTransactionWitnessSet struct {
 	VkeyWitnesses      []common.VkeyWitness      `cbor:"0,keyasint,omitempty"`
 	WsNativeScripts    []common.NativeScript     `cbor:"1,keyasint,omitempty"`
 	BootstrapWitnesses []common.BootstrapWitness `cbor:"2,keyasint,omitempty"`
-	WsPlutusV1Scripts  [][]byte                  `cbor:"3,keyasint,omitempty"`
+	WsPlutusV1Scripts  []common.PlutusV1Script   `cbor:"3,keyasint,omitempty"`
 	WsPlutusData       []common.Datum            `cbor:"4,keyasint,omitempty"`
 	WsRedeemers        alonzo.AlonzoRedeemers    `cbor:"5,keyasint,omitempty"`
-	WsPlutusV2Scripts  [][]byte                  `cbor:"6,keyasint,omitempty"`
+	WsPlutusV2Scripts  []common.PlutusV2Script   `cbor:"6,keyasint,omitempty"`
 }
 
 func (w *BabbageTransactionWitnessSet) UnmarshalCBOR(cborData []byte) error {
@@ -683,15 +683,15 @@ func (w BabbageTransactionWitnessSet) NativeScripts() []common.NativeScript {
 	return w.WsNativeScripts
 }
 
-func (w BabbageTransactionWitnessSet) PlutusV1Scripts() [][]byte {
+func (w BabbageTransactionWitnessSet) PlutusV1Scripts() []common.PlutusV1Script {
 	return w.WsPlutusV1Scripts
 }
 
-func (w BabbageTransactionWitnessSet) PlutusV2Scripts() [][]byte {
+func (w BabbageTransactionWitnessSet) PlutusV2Scripts() []common.PlutusV2Script {
 	return w.WsPlutusV2Scripts
 }
 
-func (w BabbageTransactionWitnessSet) PlutusV3Scripts() [][]byte {
+func (w BabbageTransactionWitnessSet) PlutusV3Scripts() []common.PlutusV3Script {
 	// No plutus v3 scripts in Babbage
 	return nil
 }

--- a/ledger/common/tx.go
+++ b/ledger/common/tx.go
@@ -84,9 +84,9 @@ type TransactionWitnessSet interface {
 	NativeScripts() []NativeScript
 	Bootstrap() []BootstrapWitness
 	PlutusData() []Datum
-	PlutusV1Scripts() [][]byte
-	PlutusV2Scripts() [][]byte
-	PlutusV3Scripts() [][]byte
+	PlutusV1Scripts() []PlutusV1Script
+	PlutusV2Scripts() []PlutusV2Script
+	PlutusV3Scripts() []PlutusV3Script
 	Redeemers() TransactionWitnessRedeemers
 }
 

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -242,11 +242,11 @@ type ConwayTransactionWitnessSet struct {
 	VkeyWitnesses      cbor.SetType[common.VkeyWitness]      `cbor:"0,keyasint,omitempty,omitzero"`
 	WsNativeScripts    cbor.SetType[common.NativeScript]     `cbor:"1,keyasint,omitempty,omitzero"`
 	BootstrapWitnesses cbor.SetType[common.BootstrapWitness] `cbor:"2,keyasint,omitempty,omitzero"`
-	WsPlutusV1Scripts  cbor.SetType[[]byte]                  `cbor:"3,keyasint,omitempty,omitzero"`
+	WsPlutusV1Scripts  cbor.SetType[common.PlutusV1Script]   `cbor:"3,keyasint,omitempty,omitzero"`
 	WsPlutusData       cbor.SetType[common.Datum]            `cbor:"4,keyasint,omitempty,omitzero"`
 	WsRedeemers        ConwayRedeemers                       `cbor:"5,keyasint,omitempty,omitzero"`
-	WsPlutusV2Scripts  cbor.SetType[[]byte]                  `cbor:"6,keyasint,omitempty,omitzero"`
-	WsPlutusV3Scripts  cbor.SetType[[]byte]                  `cbor:"7,keyasint,omitempty,omitzero"`
+	WsPlutusV2Scripts  cbor.SetType[common.PlutusV2Script]   `cbor:"6,keyasint,omitempty,omitzero"`
+	WsPlutusV3Scripts  cbor.SetType[common.PlutusV3Script]   `cbor:"7,keyasint,omitempty,omitzero"`
 }
 
 func (w *ConwayTransactionWitnessSet) UnmarshalCBOR(cborData []byte) error {
@@ -272,15 +272,15 @@ func (w ConwayTransactionWitnessSet) NativeScripts() []common.NativeScript {
 	return w.WsNativeScripts.Items()
 }
 
-func (w ConwayTransactionWitnessSet) PlutusV1Scripts() [][]byte {
+func (w ConwayTransactionWitnessSet) PlutusV1Scripts() []common.PlutusV1Script {
 	return w.WsPlutusV1Scripts.Items()
 }
 
-func (w ConwayTransactionWitnessSet) PlutusV2Scripts() [][]byte {
+func (w ConwayTransactionWitnessSet) PlutusV2Scripts() []common.PlutusV2Script {
 	return w.WsPlutusV2Scripts.Items()
 }
 
-func (w ConwayTransactionWitnessSet) PlutusV3Scripts() [][]byte {
+func (w ConwayTransactionWitnessSet) PlutusV3Scripts() []common.PlutusV3Script {
 	return w.WsPlutusV3Scripts.Items()
 }
 

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -479,17 +479,17 @@ func (w ShelleyTransactionWitnessSet) PlutusData() []common.Datum {
 	return nil
 }
 
-func (w ShelleyTransactionWitnessSet) PlutusV1Scripts() [][]byte {
+func (w ShelleyTransactionWitnessSet) PlutusV1Scripts() []common.PlutusV1Script {
 	// No plutus v1 scripts in Shelley
 	return nil
 }
 
-func (w ShelleyTransactionWitnessSet) PlutusV2Scripts() [][]byte {
+func (w ShelleyTransactionWitnessSet) PlutusV2Scripts() []common.PlutusV2Script {
 	// No plutus v2 scripts in Shelley
 	return nil
 }
 
-func (w ShelleyTransactionWitnessSet) PlutusV3Scripts() [][]byte {
+func (w ShelleyTransactionWitnessSet) PlutusV3Scripts() []common.PlutusV3Script {
 	// No plutus v3 scripts in Shelley
 	return nil
 }


### PR DESCRIPTION
1. Used common.PlutusV1Script, PlutusV2Script, and PlutusV3Script types instead of raw []byte when returning scripts from transaction witness sets.

Closes #1146 