### PR TITLE
feat(ledger): Add friendly string representation of TX outputs

### DIFF
--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -447,6 +447,19 @@ func (o AlonzoTransactionOutput) Utxorpc() (*utxorpc.TxOutput, error) {
 		nil
 }
 
+func (o AlonzoTransactionOutput) String() string {
+	assets := ""
+	if o.OutputAmount.Assets != nil && len(o.OutputAmount.Assets.Policies()) > 0 {
+		assets = " assets=..."
+	}
+	return fmt.Sprintf(
+		"(AlonzoTransactionOutput address=%s amount=%d%s)",
+		o.OutputAddress.String(),
+		o.OutputAmount.Amount,
+		assets,
+	)
+}
+
 type AlonzoRedeemer struct {
 	cbor.StructAsArray
 	Tag     common.RedeemerTag

--- a/ledger/alonzo/alonzo_test.go
+++ b/ledger/alonzo/alonzo_test.go
@@ -17,6 +17,7 @@ package alonzo
 import (
 	"math/big"
 	"reflect"
+	"regexp"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -275,5 +276,25 @@ func TestAlonzoRedeemersIter(t *testing.T) {
 			)
 		}
 		iterIdx++
+	}
+}
+
+func TestAlonzoTransactionOutputString(t *testing.T) {
+	addr, _ := common.NewAddress(
+		"addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd",
+	)
+	ma := common.NewMultiAsset[common.MultiAssetTypeOutput](
+		map[common.Blake2b224]map[cbor.ByteString]uint64{
+			common.NewBlake2b224(make([]byte, 28)): {cbor.NewByteString([]byte("t")): 2},
+		},
+	)
+	out := AlonzoTransactionOutput{
+		OutputAddress: addr,
+		OutputAmount:  mary.MaryTransactionOutputValue{Amount: 456, Assets: &ma},
+	}
+	s := out.String()
+	re := regexp.MustCompile(`^\(AlonzoTransactionOutput address=addr1[0-9a-z]+ amount=456 assets=\.\.\.\)$`)
+	if !re.MatchString(s) {
+		t.Fatalf("unexpected string: %s", s)
 	}
 }

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -649,6 +649,19 @@ func (o BabbageTransactionOutput) Utxorpc() (*utxorpc.TxOutput, error) {
 		nil
 }
 
+func (o BabbageTransactionOutput) String() string {
+	assets := ""
+	if o.OutputAmount.Assets != nil && len(o.OutputAmount.Assets.Policies()) > 0 {
+		assets = " assets=..."
+	}
+	return fmt.Sprintf(
+		"(BabbageTransactionOutput address=%s amount=%d%s)",
+		o.OutputAddress.String(),
+		o.OutputAmount.Amount,
+		assets,
+	)
+}
+
 type BabbageTransactionWitnessSet struct {
 	cbor.DecodeStoreCbor
 	VkeyWitnesses      []common.VkeyWitness      `cbor:"0,keyasint,omitempty"`

--- a/ledger/babbage/babbage_test.go
+++ b/ledger/babbage/babbage_test.go
@@ -17,6 +17,7 @@ package babbage
 import (
 	"math/big"
 	"reflect"
+	"regexp"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -2968,5 +2969,25 @@ func TestBabbageTransactionOutputToPlutusDataCoinAssets(t *testing.T) {
 			tmpData,
 			expectedData,
 		)
+	}
+}
+
+func TestBabbageTransactionOutputString(t *testing.T) {
+	addr, _ := common.NewAddress(
+		"addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd",
+	)
+	ma := common.NewMultiAsset[common.MultiAssetTypeOutput](
+		map[common.Blake2b224]map[cbor.ByteString]uint64{
+			common.NewBlake2b224(make([]byte, 28)): {cbor.NewByteString([]byte("x")): 2},
+		},
+	)
+	out := BabbageTransactionOutput{
+		OutputAddress: addr,
+		OutputAmount:  mary.MaryTransactionOutputValue{Amount: 456, Assets: &ma},
+	}
+	s := out.String()
+	re := regexp.MustCompile(`^\(BabbageTransactionOutput address=addr1[0-9a-z]+ amount=456 assets=\.\.\.\)$`)
+	if !re.MatchString(s) {
+		t.Fatalf("unexpected string: %s", s)
 	}
 }

--- a/ledger/byron/byron.go
+++ b/ledger/byron/byron.go
@@ -462,6 +462,14 @@ func (o ByronTransactionOutput) Utxorpc() (*utxorpc.TxOutput, error) {
 		nil
 }
 
