### PR TITLE
fix(ledger/byron): ByronGenesis.FtsSeed can be object

### DIFF
--- a/ledger/byron/genesis.go
+++ b/ledger/byron/genesis.go
@@ -26,14 +26,14 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
-type ByronFtsSeed struct {
+type ByronGenesisFtsSeed struct {
 	Value    string
 	IsObject bool
 }
 type ByronGenesis struct {
 	AvvmDistr        map[string]string                      `json:"avvmDistr"`
 	BlockVersionData ByronGenesisBlockVersionData           `json:"blockVersionData"`
-	FtsSeed          ByronFtsSeed                           `json:"ftsSeed"`
+	FtsSeed          ByronGenesisFtsSeed                    `json:"ftsSeed"`
 	ProtocolConsts   ByronGenesisProtocolConsts             `json:"protocolConsts"`
 	StartTime        int                                    `json:"startTime"`
 	BootStakeholders map[string]int                         `json:"bootStakeholders"`
@@ -200,7 +200,7 @@ func NewByronGenesisFromFile(path string) (ByronGenesis, error) {
 }
 
 // UnmarshalJSON accepts: "string", {}, or null
-func (f *ByronFtsSeed) UnmarshalJSON(b []byte) error {
+func (f *ByronGenesisFtsSeed) UnmarshalJSON(b []byte) error {
 	var first byte
 	for _, c := range b {
 		if c > ' ' {
@@ -237,7 +237,7 @@ func (f *ByronFtsSeed) UnmarshalJSON(b []byte) error {
 	}
 }
 
-func (f ByronFtsSeed) MarshalJSON() ([]byte, error) {
+func (f ByronGenesisFtsSeed) MarshalJSON() ([]byte, error) {
 	if f.IsObject {
 		// serialize as empty object
 		return []byte(`{}`), nil

--- a/ledger/byron/genesis_test.go
+++ b/ledger/byron/genesis_test.go
@@ -128,7 +128,7 @@ var expectedGenesisObj = byron.ByronGenesis{
 		UpdateProposalThd: 100000000000000,
 		UpdateVoteThd:     1000000000000,
 	},
-	FtsSeed: byron.ByronFtsSeed{
+	FtsSeed: byron.ByronGenesisFtsSeed{
 		Value:    "76617361206f7061736120736b6f766f726f64612047677572646120626f726f64612070726f766f6461",
 		IsObject: false,
 	},

--- a/ledger/byron/genesis_test.go
+++ b/ledger/byron/genesis_test.go
@@ -55,7 +55,7 @@ const byronGenesisConfig = `
         "updateProposalThd": "100000000000000",
         "updateVoteThd": "1000000000000"
     },
-    "ftsSeed": "76617361206f7061736120736b6f766f726f64612047677572646120626f726f64612070726f766f6461",
+	"ftsSeed": "76617361206f7061736120736b6f766f726f64612047677572646120626f726f64612070726f766f6461",
     "protocolConsts": {
         "k": 2160,
         "protocolMagic": 764824073,
@@ -128,7 +128,10 @@ var expectedGenesisObj = byron.ByronGenesis{
 		UpdateProposalThd: 100000000000000,
 		UpdateVoteThd:     1000000000000,
 	},
-	FtsSeed: "76617361206f7061736120736b6f766f726f64612047677572646120626f726f64612070726f766f6461",
+	FtsSeed: byron.ByronFtsSeed{
+		Value:    "76617361206f7061736120736b6f766f726f64612047677572646120626f726f64612070726f766f6461",
+		IsObject: false,
+	},
 	ProtocolConsts: byron.ByronGenesisProtocolConsts{
 		K:             2160,
 		ProtocolMagic: 764824073,
@@ -429,5 +432,67 @@ func TestNewByronGenesisFromReader(t *testing.T) {
 			result,
 			expected,
 		)
+	}
+}
+
+func TestGenesis_FtsSeed_EmptyObject(t *testing.T) {
+	jsonData := `{
+        "avvmDistr": { "addr1": "1000" },
+        "blockVersionData": {
+            "heavyDelThd": "1",
+            "maxBlockSize": "2",
+            "maxHeaderSize": "3",
+            "maxProposalSize": "4",
+            "maxTxSize": "5",
+            "mpcThd": "6",
+            "scriptVersion": 1,
+            "slotDuration": "7",
+            "softforkRule": {
+                "initThd": "8",
+                "minThd": "9",
+                "thdDecrement": "10"
+            },
+            "txFeePolicy": {
+                "multiplier": "11",
+                "summand": "12"
+            },
+            "unlockStakeEpoch": "13",
+            "updateImplicit": "14",
+            "updateProposalThd": "15",
+            "updateVoteThd": "16"
+        },
+        "ftsSeed": {},
+        "protocolConsts": {
+            "k": 1,
+            "protocolMagic": 42,
+            "vssMinTtl": 2,
+            "vssMaxTtl": 10
+        },
+        "startTime": 100000,
+        "bootStakeholders": { "stakeholder1": 1 },
+        "heavyDelegation": {
+            "key1": {
+                "cert": "cert-val",
+                "delegatePk": "delegate-pk",
+                "issuerPk": "issuer-pk",
+                "omega": 5
+            }
+        },
+        "nonAvvmBalances": { "addr2": "2000" },
+        "vssCerts": {
+            "cert1": {
+                "expiryEpoch": 5,
+                "signature": "sig",
+                "signingKey": "sign-key",
+                "vssKey": "vss-key"
+            }
+        }
+    }`
+	got, err := byron.NewByronGenesisFromReader(strings.NewReader(jsonData))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.FtsSeed.Value != "" || !got.FtsSeed.IsObject {
+		t.Fatalf("ftsSeed not parsed as empty object; got=%#v", got.FtsSeed)
 	}
 }


### PR DESCRIPTION
1. Added custom type `ByronGenesisFtsSeed` with UnmarshalJSON/MarshalJSON.
2. Allow ftsSeed to be parsed from either a JSON string or an empty object.
3. Update tests to expect ByronFtsSeed instead of plain string and added optional test coverage for empty object case.

Closes #1039 
