### PR TITLE
fix(ledger): use amount for conway per CIP-0094

### DIFF
--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -502,6 +502,7 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 	var testInputAmount uint64 = 555666777
 	var testFee uint64 = 123456
 	var testStakeDeposit uint64 = 2_000_000
+	var testDepositAmount uint64 = 1_500_000
 	testOutputExactAmount := testInputAmount - testFee
 	testOutputUnderAmount := testOutputExactAmount - 999
 	testOutputOverAmount := testOutputExactAmount + 999
@@ -652,6 +653,136 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 				return
 			}
 			testErrType := shelley.ValueNotConservedUtxoError{}
+			assert.IsType(
+				t,
+				testErrType,
+				err,
+				"did not get expected error type: got %T, wanted %T",
+				err,
+				testErrType,
+			)
+		},
+	)
+	// CIP-0094 Registration certificate with valid deposit
+	t.Run(
+		"registration certificate valid deposit",
+		func(t *testing.T) {
+			testTx.Body.TxOutputs[0].OutputAmount.Amount = testOutputExactAmount - testDepositAmount // Subtract deposit from output
+			testTx.Body.TxCertificates = []common.CertificateWrapper{
+				{
+					Type: uint(common.CertificateTypeRegistration),
+					Certificate: &common.RegistrationCertificate{
+						StakeCredential: common.Credential{},
+						Amount:          int64(testDepositAmount),
+					},
+				},
+			}
+			err := conway.UtxoValidateValueNotConservedUtxo(
+				testTx,
+				testSlot,
+				testLedgerState,
+				testProtocolParams,
+			)
+			if err != nil {
+				t.Errorf(
+					"UtxoValidateValueNotConservedUtxo should succeed with valid registration deposit\n  got error: %v",
+					err,
+				)
+			}
+		},
+	)
+	// CIP-0094 Registration certificate with invalid deposit (zero)
+	t.Run(
+		"registration certificate invalid deposit zero",
+		func(t *testing.T) {
+			testTx.Body.TxOutputs[0].OutputAmount.Amount = testOutputExactAmount
+			testTx.Body.TxCertificates = []common.CertificateWrapper{
+				{
+					Type: uint(common.CertificateTypeRegistration),
+					Certificate: &common.RegistrationCertificate{
+						StakeCredential: common.Credential{},
+						Amount:          0,
+					},
+				},
+			}
+			err := conway.UtxoValidateValueNotConservedUtxo(
+				testTx,
+				testSlot,
+				testLedgerState,
+				testProtocolParams,
+			)
+			if err == nil {
+				t.Errorf(
+					"UtxoValidateValueNotConservedUtxo should fail with zero registration deposit",
+				)
+				return
+			}
+			testErrType := shelley.InvalidCertificateDepositError{}
+			assert.IsType(
+				t,
+				testErrType,
+				err,
+				"did not get expected error type: got %T, wanted %T",
+				err,
+				testErrType,
+			)
+		},
+	)
+	// CIP-0094 Deregistration certificate with valid refund
+	t.Run(
+		"deregistration certificate valid refund",
+		func(t *testing.T) {
+			testTx.Body.TxOutputs[0].OutputAmount.Amount = testOutputExactAmount + testDepositAmount // Add refund to output
+			testTx.Body.TxCertificates = []common.CertificateWrapper{
+				{
+					Type: uint(common.CertificateTypeDeregistration),
+					Certificate: &common.DeregistrationCertificate{
+						StakeCredential: common.Credential{},
+						Amount:          int64(testDepositAmount),
+					},
+				},
+			}
+			err := conway.UtxoValidateValueNotConservedUtxo(
+				testTx,
+				testSlot,
+				testLedgerState,
+				testProtocolParams,
+			)
+			if err != nil {
+				t.Errorf(
+					"UtxoValidateValueNotConservedUtxo should succeed with valid deregistration refund\n  got error: %v",
+					err,
+				)
+			}
+		},
+	)
+	// CIP-0094 Deregistration certificate with invalid refund (zero)
+	t.Run(
+		"deregistration certificate invalid refund zero",
+		func(t *testing.T) {
+			testTx.Body.TxOutputs[0].OutputAmount.Amount = testOutputExactAmount
+			testTx.Body.TxCertificates = []common.CertificateWrapper{
+				{
+					Type: uint(common.CertificateTypeDeregistration),
+					Certificate: &common.DeregistrationCertificate{
+						StakeCredential: common.Credential{},
+						Amount:          0,
+					},
+				},
+			}
+			err := conway.UtxoValidateValueNotConservedUtxo(
+				testTx,
+				testSlot,
+				testLedgerState,
+				testProtocolParams,
+			)
+			if err == nil {
+				t.Errorf(
+					"UtxoValidateValueNotConservedUtxo should fail with zero deregistration refund",
+				)
+				return
+			}
+			testErrType := shelley.InvalidCertificateDepositError{}
 			assert.IsType(
 				t,
 				testErrType,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate deposit and refund validation to ensure transactions properly validate amounts for registration and deregistration operations, rejecting invalid zero-deposit scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->