### PR TITLE
ci: use go 1.25

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,8 +16,7 @@ jobs:
     name: go-test
     strategy:
       matrix:
-        # TODO: go back to last 2 versions once 1.25 is released
-        go-version: [1.24.x]
+        go-version: [1.24.x, 1.25.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0 https://github.com/actions/checkout/releases/tag/v5.0.0
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0 https://github.com/actions/setup-go/releases/tag/v6.1.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: golangci-lint
         uses: golangci/golangci-lint-action@e7fa5ac41e1cf5b7d48e45e42232ce7ada589601 # v9.1.0 https://github.com/golangci/golangci-lint-action/releases/tag/v9.1.0


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update CI to include Go 1.25 to ensure compatibility with the latest release. Tests now run on Go 1.24.x and 1.25.x, and golangci-lint uses Go 1.25.x.

<sup>Written for commit 5f0e908be02c42b095742b6f34f678a8bb677e07. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to test against Go versions 1.24.x and 1.25.x in parallel, improving test coverage and compatibility verification across multiple toolchains.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->