### PR TITLE
fix(ledger): add min pool cost to protocol parameters

### DIFF
--- a/ledger/alonzo/pparams.go
+++ b/ledger/alonzo/pparams.go
@@ -378,5 +378,6 @@ func UpgradePParams(
 		ProtocolMajor:      prevPParams.ProtocolMajor,
 		ProtocolMinor:      prevPParams.ProtocolMinor,
 		MinUtxoValue:       prevPParams.MinUtxoValue,
+		MinPoolCost:        prevPParams.MinPoolCost,
 	}
 }

--- a/ledger/alonzo/pparams_test.go
+++ b/ledger/alonzo/pparams_test.go
@@ -615,3 +615,455 @@ func TestAlonzoTransaction_Utxorpc(t *testing.T) {
 		t.Error("Expected non-empty transaction hash")
 	}
 }
+
+// ===================================================================
+// Tests for UpgradePParams with MinPoolCost
+// ===================================================================
+
+func TestAlonzoUpgradePParams(t *testing.T) {
+	testCases := []struct {
+		name       string
+		prevParams mary.MaryProtocolParameters
+		validate   func(*testing.T, alonzo.AlonzoProtocolParameters)
+	}{
+		{
+			name: "Upgrade with MinPoolCost zero",
+			prevParams: mary.MaryProtocolParameters{
+				MinFeeA:            44,
+				MinFeeB:            155381,
+				MaxBlockBodySize:   65536,
+				MaxTxSize:          16384,
+				MaxBlockHeaderSize: 1100,
+				KeyDeposit:         2000000,
+				PoolDeposit:        500000000,
+				MaxEpoch:           18,
+				NOpt:               500,
+				A0:                 &cbor.Rat{Rat: big.NewRat(3, 10)},
+				Rho:                &cbor.Rat{Rat: big.NewRat(3, 1000)},
+				Tau:                &cbor.Rat{Rat: big.NewRat(2, 10)},
+				Decentralization:   &cbor.Rat{Rat: big.NewRat(1, 2)},
+				ExtraEntropy:       common.Nonce{},
+				ProtocolMajor:      6,
+				ProtocolMinor:      0,
+				MinUtxoValue:       1000000,
+				MinPoolCost:        0,
+			},
+			validate: func(t *testing.T, alonzoParams alonzo.AlonzoProtocolParameters) {
+				if alonzoParams.MinPoolCost != 0 {
+					t.Errorf(
+						"MinPoolCost: got %d, want 0",
+						alonzoParams.MinPoolCost,
+					)
+				}
+				if alonzoParams.MinFeeA != 44 {
+					t.Errorf("MinFeeA: got %d, want 44", alonzoParams.MinFeeA)
+				}
+				if alonzoParams.ProtocolMajor != 6 {
+					t.Errorf(
+						"ProtocolMajor: got %d, want 6",
+						alonzoParams.ProtocolMajor,
+					)
+				}
+			},
+		},
+		{
+			name: "Upgrade with MinPoolCost standard value",
+			prevParams: mary.MaryProtocolParameters{
+				MinFeeA:            44,
+				MinFeeB:            155381,
+				MaxBlockBodySize:   65536,
+				MaxTxSize:          16384,
+				MaxBlockHeaderSize: 1100,
+				KeyDeposit:         2000000,
+				PoolDeposit:        500000000,
+				MaxEpoch:           18,
+				NOpt:               500,
+				A0:                 &cbor.Rat{Rat: big.NewRat(3, 10)},
+				Rho:                &cbor.Rat{Rat: big.NewRat(3, 1000)},
+				Tau:                &cbor.Rat{Rat: big.NewRat(2, 10)},
+				Decentralization:   &cbor.Rat{Rat: big.NewRat(1, 2)},
+				ExtraEntropy:       common.Nonce{},
+				ProtocolMajor:      6,
+				ProtocolMinor:      0,
+				MinUtxoValue:       1000000,
+				MinPoolCost:        340000000,
+			},
+			validate: func(t *testing.T, alonzoParams alonzo.AlonzoProtocolParameters) {
+				if alonzoParams.MinPoolCost != 340000000 {
+					t.Errorf(
+						"MinPoolCost: got %d, want 340000000",
+						alonzoParams.MinPoolCost,
+					)
+				}
+				if alonzoParams.MinFeeB != 155381 {
+					t.Errorf(
+						"MinFeeB: got %d, want 155381",
+						alonzoParams.MinFeeB,
+					)
+				}
+			},
+		},
+		{
+			name: "Upgrade with MinPoolCost maximum uint64",
+			prevParams: mary.MaryProtocolParameters{
+				MinFeeA:            100,
+				MinFeeB:            200,
+				MaxBlockBodySize:   1000,
+				MaxTxSize:          500,
+				MaxBlockHeaderSize: 100,
+				KeyDeposit:         1000,
+				PoolDeposit:        5000,
+				MaxEpoch:           100,
+				NOpt:               50,
+				A0:                 &cbor.Rat{Rat: big.NewRat(1, 2)},
+				Rho:                &cbor.Rat{Rat: big.NewRat(1, 3)},
+				Tau:                &cbor.Rat{Rat: big.NewRat(1, 4)},
+				Decentralization:   &cbor.Rat{Rat: big.NewRat(1, 5)},
+				ExtraEntropy:       common.Nonce{},
+				ProtocolMajor:      5,
+				ProtocolMinor:      2,
+				MinUtxoValue:       500000,
+				MinPoolCost:        18446744073709551615,
+			},
+			validate: func(t *testing.T, alonzoParams alonzo.AlonzoProtocolParameters) {
+				if alonzoParams.MinPoolCost != 18446744073709551615 {
+					t.Errorf(
+						"MinPoolCost: got %d, want 18446744073709551615",
+						alonzoParams.MinPoolCost,
+					)
+				}
+				if alonzoParams.ProtocolMinor != 2 {
+					t.Errorf(
+						"ProtocolMinor: got %d, want 2",
+						alonzoParams.ProtocolMinor,
+					)
+				}
+			},
+		},
+		{
+			name: "Upgrade with all Mary fields",
+			prevParams: mary.MaryProtocolParameters{
+				MinFeeA:            44,
+				MinFeeB:            155381,
+				MaxBlockBodySize:   65536,
+				MaxTxSize:          16384,
+				MaxBlockHeaderSize: 1100,
+				KeyDeposit:         2000000,
+				PoolDeposit:        500000000,
+				MaxEpoch:           18,
+				NOpt:               500,
+				A0:                 &cbor.Rat{Rat: big.NewRat(3, 10)},
+				Rho:                &cbor.Rat{Rat: big.NewRat(3, 1000)},
+				Tau:                &cbor.Rat{Rat: big.NewRat(2, 10)},
+				Decentralization:   &cbor.Rat{Rat: big.NewRat(1, 2)},
+				ExtraEntropy:       common.Nonce{},
+				ProtocolMajor:      6,
+				ProtocolMinor:      0,
+				MinUtxoValue:       1000000,
+				MinPoolCost:        340000000,
+			},
+			validate: func(t *testing.T, alonzoParams alonzo.AlonzoProtocolParameters) {
+				if alonzoParams.MinFeeA != 44 {
+					t.Errorf("MinFeeA: got %d, want 44", alonzoParams.MinFeeA)
+				}
+				if alonzoParams.MinFeeB != 155381 {
+					t.Errorf(
+						"MinFeeB: got %d, want 155381",
+						alonzoParams.MinFeeB,
+					)
+				}
+				if alonzoParams.MaxBlockBodySize != 65536 {
+					t.Errorf(
+						"MaxBlockBodySize: got %d, want 65536",
+						alonzoParams.MaxBlockBodySize,
+					)
+				}
+				if alonzoParams.MaxTxSize != 16384 {
+					t.Errorf(
+						"MaxTxSize: got %d, want 16384",
+						alonzoParams.MaxTxSize,
+					)
+				}
+				if alonzoParams.MaxBlockHeaderSize != 1100 {
+					t.Errorf(
+						"MaxBlockHeaderSize: got %d, want 1100",
+						alonzoParams.MaxBlockHeaderSize,
+					)
+				}
+				if alonzoParams.KeyDeposit != 2000000 {
+					t.Errorf(
+						"KeyDeposit: got %d, want 2000000",
+						alonzoParams.KeyDeposit,
+					)
+				}
+				if alonzoParams.PoolDeposit != 500000000 {
+					t.Errorf(
+						"PoolDeposit: got %d, want 500000000",
+						alonzoParams.PoolDeposit,
+					)
+				}
+				if alonzoParams.MaxEpoch != 18 {
+					t.Errorf("MaxEpoch: got %d, want 18", alonzoParams.MaxEpoch)
+				}
+				if alonzoParams.NOpt != 500 {
+					t.Errorf("NOpt: got %d, want 500", alonzoParams.NOpt)
+				}
+				if alonzoParams.A0 == nil ||
+					alonzoParams.A0.Cmp(big.NewRat(3, 10)) != 0 {
+					t.Error("A0 not correctly copied")
+				}
+				if alonzoParams.Rho == nil ||
+					alonzoParams.Rho.Cmp(big.NewRat(3, 1000)) != 0 {
+					t.Error("Rho not correctly copied")
+				}
+				if alonzoParams.Tau == nil ||
+					alonzoParams.Tau.Cmp(big.NewRat(2, 10)) != 0 {
+					t.Error("Tau not correctly copied")
+				}
+				if alonzoParams.Decentralization == nil ||
+					alonzoParams.Decentralization.Cmp(big.NewRat(1, 2)) != 0 {
+					t.Error("Decentralization not correctly copied")
+				}
+				if alonzoParams.ProtocolMajor != 6 {
+					t.Errorf(
+						"ProtocolMajor: got %d, want 6",
+						alonzoParams.ProtocolMajor,
+					)
+				}
+				if alonzoParams.ProtocolMinor != 0 {
+					t.Errorf(
+						"ProtocolMinor: got %d, want 0",
+						alonzoParams.ProtocolMinor,
+					)
+				}
+				if alonzoParams.MinUtxoValue != 1000000 {
+					t.Errorf(
+						"MinUtxoValue: got %d, want 1000000",
+						alonzoParams.MinUtxoValue,
+					)
+				}
+				if alonzoParams.MinPoolCost != 340000000 {
+					t.Errorf(
+						"MinPoolCost: got %d, want 340000000",
+						alonzoParams.MinPoolCost,
+					)
+				}
+			},
+		},
+		{
+			name: "Upgrade with nil rational numbers",
+			prevParams: mary.MaryProtocolParameters{
+				MinFeeA:            100,
+				MinFeeB:            200,
+				MaxBlockBodySize:   1000,
+				MaxTxSize:          500,
+				MaxBlockHeaderSize: 100,
+				KeyDeposit:         1000,
+				PoolDeposit:        5000,
+				MaxEpoch:           100,
+				NOpt:               50,
+				A0:                 nil,
+				Rho:                nil,
+				Tau:                nil,
+				Decentralization:   nil,
+				ExtraEntropy:       common.Nonce{},
+				ProtocolMajor:      5,
+				ProtocolMinor:      0,
+				MinUtxoValue:       1000,
+				MinPoolCost:        123456789,
+			},
+			validate: func(t *testing.T, alonzoParams alonzo.AlonzoProtocolParameters) {
+				if alonzoParams.A0 != nil {
+					t.Error("A0 should be nil")
+				}
+				if alonzoParams.Rho != nil {
+					t.Error("Rho should be nil")
+				}
+				if alonzoParams.Tau != nil {
+					t.Error("Tau should be nil")
+				}
+				if alonzoParams.Decentralization != nil {
+					t.Error("Decentralization should be nil")
+				}
+				if alonzoParams.MinPoolCost != 123456789 {
+					t.Errorf(
+						"MinPoolCost: got %d, want 123456789",
+						alonzoParams.MinPoolCost,
+					)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			alonzoParams := alonzo.UpgradePParams(tc.prevParams)
+			tc.validate(t, alonzoParams)
+		})
+	}
+}
+
+func TestAlonzoUpgradePParams_PointerIdentity(t *testing.T) {
+	// Test that pointers to rational numbers are correctly copied (not shared)
+	prevParams := mary.MaryProtocolParameters{
+		MinFeeA:            100,
+		MinFeeB:            200,
+		MaxBlockBodySize:   1000,
+		MaxTxSize:          500,
+		MaxBlockHeaderSize: 100,
+		KeyDeposit:         1000,
+		PoolDeposit:        5000,
+		MaxEpoch:           100,
+		NOpt:               50,
+		A0:                 &cbor.Rat{Rat: big.NewRat(1, 2)},
+		Rho:                &cbor.Rat{Rat: big.NewRat(1, 3)},
+		Tau:                &cbor.Rat{Rat: big.NewRat(1, 4)},
+		Decentralization:   &cbor.Rat{Rat: big.NewRat(1, 5)},
+		ExtraEntropy:       common.Nonce{},
+		ProtocolMajor:      5,
+		ProtocolMinor:      0,
+		MinUtxoValue:       1000,
+		MinPoolCost:        340000000,
+	}
+
+	alonzoParams := alonzo.UpgradePParams(prevParams)
+
+	// Verify that the pointers are the same (direct copy)
+	if alonzoParams.A0 != prevParams.A0 {
+		t.Error("A0 pointer should be the same")
+	}
+	if alonzoParams.Rho != prevParams.Rho {
+		t.Error("Rho pointer should be the same")
+	}
+	if alonzoParams.Tau != prevParams.Tau {
+		t.Error("Tau pointer should be the same")
+	}
+	if alonzoParams.Decentralization != prevParams.Decentralization {
+		t.Error("Decentralization pointer should be the same")
+	}
+}
+
+func TestAlonzoUpgradePParams_AlonzoSpecificFieldsZero(t *testing.T) {
+	// Verify that Alonzo-specific fields are initialized to zero values
+	prevParams := mary.MaryProtocolParameters{
+		MinFeeA:            100,
+		MinFeeB:            200,
+		MaxBlockBodySize:   1000,
+		MaxTxSize:          500,
+		MaxBlockHeaderSize: 100,
+		KeyDeposit:         1000,
+		PoolDeposit:        5000,
+		MaxEpoch:           100,
+		NOpt:               50,
+		A0:                 &cbor.Rat{Rat: big.NewRat(1, 2)},
+		Rho:                &cbor.Rat{Rat: big.NewRat(1, 3)},
+		Tau:                &cbor.Rat{Rat: big.NewRat(1, 4)},
+		Decentralization:   &cbor.Rat{Rat: big.NewRat(1, 5)},
+		ExtraEntropy:       common.Nonce{},
+		ProtocolMajor:      5,
+		ProtocolMinor:      0,
+		MinUtxoValue:       1000,
+		MinPoolCost:        340000000,
+	}
+
+	alonzoParams := alonzo.UpgradePParams(prevParams)
+
+	// Alonzo-specific fields should be zero/nil
+	if alonzoParams.AdaPerUtxoByte != 0 {
+		t.Errorf(
+			"AdaPerUtxoByte should be 0, got %d",
+			alonzoParams.AdaPerUtxoByte,
+		)
+	}
+	if alonzoParams.CostModels != nil {
+		t.Error("CostModels should be nil")
+	}
+	if alonzoParams.ExecutionCosts.MemPrice != nil {
+		t.Error("ExecutionCosts.MemPrice should be nil")
+	}
+	if alonzoParams.ExecutionCosts.StepPrice != nil {
+		t.Error("ExecutionCosts.StepPrice should be nil")
+	}
+	if alonzoParams.MaxTxExUnits.Memory != 0 {
+		t.Errorf(
+			"MaxTxExUnits.Memory should be 0, got %d",
+			alonzoParams.MaxTxExUnits.Memory,
+		)
+	}
+	if alonzoParams.MaxTxExUnits.Steps != 0 {
+		t.Errorf(
+			"MaxTxExUnits.Steps should be 0, got %d",
+			alonzoParams.MaxTxExUnits.Steps,
+		)
+	}
+	if alonzoParams.MaxBlockExUnits.Memory != 0 {
+		t.Errorf(
+			"MaxBlockExUnits.Memory should be 0, got %d",
+			alonzoParams.MaxBlockExUnits.Memory,
+		)
+	}
+	if alonzoParams.MaxBlockExUnits.Steps != 0 {
+		t.Errorf(
+			"MaxBlockExUnits.Steps should be 0, got %d",
+			alonzoParams.MaxBlockExUnits.Steps,
+		)
+	}
+	if alonzoParams.MaxValueSize != 0 {
+		t.Errorf("MaxValueSize should be 0, got %d", alonzoParams.MaxValueSize)
+	}
+	if alonzoParams.CollateralPercentage != 0 {
+		t.Errorf(
+			"CollateralPercentage should be 0, got %d",
+			alonzoParams.CollateralPercentage,
+		)
+	}
+	if alonzoParams.MaxCollateralInputs != 0 {
+		t.Errorf(
+			"MaxCollateralInputs should be 0, got %d",
+			alonzoParams.MaxCollateralInputs,
+		)
+	}
+}
+
+func TestAlonzoUpgradePParams_CompareWithExistingParams(t *testing.T) {
+	// Create Mary params that match existing test patterns
+	prevParams := mary.MaryProtocolParameters{
+		MinFeeA:            44,
+		MinFeeB:            155381,
+		MaxBlockBodySize:   65536,
+		MaxTxSize:          16384,
+		MaxBlockHeaderSize: 1100,
+		KeyDeposit:         2000000,
+		PoolDeposit:        500000000,
+		MaxEpoch:           18,
+		NOpt:               500,
+		A0:                 &cbor.Rat{Rat: big.NewRat(1, 2)},
+		Rho:                &cbor.Rat{Rat: big.NewRat(3, 4)},
+		Tau:                &cbor.Rat{Rat: big.NewRat(5, 6)},
+		ProtocolMajor:      8,
+		ProtocolMinor:      0,
+		MinUtxoValue:       1000000,
+		MinPoolCost:        340000000,
+	}
+
+	alonzoParams := alonzo.UpgradePParams(prevParams)
+
+	if alonzoParams.MinFeeA != prevParams.MinFeeA {
+		t.Error("MinFeeA mismatch after upgrade")
+	}
+	if alonzoParams.MinFeeB != prevParams.MinFeeB {
+		t.Error("MinFeeB mismatch after upgrade")
+	}
+	if alonzoParams.MinPoolCost != prevParams.MinPoolCost {
+		t.Errorf(
+			"MinPoolCost mismatch: got %d, want %d",
+			alonzoParams.MinPoolCost,
+			prevParams.MinPoolCost,
+		)
+	}
+
+	// Verify Alonzo-specific fields are zero (not from Mary)
+	if alonzoParams.AdaPerUtxoByte != 0 {
+		t.Error("AdaPerUtxoByte should be zero after upgrade, not base value")
+	}
+}

--- a/ledger/mary/pparams.go
+++ b/ledger/mary/pparams.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Blink Labs Software
+// Copyright 2025 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,14 +14,207 @@
 
 package mary
 
-import "github.com/blinklabs-io/gouroboros/ledger/shelley"
+import (
+	"errors"
+	"math"
+	"math/big"
 
-type MaryProtocolParameters = shelley.ShelleyProtocolParameters
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	cardano "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
 
-type MaryProtocolParameterUpdate = shelley.ShelleyProtocolParameterUpdate
+type MaryProtocolParameters struct {
+	cbor.StructAsArray
+	MinFeeA            uint
+	MinFeeB            uint
+	MaxBlockBodySize   uint
+	MaxTxSize          uint
+	MaxBlockHeaderSize uint
+	KeyDeposit         uint
+	PoolDeposit        uint
+	MaxEpoch           uint
+	NOpt               uint
+	A0                 *cbor.Rat
+	Rho                *cbor.Rat
+	Tau                *cbor.Rat
+	Decentralization   *cbor.Rat
+	ExtraEntropy       common.Nonce
+	ProtocolMajor      uint
+	ProtocolMinor      uint
+	MinUtxoValue       uint
+	MinPoolCost        uint64
+}
+
+func (p *MaryProtocolParameters) Update(
+	paramUpdate *MaryProtocolParameterUpdate,
+) {
+	if paramUpdate.MinFeeA != nil {
+		p.MinFeeA = *paramUpdate.MinFeeA
+	}
+	if paramUpdate.MinFeeB != nil {
+		p.MinFeeB = *paramUpdate.MinFeeB
+	}
+	if paramUpdate.MaxBlockBodySize != nil {
+		p.MaxBlockBodySize = *paramUpdate.MaxBlockBodySize
+	}
+	if paramUpdate.MaxTxSize != nil {
+		p.MaxTxSize = *paramUpdate.MaxTxSize
+	}
+	if paramUpdate.MaxBlockHeaderSize != nil {
+		p.MaxBlockHeaderSize = *paramUpdate.MaxBlockHeaderSize
+	}
+	if paramUpdate.KeyDeposit != nil {
+		p.KeyDeposit = *paramUpdate.KeyDeposit
+	}
+	if paramUpdate.PoolDeposit != nil {
+		p.PoolDeposit = *paramUpdate.PoolDeposit
+	}
+	if paramUpdate.MaxEpoch != nil {
+		p.MaxEpoch = *paramUpdate.MaxEpoch
+	}
+	if paramUpdate.NOpt != nil {
+		p.NOpt = *paramUpdate.NOpt
+	}
+	if paramUpdate.A0 != nil {
+		p.A0 = &cbor.Rat{Rat: new(big.Rat).Set(paramUpdate.A0.Rat)}
+	}
+	if paramUpdate.Rho != nil {
+		p.Rho = &cbor.Rat{Rat: new(big.Rat).Set(paramUpdate.Rho.Rat)}
+	}
+	if paramUpdate.Tau != nil {
+		p.Tau = &cbor.Rat{Rat: new(big.Rat).Set(paramUpdate.Tau.Rat)}
+	}
+	if paramUpdate.Decentralization != nil {
+		p.Decentralization = &cbor.Rat{
+			Rat: new(big.Rat).Set(paramUpdate.Decentralization.Rat),
+		}
+	}
+	if paramUpdate.ProtocolVersion != nil {
+		p.ProtocolMajor = paramUpdate.ProtocolVersion.Major
+		p.ProtocolMinor = paramUpdate.ProtocolVersion.Minor
+	}
+	if paramUpdate.ExtraEntropy != nil {
+		p.ExtraEntropy = *paramUpdate.ExtraEntropy
+	}
+	if paramUpdate.MinUtxoValue != nil {
+		p.MinUtxoValue = *paramUpdate.MinUtxoValue
+	}
+	if paramUpdate.MinPoolCost != nil {
+		p.MinPoolCost = *paramUpdate.MinPoolCost
+	}
+}
+
+type MaryProtocolParameterUpdate struct {
+	cbor.DecodeStoreCbor
+	MinFeeA            *uint                                     `cbor:"0,keyasint"`
+	MinFeeB            *uint                                     `cbor:"1,keyasint"`
+	MaxBlockBodySize   *uint                                     `cbor:"2,keyasint"`
+	MaxTxSize          *uint                                     `cbor:"3,keyasint"`
+	MaxBlockHeaderSize *uint                                     `cbor:"4,keyasint"`
+	KeyDeposit         *uint                                     `cbor:"5,keyasint"`
+	PoolDeposit        *uint                                     `cbor:"6,keyasint"`
+	MaxEpoch           *uint                                     `cbor:"7,keyasint"`
+	NOpt               *uint                                     `cbor:"8,keyasint"`
+	A0                 *cbor.Rat                                 `cbor:"9,keyasint"`
+	Rho                *cbor.Rat                                 `cbor:"10,keyasint"`
+	Tau                *cbor.Rat                                 `cbor:"11,keyasint"`
+	Decentralization   *cbor.Rat                                 `cbor:"12,keyasint"`
+	ExtraEntropy       *common.Nonce                             `cbor:"13,keyasint"`
+	ProtocolVersion    *common.ProtocolParametersProtocolVersion `cbor:"14,keyasint"`
+	MinUtxoValue       *uint                                     `cbor:"15,keyasint"`
+	MinPoolCost        *uint64                                   `cbor:"16,keyasint"`
+}
+
+func (MaryProtocolParameterUpdate) IsProtocolParameterUpdate() {}
+
+func (u *MaryProtocolParameterUpdate) UnmarshalCBOR(cborData []byte) error {
+	type tMaryProtocolParameterUpdate MaryProtocolParameterUpdate
+	var tmp tMaryProtocolParameterUpdate
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*u = MaryProtocolParameterUpdate(tmp)
+	u.SetCbor(cborData)
+	return nil
+}
+
+func (p *MaryProtocolParameters) Utxorpc() (*cardano.PParams, error) {
+	// sanity check
+	if p.A0 == nil ||
+		p.A0.Num().Int64() < math.MinInt32 ||
+		p.A0.Num().Int64() > math.MaxInt32 ||
+		p.A0.Denom().Int64() < 0 ||
+		p.A0.Denom().Int64() > math.MaxUint32 {
+		return nil, errors.New("invalid A0 rational number values")
+	}
+	if p.Rho == nil ||
+		p.Rho.Num().Int64() < math.MinInt32 ||
+		p.Rho.Num().Int64() > math.MaxInt32 ||
+		p.Rho.Denom().Int64() < 0 ||
+		p.Rho.Denom().Int64() > math.MaxUint32 {
+		return nil, errors.New("invalid Rho rational number values")
+	}
+	if p.Tau == nil ||
+		p.Tau.Num().Int64() < math.MinInt32 ||
+		p.Tau.Num().Int64() > math.MaxInt32 ||
+		p.Tau.Denom().Int64() < 0 ||
+		p.Tau.Denom().Int64() > math.MaxUint32 {
+		return nil, errors.New("invalid Tau rational number values")
+	}
+	// #nosec G115
+	return &cardano.PParams{
+		MaxTxSize:                uint64(p.MaxTxSize),
+		MinFeeCoefficient:        uint64(p.MinFeeA),
+		MinFeeConstant:           uint64(p.MinFeeB),
+		MaxBlockBodySize:         uint64(p.MaxBlockBodySize),
+		MaxBlockHeaderSize:       uint64(p.MaxBlockHeaderSize),
+		StakeKeyDeposit:          uint64(p.KeyDeposit),
+		PoolDeposit:              uint64(p.PoolDeposit),
+		PoolRetirementEpochBound: uint64(p.MaxEpoch),
+		DesiredNumberOfPools:     uint64(p.NOpt),
+		PoolInfluence: &cardano.RationalNumber{
+			Numerator:   int32(p.A0.Num().Int64()),
+			Denominator: uint32(p.A0.Denom().Int64()),
+		},
+		MonetaryExpansion: &cardano.RationalNumber{
+			Numerator:   int32(p.Rho.Num().Int64()),
+			Denominator: uint32(p.Rho.Denom().Int64()),
+		},
+		TreasuryExpansion: &cardano.RationalNumber{
+			Numerator:   int32(p.Tau.Num().Int64()),
+			Denominator: uint32(p.Tau.Denom().Int64()),
+		},
+		MinPoolCost: p.MinPoolCost,
+		ProtocolVersion: &cardano.ProtocolVersion{
+			Major: uint32(p.ProtocolMajor),
+			Minor: uint32(p.ProtocolMinor),
+		},
+	}, nil
+}
 
 func UpgradePParams(
 	prevPParams shelley.ShelleyProtocolParameters,
 ) MaryProtocolParameters {
-	return MaryProtocolParameters(prevPParams)
+	return MaryProtocolParameters{
+		MinFeeA:            prevPParams.MinFeeA,
+		MinFeeB:            prevPParams.MinFeeB,
+		MaxBlockBodySize:   prevPParams.MaxBlockBodySize,
+		MaxTxSize:          prevPParams.MaxTxSize,
+		MaxBlockHeaderSize: prevPParams.MaxBlockHeaderSize,
+		KeyDeposit:         prevPParams.KeyDeposit,
+		PoolDeposit:        prevPParams.PoolDeposit,
+		MaxEpoch:           prevPParams.MaxEpoch,
+		NOpt:               prevPParams.NOpt,
+		A0:                 prevPParams.A0,
+		Rho:                prevPParams.Rho,
+		Tau:                prevPParams.Tau,
+		Decentralization:   prevPParams.Decentralization,
+		ExtraEntropy:       prevPParams.ExtraEntropy,
+		ProtocolMajor:      prevPParams.ProtocolMajor,
+		ProtocolMinor:      prevPParams.ProtocolMinor,
+		MinUtxoValue:       prevPParams.MinUtxoValue,
+		MinPoolCost:        340000000, // initial MinPoolCost at Mary on mainnet
+	}
 }

--- a/ledger/mary/pparams_test.go
+++ b/ledger/mary/pparams_test.go
@@ -284,3 +284,608 @@ func TestMaryTransaction_Utxorpc(t *testing.T) {
 		t.Error("Expected non-empty transaction hash")
 	}
 }
+
+// ===================================================================
+// Tests for new MaryProtocolParameters implementation
+// ===================================================================
+
+func TestMaryProtocolParametersUpdate_MinPoolCost(t *testing.T) {
+	testCases := []struct {
+		name           string
+		startParams    mary.MaryProtocolParameters
+		updateCbor     string
+		expectedParams mary.MaryProtocolParameters
+	}{
+		{
+			name: "Update MinPoolCost from zero to value",
+			startParams: mary.MaryProtocolParameters{
+				MinPoolCost: 0,
+			},
+			updateCbor: "a1101a1443fd00", // {16: 340000000}
+			expectedParams: mary.MaryProtocolParameters{
+				MinPoolCost: 340000000,
+			},
+		},
+		{
+			name: "Update MinPoolCost from existing value to new value",
+			startParams: mary.MaryProtocolParameters{
+				MinPoolCost: 340000000,
+			},
+			updateCbor: "a1101a0007a120", // {16: 500000}
+			expectedParams: mary.MaryProtocolParameters{
+				MinPoolCost: 500000,
+			},
+		},
+		{
+			name: "Update MinPoolCost to maximum uint64 value",
+			startParams: mary.MaryProtocolParameters{
+				MinPoolCost: 100,
+			},
+			updateCbor: "a1101bffffffffffffffff", // {16: 18446744073709551615}
+			expectedParams: mary.MaryProtocolParameters{
+				MinPoolCost: 18446744073709551615,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cborBytes, err := hex.DecodeString(tc.updateCbor)
+			if err != nil {
+				t.Fatalf("failed to decode CBOR hex: %s", err)
+			}
+
+			var update mary.MaryProtocolParameterUpdate
+			if _, err := cbor.Decode(cborBytes, &update); err != nil {
+				t.Fatalf("failed to decode CBOR: %s", err)
+			}
+
+			params := tc.startParams
+			params.Update(&update)
+
+			if params.MinPoolCost != tc.expectedParams.MinPoolCost {
+				t.Errorf(
+					"MinPoolCost mismatch: got %d, want %d",
+					params.MinPoolCost,
+					tc.expectedParams.MinPoolCost,
+				)
+			}
+		})
+	}
+}
+
+func TestMaryProtocolParametersUpdate_MultipleFields(t *testing.T) {
+	startParams := mary.MaryProtocolParameters{
+		MinFeeA:       100,
+		MinFeeB:       200,
+		MinPoolCost:   0,
+		ProtocolMajor: 7,
+	}
+
+	// Update with multiple fields including MinPoolCost
+	updateCbor := "a3101a00989680001818011819" // {0:24, 1:25, 16:10000000}
+	cborBytes, err := hex.DecodeString(updateCbor)
+	if err != nil {
+		t.Fatalf("failed to decode CBOR hex: %s", err)
+	}
+
+	var update mary.MaryProtocolParameterUpdate
+	if _, err := cbor.Decode(cborBytes, &update); err != nil {
+		t.Fatalf("failed to decode CBOR: %s", err)
+	}
+
+	startParams.Update(&update)
+
+	if startParams.MinFeeA != 24 {
+		t.Errorf("MinFeeA not updated: got %d, want 24", startParams.MinFeeA)
+	}
+	if startParams.MinFeeB != 25 {
+		t.Errorf("MinFeeB not updated: got %d, want 25", startParams.MinFeeB)
+	}
+	if startParams.MinPoolCost != 10000000 {
+		t.Errorf(
+			"MinPoolCost not updated: got %d, want 10000000",
+			startParams.MinPoolCost,
+		)
+	}
+	if startParams.ProtocolMajor != 7 {
+		t.Errorf(
+			"ProtocolMajor should not change: got %d, want 7",
+			startParams.ProtocolMajor,
+		)
+	}
+}
+
+func TestMaryUtxorpc_WithMinPoolCost(t *testing.T) {
+	testCases := []struct {
+		name                string
+		inputParams         mary.MaryProtocolParameters
+		expectedMinPoolCost uint64
+	}{
+		{
+			name: "MinPoolCost zero",
+			inputParams: mary.MaryProtocolParameters{
+				MinFeeA:            500,
+				MinFeeB:            2,
+				MaxBlockBodySize:   65536,
+				MaxTxSize:          16384,
+				MaxBlockHeaderSize: 1024,
+				KeyDeposit:         2000,
+				PoolDeposit:        500000,
+				MaxEpoch:           2160,
+				NOpt:               100,
+				A0:                 &cbor.Rat{Rat: big.NewRat(1, 2)},
+				Rho:                &cbor.Rat{Rat: big.NewRat(3, 4)},
+				Tau:                &cbor.Rat{Rat: big.NewRat(5, 6)},
+				ProtocolMajor:      8,
+				ProtocolMinor:      0,
+				MinUtxoValue:       1000000,
+				MinPoolCost:        0,
+			},
+			expectedMinPoolCost: 0,
+		},
+		{
+			name: "MinPoolCost standard value",
+			inputParams: mary.MaryProtocolParameters{
+				MinFeeA:            500,
+				MinFeeB:            2,
+				MaxBlockBodySize:   65536,
+				MaxTxSize:          16384,
+				MaxBlockHeaderSize: 1024,
+				KeyDeposit:         2000,
+				PoolDeposit:        500000,
+				MaxEpoch:           2160,
+				NOpt:               100,
+				A0:                 &cbor.Rat{Rat: big.NewRat(1, 2)},
+				Rho:                &cbor.Rat{Rat: big.NewRat(3, 4)},
+				Tau:                &cbor.Rat{Rat: big.NewRat(5, 6)},
+				ProtocolMajor:      8,
+				ProtocolMinor:      0,
+				MinUtxoValue:       1000000,
+				MinPoolCost:        340000000,
+			},
+			expectedMinPoolCost: 340000000,
+		},
+		{
+			name: "MinPoolCost maximum value",
+			inputParams: mary.MaryProtocolParameters{
+				MinFeeA:            500,
+				MinFeeB:            2,
+				MaxBlockBodySize:   65536,
+				MaxTxSize:          16384,
+				MaxBlockHeaderSize: 1024,
+				KeyDeposit:         2000,
+				PoolDeposit:        500000,
+				MaxEpoch:           2160,
+				NOpt:               100,
+				A0:                 &cbor.Rat{Rat: big.NewRat(1, 2)},
+				Rho:                &cbor.Rat{Rat: big.NewRat(3, 4)},
+				Tau:                &cbor.Rat{Rat: big.NewRat(5, 6)},
+				ProtocolMajor:      8,
+				ProtocolMinor:      0,
+				MinUtxoValue:       1000000,
+				MinPoolCost:        18446744073709551615,
+			},
+			expectedMinPoolCost: 18446744073709551615,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := tc.inputParams.Utxorpc()
+			if err != nil {
+				t.Fatalf("Utxorpc() conversion failed: %v", err)
+			}
+
+			if result.MinPoolCost != tc.expectedMinPoolCost {
+				t.Errorf(
+					"MinPoolCost mismatch: got %d, want %d",
+					result.MinPoolCost,
+					tc.expectedMinPoolCost,
+				)
+			}
+		})
+	}
+}
+
+func TestMaryProtocolParameterUpdate_CBORDecoding(t *testing.T) {
+	testCases := []struct {
+		name        string
+		cborHex     string
+		expectError bool
+		validate    func(*testing.T, *mary.MaryProtocolParameterUpdate)
+	}{
+		{
+			name:        "Decode MinPoolCost only",
+			cborHex:     "a1101a1443fd00",
+			expectError: false,
+			validate: func(t *testing.T, u *mary.MaryProtocolParameterUpdate) {
+				if u.MinPoolCost == nil {
+					t.Error("MinPoolCost should not be nil")
+				} else if *u.MinPoolCost != 340000000 {
+					t.Errorf("MinPoolCost: got %d, want 340000000", *u.MinPoolCost)
+				}
+			},
+		},
+		{
+			name:        "Decode empty update",
+			cborHex:     "a0",
+			expectError: false,
+			validate: func(t *testing.T, u *mary.MaryProtocolParameterUpdate) {
+				if u.MinPoolCost != nil {
+					t.Error("MinPoolCost should be nil for empty update")
+				}
+			},
+		},
+		{
+			name:        "Decode MinPoolCost with other fields",
+			cborHex:     "a3011901f4101a000186a0001864",
+			expectError: false,
+			validate: func(t *testing.T, u *mary.MaryProtocolParameterUpdate) {
+				if u.MinFeeA == nil || *u.MinFeeA != 100 {
+					t.Error("MinFeeA should be 100")
+				}
+				if u.MinFeeB == nil || *u.MinFeeB != 500 {
+					t.Error("MinFeeB should be 500")
+				}
+				if u.MinPoolCost == nil || *u.MinPoolCost != 100000 {
+					t.Error("MinPoolCost should be 100000")
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cborBytes, err := hex.DecodeString(tc.cborHex)
+			if err != nil {
+				t.Fatalf("failed to decode hex: %s", err)
+			}
+
+			var update mary.MaryProtocolParameterUpdate
+			_, err = cbor.Decode(cborBytes, &update)
+
+			if tc.expectError && err == nil {
+				t.Fatal("expected error but got none")
+			}
+			if !tc.expectError && err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			if !tc.expectError && tc.validate != nil {
+				tc.validate(t, &update)
+			}
+		})
+	}
+}
+
+func TestMaryUpgradePParams(t *testing.T) {
+	testCases := []struct {
+		name       string
+		prevParams shelley.ShelleyProtocolParameters
+		validate   func(*testing.T, mary.MaryProtocolParameters)
+	}{
+		{
+			name: "Upgrade with all fields",
+			prevParams: shelley.ShelleyProtocolParameters{
+				MinFeeA:            44,
+				MinFeeB:            155381,
+				MaxBlockBodySize:   65536,
+				MaxTxSize:          16384,
+				MaxBlockHeaderSize: 1100,
+				KeyDeposit:         2000000,
+				PoolDeposit:        500000000,
+				MaxEpoch:           18,
+				NOpt:               500,
+				A0:                 &cbor.Rat{Rat: big.NewRat(3, 10)},
+				Rho:                &cbor.Rat{Rat: big.NewRat(3, 1000)},
+				Tau:                &cbor.Rat{Rat: big.NewRat(2, 10)},
+				Decentralization:   &cbor.Rat{Rat: big.NewRat(1, 2)},
+				ExtraEntropy:       common.Nonce{},
+				ProtocolMajor:      6,
+				ProtocolMinor:      0,
+				MinUtxoValue:       1000000,
+			},
+			validate: func(t *testing.T, maryParams mary.MaryProtocolParameters) {
+				if maryParams.MinFeeA != 44 {
+					t.Errorf("MinFeeA: got %d, want 44", maryParams.MinFeeA)
+				}
+				if maryParams.MinFeeB != 155381 {
+					t.Errorf("MinFeeB: got %d, want 155381", maryParams.MinFeeB)
+				}
+				if maryParams.MaxBlockBodySize != 65536 {
+					t.Errorf(
+						"MaxBlockBodySize: got %d, want 65536",
+						maryParams.MaxBlockBodySize,
+					)
+				}
+				if maryParams.MaxTxSize != 16384 {
+					t.Errorf(
+						"MaxTxSize: got %d, want 16384",
+						maryParams.MaxTxSize,
+					)
+				}
+				if maryParams.MaxBlockHeaderSize != 1100 {
+					t.Errorf(
+						"MaxBlockHeaderSize: got %d, want 1100",
+						maryParams.MaxBlockHeaderSize,
+					)
+				}
+				if maryParams.KeyDeposit != 2000000 {
+					t.Errorf(
+						"KeyDeposit: got %d, want 2000000",
+						maryParams.KeyDeposit,
+					)
+				}
+				if maryParams.PoolDeposit != 500000000 {
+					t.Errorf(
+						"PoolDeposit: got %d, want 500000000",
+						maryParams.PoolDeposit,
+					)
+				}
+				if maryParams.MaxEpoch != 18 {
+					t.Errorf("MaxEpoch: got %d, want 18", maryParams.MaxEpoch)
+				}
+				if maryParams.NOpt != 500 {
+					t.Errorf("NOpt: got %d, want 500", maryParams.NOpt)
+				}
+				if maryParams.A0 == nil ||
+					maryParams.A0.Cmp(big.NewRat(3, 10)) != 0 {
+					t.Error("A0 not correctly copied")
+				}
+				if maryParams.Rho == nil ||
+					maryParams.Rho.Cmp(big.NewRat(3, 1000)) != 0 {
+					t.Error("Rho not correctly copied")
+				}
+				if maryParams.Tau == nil ||
+					maryParams.Tau.Cmp(big.NewRat(2, 10)) != 0 {
+					t.Error("Tau not correctly copied")
+				}
+				if maryParams.Decentralization == nil ||
+					maryParams.Decentralization.Cmp(big.NewRat(1, 2)) != 0 {
+					t.Error("Decentralization not correctly copied")
+				}
+				if maryParams.ProtocolMajor != 6 {
+					t.Errorf(
+						"ProtocolMajor: got %d, want 6",
+						maryParams.ProtocolMajor,
+					)
+				}
+				if maryParams.ProtocolMinor != 0 {
+					t.Errorf(
+						"ProtocolMinor: got %d, want 0",
+						maryParams.ProtocolMinor,
+					)
+				}
+				if maryParams.MinUtxoValue != 1000000 {
+					t.Errorf(
+						"MinUtxoValue: got %d, want 1000000",
+						maryParams.MinUtxoValue,
+					)
+				}
+				// MinPoolCost should default to 340 ADA for Shelley upgrade
+				if maryParams.MinPoolCost != 340000000 {
+					t.Errorf(
+						"MinPoolCost: got %d, want 340000000",
+						maryParams.MinPoolCost,
+					)
+				}
+			},
+		},
+		{
+			name: "Upgrade with zero values",
+			prevParams: shelley.ShelleyProtocolParameters{
+				MinFeeA:            0,
+				MinFeeB:            0,
+				MaxBlockBodySize:   0,
+				MaxTxSize:          0,
+				MaxBlockHeaderSize: 0,
+				KeyDeposit:         0,
+				PoolDeposit:        0,
+				MaxEpoch:           0,
+				NOpt:               0,
+				A0:                 &cbor.Rat{Rat: big.NewRat(0, 1)},
+				Rho:                &cbor.Rat{Rat: big.NewRat(0, 1)},
+				Tau:                &cbor.Rat{Rat: big.NewRat(0, 1)},
+				Decentralization:   &cbor.Rat{Rat: big.NewRat(0, 1)},
+				ExtraEntropy:       common.Nonce{},
+				ProtocolMajor:      0,
+				ProtocolMinor:      0,
+				MinUtxoValue:       0,
+			},
+			validate: func(t *testing.T, maryParams mary.MaryProtocolParameters) {
+				if maryParams.MinFeeA != 0 {
+					t.Errorf("MinFeeA should be 0, got %d", maryParams.MinFeeA)
+				}
+				if maryParams.MinPoolCost != 340000000 {
+					t.Errorf(
+						"MinPoolCost should be 340000000, got %d",
+						maryParams.MinPoolCost,
+					)
+				}
+			},
+		},
+		{
+			name: "Upgrade with nil rational numbers",
+			prevParams: shelley.ShelleyProtocolParameters{
+				MinFeeA:            100,
+				MinFeeB:            200,
+				MaxBlockBodySize:   1000,
+				MaxTxSize:          500,
+				MaxBlockHeaderSize: 100,
+				KeyDeposit:         1000,
+				PoolDeposit:        5000,
+				MaxEpoch:           100,
+				NOpt:               50,
+				A0:                 nil,
+				Rho:                nil,
+				Tau:                nil,
+				Decentralization:   nil,
+				ExtraEntropy:       common.Nonce{},
+				ProtocolMajor:      5,
+				ProtocolMinor:      0,
+				MinUtxoValue:       1000,
+			},
+			validate: func(t *testing.T, maryParams mary.MaryProtocolParameters) {
+				if maryParams.A0 != nil {
+					t.Error("A0 should be nil")
+				}
+				if maryParams.Rho != nil {
+					t.Error("Rho should be nil")
+				}
+				if maryParams.Tau != nil {
+					t.Error("Tau should be nil")
+				}
+				if maryParams.Decentralization != nil {
+					t.Error("Decentralization should be nil")
+				}
+				if maryParams.MinPoolCost != 340000000 {
+					t.Errorf(
+						"MinPoolCost should be 340000000, got %d",
+						maryParams.MinPoolCost,
+					)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			maryParams := mary.UpgradePParams(tc.prevParams)
+			tc.validate(t, maryParams)
+		})
+	}
+}
+
+func TestMaryUpgradePParams_PointerIdentity(t *testing.T) {
+	// Test that pointers to rational numbers are correctly copied (not shared)
+	prevParams := shelley.ShelleyProtocolParameters{
+		MinFeeA:            100,
+		MinFeeB:            200,
+		MaxBlockBodySize:   1000,
+		MaxTxSize:          500,
+		MaxBlockHeaderSize: 100,
+		KeyDeposit:         1000,
+		PoolDeposit:        5000,
+		MaxEpoch:           100,
+		NOpt:               50,
+		A0:                 &cbor.Rat{Rat: big.NewRat(1, 2)},
+		Rho:                &cbor.Rat{Rat: big.NewRat(1, 3)},
+		Tau:                &cbor.Rat{Rat: big.NewRat(1, 4)},
+		Decentralization:   &cbor.Rat{Rat: big.NewRat(1, 5)},
+		ExtraEntropy:       common.Nonce{},
+		ProtocolMajor:      5,
+		ProtocolMinor:      0,
+		MinUtxoValue:       1000,
+	}
+
+	maryParams := mary.UpgradePParams(prevParams)
+
+	// Verify that the pointers are the same (direct copy)
+	if maryParams.A0 != prevParams.A0 {
+		t.Error("A0 pointer should be the same")
+	}
+	if maryParams.Rho != prevParams.Rho {
+		t.Error("Rho pointer should be the same")
+	}
+	if maryParams.Tau != prevParams.Tau {
+		t.Error("Tau pointer should be the same")
+	}
+	if maryParams.Decentralization != prevParams.Decentralization {
+		t.Error("Decentralization pointer should be the same")
+	}
+}
+
+func TestMaryUtxorpc_InvalidRationalNumbers(t *testing.T) {
+	testCases := []struct {
+		name        string
+		params      mary.MaryProtocolParameters
+		expectError string
+	}{
+		{
+			name: "A0 numerator exceeds int32 max",
+			params: mary.MaryProtocolParameters{
+				MinFeeA:            500,
+				MinFeeB:            2,
+				MaxBlockBodySize:   65536,
+				MaxTxSize:          16384,
+				MaxBlockHeaderSize: 1024,
+				KeyDeposit:         2000,
+				PoolDeposit:        500000,
+				MaxEpoch:           2160,
+				NOpt:               100,
+				A0: &cbor.Rat{
+					Rat: big.NewRat(2147483648, 1),
+				}, // MaxInt32 + 1
+				Rho:           &cbor.Rat{Rat: big.NewRat(3, 4)},
+				Tau:           &cbor.Rat{Rat: big.NewRat(5, 6)},
+				ProtocolMajor: 8,
+				ProtocolMinor: 0,
+				MinUtxoValue:  1000000,
+			},
+			expectError: "invalid A0 rational number values",
+		},
+		{
+			name: "Rho numerator exceeds int32 max",
+			params: mary.MaryProtocolParameters{
+				MinFeeA:            500,
+				MinFeeB:            2,
+				MaxBlockBodySize:   65536,
+				MaxTxSize:          16384,
+				MaxBlockHeaderSize: 1024,
+				KeyDeposit:         2000,
+				PoolDeposit:        500000,
+				MaxEpoch:           2160,
+				NOpt:               100,
+				A0:                 &cbor.Rat{Rat: big.NewRat(1, 2)},
+				Rho: &cbor.Rat{
+					Rat: big.NewRat(2147483648, 1),
+				}, // MaxInt32 + 1
+				Tau:           &cbor.Rat{Rat: big.NewRat(5, 6)},
+				ProtocolMajor: 8,
+				ProtocolMinor: 0,
+				MinUtxoValue:  1000000,
+			},
+			expectError: "invalid Rho rational number values",
+		},
+		{
+			name: "Tau denominator exceeds uint32 max",
+			params: mary.MaryProtocolParameters{
+				MinFeeA:            500,
+				MinFeeB:            2,
+				MaxBlockBodySize:   65536,
+				MaxTxSize:          16384,
+				MaxBlockHeaderSize: 1024,
+				KeyDeposit:         2000,
+				PoolDeposit:        500000,
+				MaxEpoch:           2160,
+				NOpt:               100,
+				A0:                 &cbor.Rat{Rat: big.NewRat(1, 2)},
+				Rho:                &cbor.Rat{Rat: big.NewRat(3, 4)},
+				Tau: &cbor.Rat{
+					Rat: big.NewRat(1, 4294967296),
+				}, // MaxUint32 + 1
+				ProtocolMajor: 8,
+				ProtocolMinor: 0,
+				MinUtxoValue:  1000000,
+			},
+			expectError: "invalid Tau rational number values",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.params.Utxorpc()
+			if err == nil {
+				t.Fatal("expected error but got none")
+			}
+			if !reflect.DeepEqual(err.Error(), tc.expectError) {
+				t.Errorf(
+					"expected error %q, got %q",
+					tc.expectError,
+					err.Error(),
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Preserve and expose MinPoolCost across protocol-parameter upgrades and conversions; improved mapping and validation across eras, including Alonzo upgrades.
  * Centralized and strengthened value/fee/size validation to ensure conservation, correct fee/min-UTXO calculations, and max-tx-size checks.

* **New Features**
  * New structured protocol-parameter type with CBOR-backed partial updates and reliable conversion to UTxO-era parameters, including rational-field validation.
  * Public helpers to compute minimum fee and minimum UTXO value.

* **Tests**
  * Extensive unit tests for upgrades, conversions, CBOR decoding, pointer semantics, edge cases (min/max), Alonzo-specific field handling, and error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->