### PR TITLE
refactor: remove explicit type parameters from generic calls

### DIFF
--- a/cbor/value.go
+++ b/cbor/value.go
@@ -176,13 +176,13 @@ func generateAstJson(obj any) ([]byte, error) {
 	case WrappedCbor:
 		tmpJsonObj["bytes"] = hex.EncodeToString(v.Bytes())
 	case []any:
-		return generateAstJsonList[[]any](v)
+		return generateAstJsonList(v)
 	case Set:
-		return generateAstJsonList[Set](v)
+		return generateAstJsonList(v)
 	case map[any]any:
-		return generateAstJsonMap[map[any]any](v)
+		return generateAstJsonMap(v)
 	case Map:
-		return generateAstJsonMap[Map](v)
+		return generateAstJsonMap(v)
 	case Constructor:
 		return json.Marshal(obj)
 	case big.Int:

--- a/ledger/babbage/babbage_test.go
+++ b/ledger/babbage/babbage_test.go
@@ -2874,7 +2874,7 @@ func TestBabbageTransactionOutputToPlutusDataCoinOnly(t *testing.T) {
 func TestBabbageTransactionOutputToPlutusDataCoinAssets(t *testing.T) {
 	testAddr := "addr_test1vqg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygxrcya6"
 	var testAmount uint64 = 123_456_789
-	testAssets := common.NewMultiAsset[common.MultiAssetTypeOutput](
+	testAssets := common.NewMultiAsset(
 		map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{
 			common.NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
 				cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): 123456,
@@ -2980,7 +2980,7 @@ func TestBabbageTransactionOutputToPlutusDataCoinAssets(t *testing.T) {
 func TestBabbageTransactionOutputString(t *testing.T) {
 	addrStr := "addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd"
 	addr, _ := common.NewAddress(addrStr)
-	ma := common.NewMultiAsset[common.MultiAssetTypeOutput](
+	ma := common.NewMultiAsset(
 		map[common.Blake2b224]map[cbor.ByteString]uint64{
 			common.NewBlake2b224(make([]byte, 28)): {
 				cbor.NewByteString([]byte("x")): 2,

--- a/ledger/babbage/rules_test.go
+++ b/ledger/babbage/rules_test.go
@@ -751,7 +751,7 @@ func TestUtxoValidateOutputTooBigUtxo(t *testing.T) {
 			cbor.NewByteString(tmpAssetName): 1,
 		}
 	}
-	tmpBadMultiAsset := common.NewMultiAsset[common.MultiAssetTypeOutput](
+	tmpBadMultiAsset := common.NewMultiAsset(
 		tmpBadAssets,
 	)
 	var testOutputValueBad = mary.MaryTransactionOutputValue{
@@ -997,7 +997,7 @@ func TestUtxoValidateInsufficientCollateral(t *testing.T) {
 	t.Run(
 		"insufficient collateral",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+			testTx.Body.TxCollateral = cbor.NewSetType(
 				[]shelley.ShelleyTransactionInput{
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 				},
@@ -1030,7 +1030,7 @@ func TestUtxoValidateInsufficientCollateral(t *testing.T) {
 	t.Run(
 		"sufficient collateral",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+			testTx.Body.TxCollateral = cbor.NewSetType(
 				[]shelley.ShelleyTransactionInput{
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 					shelley.NewShelleyTransactionInput(testInputTxId, 1),
@@ -1067,14 +1067,14 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 			},
 		},
 	}
-	tmpMultiAsset := common.NewMultiAsset[common.MultiAssetTypeOutput](
+	tmpMultiAsset := common.NewMultiAsset(
 		map[common.Blake2b224]map[cbor.ByteString]uint64{
 			common.Blake2b224Hash([]byte("abcd")): {
 				cbor.NewByteString([]byte("efgh")): 123,
 			},
 		},
 	)
-	tmpZeroMultiAsset := common.NewMultiAsset[common.MultiAssetTypeOutput](
+	tmpZeroMultiAsset := common.NewMultiAsset(
 		map[common.Blake2b224]map[cbor.ByteString]uint64{
 			common.Blake2b224Hash([]byte("abcd")): {
 				cbor.NewByteString([]byte("efgh")): 0,
@@ -1115,7 +1115,7 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 	t.Run(
 		"coin and assets",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+			testTx.Body.TxCollateral = cbor.NewSetType(
 				[]shelley.ShelleyTransactionInput{
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 					shelley.NewShelleyTransactionInput(testInputTxId, 1),
@@ -1149,7 +1149,7 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 	t.Run(
 		"coin only",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+			testTx.Body.TxCollateral = cbor.NewSetType(
 				[]shelley.ShelleyTransactionInput{
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 				},
@@ -1173,7 +1173,7 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 	t.Run(
 		"coin and assets with return",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+			testTx.Body.TxCollateral = cbor.NewSetType(
 				[]shelley.ShelleyTransactionInput{
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 					shelley.NewShelleyTransactionInput(testInputTxId, 1),
@@ -1204,7 +1204,7 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 	t.Run(
 		"coin and zero assets with return",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+			testTx.Body.TxCollateral = cbor.NewSetType(
 				[]shelley.ShelleyTransactionInput{
 					shelley.NewShelleyTransactionInput(testInputTxId, 2),
 				},
@@ -1286,7 +1286,7 @@ func TestUtxoValidateNoCollateralInputs(t *testing.T) {
 	t.Run(
 		"collateral",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+			testTx.Body.TxCollateral = cbor.NewSetType(
 				[]shelley.ShelleyTransactionInput{
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 				},
@@ -1394,7 +1394,7 @@ func TestUtxoValidateCollateralEqBalance(t *testing.T) {
 	testTx := &babbage.BabbageTransaction{
 		Body: babbage.BabbageTransactionBody{
 			TxTotalCollateral: testTotalCollateral,
-			TxCollateral: cbor.NewSetType[shelley.ShelleyTransactionInput](
+			TxCollateral: cbor.NewSetType(
 				[]shelley.ShelleyTransactionInput{
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 				},
@@ -1515,7 +1515,7 @@ func TestUtxoValidateTooManyCollateralInputs(t *testing.T) {
 	t.Run(
 		"too many collateral inputs",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+			testTx.Body.TxCollateral = cbor.NewSetType(
 				[]shelley.ShelleyTransactionInput{
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 					shelley.NewShelleyTransactionInput(testInputTxId, 1),
@@ -1549,7 +1549,7 @@ func TestUtxoValidateTooManyCollateralInputs(t *testing.T) {
 	t.Run(
 		"single collateral input",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+			testTx.Body.TxCollateral = cbor.NewSetType(
 				[]shelley.ShelleyTransactionInput{
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 				},

--- a/ledger/conway/pparams_test.go
+++ b/ledger/conway/pparams_test.go
@@ -631,12 +631,12 @@ func TestConwayTransactionBody_Utxorpc(t *testing.T) {
 		OutputAddress: address,
 		OutputAmount:  mary.MaryTransactionOutputValue{Amount: 5000},
 	}
-	txCollateral := cbor.NewSetType[shelley.ShelleyTransactionInput](
+	txCollateral := cbor.NewSetType(
 		[]shelley.ShelleyTransactionInput{input},
 		false,
 	)
 	txTotalCollateral := uint64(200)
-	txReferenceInputs := cbor.NewSetType[shelley.ShelleyTransactionInput](
+	txReferenceInputs := cbor.NewSetType(
 		[]shelley.ShelleyTransactionInput{input},
 		false,
 	)
@@ -644,7 +644,7 @@ func TestConwayTransactionBody_Utxorpc(t *testing.T) {
 	txValidityIntervalStart := uint64(4000)
 	var signer common.Blake2b224
 	copy(signer[:], []byte{0xab, 0xcd, 0xef})
-	txRequiredSigners := cbor.NewSetType[common.Blake2b224](
+	txRequiredSigners := cbor.NewSetType(
 		[]common.Blake2b224{signer},
 		false,
 	)
@@ -715,12 +715,12 @@ func TestConwayTransaction_Utxorpc(t *testing.T) {
 		OutputAmount:  mary.MaryTransactionOutputValue{Amount: 5000},
 	}
 
-	txCollateral := cbor.NewSetType[shelley.ShelleyTransactionInput](
+	txCollateral := cbor.NewSetType(
 		[]shelley.ShelleyTransactionInput{input},
 		false,
 	)
 	txTotalCollateral := uint64(200)
-	txReferenceInputs := cbor.NewSetType[shelley.ShelleyTransactionInput](
+	txReferenceInputs := cbor.NewSetType(
 		[]shelley.ShelleyTransactionInput{input},
 		false,
 	)
@@ -728,7 +728,7 @@ func TestConwayTransaction_Utxorpc(t *testing.T) {
 	txValidityIntervalStart := uint64(4000)
 	var signer common.Blake2b224
 	copy(signer[:], []byte{0xab, 0xcd, 0xef})
-	txRequiredSigners := cbor.NewSetType[common.Blake2b224](
+	txRequiredSigners := cbor.NewSetType(
 		[]common.Blake2b224{signer},
 		false,
 	)

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -880,7 +880,7 @@ func TestUtxoValidateOutputTooBigUtxo(t *testing.T) {
 			cbor.NewByteString(tmpAssetName): 1,
 		}
 	}
-	tmpBadMultiAsset := common.NewMultiAsset[common.MultiAssetTypeOutput](
+	tmpBadMultiAsset := common.NewMultiAsset(
 		tmpBadAssets,
 	)
 	var testOutputValueBad = mary.MaryTransactionOutputValue{
@@ -1128,7 +1128,7 @@ func TestUtxoValidateInsufficientCollateral(t *testing.T) {
 	t.Run(
 		"insufficient collateral",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+			testTx.Body.TxCollateral = cbor.NewSetType(
 				[]shelley.ShelleyTransactionInput{
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 				},
@@ -1161,7 +1161,7 @@ func TestUtxoValidateInsufficientCollateral(t *testing.T) {
 	t.Run(
 		"sufficient collateral",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+			testTx.Body.TxCollateral = cbor.NewSetType(
 				[]shelley.ShelleyTransactionInput{
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 					shelley.NewShelleyTransactionInput(testInputTxId, 1),
@@ -1200,14 +1200,14 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 			},
 		},
 	}
-	tmpMultiAsset := common.NewMultiAsset[common.MultiAssetTypeOutput](
+	tmpMultiAsset := common.NewMultiAsset(
 		map[common.Blake2b224]map[cbor.ByteString]uint64{
 			common.Blake2b224Hash([]byte("abcd")): {
 				cbor.NewByteString([]byte("efgh")): 123,
 			},
 		},
 	)
-	tmpZeroMultiAsset := common.NewMultiAsset[common.MultiAssetTypeOutput](
+	tmpZeroMultiAsset := common.NewMultiAsset(
 		map[common.Blake2b224]map[cbor.ByteString]uint64{
 			common.Blake2b224Hash([]byte("abcd")): {
 				cbor.NewByteString([]byte("efgh")): 0,
@@ -1248,7 +1248,7 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 	t.Run(
 		"coin and assets",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+			testTx.Body.TxCollateral = cbor.NewSetType(
 				[]shelley.ShelleyTransactionInput{
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 					shelley.NewShelleyTransactionInput(testInputTxId, 1),
@@ -1282,7 +1282,7 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 	t.Run(
 		"coin only",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+			testTx.Body.TxCollateral = cbor.NewSetType(
 				[]shelley.ShelleyTransactionInput{
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 				},
@@ -1306,7 +1306,7 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 	t.Run(
 		"coin and assets with return",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+			testTx.Body.TxCollateral = cbor.NewSetType(
 				[]shelley.ShelleyTransactionInput{
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 					shelley.NewShelleyTransactionInput(testInputTxId, 1),
@@ -1337,7 +1337,7 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 	t.Run(
 		"coin and zero assets with return",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+			testTx.Body.TxCollateral = cbor.NewSetType(
 				[]shelley.ShelleyTransactionInput{
 					shelley.NewShelleyTransactionInput(testInputTxId, 2),
 				},
@@ -1421,7 +1421,7 @@ func TestUtxoValidateNoCollateralInputs(t *testing.T) {
 	t.Run(
 		"collateral",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+			testTx.Body.TxCollateral = cbor.NewSetType(
 				[]shelley.ShelleyTransactionInput{
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 				},
@@ -1541,7 +1541,7 @@ func TestUtxoValidateDisjointRefInputs(t *testing.T) {
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 				},
 			)
-			testTx.Body.TxReferenceInputs = cbor.NewSetType[shelley.ShelleyTransactionInput](
+			testTx.Body.TxReferenceInputs = cbor.NewSetType(
 				[]shelley.ShelleyTransactionInput{
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 				},
@@ -1579,7 +1579,7 @@ func TestUtxoValidateDisjointRefInputs(t *testing.T) {
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 				},
 			)
-			testTx.Body.TxReferenceInputs = cbor.NewSetType[shelley.ShelleyTransactionInput](
+			testTx.Body.TxReferenceInputs = cbor.NewSetType(
 				[]shelley.ShelleyTransactionInput{
 					shelley.NewShelleyTransactionInput(testInputTxId, 1),
 				},
@@ -1610,7 +1610,7 @@ func TestUtxoValidateCollateralEqBalance(t *testing.T) {
 	testTx := &conway.ConwayTransaction{
 		Body: conway.ConwayTransactionBody{
 			TxTotalCollateral: testTotalCollateral,
-			TxCollateral: cbor.NewSetType[shelley.ShelleyTransactionInput](
+			TxCollateral: cbor.NewSetType(
 				[]shelley.ShelleyTransactionInput{
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 				},
@@ -1704,7 +1704,7 @@ func TestUtxoValidateTooManyCollateralInputs(t *testing.T) {
 	t.Run(
 		"too many collateral inputs",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+			testTx.Body.TxCollateral = cbor.NewSetType(
 				[]shelley.ShelleyTransactionInput{
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 					shelley.NewShelleyTransactionInput(testInputTxId, 1),
@@ -1738,7 +1738,7 @@ func TestUtxoValidateTooManyCollateralInputs(t *testing.T) {
 	t.Run(
 		"single collateral input",
 		func(t *testing.T) {
-			testTx.Body.TxCollateral = cbor.NewSetType[shelley.ShelleyTransactionInput](
+			testTx.Body.TxCollateral = cbor.NewSetType(
 				[]shelley.ShelleyTransactionInput{
 					shelley.NewShelleyTransactionInput(testInputTxId, 0),
 				},

--- a/ledger/mary/mary_test.go
+++ b/ledger/mary/mary_test.go
@@ -37,7 +37,7 @@ func createMaryTransactionOutputValueAssets(
 	data[policyIdKey] = map[cbor.ByteString]uint64{
 		assetKey: amount,
 	}
-	ret := common.NewMultiAsset[common.MultiAssetTypeOutput](data)
+	ret := common.NewMultiAsset(data)
 	return &ret
 }
 
@@ -120,7 +120,7 @@ func TestMaryTransactionOutputValueEncodeDecode(t *testing.T) {
 func TestMaryTransactionOutputString(t *testing.T) {
 	addrStr := "addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd"
 	addr, _ := common.NewAddress(addrStr)
-	ma := common.NewMultiAsset[common.MultiAssetTypeOutput](
+	ma := common.NewMultiAsset(
 		map[common.Blake2b224]map[cbor.ByteString]uint64{
 			common.NewBlake2b224(make([]byte, 28)): {
 				cbor.NewByteString([]byte("token")): 2,

--- a/ledger/mary/rules_test.go
+++ b/ledger/mary/rules_test.go
@@ -748,7 +748,7 @@ func TestUtxoValidateOutputTooBigUtxo(t *testing.T) {
 			cbor.NewByteString(tmpAssetName): 1,
 		}
 	}
-	tmpBadMultiAsset := common.NewMultiAsset[common.MultiAssetTypeOutput](
+	tmpBadMultiAsset := common.NewMultiAsset(
 		tmpBadAssets,
 	)
 	var testOutputValueBad = mary.MaryTransactionOutputValue{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored generic calls to rely on type inference, removing explicit type parameters across CBOR helpers and ledger tests. No functional changes.

- **Refactors**
  - Simplified generateAstJsonList and generateAstJsonMap calls in cbor/value.go.
  - Removed [common.MultiAssetTypeOutput] from common.NewMultiAsset calls in Mary and Babbage tests.
  - Dropped explicit type args from cbor.NewSetType in collateral, reference inputs, and required signers across Babbage and Conway tests.

<sup>Written for commit 4bdef62e988bc8f66dd770cb69f278db0ef8dc88. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

