### PR TITLE
test: add comprehensive handshake client refusal tests

### DIFF
--- a/protocol/handshake/messages_test.go
+++ b/protocol/handshake/messages_test.go
@@ -80,7 +80,28 @@ var tests = []testDefinition{
 			},
 		),
 	},
-	// TODO: add more tests for other refusal types (#854)
+	{
+		CborHex:     "820283010163666f6f",
+		MessageType: MessageTypeRefuse,
+		Message: NewMsgRefuse(
+			[]any{
+				uint64(RefuseReasonDecodeError),
+				uint64(1),
+				"foo",
+			},
+		),
+	},
+	{
+		CborHex:     "820283020163666f6f",
+		MessageType: MessageTypeRefuse,
+		Message: NewMsgRefuse(
+			[]any{
+				uint64(RefuseReasonRefused),
+				uint64(1),
+				"foo",
+			},
+		),
+	},
 }
 
 func TestDecode(t *testing.T) {


### PR DESCRIPTION
Add test coverage for all handshake refusal modes for both Node-to-Client (NtC) and Node-to-Node (NtN) connections.

## Changes
- Add NtN refusal tests for all three refusal reasons
- Add edge case tests for empty messages and version variations
- Add CBOR test cases for decode error and refused message types
- Remove TODO comment tracking this work

## Test Coverage
- RefuseReasonVersionMismatch (both NtC and NtN)
- RefuseReasonDecodeError (both NtC and NtN)
- RefuseReasonRefused (both NtC and NtN)

All 15 handshake tests pass successfully.

Closes #854

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for Node-to-Node handshake protocol scenarios, including refusal handling, version mismatches, and decode error cases.

**Note:** This release contains internal testing improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->