### PR TITLE
fix(ledger): encode invalid tx in conway/babbage

### DIFF
--- a/ledger/babbage/block_test.go
+++ b/ledger/babbage/block_test.go
@@ -48,6 +48,8 @@ func TestBabbageBlock_CborRoundTrip_UsingCborEncode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to unmarshal CBOR data into BabbageBlock: %v", err)
 	}
+	// Reset stored CBOR to nil
+	block.SetCbor(nil)
 
 	// Re-encode using the cbor Encode function
 	encoded, err := cbor.Encode(block)

--- a/ledger/conway/block_test.go
+++ b/ledger/conway/block_test.go
@@ -47,6 +47,8 @@ func TestConwayBlock_CborRoundTrip_UsingCborEncode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to unmarshal CBOR data into ConwayBlock: %v", err)
 	}
+	// Reset stored CBOR to nil
+	block.SetCbor(nil)
 
 	// Re-encode using the cbor Encode function
 	encoded, err := cbor.Encode(block)

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -105,7 +105,11 @@ func (b *ConwayBlock) UnmarshalCBOR(cborData []byte) error {
 			continue
 		}
 	}
-	b.InvalidTransactions = result
+	if len(result) == 0 {
+		b.InvalidTransactions = nil
+	} else {
+		b.InvalidTransactions = result
+	}
 
 	// Assign the other fields
 	b.BlockHeader = tmp.BlockHeader
@@ -136,36 +140,19 @@ func (b *ConwayBlock) MarshalCBOR() ([]byte, error) {
 		return b.Cbor(), nil
 	}
 
-	// When encoding from scratch, we need to ensure InvalidTransactions
-	// is encoded as indefinite-length to match on-chain format
-	// Create a temporary struct for encoding with the correct types
-	type tmpBlock struct {
-		cbor.StructAsArray
-		BlockHeader            *ConwayBlockHeader
-		TransactionBodies      []ConwayTransactionBody
-		TransactionWitnessSets []ConwayTransactionWitnessSet
-		TransactionMetadataSet common.TransactionMetadataSet
-		InvalidTransactions    cbor.IndefLengthList
+	// Ensure InvalidTransactions is encoded as empty array if nil
+	invalidTxs := b.InvalidTransactions
+	if invalidTxs == nil {
+		invalidTxs = []uint{}
 	}
 
-	// Convert InvalidTransactions to IndefLengthList
-	var invalidTx cbor.IndefLengthList
-	if b.InvalidTransactions != nil {
-		invalidTx = make(cbor.IndefLengthList, len(b.InvalidTransactions))
-		for i, tx := range b.InvalidTransactions {
-			invalidTx[i] = tx
-		}
-	}
-
-	tmp := tmpBlock{
-		BlockHeader:            b.BlockHeader,
-		TransactionBodies:      b.TransactionBodies,
-		TransactionWitnessSets: b.TransactionWitnessSets,
-		TransactionMetadataSet: b.TransactionMetadataSet,
-		InvalidTransactions:    invalidTx,
-	}
-
-	return cbor.Encode(&tmp)
+	return cbor.Encode([]any{
+		b.BlockHeader,
+		b.TransactionBodies,
+		b.TransactionWitnessSets,
+		b.TransactionMetadataSet,
+		invalidTxs,
+	})
 }
 
 func (ConwayBlock) Type() int {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes CBOR encoding of InvalidTransactions for Conway and Babbage blocks to always encode as an array (empty when nil) and to decode empty lists back to nil. This ensures correct on-chain compatibility and reliable round-trip encoding.

- **Bug Fixes**
  - MarshalCBOR now encodes InvalidTransactions as []uint, using an empty array when nil.
  - UnmarshalCBOR sets InvalidTransactions to nil when the decoded list is empty.
  - Simplified encoding by passing a fixed array of fields to cbor.Encode.
  - Tests reset stored CBOR before re-encoding to verify fresh encodes.

<sup>Written for commit d1091301e1e32b6c38e8fa481d35a6840880a2e1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid transactions during block serialization and deserialization to ensure consistent encoding behavior.
  * Simplified block encoding process for more reliable data serialization.

* **Tests**
  * Updated block serialization tests to verify proper handling of cached data during round-trip encoding operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->