### PR TITLE
fix(protocols): guard against empty leiosfetch messages

### DIFF
--- a/protocol/leiosfetch/server.go
+++ b/protocol/leiosfetch/server.go
@@ -104,6 +104,11 @@ func (s *Server) handleBlockRequest(msg protocol.Message) error {
 	if err != nil {
 		return err
 	}
+	if resp == nil {
+		return errors.New(
+			"received leios-fetch BlockRequest message but callback returned nil",
+		)
+	}
 	if err := s.SendMessage(resp); err != nil {
 		return err
 	}
@@ -133,6 +138,11 @@ func (s *Server) handleBlockTxsRequest(msg protocol.Message) error {
 	if err != nil {
 		return err
 	}
+	if resp == nil {
+		return errors.New(
+			"received leios-fetch BlockTxsRequest message but callback returned nil",
+		)
+	}
 	if err := s.SendMessage(resp); err != nil {
 		return err
 	}
@@ -159,6 +169,11 @@ func (s *Server) handleVotesRequest(msg protocol.Message) error {
 	)
 	if err != nil {
 		return err
+	}
+	if resp == nil {
+		return errors.New(
+			"received leios-fetch VotesRequest message but callback returned nil",
+		)
 	}
 	if err := s.SendMessage(resp); err != nil {
 		return err


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to block, block-transaction, and vote request handling to prevent sending nil/invalid responses. When an upstream callback supplies no response, the server now returns an error instead of proceeding, reducing the chance of invalid messages and improving stability and reliability during request processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->