### PR TITLE
refactor(ledger): use PoolKeyHash for state

### DIFF
--- a/internal/test/ledger/ledger.go
+++ b/internal/test/ledger/ledger.go
@@ -64,13 +64,13 @@ func (ls MockLedgerState) StakeRegistration(
 }
 
 func (ls MockLedgerState) PoolCurrentState(
-	poolKeyHash []byte,
+	poolKeyHash common.PoolKeyHash,
 ) (*common.PoolRegistrationCertificate, *uint64, error) {
 	for _, cert := range ls.MockPoolRegistration {
 		if string(
 			common.Blake2b224(cert.Operator).Bytes(),
 		) == string(
-			poolKeyHash,
+			common.Blake2b224(poolKeyHash).Bytes(),
 		) {
 			// pretend latest registration is current; no retirement support in mock
 			c := cert

--- a/ledger/alonzo/rules.go
+++ b/ledger/alonzo/rules.go
@@ -289,7 +289,7 @@ func UtxoValidateValueNotConservedUtxo(
 	for _, cert := range tx.Certificates() {
 		switch tmpCert := cert.(type) {
 		case *common.PoolRegistrationCertificate:
-			reg, _, err := ls.PoolCurrentState(common.Blake2b224(tmpCert.Operator).Bytes())
+			reg, _, err := ls.PoolCurrentState(common.Blake2b224(tmpCert.Operator))
 			if err != nil {
 				return err
 			}

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -275,7 +275,7 @@ func UtxoValidateValueNotConservedUtxo(
 	for _, cert := range tx.Certificates() {
 		switch tmpCert := cert.(type) {
 		case *common.PoolRegistrationCertificate:
-			reg, _, err := ls.PoolCurrentState(common.Blake2b224(tmpCert.Operator).Bytes())
+			reg, _, err := ls.PoolCurrentState(common.Blake2b224(tmpCert.Operator))
 			if err != nil {
 				return err
 			}

--- a/ledger/common/state.go
+++ b/ledger/common/state.go
@@ -35,7 +35,7 @@ type PoolState interface {
 	// PoolCurrentState returns the latest active registration certificate for the given pool key hash.
 	// It also returns the epoch of a pending retirement certificate, if one exists.
 	// If the pool is not registered, the registration certificate will be nil.
-	PoolCurrentState([]byte) (*PoolRegistrationCertificate, *uint64, error)
+	PoolCurrentState(PoolKeyHash) (*PoolRegistrationCertificate, *uint64, error)
 }
 
 // LedgerState defines the interface for querying the ledger

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -272,7 +272,7 @@ func UtxoValidateValueNotConservedUtxo(
 	for _, cert := range tx.Certificates() {
 		switch tmpCert := cert.(type) {
 		case *common.PoolRegistrationCertificate:
-			reg, _, err := ls.PoolCurrentState(common.Blake2b224(tmpCert.Operator).Bytes())
+			reg, _, err := ls.PoolCurrentState(common.Blake2b224(tmpCert.Operator))
 			if err != nil {
 				return err
 			}

--- a/ledger/mary/rules.go
+++ b/ledger/mary/rules.go
@@ -175,7 +175,7 @@ func UtxoValidateValueNotConservedUtxo(
 	for _, cert := range tx.Certificates() {
 		switch tmpCert := cert.(type) {
 		case *common.PoolRegistrationCertificate:
-			reg, _, err := ls.PoolCurrentState(common.Blake2b224(tmpCert.Operator).Bytes())
+			reg, _, err := ls.PoolCurrentState(common.Blake2b224(tmpCert.Operator))
 			if err != nil {
 				return err
 			}

--- a/ledger/shelley/rules.go
+++ b/ledger/shelley/rules.go
@@ -196,7 +196,7 @@ func UtxoValidateValueNotConservedUtxo(
 	for _, cert := range tx.Certificates() {
 		switch tmpCert := cert.(type) {
 		case *common.PoolRegistrationCertificate:
-			reg, _, err := ls.PoolCurrentState(common.Blake2b224(tmpCert.Operator).Bytes())
+			reg, _, err := ls.PoolCurrentState(common.Blake2b224(tmpCert.Operator))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated pool state lookup mechanism to use stricter type parameters instead of generic byte arrays, improving type safety across ledger implementations. Consolidated API consistency across multiple ledger rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->