### PR TITLE
fix: retain original datum CBOR on decode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.1
 require (
 	filippo.io/edwards25519 v1.1.0
 	github.com/blinklabs-io/ouroboros-mock v0.3.8
-	github.com/blinklabs-io/plutigo v0.0.9
+	github.com/blinklabs-io/plutigo v0.0.10
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/fxamacker/cbor/v2 v2.9.0
 	github.com/jinzhu/copier v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/bits-and-blooms/bitset v1.20.0 h1:2F+rfL86jE2d/bmw7OhqUg2Sj/1rURkBn3M
 github.com/bits-and-blooms/bitset v1.20.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blinklabs-io/ouroboros-mock v0.3.8 h1:+DAt2rx0ouZUxee5DBMgZq3I1+ZdxFSHG9g3tYl/FKU=
 github.com/blinklabs-io/ouroboros-mock v0.3.8/go.mod h1:UwQIf4KqZwO13P9d90fbi3UL/X7JaJfeEbqk+bEeFQA=
-github.com/blinklabs-io/plutigo v0.0.9 h1:GPMJNfaiT6/wYs8MGZUfJYQ8tSHT9y+dpdvFprPOYYg=
-github.com/blinklabs-io/plutigo v0.0.9/go.mod h1:L639Q8i2cSRuBhjgCHttPR0nnYwwsYVT4Btz7KpQjSw=
+github.com/blinklabs-io/plutigo v0.0.10 h1:h/yg65Krkzkg45AfOhbZLRgGD51zwS8RR91eQa5qDow=
+github.com/blinklabs-io/plutigo v0.0.10/go.mod h1:L639Q8i2cSRuBhjgCHttPR0nnYwwsYVT4Btz7KpQjSw=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -408,9 +408,7 @@ func (d *BabbageTransactionOutputDatumOption) UnmarshalCBOR(
 		if _, err := cbor.Decode(tmpDatumData.DataCbor, &datumValue); err != nil {
 			return err
 		}
-		d.data = &common.Datum{
-			Data: datumValue.Data,
-		}
+		d.data = &datumValue
 	default:
 		return fmt.Errorf("unsupported datum option type: %d", datumOptionType)
 	}


### PR DESCRIPTION
This also updates blinklabs-io/plutigo to v0.0.10