### PR TITLE
refactor(ledger): put error at end of return

### DIFF
--- a/ledger/verify_block_test.go
+++ b/ledger/verify_block_test.go
@@ -50,7 +50,7 @@ func TestVerifyBlockBody(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err, isValid, _, _, _ := VerifyBlock(tc.blockHexCbor)
+			isValid, _, _, _, err := VerifyBlock(tc.blockHexCbor)
 			if tc.expectedValid != isValid {
 				t.Errorf("unexpected error: %v", err)
 			}


### PR DESCRIPTION
Signed-off-by: Chris Gianelloni <wolf31o2@blinklabs.io>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed block verification error handling so failures return consistent, reliable results.

* **Refactor**
  * Reordered verification outputs for clearer success/error signaling.
  * Adjusted header checks to prevent incorrect validations.

* **New Features**
  * Exposed additional block metadata fields for downstream use.

* **Tests**
  * Updated tests to align with new verification output ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->