### PR TITLE
test(ledger): empty block cbor for shelley/allegra round-trip test

### DIFF
--- a/ledger/allegra/block_test.go
+++ b/ledger/allegra/block_test.go
@@ -49,6 +49,8 @@ func TestAllegraBlock_CborRoundTrip_UsingCborEncode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to unmarshal CBOR data into AllegraBlock: %v", err)
 	}
+	// Reset stored CBOR to nil
+	block.SetCbor(nil)
 
 	// Re-encode using the cbor Encode function
 	encoded, err := cbor.Encode(block)

--- a/ledger/shelley/block_test.go
+++ b/ledger/shelley/block_test.go
@@ -48,6 +48,8 @@ func TestShelleyBlock_CborRoundTrip_UsingCborEncode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to unmarshal CBOR data into ShelleyBlock: %v", err)
 	}
+	// Reset stored CBOR to nil
+	block.SetCbor(nil)
 
 	// Re-encode using the cbor Encode function
 	encoded, err := cbor.Encode(block)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reset stored CBOR to nil in Shelley and Allegra block round-trip tests so re-encoding uses the object state instead of cached bytes, preventing false positives.

<sup>Written for commit d34b5793d5b0d2033375b7dd03ff0ba1d525a4a0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

