### PR TITLE
fix: ensure InvalidTransactions CBOR encoding uses indefinite-length arrays

### DIFF
--- a/ledger/common/common.go
+++ b/ledger/common/common.go
@@ -537,3 +537,47 @@ func ToUtxorpcBigInt(v uint64) *utxorpc.BigInt {
 		},
 	}
 }
+
+// convertUintSliceToAnySlice converts []uint to []any for CBOR encoding
+func ConvertUintSliceToAnySlice(uints []uint) []any {
+	result := make([]any, len(uints))
+	for i, v := range uints {
+		result[i] = v
+	}
+	return result
+}
+
+// ConvertAnySliceToUintSlice converts []any to []uint for internal use
+// Invalid entries (non-integers, negative numbers, or unreasonably large numbers) are skipped
+func ConvertAnySliceToUintSlice(anys []any) []uint {
+	const maxReasonableIndex = 1000000 // Reasonable upper bound for transaction indices
+	result := make([]uint, 0, len(anys))
+	for _, v := range anys {
+		switch val := v.(type) {
+		case uint:
+			if val > maxReasonableIndex {
+				continue // Skip unreasonably large indices
+			}
+			result = append(result, val)
+		case uint64:
+			if val > maxReasonableIndex {
+				continue // Skip unreasonably large indices
+			}
+			result = append(result, uint(val))
+		case int:
+			if val < 0 || val > maxReasonableIndex {
+				continue // Skip negative or unreasonably large indices
+			}
+			result = append(result, uint(val))
+		case int64:
+			if val < 0 || val > maxReasonableIndex {
+				continue // Skip negative or unreasonably large indices
+			}
+			result = append(result, uint(val))
+		default:
+			// Skip invalid types (strings, floats, etc.)
+			continue
+		}
+	}
+	return result
+}

