### PR TITLE
ci: only skip unused linter

### DIFF
--- a/ledger/common/gov.go
+++ b/ledger/common/gov.go
@@ -139,7 +139,7 @@ type ProposalProcedure interface {
 
 type ProposalProcedureBase struct{}
 
-//nolint:all
+//nolint:unused
 func (ProposalProcedureBase) isProposalProcedure() {}
 
 const (
@@ -159,7 +159,7 @@ type GovAction interface {
 
 type GovActionBase struct{}
 
-//nolint:all
+//nolint:unused
 func (GovActionBase) isGovAction() {}
 
 type HardForkInitiationGovAction struct {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Scope lint suppression to only the unused linter in ledger/common/gov.go by replacing //nolint:all with //nolint:unused on marker methods. This keeps other linters active in CI while acknowledging intentionally unused methods.

<sup>Written for commit 4549c877631462ab96d6be402298870f1cdb827c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code quality improvements with no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->