### PR TITLE
fix(ledger): metadata encoding/decoding

### DIFF
--- a/ledger/common/metadata.go
+++ b/ledger/common/metadata.go
@@ -170,7 +170,13 @@ func decodeMapUint(b []byte) (TransactionMetadatum, bool, error) {
 		if err != nil {
 			return nil, true, fmt.Errorf("decode map(uint) value: %w", err)
 		}
-		pairs = append(pairs, MetaPair{Key: MetaInt{Value: new(big.Int).SetUint64(uint64(k))}, Value: val})
+		pairs = append(
+			pairs,
+			MetaPair{
+				Key:   MetaInt{Value: new(big.Int).SetUint64(uint64(k))},
+				Value: val,
+			},
+		)
 	}
 	return MetaMap{Pairs: pairs}, true, nil
 }
@@ -221,7 +227,11 @@ func (s *TransactionMetadataSet) UnmarshalCBOR(cborData []byte) error {
 			for k, v := range tmp {
 				md, err := DecodeMetadatumRaw(v)
 				if err != nil {
-					return fmt.Errorf("decode metadata value for index %d: %w", k, err)
+					return fmt.Errorf(
+						"decode metadata value for index %d: %w",
+						k,
+						err,
+					)
 				}
 				out[k] = md
 			}
@@ -236,12 +246,17 @@ func (s *TransactionMetadataSet) UnmarshalCBOR(cborData []byte) error {
 			out := make(TransactionMetadataSet)
 			for i, raw := range arr {
 				var probe any
-				if _, err := cbor.Decode(raw, &probe); err == nil && probe == nil {
+				if _, err := cbor.Decode(raw, &probe); err == nil &&
+					probe == nil {
 					continue // skip nulls
 				}
 				md, err := DecodeMetadatumRaw(raw)
 				if err != nil {
-					return fmt.Errorf("decode metadata list item %d: %w", i, err)
+					return fmt.Errorf(
+						"decode metadata list item %d: %w",
+						i,
+						err,
+					)
 				}
 				out[uint(i)] = md // #nosec G115
 			}

--- a/ledger/common/metadata_test.go
+++ b/ledger/common/metadata_test.go
@@ -27,6 +27,10 @@ func Test_Metadata_RoundTrip_AllegraSample(t *testing.T) {
 	}
 
 	if hex.EncodeToString(enc) != allegraBlockHex {
-		t.Fatalf("mismatch:\n got: %s\nwant: %s", hex.EncodeToString(enc), allegraBlockHex)
+		t.Fatalf(
+			"mismatch:\n got: %s\nwant: %s",
+			hex.EncodeToString(enc),
+			allegraBlockHex,
+		)
 	}
 }

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -111,7 +111,20 @@ func (b *ConwayBlock) UnmarshalCBOR(cborData []byte) error {
 	b.BlockHeader = tmp.BlockHeader
 	b.TransactionBodies = tmp.TransactionBodies
 	b.TransactionWitnessSets = tmp.TransactionWitnessSets
-	b.TransactionMetadataSet = tmp.TransactionMetadataSet
+	// Decode TransactionMetadataSet from LazyValue to TransactionMetadatum
+	b.TransactionMetadataSet = make(
+		common.TransactionMetadataSet,
+		len(tmp.TransactionMetadataSet),
+	)
+	for k, lv := range tmp.TransactionMetadataSet {
+		if lv != nil {
+			md, err := common.DecodeMetadatumRaw(lv.Cbor())
+			if err != nil {
+				return fmt.Errorf("decode metadata for index %d: %w", k, err)
+			}
+			b.TransactionMetadataSet[k] = md
+		}
+	}
 
 	b.SetCbor(cborData)
 	return nil
@@ -131,7 +144,7 @@ func (b *ConwayBlock) MarshalCBOR() ([]byte, error) {
 		BlockHeader            *ConwayBlockHeader
 		TransactionBodies      []ConwayTransactionBody
 		TransactionWitnessSets []ConwayTransactionWitnessSet
-		TransactionMetadataSet map[uint]*cbor.LazyValue
+		TransactionMetadataSet common.TransactionMetadataSet
 		InvalidTransactions    cbor.IndefLengthList
 	}
 

--- a/ledger/verify_block_test.go
+++ b/ledger/verify_block_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/allegra"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
@@ -157,6 +158,21 @@ func TestVerifyBlockBody(t *testing.T) {
 					"Shelley",
 				)
 				transactionMetadataSet := make(map[uint]*cbor.LazyValue)
+				// Decode metadata
+				metadataSet := make(common.TransactionMetadataSet)
+				for k, lv := range transactionMetadataSet {
+					if lv != nil {
+						md, err := common.DecodeMetadatumRaw(lv.Cbor())
+						if err != nil {
+							t.Fatalf(
+								"failed to decode Shelley metadata for index %d: %v",
+								k,
+								err,
+							)
+						}
+						metadataSet[k] = md
+					}
+				}
 				shelleyHeader := header.(*shelley.ShelleyBlockHeader)
 				block = &shelley.ShelleyBlock{
 					BlockHeader:       shelleyHeader,
@@ -165,7 +181,7 @@ func TestVerifyBlockBody(t *testing.T) {
 						[]shelley.ShelleyTransactionWitnessSet,
 						len(txs),
 					),
-					TransactionMetadataSet: transactionMetadataSet,
+					TransactionMetadataSet: metadataSet,
 				}
 			case BlockTypeAllegra:
 				transactionBodies := decodeTxBodies[allegra.AllegraTransactionBody](
@@ -174,6 +190,21 @@ func TestVerifyBlockBody(t *testing.T) {
 					"Allegra",
 				)
 				transactionMetadataSet := make(map[uint]*cbor.LazyValue)
+				// Decode metadata
+				metadataSet := make(common.TransactionMetadataSet)
+				for k, lv := range transactionMetadataSet {
+					if lv != nil {
+						md, err := common.DecodeMetadatumRaw(lv.Cbor())
+						if err != nil {
+							t.Fatalf(
+								"failed to decode Allegra metadata for index %d: %v",
+								k,
+								err,
+							)
+						}
+						metadataSet[k] = md
+					}
+				}
 				allegraHeader := header.(*allegra.AllegraBlockHeader)
 				block = &allegra.AllegraBlock{
 					BlockHeader:       allegraHeader,
@@ -182,7 +213,7 @@ func TestVerifyBlockBody(t *testing.T) {
 						[]shelley.ShelleyTransactionWitnessSet,
 						len(txs),
 					),
-					TransactionMetadataSet: transactionMetadataSet,
+					TransactionMetadataSet: metadataSet,
 				}
 			case BlockTypeMary:
 				transactionBodies := decodeTxBodies[mary.MaryTransactionBody](
@@ -191,6 +222,21 @@ func TestVerifyBlockBody(t *testing.T) {
 					"Mary",
 				)
 				transactionMetadataSet := make(map[uint]*cbor.LazyValue)
+				// Decode metadata
+				metadataSet := make(common.TransactionMetadataSet)
+				for k, lv := range transactionMetadataSet {
+					if lv != nil {
+						md, err := common.DecodeMetadatumRaw(lv.Cbor())
+						if err != nil {
+							t.Fatalf(
+								"failed to decode Mary metadata for index %d: %v",
+								k,
+								err,
+							)
+						}
+						metadataSet[k] = md
+					}
+				}
 				maryHeader := header.(*mary.MaryBlockHeader)
 				block = &mary.MaryBlock{
 					BlockHeader:       maryHeader,
@@ -199,7 +245,7 @@ func TestVerifyBlockBody(t *testing.T) {
 						[]shelley.ShelleyTransactionWitnessSet,
 						len(txs),
 					),
-					TransactionMetadataSet: transactionMetadataSet,
+					TransactionMetadataSet: metadataSet,
 				}
 			case BlockTypeAlonzo:
 				transactionBodies := decodeTxBodies[alonzo.AlonzoTransactionBody](
@@ -208,6 +254,21 @@ func TestVerifyBlockBody(t *testing.T) {
 					"Alonzo",
 				)
 				transactionMetadataSet := make(map[uint]*cbor.LazyValue)
+				// Decode metadata
+				metadataSet := make(common.TransactionMetadataSet)
+				for k, lv := range transactionMetadataSet {
+					if lv != nil {
+						md, err := common.DecodeMetadatumRaw(lv.Cbor())
+						if err != nil {
+							t.Fatalf(
+								"failed to decode Alonzo metadata for index %d: %v",
+								k,
+								err,
+							)
+						}
+						metadataSet[k] = md
+					}
+				}
 				alonzoHeader := header.(*alonzo.AlonzoBlockHeader)
 				block = &alonzo.AlonzoBlock{
 					BlockHeader:       alonzoHeader,
@@ -216,7 +277,7 @@ func TestVerifyBlockBody(t *testing.T) {
 						[]alonzo.AlonzoTransactionWitnessSet,
 						len(txs),
 					),
-					TransactionMetadataSet: transactionMetadataSet,
+					TransactionMetadataSet: metadataSet,
 					InvalidTransactions:    []uint{},
 				}
 			case BlockTypeBabbage:
@@ -226,6 +287,21 @@ func TestVerifyBlockBody(t *testing.T) {
 					"Babbage",
 				)
 				transactionMetadataSet := make(map[uint]*cbor.LazyValue)
+				// Decode metadata
+				metadataSet := make(common.TransactionMetadataSet)
+				for k, lv := range transactionMetadataSet {
+					if lv != nil {
+						md, err := common.DecodeMetadatumRaw(lv.Cbor())
+						if err != nil {
+							t.Fatalf(
+								"failed to decode Babbage metadata for index %d: %v",
+								k,
+								err,
+							)
+						}
+						metadataSet[k] = md
+					}
+				}
 				babbageHeader := header.(*babbage.BabbageBlockHeader)
 				block = &babbage.BabbageBlock{
 					BlockHeader:       babbageHeader,
@@ -234,7 +310,7 @@ func TestVerifyBlockBody(t *testing.T) {
 						[]babbage.BabbageTransactionWitnessSet,
 						len(txs),
 					),
-					TransactionMetadataSet: transactionMetadataSet,
+					TransactionMetadataSet: metadataSet,
 					InvalidTransactions:    []uint{},
 				}
 			case BlockTypeConway:
@@ -244,6 +320,21 @@ func TestVerifyBlockBody(t *testing.T) {
 					"Conway",
 				)
 				transactionMetadataSet := make(map[uint]*cbor.LazyValue)
+				// Decode metadata
+				metadataSet := make(common.TransactionMetadataSet)
+				for k, lv := range transactionMetadataSet {
+					if lv != nil {
+						md, err := common.DecodeMetadatumRaw(lv.Cbor())
+						if err != nil {
+							t.Fatalf(
+								"failed to decode Conway metadata for index %d: %v",
+								k,
+								err,
+							)
+						}
+						metadataSet[k] = md
+					}
+				}
 				conwayHeader := header.(*conway.ConwayBlockHeader)
 				block = &conway.ConwayBlock{
 					BlockHeader:       conwayHeader,
@@ -252,7 +343,7 @@ func TestVerifyBlockBody(t *testing.T) {
 						[]conway.ConwayTransactionWitnessSet,
 						len(txs),
 					),
-					TransactionMetadataSet: transactionMetadataSet,
+					TransactionMetadataSet: metadataSet,
 					InvalidTransactions:    []uint{},
 				}
 			default:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes metadata encoding/decoding by converting CBOR LazyValue entries to TransactionMetadatum and tightening metadata parsing. Prevents incorrect block metadata and flaky tests across eras.

- **Bug Fixes**
  - Decode TransactionMetadataSet from LazyValue in Babbage and Conway UnmarshalCBOR; use common.TransactionMetadataSet in MarshalCBOR.
  - Improve TransactionMetadataSet Unmarshal in common to handle nulls and map(uint) values with clearer errors.
  - Update block verification tests to decode metadata for Shelley through Conway, ensuring consistent round-trip encoding.

<sup>Written for commit 656f7c544cb15225af48cd887e282af57bb7ea90. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transaction metadata handling with improved error reporting and per-item error context.
  * Implemented bounds validation for invalid transaction entries to prevent out-of-range values.
  * Strengthened metadata decoding with explicit error handling and null-value skipping across all ledger eras.

* **Tests**
  * Updated and expanded transaction metadata processing tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->