### PR TITLE
feat(ledger): bech32 for hashes (CIP-0005)

### DIFF
--- a/ledger/common/address.go
+++ b/ledger/common/address.go
@@ -179,7 +179,7 @@ func NewByronAddressRedeem(
 	return Address{
 		addressType: AddressTypeByron,
 		paymentPayload: AddressPayloadKeyHash{
-			Hash: AddrKeyHash(addrHash.Bytes()),
+			Hash: AddrKeyHash(addrHash),
 		},
 		byronAddressType: ByronAddressTypeRedeem,
 		byronAddressAttr: attr,
@@ -221,7 +221,7 @@ func (a *Address) populateFromBytes(data []byte) error {
 		a.byronAddressType = byronAddr.AddrType
 		a.byronAddressAttr = byronAddr.Attr
 		a.paymentPayload = AddressPayloadKeyHash{
-			Hash: AddrKeyHash(byronAddr.Hash),
+			Hash: AddrKeyHash(NewBlake2b224(byronAddr.Hash)),
 		}
 		return nil
 	}
@@ -338,12 +338,12 @@ func (a *Address) ToPlutusData() data.PlutusData {
 	case AddressPayloadKeyHash:
 		paymentPd = data.NewConstr(
 			0,
-			data.NewByteString(p.Hash[:]),
+			data.NewByteString(p.Hash.Bytes()),
 		)
 	case AddressPayloadScriptHash:
 		paymentPd = data.NewConstr(
 			1,
-			data.NewByteString(p.Hash[:]),
+			data.NewByteString(p.Hash.Bytes()),
 		)
 	}
 	// Build stake part
@@ -355,7 +355,7 @@ func (a *Address) ToPlutusData() data.PlutusData {
 		case AddressPayloadKeyHash:
 			tmpCred := &Credential{
 				CredType:   CredentialTypeAddrKeyHash,
-				Credential: NewBlake2b224(p.Hash[:]),
+				Credential: NewBlake2b224(p.Hash.Bytes()),
 			}
 			stakePd = data.NewConstr(
 				0,
@@ -367,7 +367,7 @@ func (a *Address) ToPlutusData() data.PlutusData {
 		case AddressPayloadScriptHash:
 			tmpCred := &Credential{
 				CredType:   CredentialTypeScriptHash,
-				Credential: NewBlake2b224(p.Hash[:]),
+				Credential: NewBlake2b224(p.Hash.Bytes()),
 			}
 			stakePd = data.NewConstr(
 				0,
@@ -453,9 +453,9 @@ func (a *Address) PaymentKeyHash() Blake2b224 {
 	}
 	switch p := a.paymentPayload.(type) {
 	case AddressPayloadKeyHash:
-		return Blake2b224(p.Hash[:])
+		return p.Hash
 	case AddressPayloadScriptHash:
-		return Blake2b224(p.Hash[:])
+		return p.Hash
 	default:
 		// Return empty hash
 		return Blake2b224([AddressHashSize]byte{})
@@ -495,9 +495,9 @@ func (a *Address) StakeKeyHash() Blake2b224 {
 	}
 	switch p := a.stakingPayload.(type) {
 	case AddressPayloadKeyHash:
-		return Blake2b224(p.Hash[:])
+		return p.Hash
 	case AddressPayloadScriptHash:
-		return Blake2b224(p.Hash[:])
+		return p.Hash
 	default:
 		// Return empty hash
 		return Blake2b224([AddressHashSize]byte{})

--- a/ledger/common/certs.go
+++ b/ledger/common/certs.go
@@ -321,7 +321,7 @@ func (c *StakeDelegationCertificate) Utxorpc() (*utxorpc.Certificate, error) {
 			Certificate: &utxorpc.Certificate_StakeDelegation{
 				StakeDelegation: &utxorpc.StakeDelegationCert{
 					StakeCredential: stakeCred,
-					PoolKeyhash:     c.PoolKeyHash[:],
+					PoolKeyhash:     c.PoolKeyHash.Bytes(),
 				},
 			},
 		},
@@ -519,7 +519,7 @@ func (p *PoolRegistrationCertificate) UnmarshalJSON(data []byte) error {
 					len(hashBytes),
 				)
 			}
-			p.RewardAccount = AddrKeyHash(NewBlake2b224(hashBytes))
+			p.RewardAccount = AddrKeyHash(hashBytes)
 		}
 	}
 
@@ -529,7 +529,7 @@ func (p *PoolRegistrationCertificate) UnmarshalJSON(data []byte) error {
 		if err != nil {
 			return fmt.Errorf("invalid operator key: %w", err)
 		}
-		p.Operator = PoolKeyHash(NewBlake2b224(opBytes))
+		p.Operator = PoolKeyHash(opBytes)
 	}
 
 	// Convert VRF key hash
@@ -573,7 +573,7 @@ func (c *PoolRegistrationCertificate) UnmarshalCBOR(cborData []byte) error {
 func (c *PoolRegistrationCertificate) Utxorpc() (*utxorpc.Certificate, error) {
 	tmpPoolOwners := make([][]byte, len(c.PoolOwners))
 	for i, owner := range c.PoolOwners {
-		tmpPoolOwners[i] = owner[:]
+		tmpPoolOwners[i] = owner.Bytes()
 	}
 	tmpRelays := make([]*utxorpc.Relay, len(c.Relays))
 	for i, relay := range c.Relays {
@@ -593,7 +593,7 @@ func (c *PoolRegistrationCertificate) Utxorpc() (*utxorpc.Certificate, error) {
 		Certificate: &utxorpc.Certificate_PoolRegistration{
 			// #nosec G115
 			PoolRegistration: &utxorpc.PoolRegistrationCert{
-				Operator:   c.Operator[:],
+				Operator:   c.Operator.Bytes(),
 				VrfKeyhash: c.VrfKeyHash[:],
 				Pledge:     ToUtxorpcBigInt(c.Pledge),
 				Cost:       ToUtxorpcBigInt(c.Cost),
@@ -601,7 +601,7 @@ func (c *PoolRegistrationCertificate) Utxorpc() (*utxorpc.Certificate, error) {
 					Numerator:   int32(c.Margin.Num().Int64()),
 					Denominator: uint32(c.Margin.Denom().Uint64()),
 				},
-				RewardAccount: c.RewardAccount[:],
+				RewardAccount: c.RewardAccount.Bytes(),
 				PoolOwners:    tmpPoolOwners,
 				Relays:        tmpRelays,
 				PoolMetadata:  poolMetadata,
@@ -639,7 +639,7 @@ func (c *PoolRetirementCertificate) Utxorpc() (*utxorpc.Certificate, error) {
 	return &utxorpc.Certificate{
 		Certificate: &utxorpc.Certificate_PoolRetirement{
 			PoolRetirement: &utxorpc.PoolRetirementCert{
-				PoolKeyhash: c.PoolKeyHash[:],
+				PoolKeyhash: c.PoolKeyHash.Bytes(),
 				Epoch:       c.Epoch,
 			},
 		},
@@ -950,7 +950,7 @@ func (c *StakeVoteDelegationCertificate) Utxorpc() (*utxorpc.Certificate, error)
 		Certificate: &utxorpc.Certificate_StakeVoteDelegCert{
 			StakeVoteDelegCert: &utxorpc.StakeVoteDelegCert{
 				StakeCredential: stakeCred,
-				PoolKeyhash:     c.PoolKeyHash[:],
+				PoolKeyhash:     c.PoolKeyHash.Bytes(),
 				Drep:            drepProto,
 			},
 		},
@@ -994,7 +994,7 @@ func (c *StakeRegistrationDelegationCertificate) Utxorpc() (*utxorpc.Certificate
 		Certificate: &utxorpc.Certificate_StakeRegDelegCert{
 			StakeRegDelegCert: &utxorpc.StakeRegDelegCert{
 				StakeCredential: stakeCred,
-				PoolKeyhash:     c.PoolKeyHash[:],
+				PoolKeyhash:     c.PoolKeyHash.Bytes(),
 			},
 		},
 	}, nil

--- a/ledger/common/common.go
+++ b/ledger/common/common.go
@@ -115,6 +115,21 @@ func (b Blake2b224) MarshalCBOR() ([]byte, error) {
 	return cbor.Encode(hashBytes)
 }
 
+func (b Blake2b224) Bech32(prefix string) string {
+	// Convert data to base32 and encode as bech32
+	convData, err := bech32.ConvertBits(b[:], 8, 5, true)
+	if err != nil {
+		panic(
+			fmt.Sprintf("unexpected error converting data to base32: %s", err),
+		)
+	}
+	encoded, err := bech32.Encode(prefix, convData)
+	if err != nil {
+		panic(fmt.Sprintf("unexpected error encoding data as bech32: %s", err))
+	}
+	return encoded
+}
+
 // Blake2b224Hash generates a Blake2b-224 hash from the provided data
 func Blake2b224Hash(data []byte) Blake2b224 {
 	tmpHash, err := blake2b.New(Blake2b224Size, nil)

--- a/ledger/common/rewards_test.go
+++ b/ledger/common/rewards_test.go
@@ -79,20 +79,20 @@ func TestCalculateRewards(t *testing.T) {
 	snapshot := RewardSnapshot{
 		TotalActiveStake: 50000000, // 50 million ADA total active stake (delegated to pools)
 		PoolStake: map[PoolKeyHash]uint64{
-			{1}: 30000000, // Pool 1: 30 million ADA
-			{2}: 20000000, // Pool 2: 20 million ADA
+			PoolKeyHash{1}: 30000000, // Pool 1: 30 million ADA
+			PoolKeyHash{2}: 20000000, // Pool 2: 20 million ADA
 		},
 		DelegatorStake: map[PoolKeyHash]map[AddrKeyHash]uint64{
-			{1}: {
+			PoolKeyHash{1}: {
 				AddrKeyHash{1}: 25000000, // Delegator 1: 25 million ADA
 				AddrKeyHash{2}: 5000000,  // Delegator 2: 5 million ADA
 			},
-			{2}: {
+			PoolKeyHash{2}: {
 				AddrKeyHash{3}: 20000000, // Delegator 3: 20 million ADA
 			},
 		},
 		PoolParams: map[PoolKeyHash]*PoolRegistrationCertificate{
-			{1}: {
+			Blake2b224{1}: {
 				Cost:   50000,                   // 50k ADA fixed cost
 				Margin: createGenesisRat(1, 20), // 5% margin
 				Pledge: 1000000,                 // 1M ADA pledge
@@ -101,7 +101,7 @@ func TestCalculateRewards(t *testing.T) {
 					{2}, // Owner 2
 				},
 			},
-			{2}: {
+			Blake2b224{2}: {
 				Cost:   30000,                   // 30k ADA fixed cost
 				Margin: createGenesisRat(1, 10), // 10% margin
 				Pledge: 500000,                  // 500k ADA pledge
@@ -111,8 +111,8 @@ func TestCalculateRewards(t *testing.T) {
 			},
 		},
 		StakeRegistrations: map[AddrKeyHash]bool{
-			{1}: true,
-			{2}: true,
+			Blake2b224{1}: true,
+			Blake2b224{2}: true,
 			{3}: true,
 		},
 		PoolBlocks: map[PoolKeyHash]uint32{
@@ -230,20 +230,20 @@ func TestRewardServiceIntegration(t *testing.T) {
 	snapshot := RewardSnapshot{
 		TotalActiveStake: 50000000, // 50 million ADA total active stake
 		PoolStake: map[PoolKeyHash]uint64{
-			{1}: 30000000, // Pool 1: 30 million ADA
-			{2}: 20000000, // Pool 2: 20 million ADA
+			Blake2b224{1}: 30000000, // Pool 1: 30 million ADA
+			Blake2b224{2}: 20000000, // Pool 2: 20 million ADA
 		},
 		DelegatorStake: map[PoolKeyHash]map[AddrKeyHash]uint64{
-			{1}: {
+			Blake2b224{1}: {
 				AddrKeyHash{1}: 25000000, // Delegator 1: 25 million ADA
 				AddrKeyHash{2}: 5000000,  // Delegator 2: 5 million ADA
 			},
-			{2}: {
+			Blake2b224{2}: {
 				AddrKeyHash{3}: 20000000, // Delegator 3: 20 million ADA
 			},
 		},
 		PoolParams: map[PoolKeyHash]*PoolRegistrationCertificate{
-			{1}: {
+			Blake2b224{1}: {
 				Cost:   50000,                   // 50k ADA fixed cost
 				Margin: createGenesisRat(1, 20), // 5% margin
 				Pledge: 1000000,                 // 1M ADA pledge
@@ -252,7 +252,7 @@ func TestRewardServiceIntegration(t *testing.T) {
 					{2}, // Owner 2
 				},
 			},
-			{2}: {
+			Blake2b224{2}: {
 				Cost:   30000,                   // 30k ADA fixed cost
 				Margin: createGenesisRat(1, 10), // 10% margin
 				Pledge: 500000,                  // 500k ADA pledge
@@ -262,8 +262,8 @@ func TestRewardServiceIntegration(t *testing.T) {
 			},
 		},
 		StakeRegistrations: map[AddrKeyHash]bool{
-			{1}: true,
-			{2}: true,
+			Blake2b224{1}: true,
+			Blake2b224{2}: true,
 			{3}: true,
 		},
 		PoolBlocks: map[PoolKeyHash]uint32{

--- a/ledger/common/script.go
+++ b/ledger/common/script.go
@@ -23,6 +23,7 @@ import (
 	"github.com/blinklabs-io/plutigo/cek"
 	"github.com/blinklabs-io/plutigo/data"
 	"github.com/blinklabs-io/plutigo/syn"
+	"github.com/btcsuite/btcd/btcutil/bech32"
 )
 
 const (
@@ -38,6 +39,23 @@ type Script interface {
 	isScript()
 	Hash() ScriptHash
 	RawScriptBytes() []byte
+}
+
+func NewScriptHashFromBech32(scriptHash string) (ScriptHash, error) {
+	var s ScriptHash
+	_, data, err := bech32.DecodeNoLimit(scriptHash)
+	if err != nil {
+		return s, err
+	}
+	decoded, err := bech32.ConvertBits(data, 5, 8, false)
+	if err != nil {
+		return s, err
+	}
+	if len(decoded) != 28 {
+		return s, fmt.Errorf("invalid script hash length: %d", len(decoded))
+	}
+	s = ScriptHash(decoded)
+	return s, nil
 }
 
 type ScriptRef struct {
@@ -107,12 +125,12 @@ type PlutusV1Script []byte
 func (PlutusV1Script) isScript() {}
 
 func (s PlutusV1Script) Hash() ScriptHash {
-	return Blake2b224Hash(
+	return ScriptHash(Blake2b224Hash(
 		slices.Concat(
 			[]byte{ScriptRefTypePlutusV1},
 			[]byte(s),
 		),
-	)
+	))
 }
 
 func (s PlutusV1Script) RawScriptBytes() []byte {
@@ -124,12 +142,12 @@ type PlutusV2Script []byte
 func (PlutusV2Script) isScript() {}
 
 func (s PlutusV2Script) Hash() ScriptHash {
-	return Blake2b224Hash(
+	return ScriptHash(Blake2b224Hash(
 		slices.Concat(
 			[]byte{ScriptRefTypePlutusV2},
 			[]byte(s),
 		),
-	)
+	))
 }
 
 func (s PlutusV2Script) RawScriptBytes() []byte {
@@ -141,12 +159,12 @@ type PlutusV3Script []byte
 func (PlutusV3Script) isScript() {}
 
 func (s PlutusV3Script) Hash() ScriptHash {
-	return Blake2b224Hash(
+	return ScriptHash(Blake2b224Hash(
 		slices.Concat(
 			[]byte{ScriptRefTypePlutusV3},
 			[]byte(s),
 		),
-	)
+	))
 }
 
 func (s PlutusV3Script) RawScriptBytes() []byte {
@@ -243,12 +261,12 @@ func (n *NativeScript) UnmarshalCBOR(data []byte) error {
 }
 
 func (s NativeScript) Hash() ScriptHash {
-	return Blake2b224Hash(
+	return ScriptHash(Blake2b224Hash(
 		slices.Concat(
 			[]byte{ScriptRefTypeNativeScript},
 			[]byte(s.Cbor()),
 		),
-	)
+	))
 }
 
 func (s NativeScript) RawScriptBytes() []byte {

--- a/ledger/common/script/purpose.go
+++ b/ledger/common/script/purpose.go
@@ -44,7 +44,7 @@ type ScriptPurposeMinting struct {
 func (ScriptPurposeMinting) isScriptPurpose() {}
 
 func (s ScriptPurposeMinting) ScriptHash() lcommon.ScriptHash {
-	return s.PolicyId
+	return lcommon.ScriptHash(s.PolicyId)
 }
 
 func (s ScriptPurposeMinting) ToPlutusData() data.PlutusData {
@@ -67,7 +67,7 @@ func (ScriptPurposeSpending) isScriptPurpose() {}
 
 func (s ScriptPurposeSpending) ScriptHash() lcommon.ScriptHash {
 	tmpAddr := s.Input.Output.Address()
-	return tmpAddr.PaymentKeyHash()
+	return lcommon.ScriptHash(tmpAddr.PaymentKeyHash())
 }
 
 func (s ScriptPurposeSpending) ToPlutusData() data.PlutusData {
@@ -143,7 +143,7 @@ func (s ScriptPurposeCertifying) ScriptHash() lcommon.ScriptHash {
 	}
 	if cred != nil {
 		if cred.CredType == lcommon.CredentialTypeScriptHash {
-			return cred.Credential
+			return lcommon.ScriptHash(cred.Credential)
 		}
 	}
 	return lcommon.ScriptHash{}
@@ -168,7 +168,7 @@ type ScriptPurposeVoting struct {
 func (ScriptPurposeVoting) isScriptPurpose() {}
 
 func (s ScriptPurposeVoting) ScriptHash() lcommon.ScriptHash {
-	return lcommon.ScriptHash(s.Voter.Hash[:])
+	return lcommon.ScriptHash(lcommon.NewBlake2b224(s.Voter.Hash[:]))
 }
 
 func (s ScriptPurposeVoting) ToPlutusData() data.PlutusData {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds bech32 encoding/decoding for ledger hash types per CIP-0005, and standardizes hash handling across addresses, certs, scripts, and tests for cleaner APIs.

- **New Features**
  - Blake2b224.Bech32(prefix) to encode hashes as bech32.
  - NewScriptHashFromBech32(...) to parse bech32 script hashes.
  - Uses btcsuite bech32 for encoding/decoding.

- **Refactors**
  - Replace raw byte slicing with typed Blake2b224 and Hash.Bytes() across address, cert, and PlutusData paths.
  - Script hash functions now return typed ScriptHash from Blake2b224.
  - Updated UTXORPC conversions to pass Bytes() for keyhash fields (operator, pool owners, reward account, pool keyhash).
  - Fixed Byron and staking hash handling to use NewBlake2b224 and Bytes().
  - Adjusted tests to use typed Blake2b224 for keys and pool IDs.

<sup>Written for commit 67896ca354b9d6a0da6dd6743416c291bac64640. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Bech32 encoding support for hash values
  * Added Bech32 decoding capability for script hash validation

* **Refactor**
  * Improved hash handling consistency across address and certificate processing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->