### PR TITLE
fix: don't activate protocol state timeout until after initial state

### DIFF
--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -524,6 +524,7 @@ func (p *Protocol) recvLoop() {
 
 func (p *Protocol) stateLoop(ch <-chan protocolStateTransition) {
 	var transitionTimer *time.Timer
+	var initialStateSet bool
 
 	setState := func(s State) {
 		// Disable any previous state transition timer
@@ -573,6 +574,11 @@ func (p *Protocol) stateLoop(ch <-chan protocolStateTransition) {
 			}
 		}
 
+		// Don't activate timeouts on initial protocol state
+		if !initialStateSet {
+			return
+		}
+
 		// Set timeout for state transition
 		if p.config.StateMap[s].Timeout > 0 {
 			transitionTimer = time.NewTimer(
@@ -587,7 +593,9 @@ func (p *Protocol) stateLoop(ch <-chan protocolStateTransition) {
 		return transitionTimer.C
 	}
 
+	// Set initial state
 	setState(p.config.InitialState)
+	initialStateSet = true
 
 	for {
 		select {


### PR DESCRIPTION
Fixes #1262

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delay activation of protocol state timeouts until after the initial state is set to prevent premature transitions on startup. Fixes #1262.

- **Bug Fixes**
  - Added an initialStateSet guard so no timeout is scheduled during the initial protocol state.
  - Ensures stable startup by avoiding unintended timeouts immediately after initialization.

<sup>Written for commit 2f135b8e7c414934bd6c92d78e7a0494e7a7e826. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed state transition handling during protocol initialization to prevent premature timeout activation, ensuring smoother startup and more reliable state management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->