### PR TITLE
feat(ledger): Add RawScriptBytes to Script interface

### DIFF
--- a/ledger/common/script.go
+++ b/ledger/common/script.go
@@ -37,6 +37,7 @@ type ScriptHash = Blake2b224
 type Script interface {
 	isScript()
 	Hash() ScriptHash
+	RawScriptBytes() []byte
 }
 
 type ScriptRef struct {
@@ -114,6 +115,10 @@ func (s PlutusV1Script) Hash() ScriptHash {
 	)
 }
 
+func (s PlutusV1Script) RawScriptBytes() []byte {
+	return []byte(s)
+}
+
 type PlutusV2Script []byte
 
 func (PlutusV2Script) isScript() {}
@@ -127,6 +132,10 @@ func (s PlutusV2Script) Hash() ScriptHash {
 	)
 }
 
+func (s PlutusV2Script) RawScriptBytes() []byte {
+	return []byte(s)
+}
+
 type PlutusV3Script []byte
 
 func (PlutusV3Script) isScript() {}
@@ -138,6 +147,10 @@ func (s PlutusV3Script) Hash() ScriptHash {
 			[]byte(s),
 		),
 	)
+}
+
+func (s PlutusV3Script) RawScriptBytes() []byte {
+	return []byte(s)
 }
 
 func (s PlutusV3Script) Evaluate(
@@ -236,6 +249,10 @@ func (s NativeScript) Hash() ScriptHash {
 			[]byte(s.Cbor()),
 		),
 	)
+}
+
+func (s NativeScript) RawScriptBytes() []byte {
+	return s.Cbor()
 }
 
 type NativeScriptPubkey struct {

--- a/ledger/common/script_test.go
+++ b/ledger/common/script_test.go
@@ -15,6 +15,7 @@
 package common_test
 
 import (
+	"bytes"
 	"encoding/hex"
 	"reflect"
 	"testing"
@@ -38,6 +39,13 @@ func TestScriptRefDecodeEncode(t *testing.T) {
 			"did not get expected script\n     got: %#v\n  wanted: %#v",
 			testScriptRef.Script,
 			&expectedScript,
+		)
+	}
+	if !bytes.Equal(testScriptRef.Script.RawScriptBytes(), scriptCbor) {
+		t.Fatalf(
+			"did not get expected raw script bytes\n     got: %x\n  wanted: %x",
+			testScriptRef.Script.RawScriptBytes(),
+			scriptCbor,
 		)
 	}
 	scriptRefCbor, err := cbor.Encode(testScriptRef)


### PR DESCRIPTION
It's rather awkward to get the script bytes right now, as you have to try casting it to different script types.

If you just need the bytes (ex: to store those in a database, etc.) then the RawScriptBytes method gives you access directly to those bytes (without the version wrapper).

Might also consider adding a RawBytes to give *exactly* what's on chain, and/or a Version, to indicate which script version it is, but I held off on that for now as this is all that I need to unblock myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new method to retrieve raw script bytes, enabling direct access to the underlying byte representation of scripts for further processing and analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->