### PR TITLE
fix: use dynamic era name in UtxoFailure error message

### DIFF
--- a/ledger/error.go
+++ b/ledger/error.go
@@ -299,8 +299,9 @@ func (e *UtxoFailure) UnmarshalCBOR(data []byte) error {
 }
 
 func (e *UtxoFailure) Error() string {
-	// TODO: lookup era name programmatically (#846)
-	return fmt.Sprintf("UtxoFailure (FromAlonzoUtxoFail (%s))", e.Err)
+	// Dynamically determine era name using the era ID from the struct
+	eraName := GetEraById(e.Era).Name
+	return fmt.Sprintf("UtxoFailure (From%sUtxoFail (%s))", eraName, e.Err)
 }
 
 type UtxoFailureErrorBase struct {


### PR DESCRIPTION
## Summary

Replace hardcoded 'Alonzo' with dynamic era name lookup using the era ID stored in the UtxoFailure struct.

## Changes

- Modified  method in  to use  instead of hardcoded 'Alonzo'
- Removed the TODO comment as the issue is now resolved
- The error message format is now consistent across all eras

## Before


## After


Where  is dynamically determined based on the era ID stored in the struct.

Closes #846

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages now display the correct era name at runtime instead of a hardcoded value, so failure messages reflect the actual era and are clearer for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->