### PR TITLE
test: replace reflect.DeepEqual with error comparison in CBOR tests

### DIFF
--- a/cbor/decode_test.go
+++ b/cbor/decode_test.go
@@ -109,7 +109,8 @@ func TestListLen(t *testing.T) {
 			t.Fatalf("failed to decode CBOR hex: %s", err)
 		}
 		listLen, err := cbor.ListLength(cborData)
-		if !reflect.DeepEqual(err, test.Error) {
+		if (err == nil) != (test.Error == nil) ||
+			(err != nil && test.Error != nil && err.Error() != test.Error.Error()) {
 			t.Fatalf(
 				"did not find expected error\n  got: %#v\n  wanted:  %#v",
 				err,
@@ -167,7 +168,8 @@ func TestDecodeIdFromList(t *testing.T) {
 			t.Fatalf("failed to decode CBOR hex: %s", err)
 		}
 		id, err := cbor.DecodeIdFromList(cborData)
-		if !reflect.DeepEqual(err, test.Error) {
+		if (err == nil) != (test.Error == nil) ||
+			(err != nil && test.Error != nil && err.Error() != test.Error.Error()) {
 			t.Fatalf(
 				"did not find expected error\n  got: %#v\n  wanted:  %#v",
 				err,
@@ -255,7 +257,8 @@ func TestDecodeById(t *testing.T) {
 			t.Fatalf("failed to decode CBOR hex: %s", err)
 		}
 		obj, err := cbor.DecodeById(cborData, decodeByIdObjectMap)
-		if !reflect.DeepEqual(err, test.Error) {
+		if (err == nil) != (test.Error == nil) ||
+			(err != nil && test.Error != nil && err.Error() != test.Error.Error()) {
 			t.Fatalf(
 				"did not find expected error\n  got: %#v\n  wanted:  %#v",
 				err,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced reflect.DeepEqual with direct error comparison in CBOR tests to correctly match expected errors and avoid brittle failures.
Updated tests for ListLength, DecodeIdFromList, and DecodeById to compare nilness and err.Error() strings.

<sup>Written for commit 03dc972d998a5399bb66ff4a31f05e73f7f1aaaf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced error validation in tests to robustly handle both nil and non-nil error comparisons, improving test reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->