### PR TITLE
feat: deterministic CBOR encoding for MultiAsset

### DIFF
--- a/ledger/common/common.go
+++ b/ledger/common/common.go
@@ -215,7 +215,9 @@ func (m *MultiAsset[T]) UnmarshalCBOR(data []byte) error {
 }
 
 func (m *MultiAsset[T]) MarshalCBOR() ([]byte, error) {
-	return cbor.Encode(&(m.data))
+	// The CBOR library is configured with SortCoreDeterministic, so direct encoding
+	// of the map produces deterministic output without manual sorting
+	return cbor.Encode(m.data)
 }
 
 func (m MultiAsset[T]) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes MultiAsset CBOR encoding deterministic by using the CBOR encoder’s deterministic map ordering, ensuring stable bytes across runs. Adds round-trip and repeat-encode tests to lock in byte-for-byte stability.

- **New Features**
  - MarshalCBOR now delegates to cbor.Encode with SortCoreDeterministic; no manual sorting.
  - Tests cover round-trips for outputs and mint (negative values), EncodeGeneric decode, and identical outputs across repeated encodes.
  - No API changes; JSON encoding remains unchanged.

<sup>Written for commit be7c3f876339d2446a9f94fb8d4de264ce9a5851. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CBOR serialization for multi-asset data is now deterministic — identical logical data produces consistent, reproducible serialized output.

* **Tests**
  * Added tests that verify encode→decode→re-encode round-trips and assert identical outputs across repeated encodings, covering multiple asset and policy scenarios to ensure serialization fidelity and determinism.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->