### PR TITLE
feat(ledger): leios endorser block body

### DIFF
--- a/ledger/leios/leios_test.go
+++ b/ledger/leios/leios_test.go
@@ -120,9 +120,11 @@ func TestLeiosRankingBlock_Era(t *testing.T) {
 
 func TestLeiosEndorserBlock_Hash(t *testing.T) {
 	block := &LeiosEndorserBlock{
-		TxReferences: map[common.Blake2b256]uint16{
-			{0x01, 0x02}: 100,
-			{0x03, 0x04}: 200,
+		Body: &LeiosEndorserBlockBody{
+			TxReferences: map[common.Blake2b256]uint16{
+				{0x01, 0x02}: 100,
+				{0x03, 0x04}: 200,
+			},
 		},
 	}
 	hash := block.Hash()
@@ -161,9 +163,11 @@ func TestLeiosBlockHeader_Hash(t *testing.T) {
 
 func TestLeiosEndorserBlock_CborRoundTrip(t *testing.T) {
 	original := &LeiosEndorserBlock{
-		TxReferences: map[common.Blake2b256]uint16{
-			{0x01, 0x02}: 100,
-			{0x03, 0x04}: 200,
+		Body: &LeiosEndorserBlockBody{
+			TxReferences: map[common.Blake2b256]uint16{
+				{0x01, 0x02}: 100,
+				{0x03, 0x04}: 200,
+			},
 		},
 	}
 
@@ -180,20 +184,23 @@ func TestLeiosEndorserBlock_CborRoundTrip(t *testing.T) {
 	}
 
 	// Check TxReferences
-	if len(decoded.TxReferences) != len(original.TxReferences) {
+	if original.Body == nil || decoded.Body == nil {
+		t.Fatal("Body is nil")
+	}
+	if len(decoded.Body.TxReferences) != len(original.Body.TxReferences) {
 		t.Errorf(
 			"TxReferences length mismatch: expected %d, got %d",
-			len(original.TxReferences),
-			len(decoded.TxReferences),
+			len(original.Body.TxReferences),
+			len(decoded.Body.TxReferences),
 		)
 	}
-	for hash, size := range original.TxReferences {
-		if decoded.TxReferences[hash] != size {
+	for hash, size := range original.Body.TxReferences {
+		if decoded.Body.TxReferences[hash] != size {
 			t.Errorf(
 				"TxReference mismatch for hash %x: expected %d, got %d",
 				hash,
 				size,
-				decoded.TxReferences[hash],
+				decoded.Body.TxReferences[hash],
 			)
 		}
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduces LeiosEndorserBlockBody to hold endorser block contents and compute a body hash. LeiosEndorserBlock now wraps Body, with nil-safe accessors and hashing, and tests updated accordingly.

- **New Features**
  - Added LeiosEndorserBlockBody with CBOR array encoding and BlockBodyHash().
  - LeiosEndorserBlock.BlockBodyHash() delegates to Body; returns zero hash if Body is nil.
  - Transactions() now reads from Body; tests updated to nest TxReferences under Body.

- **Migration**
  - Access TxReferences and transactions via b.Body (check for nil).
  - Use BlockBodyHash() for body-level hashing.

<sup>Written for commit 8b61a68347a66a6f0c5063532fb07692b85859b2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal block data organization for improved consistency.
  * Updated tests to reflect structural changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->