+func (o ByronTransactionOutput) String() string {
+	return fmt.Sprintf(
+		"(ByronTransactionOutput address=%s amount=%d)",
+		o.OutputAddress.String(),
+		o.OutputAmount,
+	)
+}
+
 type ByronBlockVersion struct {
 	cbor.StructAsArray
 	Major   uint16

--- a/ledger/byron/byron_test.go
+++ b/ledger/byron/byron_test.go
@@ -16,6 +16,7 @@ package byron_test
 
 import (
 	"reflect"
+	"regexp"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
@@ -102,5 +103,25 @@ func TestByronTransaction_Utxorpc_Empty(t *testing.T) {
 	}
 	if result.Fee != 0 {
 		t.Errorf("Expected fee = 0, got %d", result.Fee)
+	}
+}
+
+func TestByronTransactionOutputString(t *testing.T) {
+	addr, err := common.NewByronAddressFromParts(
+		0,
+		make([]byte, common.AddressHashSize),
+		common.ByronAddressAttributes{},
+	)
+	if err != nil {
+		t.Fatalf("address: %v", err)
+	}
+	out := byron.ByronTransactionOutput{
+		OutputAddress: addr,
+		OutputAmount:  456,
+	}
+	s := out.String()
+	re := regexp.MustCompile(`^\(ByronTransactionOutput address=[1-9A-HJ-NP-Za-km-z]+ amount=456\)$`)
+	if !re.MatchString(s) {
+		t.Fatalf("unexpected string: %s", s)
 	}
 }

--- a/ledger/common/tx.go
+++ b/ledger/common/tx.go
@@ -77,6 +77,7 @@ type TransactionOutput interface {
 	Utxorpc() (*utxorpc.TxOutput, error)
 	ScriptRef() Script
 	ToPlutusData() data.PlutusData
+	String() string
 }
 
 type TransactionWitnessSet interface {

--- a/ledger/mary/errors.go
+++ b/ledger/mary/errors.go
@@ -15,7 +15,6 @@
 package mary
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/blinklabs-io/gouroboros/ledger/common"
@@ -28,7 +27,7 @@ type OutputTooBigUtxoError struct {
 func (e OutputTooBigUtxoError) Error() string {
 	tmpOutputs := make([]string, len(e.Outputs))
 	for idx, tmpOutput := range e.Outputs {
-		tmpOutputs[idx] = fmt.Sprintf("%#v", tmpOutput)
+		tmpOutputs[idx] = tmpOutput.String()
 	}
 	return "output value too large: " + strings.Join(tmpOutputs, ", ")
 }

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -490,6 +490,19 @@ func (o MaryTransactionOutput) Utxorpc() (*utxorpc.TxOutput, error) {
 		err
 }
 
+func (o MaryTransactionOutput) String() string {
+	assets := ""
+	if o.OutputAmount.Assets != nil && len(o.OutputAmount.Assets.Policies()) > 0 {
+		assets = " assets=..."
+	}
+	return fmt.Sprintf(
+		"(MaryTransactionOutput address=%s amount=%d%s)",
+		o.OutputAddress.String(),
+		o.OutputAmount.Amount,
+		assets,
+	)
+}
+
 type MaryTransactionOutputValue struct {
 	cbor.StructAsArray
 	Amount uint64

--- a/ledger/shelley/errors.go
+++ b/ledger/shelley/errors.go
@@ -111,7 +111,7 @@ type OutputTooSmallUtxoError struct {
 func (e OutputTooSmallUtxoError) Error() string {
 	tmpOutputs := make([]string, len(e.Outputs))
 	for idx, tmpOutput := range e.Outputs {
-		tmpOutputs[idx] = fmt.Sprintf("%#v", tmpOutput)
+		tmpOutputs[idx] = tmpOutput.String()
 	}
 	return "output too small: " + strings.Join(tmpOutputs, ", ")
 }
@@ -123,7 +123,7 @@ type OutputBootAddrAttrsTooBigError struct {
 func (e OutputBootAddrAttrsTooBigError) Error() string {
 	tmpOutputs := make([]string, len(e.Outputs))
 	for idx, tmpOutput := range e.Outputs {
-		tmpOutputs[idx] = fmt.Sprintf("%#v", tmpOutput)
+		tmpOutputs[idx] = tmpOutput.String()
 	}
 	return "output bootstrap address attributes too big: " + strings.Join(
 		tmpOutputs,

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -444,6 +444,14 @@ func (o ShelleyTransactionOutput) Utxorpc() (*utxorpc.TxOutput, error) {
 	}, nil
 }
 
+func (o ShelleyTransactionOutput) String() string {
+	return fmt.Sprintf(
+		"(ShelleyTransactionOutput address=%s amount=%d)",
+		o.OutputAddress.String(),
+		o.OutputAmount,
+	)
+}
+
 type ShelleyTransactionWitnessSet struct {
 	cbor.DecodeStoreCbor
 	VkeyWitnesses      []common.VkeyWitness      `cbor:"0,keyasint,omitempty"`

--- a/ledger/shelley/shelley_test.go
+++ b/ledger/shelley/shelley_test.go
@@ -1,0 +1,34 @@
+package shelley_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+func TestShelleyTransactionOutputString(t *testing.T) {
+	addr, _ := common.NewAddress("addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd")
+	out := shelley.ShelleyTransactionOutput{
+		OutputAddress: addr,
+		OutputAmount:  456,
+	}
+	s := out.String()
+	re := regexp.MustCompile(`^\(ShelleyTransactionOutput address=addr1[0-9a-z]+ amount=456\)$`)
+	if !re.MatchString(s) {
+		t.Fatalf("unexpected string: %s", s)
+	}
+}
+
+func TestShelleyOutputTooSmallErrorFormatting(t *testing.T) {
+	addr, _ := common.NewAddress("addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd")
+	out := &shelley.ShelleyTransactionOutput{
+		OutputAddress: addr,
+		OutputAmount:  456,
+	}
+	errStr := shelley.OutputTooSmallUtxoError{Outputs: []common.TransactionOutput{out}}.Error()
+	if matched, _ := regexp.MatchString(`^output too small: \(ShelleyTransactionOutput address=addr1[0-9a-z]+ amount=456\)$`, errStr); !matched {
+		t.Fatalf("unexpected error: %s", errStr)
+	}
+}


### PR DESCRIPTION
1. Added String() to the ledger.TransactionOutput interface and created the function on each era-specific TransactionOutput object.
2. Used this new String() function in the Error() function for any validation rule errors that take TX outputs.
3. Updated validation error messages to use String() instead of raw struct.

Closes #958 