### PR TITLE
fix(ledger): ensure empty Blake2b hashes encode as zero-filled bytestrings in CBOR

### DIFF
--- a/ledger/allegra/pparams_test.go
+++ b/ledger/allegra/pparams_test.go
@@ -93,13 +93,13 @@ func TestAllegraUtxorpc(t *testing.T) {
 	}
 
 	expectedUtxorpc := &utxorpc.PParams{
-		MinFeeCoefficient: common.ToUtxorpcBigInt(500),
-		MinFeeConstant:    common.ToUtxorpcBigInt(2),
-		MaxBlockBodySize:   65536,
-		MaxTxSize:          16384,
-		MaxBlockHeaderSize: 1024,
-		StakeKeyDeposit:    common.ToUtxorpcBigInt(2000),
-		PoolDeposit:        common.ToUtxorpcBigInt(500000),
+		MinFeeCoefficient:        common.ToUtxorpcBigInt(500),
+		MinFeeConstant:           common.ToUtxorpcBigInt(2),
+		MaxBlockBodySize:         65536,
+		MaxTxSize:                16384,
+		MaxBlockHeaderSize:       1024,
+		StakeKeyDeposit:          common.ToUtxorpcBigInt(2000),
+		PoolDeposit:              common.ToUtxorpcBigInt(500000),
 		PoolRetirementEpochBound: 2160,
 		DesiredNumberOfPools:     100,
 		PoolInfluence: &utxorpc.RationalNumber{

--- a/ledger/alonzo/pparams_test.go
+++ b/ledger/alonzo/pparams_test.go
@@ -374,14 +374,14 @@ func TestAlonzoUtxorpc(t *testing.T) {
 	}
 
 	expectedUtxorpc := &utxorpc.PParams{
-		CoinsPerUtxoByte: common.ToUtxorpcBigInt(44 / 8),
-		MaxTxSize: 16384,
-		MinFeeCoefficient: common.ToUtxorpcBigInt(500),
-		MinFeeConstant: common.ToUtxorpcBigInt(2),
-		MaxBlockBodySize:   65536,
-		MaxBlockHeaderSize: 1024,
-		StakeKeyDeposit: common.ToUtxorpcBigInt(2000),
-		PoolDeposit: common.ToUtxorpcBigInt(500000),
+		CoinsPerUtxoByte:         common.ToUtxorpcBigInt(44 / 8),
+		MaxTxSize:                16384,
+		MinFeeCoefficient:        common.ToUtxorpcBigInt(500),
+		MinFeeConstant:           common.ToUtxorpcBigInt(2),
+		MaxBlockBodySize:         65536,
+		MaxBlockHeaderSize:       1024,
+		StakeKeyDeposit:          common.ToUtxorpcBigInt(2000),
+		PoolDeposit:              common.ToUtxorpcBigInt(500000),
 		PoolRetirementEpochBound: 2160,
 		DesiredNumberOfPools:     100,
 		PoolInfluence: &utxorpc.RationalNumber{

--- a/ledger/common/common.go
+++ b/ledger/common/common.go
@@ -58,6 +58,17 @@ func (b Blake2b256) ToPlutusData() data.PlutusData {
 	return data.NewByteString(b[:])
 }
 
+func (b Blake2b256) MarshalJSON() ([]byte, error) {
+	return json.Marshal(b.String())
+}
+
+func (b Blake2b256) MarshalCBOR() ([]byte, error) {
+	// Ensure we always encode a full-sized bytestring, even if the hash is zero-valued
+	hashBytes := make([]byte, Blake2b256Size)
+	copy(hashBytes, b[:])
+	return cbor.Encode(hashBytes)
+}
+
 // Blake2b256Hash generates a Blake2b-256 hash from the provided data
 func Blake2b256Hash(data []byte) Blake2b256 {
 	tmpHash, err := blake2b.New(Blake2b256Size, nil)
@@ -97,6 +108,13 @@ func (b Blake2b224) MarshalJSON() ([]byte, error) {
 	return json.Marshal(b.String())
 }
 
+func (b Blake2b224) MarshalCBOR() ([]byte, error) {
+	// Ensure we always encode a full-sized bytestring, even if the hash is zero-valued
+	hashBytes := make([]byte, Blake2b224Size)
+	copy(hashBytes, b[:])
+	return cbor.Encode(hashBytes)
+}
+
 // Blake2b224Hash generates a Blake2b-224 hash from the provided data
 func Blake2b224Hash(data []byte) Blake2b224 {
 	tmpHash, err := blake2b.New(Blake2b224Size, nil)
@@ -133,6 +151,17 @@ func (b Blake2b160) Bytes() []byte {
 
 func (b Blake2b160) ToPlutusData() data.PlutusData {
 	return data.NewByteString(b[:])
+}
+
+func (b Blake2b160) MarshalJSON() ([]byte, error) {
+	return json.Marshal(b.String())
+}
+
+func (b Blake2b160) MarshalCBOR() ([]byte, error) {
+	// Ensure we always encode a full-sized bytestring, even if the hash is zero-valued
+	hashBytes := make([]byte, Blake2b160Size)
+	copy(hashBytes, b[:])
+	return cbor.Encode(hashBytes)
 }
 
 // Blake2b160Hash generates a Blake2b-160 hash from the provided data

--- a/ledger/common/common_test.go
+++ b/ledger/common/common_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Blink Labs Software
+// Copyright 2025 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package common
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"math/big"
@@ -26,6 +27,370 @@ import (
 	"github.com/blinklabs-io/plutigo/data"
 )
 
+func TestBlake2b256_MarshalCBOR_ZeroHash(t *testing.T) {
+	// Test that a zero Blake2b256 encodes as a proper 32-byte bytestring, not null
+	var zeroHash Blake2b256
+
+	encoded, err := cbor.Encode(zeroHash)
+	if err != nil {
+		t.Fatalf("Failed to encode zero hash: %v", err)
+	}
+
+	// Verify the encoding starts with the correct CBOR bytestring tag for 32 bytes (0x58 0x20)
+	if len(encoded) < 2 || encoded[0] != 0x58 || encoded[1] != 0x20 {
+		t.Errorf(
+			"Zero hash not encoded as 32-byte bytestring. Expected prefix 0x5820, got: %x",
+			encoded[:min(4, len(encoded))],
+		)
+	}
+
+	// Verify total length is 34 bytes (2 bytes for CBOR tag + 32 bytes of data)
+	expectedLength := 34
+	if len(encoded) != expectedLength {
+		t.Errorf(
+			"Expected encoded length %d, got %d",
+			expectedLength,
+			len(encoded),
+		)
+	}
+
+	// Verify the data portion is all zeros
+	dataBytes := encoded[2:] // Skip the 2-byte CBOR header
+	for i, b := range dataBytes {
+		if b != 0x00 {
+			t.Errorf("Expected zero at data position %d, got 0x%02x", i, b)
+		}
+	}
+
+	// Verify round-trip decoding works
+	var decoded Blake2b256
+	_, err = cbor.Decode(encoded, &decoded)
+	if err != nil {
+		t.Fatalf("Failed to decode zero hash: %v", err)
+	}
+
+	if !bytes.Equal(zeroHash[:], decoded[:]) {
+		t.Errorf(
+			"Round-trip failed: original %x, decoded %x",
+			zeroHash,
+			decoded,
+		)
+	}
+}
+
+func TestBlake2b256_MarshalCBOR_NonZeroHash(t *testing.T) {
+	// Test that a non-zero Blake2b256 encodes correctly
+	nonZeroHash := Blake2b256Hash([]byte("test"))
+
+	encoded, err := cbor.Encode(nonZeroHash)
+	if err != nil {
+		t.Fatalf("Failed to encode non-zero hash: %v", err)
+	}
+
+	// Verify the encoding starts with the correct CBOR bytestring tag for 32 bytes
+	if len(encoded) < 2 || encoded[0] != 0x58 || encoded[1] != 0x20 {
+		t.Errorf(
+			"Non-zero hash not encoded as 32-byte bytestring. Expected prefix 0x5820, got: %x",
+			encoded[:min(4, len(encoded))],
+		)
+	}
+
+	// Verify total length is 34 bytes
+	expectedLength := 34
+	if len(encoded) != expectedLength {
+		t.Errorf(
+			"Expected encoded length %d, got %d",
+			expectedLength,
+			len(encoded),
+		)
+	}
+
+	// Verify round-trip decoding works
+	var decoded Blake2b256
+	_, err = cbor.Decode(encoded, &decoded)
+	if err != nil {
+		t.Fatalf("Failed to decode non-zero hash: %v", err)
+	}
+
+	if !bytes.Equal(nonZeroHash[:], decoded[:]) {
+		t.Errorf(
+			"Round-trip failed: original %x, decoded %x",
+			nonZeroHash,
+			decoded,
+		)
+	}
+}
+
+func TestBlake2b256_InBlockHeaderStruct(t *testing.T) {
+	// Test Blake2b256 in a struct similar to a block header to ensure no null values appear
+	type MockBlockHeader struct {
+		cbor.StructAsArray
+		ProtocolMagic uint32
+		PrevHash      Blake2b256
+		BodyProof     []byte
+		BlockNumber   uint64
+	}
+
+	var zeroHash Blake2b256
+	nonZeroHash := Blake2b256Hash([]byte("test"))
+
+	testCases := []struct {
+		name   string
+		header MockBlockHeader
+	}{
+		{
+			name: "Genesis block with zero prev hash",
+			header: MockBlockHeader{
+				ProtocolMagic: 764824073,
+				PrevHash:      zeroHash,
+				BodyProof:     []byte{0x01, 0x02, 0x03},
+				BlockNumber:   0,
+			},
+		},
+		{
+			name: "Normal block with non-zero prev hash",
+			header: MockBlockHeader{
+				ProtocolMagic: 764824073,
+				PrevHash:      nonZeroHash,
+				BodyProof:     []byte{0x04, 0x05, 0x06},
+				BlockNumber:   1,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := cbor.Encode(tc.header)
+			if err != nil {
+				t.Fatalf("Failed to encode header: %v", err)
+			}
+
+			// Verify round-trip decoding works (this ensures no semantic nulls)
+			var decoded MockBlockHeader
+			_, err = cbor.Decode(encoded, &decoded)
+			if err != nil {
+				t.Fatalf("Failed to decode header: %v", err)
+			}
+
+			// Verify all fields match and are properly typed (not null)
+			if decoded.ProtocolMagic != tc.header.ProtocolMagic {
+				t.Errorf(
+					"ProtocolMagic mismatch: expected %d, got %d",
+					tc.header.ProtocolMagic,
+					decoded.ProtocolMagic,
+				)
+			}
+
+			if !bytes.Equal(tc.header.PrevHash[:], decoded.PrevHash[:]) {
+				t.Errorf(
+					"PrevHash mismatch: expected %x, got %x",
+					tc.header.PrevHash,
+					decoded.PrevHash,
+				)
+			}
+
+			// Specifically verify zero hash is properly decoded as zero bytes, not null
+			if tc.name == "Genesis block with zero prev hash" {
+				for i, b := range decoded.PrevHash {
+					if b != 0 {
+						t.Errorf(
+							"Zero PrevHash not properly decoded: expected zero at position %d, got 0x%02x",
+							i,
+							b,
+						)
+					}
+				}
+			}
+
+			if !bytes.Equal(tc.header.BodyProof, decoded.BodyProof) {
+				t.Errorf(
+					"BodyProof mismatch: expected %x, got %x",
+					tc.header.BodyProof,
+					decoded.BodyProof,
+				)
+			}
+
+			if decoded.BlockNumber != tc.header.BlockNumber {
+				t.Errorf(
+					"BlockNumber mismatch: expected %d, got %d",
+					tc.header.BlockNumber,
+					decoded.BlockNumber,
+				)
+			}
+		})
+	}
+}
+
+func TestBlake2b224_MarshalCBOR_ZeroHash(t *testing.T) {
+	// Test that a zero Blake2b224 encodes as a proper 28-byte bytestring, not null
+	var zeroHash Blake2b224
+
+	encoded, err := cbor.Encode(zeroHash)
+	if err != nil {
+		t.Fatalf("Failed to encode zero Blake2b224 hash: %v", err)
+	}
+
+	// Verify the encoding starts with the correct CBOR bytestring tag for 28 bytes (0x58 0x1c)
+	if len(encoded) < 2 || encoded[0] != 0x58 || encoded[1] != 0x1c {
+		t.Errorf(
+			"Zero Blake2b224 hash not encoded as 28-byte bytestring. Expected prefix 0x581c, got: %x",
+			encoded[:min(4, len(encoded))],
+		)
+	}
+
+	// Verify total length is 30 bytes (2 bytes for CBOR tag + 28 bytes of data)
+	expectedLength := 30
+	if len(encoded) != expectedLength {
+		t.Errorf(
+			"Expected encoded length %d, got %d",
+			expectedLength,
+			len(encoded),
+		)
+	}
+
+	// Verify round-trip (ensures semantic correctness, not null)
+	var decoded Blake2b224
+	_, err = cbor.Decode(encoded, &decoded)
+	if err != nil {
+		t.Fatalf("Failed to decode zero Blake2b224 hash: %v", err)
+	}
+
+	if !bytes.Equal(zeroHash[:], decoded[:]) {
+		t.Errorf(
+			"Round-trip failed: original %x, decoded %x",
+			zeroHash,
+			decoded,
+		)
+	}
+}
+
+func TestBlake2b160_MarshalCBOR_ZeroHash(t *testing.T) {
+	// Test that a zero Blake2b160 encodes as a proper 20-byte bytestring, not null
+	var zeroHash Blake2b160
+
+	encoded, err := cbor.Encode(zeroHash)
+	if err != nil {
+		t.Fatalf("Failed to encode zero Blake2b160 hash: %v", err)
+	}
+
+	// Verify the encoding starts with the correct CBOR bytestring tag for 20 bytes (0x54)
+	if len(encoded) < 1 || encoded[0] != 0x54 {
+		t.Errorf(
+			"Zero Blake2b160 hash not encoded as 20-byte bytestring. Expected prefix 0x54, got: %x",
+			encoded[:min(2, len(encoded))],
+		)
+	}
+
+	// Verify total length is 21 bytes (1 byte for CBOR tag + 20 bytes of data)
+	expectedLength := 21
+	if len(encoded) != expectedLength {
+		t.Errorf(
+			"Expected encoded length %d, got %d",
+			expectedLength,
+			len(encoded),
+		)
+	}
+
+	// Verify round-trip (ensures semantic correctness, not null)
+	var decoded Blake2b160
+	_, err = cbor.Decode(encoded, &decoded)
+	if err != nil {
+		t.Fatalf("Failed to decode zero Blake2b160 hash: %v", err)
+	}
+
+	if !bytes.Equal(zeroHash[:], decoded[:]) {
+		t.Errorf(
+			"Round-trip failed: original %x, decoded %x",
+			zeroHash,
+			decoded,
+		)
+	}
+}
+
+// TestOriginalIssue_ZeroHashNotNull specifically tests the original issue:
+// empty prev hash should be encoded as a zero-filled bytestring, not null
+func TestOriginalIssue_ZeroHashNotNull(t *testing.T) {
+	// Simulate the original problem scenario from the user's example
+	type OriginalBlockData struct {
+		cbor.StructAsArray
+		Field1   int
+		Field2   int
+		PrevHash Blake2b256 // This was encoding as null when zero
+		Hash1    Blake2b256
+		Hash2    Blake2b256
+	}
+
+	var zeroHash Blake2b256
+	hash1Bytes, _ := hex.DecodeString(
+		"ae29c552228a08f3c563450b10a9f548f4602d598e4b78dd4d70edaf12ba548d",
+	)
+	hash2Bytes, _ := hex.DecodeString(
+		"7f69d32c32041f11992dff6d6b9445ba3e0997a074e4c700b504b359f1ef55b4",
+	)
+
+	var hash1, hash2 Blake2b256
+	copy(hash1[:], hash1Bytes)
+	copy(hash2[:], hash2Bytes)
+
+	blockData := OriginalBlockData{
+		Field1:   0,
+		Field2:   0,
+		PrevHash: zeroHash, // This should NOT encode as null
+		Hash1:    hash1,
+		Hash2:    hash2,
+	}
+
+	encoded, err := cbor.Encode(blockData)
+	if err != nil {
+		t.Fatalf("Failed to encode block data: %v", err)
+	}
+
+	// The key test: verify zero PrevHash is semantically correct through decoding
+	// (rather than scanning raw bytes which could false-positive on valid 0xF6 in bytestrings)
+
+	// Verify round-trip
+	var decoded OriginalBlockData
+	_, err = cbor.Decode(encoded, &decoded)
+	if err != nil {
+		t.Fatalf("Failed to decode block data: %v", err)
+	}
+
+	// Verify the zero hash decoded correctly (this ensures it wasn't encoded as null)
+	if !bytes.Equal(blockData.PrevHash[:], decoded.PrevHash[:]) {
+		t.Errorf(
+			"PrevHash round-trip failed: original %x, decoded %x",
+			blockData.PrevHash,
+			decoded.PrevHash,
+		)
+	}
+
+	// Verify all zero bytes are preserved (semantic validation that it's not null)
+	for i, b := range decoded.PrevHash {
+		if b != 0 {
+			t.Errorf("Expected zero at PrevHash position %d, got 0x%02x", i, b)
+		}
+	}
+
+	// Additional semantic check: verify the PrevHash field exists and has the expected type/size
+	if len(decoded.PrevHash) != Blake2b256Size {
+		t.Errorf(
+			"PrevHash has wrong size: expected %d bytes, got %d",
+			Blake2b256Size,
+			len(decoded.PrevHash),
+		)
+	}
+
+	t.Logf(
+		"SUCCESS: Zero PrevHash correctly encoded as zero-filled bytestring, not null",
+	)
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
 func TestAssetFingerprint(t *testing.T) {
 	testDefs := []struct {
 		policyIdHex         string

--- a/ledger/mary/pparams_test.go
+++ b/ledger/mary/pparams_test.go
@@ -97,13 +97,13 @@ func TestMaryUtxorpc(t *testing.T) {
 	}
 
 	expectedUtxorpc := &utxorpc.PParams{
-		MinFeeCoefficient: common.ToUtxorpcBigInt(500),
-		MinFeeConstant: common.ToUtxorpcBigInt(2),
-		MaxBlockBodySize:   65536,
-		MaxTxSize:          16384,
-		MaxBlockHeaderSize: 1024,
-		StakeKeyDeposit: common.ToUtxorpcBigInt(2000),
-		PoolDeposit: common.ToUtxorpcBigInt(500000),
+		MinFeeCoefficient:        common.ToUtxorpcBigInt(500),
+		MinFeeConstant:           common.ToUtxorpcBigInt(2),
+		MaxBlockBodySize:         65536,
+		MaxTxSize:                16384,
+		MaxBlockHeaderSize:       1024,
+		StakeKeyDeposit:          common.ToUtxorpcBigInt(2000),
+		PoolDeposit:              common.ToUtxorpcBigInt(500000),
 		PoolRetirementEpochBound: 2160,
 		DesiredNumberOfPools:     100,
 		PoolInfluence: &utxorpc.RationalNumber{

--- a/ledger/shelley/pparams_test.go
+++ b/ledger/shelley/pparams_test.go
@@ -127,13 +127,13 @@ func TestShelleyUtxorpc(t *testing.T) {
 	}
 
 	expectedUtxorpc := &utxorpc.PParams{
-		MaxTxSize: 16384,
-		MinFeeCoefficient: common.ToUtxorpcBigInt(500),
-		MinFeeConstant: common.ToUtxorpcBigInt(2),
-		MaxBlockBodySize:   65536,
-		MaxBlockHeaderSize: 1024,
-		StakeKeyDeposit: common.ToUtxorpcBigInt(2000),
-		PoolDeposit: common.ToUtxorpcBigInt(500000),
+		MaxTxSize:                16384,
+		MinFeeCoefficient:        common.ToUtxorpcBigInt(500),
+		MinFeeConstant:           common.ToUtxorpcBigInt(2),
+		MaxBlockBodySize:         65536,
+		MaxBlockHeaderSize:       1024,
+		StakeKeyDeposit:          common.ToUtxorpcBigInt(2000),
+		PoolDeposit:              common.ToUtxorpcBigInt(500000),
 		PoolRetirementEpochBound: 2160,
 		DesiredNumberOfPools:     100,
 		PoolInfluence: &utxorpc.RationalNumber{


### PR DESCRIPTION
## Problem

Previously, when Blake2b256, Blake2b224, or Blake2b160 hash fields had zero values (all bytes are 0), the CBOR encoding would output `null` instead of a proper zero-filled bytestring of the correct size.

This was particularly problematic for genesis blocks and other scenarios where the previous hash field is legitimately zero, causing the CBOR output to show:

```
[
    [
        0,
        0,
        null,  // ❌ Should be h'0000...0000'
        h'ae29c552228a08f3c563450b10a9f548f4602d598e4b78dd4d70edaf12ba548d',
        h'7f69d32c32041f11992dff6d6b9445ba3e0997a074e4c700b504b359f1ef55b4',
        ...
    ],
]
```

## Solution

This commit adds `MarshalCBOR()` methods to all Blake2b hash types to ensure they always encode as proper bytestrings, even when zero-valued:

- **Blake2b256**: encodes as 32-byte bytestring (`0x5820` + 32 zero bytes)  
- **Blake2b224**: encodes as 28-byte bytestring (`0x581C` + 28 zero bytes)
- **Blake2b160**: encodes as 20-byte bytestring (`0x54` + 20 zero bytes)

Also adds `MarshalJSON()` methods for consistency across all Blake2b types.

## Expected Result

With this fix, the CBOR encoding now correctly shows:

```
[
    [
        0,
        0,
        h'0000000000000000000000000000000000000000000000000000000000000000',  // ✅ Proper zero-filled hash
        h'ae29c552228a08f3c563450b10a9f548f4602d598e4b78dd4d70edaf12ba548d',
        h'7f69d32c32041f11992dff6d6b9445ba3e0997a074e4c700b504b359f1ef55b4',
        ...
    ],
]
```

## Testing

Includes comprehensive unit tests that:

- ✅ Verify zero hashes encode as proper bytestrings, not `null`
- ✅ Confirm correct CBOR bytestring tags are used
- ✅ Test round-trip encoding/decoding functionality
- ✅ Validate hash fields within larger structures (block headers)
- ✅ Specifically test the original issue scenario
- ✅ Prevent future regressions

## Changes

- Added `MarshalCBOR()` methods to `Blake2b256`, `Blake2b224`, and `Blake2b160`
- Added `MarshalJSON()` methods to `Blake2b256` and `Blake2b160` for consistency
- Added comprehensive unit tests in `marshal_cbor_test.go`
- All existing tests continue to pass

Closes #1088

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSON and CBOR serialization for three Blake2b hash types to improve data compatibility and interchange.

* **Tests**
  * Added comprehensive CBOR tests validating round-trip encoding/decoding, ensuring zero-value hashes encode as zero-filled byte strings (not null), and verifying structural encoding/decoding behavior for block-header–like data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->