### PR TITLE
fix(shelley): check rat lower bounds

### DIFF
--- a/ledger/shelley/pparams.go
+++ b/ledger/shelley/pparams.go
@@ -171,17 +171,23 @@ func (u *ShelleyProtocolParameterUpdate) UnmarshalCBOR(cborData []byte) error {
 
 func (p *ShelleyProtocolParameters) Utxorpc() (*cardano.PParams, error) {
 	// sanity check
-	if p.A0.Num().Int64() > math.MaxInt32 ||
+	if p.A0 == nil ||
+		p.A0.Num().Int64() < math.MinInt32 ||
+		p.A0.Num().Int64() > math.MaxInt32 ||
 		p.A0.Denom().Int64() < 0 ||
 		p.A0.Denom().Int64() > math.MaxUint32 {
 		return nil, errors.New("invalid A0 rational number values")
 	}
-	if p.Rho.Num().Int64() > math.MaxInt32 ||
+	if p.Rho == nil ||
+		p.Rho.Num().Int64() < math.MinInt32 ||
+		p.Rho.Num().Int64() > math.MaxInt32 ||
 		p.Rho.Denom().Int64() < 0 ||
 		p.Rho.Denom().Int64() > math.MaxUint32 {
 		return nil, errors.New("invalid Rho rational number values")
 	}
-	if p.Tau.Num().Int64() > math.MaxInt32 ||
+	if p.Tau == nil ||
+		p.Tau.Num().Int64() < math.MinInt32 ||
+		p.Tau.Num().Int64() > math.MaxInt32 ||
 		p.Tau.Denom().Int64() < 0 ||
 		p.Tau.Denom().Int64() > math.MaxUint32 {
 		return nil, errors.New("invalid Tau rational number values")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation of protocol parameters: A0, Rho, and Tau now reject nil/missing values and numerators outside the allowed range, while denominator checks remain enforced. This prevents previously accepted invalid parameter values from being used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->