--- a/ledger/common/common_test.go
+++ b/ledger/common/common_test.go
@@ -741,7 +741,10 @@ func TestMultiAssetCborRoundTrip(t *testing.T) {
 			// Test EncodeGeneric
 			encodedGeneric, err := cbor.EncodeGeneric(&test.multiAsset)
 			if err != nil {
-				t.Fatalf("Failed to encode MultiAsset with EncodeGeneric: %v", err)
+				t.Fatalf(
+					"Failed to encode MultiAsset with EncodeGeneric: %v",
+					err,
+				)
 			}
 
 			// EncodeGeneric may differ from Encode due to custom MarshalCBOR;
@@ -767,7 +770,9 @@ func TestMultiAssetCborRoundTrip(t *testing.T) {
 
 			// Check round-trip fidelity
 			if !bytes.Equal(encoded, reEncoded) {
-				t.Errorf("CBOR round-trip failed: original and re-encoded don't match")
+				t.Errorf(
+					"CBOR round-trip failed: original and re-encoded don't match",
+				)
 				t.Logf("Original:   %x", encoded)
 				t.Logf("Re-encoded: %x", reEncoded)
 			}
@@ -833,7 +838,10 @@ func TestMultiAssetCborRoundTripMint(t *testing.T) {
 			// Test EncodeGeneric
 			encodedGeneric, err := cbor.EncodeGeneric(&test.multiAsset)
 			if err != nil {
-				t.Fatalf("Failed to encode MultiAsset with EncodeGeneric: %v", err)
+				t.Fatalf(
+					"Failed to encode MultiAsset with EncodeGeneric: %v",
+					err,
+				)
 			}
 
 			// EncodeGeneric may differ from Encode due to custom MarshalCBOR;
@@ -859,7 +867,9 @@ func TestMultiAssetCborRoundTripMint(t *testing.T) {
 
 			// Check round-trip fidelity
 			if !bytes.Equal(encoded, reEncoded) {
-				t.Errorf("CBOR round-trip failed: original and re-encoded don't match")
+				t.Errorf(
+					"CBOR round-trip failed: original and re-encoded don't match",
+				)
 				t.Logf("Original:   %x", encoded)
 				t.Logf("Re-encoded: %x", reEncoded)
 			}

--- a/ledger/verify_block.go
+++ b/ledger/verify_block.go
@@ -296,7 +296,8 @@ func VerifyBlock(
 	if block.Era() != byron.EraByron {
 		rawCbor := block.Cbor()
 		if len(rawCbor) == 0 {
-			if allowMissingCbor && os.Getenv("GOUROBOROS_TEST_ALLOW_MISSING_CBOR") == "1" {
+			if allowMissingCbor &&
+				os.Getenv("GOUROBOROS_TEST_ALLOW_MISSING_CBOR") == "1" {
 				// Allow missing CBOR for tests only
 				isBodyValid = true
 			} else {

--- a/ledger/verify_block_test.go
+++ b/ledger/verify_block_test.go
@@ -48,7 +48,12 @@ func decodeTxBodies[T any](t *testing.T, txs []interface{}, label string) []T {
 		}
 		txBodyBytes := decodeTxBodyBytes(t, txArray[0])
 		if _, err := cbor.Decode(txBodyBytes, &bodies[i]); err != nil {
-			t.Fatalf("failed to decode %s transaction body %d: %v", label, i, err)
+			t.Fatalf(
+				"failed to decode %s transaction body %d: %v",
+				label,
+				i,
+				err,
+			)
 		}
 	}
 	return bodies
@@ -146,7 +151,11 @@ func TestVerifyBlockBody(t *testing.T) {
 			}
 			switch blockType {
 			case BlockTypeShelley:
-				transactionBodies := decodeTxBodies[shelley.ShelleyTransactionBody](t, txs, "Shelley")
+				transactionBodies := decodeTxBodies[shelley.ShelleyTransactionBody](
+					t,
+					txs,
+					"Shelley",
+				)
 				transactionMetadataSet := make(map[uint]*cbor.LazyValue)
 				shelleyHeader := header.(*shelley.ShelleyBlockHeader)
 				block = &shelley.ShelleyBlock{
@@ -159,7 +168,11 @@ func TestVerifyBlockBody(t *testing.T) {
 					TransactionMetadataSet: transactionMetadataSet,
 				}
 			case BlockTypeAllegra:
-				transactionBodies := decodeTxBodies[allegra.AllegraTransactionBody](t, txs, "Allegra")
+				transactionBodies := decodeTxBodies[allegra.AllegraTransactionBody](
+					t,
+					txs,
+					"Allegra",
+				)
 				transactionMetadataSet := make(map[uint]*cbor.LazyValue)
 				allegraHeader := header.(*allegra.AllegraBlockHeader)
 				block = &allegra.AllegraBlock{
@@ -172,7 +185,11 @@ func TestVerifyBlockBody(t *testing.T) {
 					TransactionMetadataSet: transactionMetadataSet,
 				}
 			case BlockTypeMary:
-				transactionBodies := decodeTxBodies[mary.MaryTransactionBody](t, txs, "Mary")
+				transactionBodies := decodeTxBodies[mary.MaryTransactionBody](
+					t,
+					txs,
+					"Mary",
+				)
 				transactionMetadataSet := make(map[uint]*cbor.LazyValue)
 				maryHeader := header.(*mary.MaryBlockHeader)
 				block = &mary.MaryBlock{
@@ -185,7 +202,11 @@ func TestVerifyBlockBody(t *testing.T) {
 					TransactionMetadataSet: transactionMetadataSet,
 				}
 			case BlockTypeAlonzo:
-				transactionBodies := decodeTxBodies[alonzo.AlonzoTransactionBody](t, txs, "Alonzo")
+				transactionBodies := decodeTxBodies[alonzo.AlonzoTransactionBody](
+					t,
+					txs,
+					"Alonzo",
+				)
 				transactionMetadataSet := make(map[uint]*cbor.LazyValue)
 				alonzoHeader := header.(*alonzo.AlonzoBlockHeader)
 				block = &alonzo.AlonzoBlock{
@@ -199,7 +220,11 @@ func TestVerifyBlockBody(t *testing.T) {
 					InvalidTransactions:    []uint{},
 				}
 			case BlockTypeBabbage:
-				transactionBodies := decodeTxBodies[babbage.BabbageTransactionBody](t, txs, "Babbage")
+				transactionBodies := decodeTxBodies[babbage.BabbageTransactionBody](
+					t,
+					txs,
+					"Babbage",
+				)
 				transactionMetadataSet := make(map[uint]*cbor.LazyValue)
 				babbageHeader := header.(*babbage.BabbageBlockHeader)
 				block = &babbage.BabbageBlock{
@@ -213,7 +238,11 @@ func TestVerifyBlockBody(t *testing.T) {
 					InvalidTransactions:    []uint{},
 				}
 			case BlockTypeConway:
-				transactionBodies := decodeTxBodies[conway.ConwayTransactionBody](t, txs, "Conway")
+				transactionBodies := decodeTxBodies[conway.ConwayTransactionBody](
+					t,
+					txs,
+					"Conway",
+				)
 				transactionMetadataSet := make(map[uint]*cbor.LazyValue)
 				conwayHeader := header.(*conway.ConwayBlockHeader)
 				block = &conway.ConwayBlock{


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures InvalidTransactions are encoded as CBOR indefinite-length arrays for Babbage and Conway blocks to match on-chain format and prevent serialization mismatches. Adds safe encode/decode helpers that skip invalid indices during unmarshaling.

- **Bug Fixes**
  - Implemented MarshalCBOR for Babbage and Conway to write InvalidTransactions as cbor.IndefLengthList; Unmarshal decodes []any and converts to []uint.
  - Added common helpers ConvertAnySliceToUintSlice and ConvertUintSliceToAnySlice to safely cast and skip bad values.

<sup>Written for commit 5c52396e84ee39fab228f9b3101a5bb6566dd270. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit CBOR marshaling support to block structures, enabling direct byte encoding independent of stored CBOR data.

* **Refactor**
  * Updated transaction index handling during CBOR encoding and decoding for improved compatibility; added conversion utilities for managing data type transformations.

* **Tests**
  * Improved test formatting and readability without functional changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->