### PR TITLE
feat(ledger): Deposit should be collected when pool is retired and re-registered #640

### DIFF
--- a/internal/test/ledger/ledger.go
+++ b/internal/test/ledger/ledger.go
@@ -62,18 +62,15 @@ func (ls MockLedgerState) StakeRegistration(
 	return ret, nil
 }
 
-func (ls MockLedgerState) PoolRegistration(
+func (ls MockLedgerState) PoolCurrentState(
 	poolKeyHash []byte,
-) ([]common.PoolRegistrationCertificate, error) {
-	ret := []common.PoolRegistrationCertificate{}
+) (*common.PoolRegistrationCertificate, *uint64, error) {
 	for _, cert := range ls.MockPoolRegistration {
-		if string(
-			common.Blake2b224(cert.Operator).Bytes(),
-		) == string(
-			poolKeyHash,
-		) {
-			ret = append(ret, cert)
+		if string(common.Blake2b224(cert.Operator).Bytes()) == string(poolKeyHash) {
+			// pretend latest registration is current; no retirement support in mock
+			c := cert
+			return &c, nil, nil
 		}
 	}
-	return ret, nil
+	return nil, nil, nil
 }

--- a/ledger/alonzo/rules.go
+++ b/ledger/alonzo/rules.go
@@ -289,11 +289,11 @@ func UtxoValidateValueNotConservedUtxo(
 	for _, cert := range tx.Certificates() {
 		switch tmpCert := cert.(type) {
 		case *common.PoolRegistrationCertificate:
-			certs, err := ls.PoolRegistration(common.Blake2b224(tmpCert.Operator).Bytes())
+			reg, _, err := ls.PoolCurrentState(common.Blake2b224(tmpCert.Operator).Bytes())
 			if err != nil {
 				return err
 			}
-			if len(certs) == 0 {
+			if reg == nil {
 				producedValue += uint64(tmpPparams.PoolDeposit)
 			}
 		case *common.StakeRegistrationCertificate:

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -275,11 +275,11 @@ func UtxoValidateValueNotConservedUtxo(
 	for _, cert := range tx.Certificates() {
 		switch tmpCert := cert.(type) {
 		case *common.PoolRegistrationCertificate:
-			certs, err := ls.PoolRegistration(common.Blake2b224(tmpCert.Operator).Bytes())
+			reg, _, err := ls.PoolCurrentState(common.Blake2b224(tmpCert.Operator).Bytes())
 			if err != nil {
 				return err
 			}
-			if len(certs) == 0 {
+			if reg == nil {
 				producedValue += uint64(tmpPparams.PoolDeposit)
 			}
 		case *common.StakeRegistrationCertificate:

--- a/ledger/common/state.go
+++ b/ledger/common/state.go
@@ -28,13 +28,18 @@ type UtxoState interface {
 // CertState defines the interface for querying the certificate state
 type CertState interface {
 	StakeRegistration([]byte) ([]StakeRegistrationCertificate, error)
-	PoolRegistration([]byte) ([]PoolRegistrationCertificate, error)
+}
+
+// PoolState defines the interface for querying the current pool state
+type PoolState interface {
+	PoolCurrentState([]byte) (*PoolRegistrationCertificate, *uint64, error)
 }
 
 // LedgerState defines the interface for querying the ledger
 type LedgerState interface {
 	UtxoState
 	CertState
+	PoolState
 	NetworkId() uint
 }
 

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -272,11 +272,11 @@ func UtxoValidateValueNotConservedUtxo(
 	for _, cert := range tx.Certificates() {
 		switch tmpCert := cert.(type) {
 		case *common.PoolRegistrationCertificate:
-			certs, err := ls.PoolRegistration(common.Blake2b224(tmpCert.Operator).Bytes())
+			reg, _, err := ls.PoolCurrentState(common.Blake2b224(tmpCert.Operator).Bytes())
 			if err != nil {
 				return err
 			}
-			if len(certs) == 0 {
+			if reg == nil {
 				producedValue += uint64(tmpPparams.PoolDeposit)
 			}
 		case *common.RegistrationCertificate:

--- a/ledger/shelley/rules.go
+++ b/ledger/shelley/rules.go
@@ -196,11 +196,11 @@ func UtxoValidateValueNotConservedUtxo(
 	for _, cert := range tx.Certificates() {
 		switch tmpCert := cert.(type) {
 		case *common.PoolRegistrationCertificate:
-			certs, err := ls.PoolRegistration(common.Blake2b224(tmpCert.Operator).Bytes())
+			reg, _, err := ls.PoolCurrentState(common.Blake2b224(tmpCert.Operator).Bytes())
 			if err != nil {
 				return err
 			}
-			if len(certs) == 0 {
+			if reg == nil {
 				producedValue += uint64(tmpPparams.PoolDeposit)
 			}
 		case *common.StakeRegistrationCertificate:


### PR DESCRIPTION
1. Added PoolState interface type in ledger/common/state.go where it helps for querying the current pool state.
2. Modified all the rules.go files of all eras for replacing PoolRegistration() to PoolCurrentState.
3. Remove PoolRegistration() function from CertState.
4. Tested by pointing dingo to a local gouroboros, disabled check for TX validation threshold & ran dingo to sync "preview" network. I did not observe any errors no “value not conserved” failures with a 500A (500,000,000 lovelace) delta.