### PR TITLE
test(ledger): empty block cbor for byron round-trip test

### DIFF
--- a/ledger/byron/block_test.go
+++ b/ledger/byron/block_test.go
@@ -50,6 +50,8 @@ func TestByronBlock_CborRoundTrip_UsingCborEncode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to unmarshal CBOR data into ByronBlock: %v", err)
 	}
+	// Reset stored CBOR to nil
+	block.SetCbor(nil)
 
 	// Re-encode using the cbor Encode function
 	encoded, err := cbor.Encode(block)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clear the cached CBOR in ByronBlock during the round-trip test to force a fresh encode. This verifies encoding works when the block’s stored CBOR is empty and avoids reusing unmarshaled bytes.

<sup>Written for commit 20ee46f60bf0b4d6891965dfd910f3ef1543713a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

