### PR TITLE
perf: update benchmarks to use b.Loop()

### DIFF
--- a/ledger/alonzo/block_test.go
+++ b/ledger/alonzo/block_test.go
@@ -157,7 +157,7 @@ func TestAlonzoBlock_Utxorpc(t *testing.T) {
 func BenchmarkAlonzoBlockDeserialization(b *testing.B) {
 	blockCbor, _ := hex.DecodeString(alonzoBlockHex)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var block alonzo.AlonzoBlock
 		err := block.UnmarshalCBOR(blockCbor)
 		if err != nil {
@@ -174,7 +174,7 @@ func BenchmarkAlonzoBlockSerialization(b *testing.B) {
 		b.Fatal(err)
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = block.Cbor()
 	}
 }

--- a/ledger/babbage/block_test.go
+++ b/ledger/babbage/block_test.go
@@ -181,7 +181,7 @@ func TestBabbageBlock_Utxorpc(t *testing.T) {
 func BenchmarkBabbageBlockDeserialization(b *testing.B) {
 	blockCbor, _ := hex.DecodeString(babbageBlockHex)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var block babbage.BabbageBlock
 		err := block.UnmarshalCBOR(blockCbor)
 		if err != nil {
@@ -198,7 +198,7 @@ func BenchmarkBabbageBlockSerialization(b *testing.B) {
 		b.Fatal(err)
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = block.Cbor()
 	}
 }

--- a/ledger/conway/block_test.go
+++ b/ledger/conway/block_test.go
@@ -193,7 +193,7 @@ func compareByteSlices(a, b []byte) bool {
 func BenchmarkConwayBlockDeserialization(b *testing.B) {
 	blockCbor, _ := hex.DecodeString(conwayBlockHex)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var block conway.ConwayBlock
 		err := block.UnmarshalCBOR(blockCbor)
 		if err != nil {
@@ -210,7 +210,7 @@ func BenchmarkConwayBlockSerialization(b *testing.B) {
 		b.Fatal(err)
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = block.Cbor()
 	}
 }

--- a/ledger/shelley/block_test.go
+++ b/ledger/shelley/block_test.go
@@ -143,7 +143,7 @@ func TestShelleyBlockUtxorpc(t *testing.T) {
 func BenchmarkShelleyBlockDeserialization(b *testing.B) {
 	blockCbor, _ := hex.DecodeString(shelleyBlockHex)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		var block shelley.ShelleyBlock
 		err := block.UnmarshalCBOR(blockCbor)
 		if err != nil {
@@ -160,7 +160,7 @@ func BenchmarkShelleyBlockSerialization(b *testing.B) {
 		b.Fatal(err)
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = block.Cbor()
 	}
 }

--- a/ledger/tx_test.go
+++ b/ledger/tx_test.go
@@ -112,8 +112,9 @@ func TestMaryTransactionCborRoundTrip(t *testing.T) {
 
 func BenchmarkDetermineTransactionType_Conway(b *testing.B) {
 	txCbor, _ := hex.DecodeString(conwayTxCborHex)
+
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := ledger.DetermineTransactionType(txCbor)
 		if err != nil {
 			b.Fatal(err)
@@ -128,8 +129,9 @@ func BenchmarkDetermineTransactionType_Conway(b *testing.B) {
 
 func BenchmarkDetermineTransactionType_Byron(b *testing.B) {
 	txCbor, _ := hex.DecodeString(byronTxCborHex)
+
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := ledger.DetermineTransactionType(txCbor)
 		if err != nil {
 			b.Fatal(err)
@@ -139,8 +141,9 @@ func BenchmarkDetermineTransactionType_Byron(b *testing.B) {
 
 func BenchmarkTransactionDeserialization_Byron(b *testing.B) {
 	txCbor, _ := hex.DecodeString(byronTxCborHex)
+
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := ledger.NewByronTransactionFromCbor(txCbor)
 		if err != nil {
 			b.Fatal(err)
@@ -157,16 +160,18 @@ func BenchmarkTransactionSerialization_Byron(b *testing.B) {
 	if tx == nil {
 		b.Fatal("tx is nil")
 	}
+
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = tx.Cbor()
 	}
 }
 
 func BenchmarkTransactionDeserialization_Conway(b *testing.B) {
 	txCbor, _ := hex.DecodeString(conwayTxCborHex)
+
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := ledger.NewConwayTransactionFromCbor(txCbor)
 		if err != nil {
 			b.Fatal(err)
@@ -183,8 +188,9 @@ func BenchmarkTransactionSerialization_Conway(b *testing.B) {
 	if tx == nil {
 		b.Fatal("tx is nil")
 	}
+
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = tx.Cbor()
 	}
 }
@@ -192,7 +198,7 @@ func BenchmarkTransactionSerialization_Conway(b *testing.B) {
 func BenchmarkTransactionDeserialization_Shelley(b *testing.B) {
 	txCbor, _ := hex.DecodeString(shelleyTxCborHex)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := ledger.NewShelleyTransactionFromCbor(txCbor)
 		if err != nil {
 			b.Fatal(err)
@@ -207,7 +213,7 @@ func BenchmarkTransactionSerialization_Shelley(b *testing.B) {
 		b.Fatal(err)
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = tx.Cbor()
 	}
 }
@@ -215,7 +221,7 @@ func BenchmarkTransactionSerialization_Shelley(b *testing.B) {
 func BenchmarkTransactionDeserialization_Allegra(b *testing.B) {
 	txCbor, _ := hex.DecodeString(allegraTxCborHex)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := ledger.NewAllegraTransactionFromCbor(txCbor)
 		if err != nil {
 			b.Fatal(err)
@@ -230,7 +236,7 @@ func BenchmarkTransactionSerialization_Allegra(b *testing.B) {
 		b.Fatal(err)
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = tx.Cbor()
 	}
 }
@@ -238,7 +244,7 @@ func BenchmarkTransactionSerialization_Allegra(b *testing.B) {
 func BenchmarkTransactionDeserialization_Mary(b *testing.B) {
 	txCbor, _ := hex.DecodeString(maryTxCborHex)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := ledger.NewMaryTransactionFromCbor(txCbor)
 		if err != nil {
 			b.Fatal(err)
@@ -253,7 +259,7 @@ func BenchmarkTransactionSerialization_Mary(b *testing.B) {
 		b.Fatal(err)
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = tx.Cbor()
 	}
 }
@@ -261,7 +267,7 @@ func BenchmarkTransactionSerialization_Mary(b *testing.B) {
 func BenchmarkTransactionDeserialization_Alonzo(b *testing.B) {
 	txCbor, _ := hex.DecodeString(alonzoTxCborHex)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := ledger.NewAlonzoTransactionFromCbor(txCbor)
 		if err != nil {
 			b.Fatal(err)
@@ -276,7 +282,7 @@ func BenchmarkTransactionSerialization_Alonzo(b *testing.B) {
 		b.Fatal(err)
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = tx.Cbor()
 	}
 }
@@ -284,7 +290,7 @@ func BenchmarkTransactionSerialization_Alonzo(b *testing.B) {
 func BenchmarkTransactionDeserialization_Babbage(b *testing.B) {
 	txCbor, _ := hex.DecodeString(babbageTxCborHex)
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, err := ledger.NewBabbageTransactionFromCbor(txCbor)
 		if err != nil {
 			b.Fatal(err)
@@ -299,7 +305,7 @@ func BenchmarkTransactionSerialization_Babbage(b *testing.B) {
 		b.Fatal(err)
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = tx.Cbor()
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated ledger benchmarks to use b.Loop() for consistent iteration and lower loop overhead. Applies to block and transaction serialization/deserialization and transaction type detection benchmarks.

- **Refactors**
  - Replaced for i := 0; i < b.N; i++ with for b.Loop() {} across all relevant benchmarks, keeping b.ResetTimer() in place.

<sup>Written for commit be68a37275540dc9f4398b77a97a5e65dd09c0e8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated benchmark test patterns across multiple test suites to use modern iteration constructs, improving testing infrastructure consistency and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->