### PR TITLE
refactor(ledger): support polymorphic metadata types

### DIFF
--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -155,10 +155,12 @@ func (b *AlonzoBlock) Transactions() []common.Transaction {
 	ret := make([]common.Transaction, len(b.TransactionBodies))
 	// #nosec G115
 	for idx := range b.TransactionBodies {
+		// Note: Ignoring the presence flag; if distinguishing "missing" vs "present but empty/failed decode" is needed, plumb the second return value through
+		txMetadata, _ := b.TransactionMetadataSet.GetMetadata(uint(idx))
 		ret[idx] = &AlonzoTransaction{
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],
-			TxMetadata: b.TransactionMetadataSet[uint(idx)],
+			TxMetadata: txMetadata,
 			TxIsValid:  !invalidTxMap[uint(idx)],
 		}
 	}

--- a/ledger/alonzo/rules.go
+++ b/ledger/alonzo/rules.go
@@ -388,6 +388,7 @@ func UtxoValidateMaxTxSizeUtxo(
 }
 
 // MinFeeTx calculates the minimum required fee for a transaction based on protocol parameters
+// Fee is calculated using the transaction body CBOR size as per Cardano protocol
 func MinFeeTx(
 	tx common.Transaction,
 	pparams common.ProtocolParameters,
@@ -396,22 +397,22 @@ func MinFeeTx(
 	if !ok {
 		return 0, errors.New("pparams are not expected type")
 	}
-	txBytes := tx.Cbor()
-	if len(txBytes) == 0 {
-		var err error
-		txBytes, err = cbor.Encode(tx)
-		if err != nil {
-			return 0, err
-		}
+	tmpTx, ok := tx.(*AlonzoTransaction)
+	if !ok {
+		return 0, errors.New("tx is not expected type")
 	}
-	// We calculate fee based on the pre-Alonzo TX format, which does not include the 'valid' field
-	// Instead of having a separate helper to build the CBOR in the custom format, we subtract 1 since
-	// a boolean is always represented by a single byte in CBOR
-	txSize := max(0, len(txBytes)-1)
-	minFee := uint64(
-		// The TX size can never be negative, so casting to uint is safe
-		//nolint:gosec
-		(tmpPparams.MinFeeA * uint(txSize)) + tmpPparams.MinFeeB,
+	// Temporarily set TxFee to 0 to calculate size without fee
+	originalFee := tmpTx.Body.TxFee
+	tmpTx.Body.TxFee = 0
+	txBytes, err := cbor.Encode(tmpTx.Body)
+	tmpTx.Body.TxFee = originalFee
+	if err != nil {
+		return 0, err
+	}
+	minFee := common.CalculateMinFee(
+		len(txBytes),
+		tmpPparams.MinFeeA,
+		tmpPparams.MinFeeB,
 	)
 	return minFee, nil
 }

--- a/ledger/alonzo/rules_test.go
+++ b/ledger/alonzo/rules_test.go
@@ -194,14 +194,11 @@ func TestUtxoValidateInputSetEmptyUtxo(t *testing.T) {
 }
 
 func TestUtxoValidateFeeTooSmallUtxo(t *testing.T) {
-	var testExactFee uint64 = 74
-	var testBelowFee uint64 = 73
-	var testAboveFee uint64 = 75
-	// NOTE: this is length 4, but 3 will be used in the calculations
+	// NOTE: this is length 4, but body size will be used
 	testTxCbor, _ := hex.DecodeString("abcdef01")
 	testTx := &alonzo.AlonzoTransaction{
 		Body: alonzo.AlonzoTransactionBody{
-			TxFee: testExactFee,
+			TxFee: 0, // Set to 0 to calculate minFee
 		},
 	}
 	testTx.SetCbor(testTxCbor)
@@ -209,6 +206,14 @@ func TestUtxoValidateFeeTooSmallUtxo(t *testing.T) {
 		MinFeeA: 7,
 		MinFeeB: 53,
 	}
+	// Calculate minFee dynamically
+	minFee, err := alonzo.MinFeeTx(testTx, testProtocolParams)
+	if err != nil {
+		t.Fatalf("failed to calculate minFee: %v", err)
+	}
+	var testExactFee uint64 = minFee
+	var testBelowFee uint64 = minFee - 1
+	var testAboveFee uint64 = minFee + 1
 	testLedgerState := test.MockLedgerState{}
 	testSlot := uint64(0)
 	// Test helper function

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -455,6 +455,7 @@ func UtxoValidateTooManyCollateralInputs(
 }
 
 // MinFeeTx calculates the minimum required fee for a transaction based on protocol parameters
+// Fee is calculated using the transaction body CBOR size as per Cardano protocol
 func MinFeeTx(
 	tx common.Transaction,
 	pparams common.ProtocolParameters,
@@ -463,22 +464,22 @@ func MinFeeTx(
 	if !ok {
 		return 0, errors.New("pparams are not expected type")
 	}
-	txBytes := tx.Cbor()
-	if len(txBytes) == 0 {
-		var err error
-		txBytes, err = cbor.Encode(tx)
-		if err != nil {
-			return 0, err
-		}
+	tmpTx, ok := tx.(*BabbageTransaction)
+	if !ok {
+		return 0, errors.New("tx is not expected type")
 	}
-	// We calculate fee based on the pre-Alonzo TX format, which does not include the 'valid' field
-	// Instead of having a separate helper to build the CBOR in the custom format, we subtract 1 since
-	// a boolean is always represented by a single byte in CBOR
-	txSize := max(0, len(txBytes)-1)
-	minFee := uint64(
-		// The TX size can never be negative, so casting to uint is safe
-		//nolint:gosec
-		(tmpPparams.MinFeeA * uint(txSize)) + tmpPparams.MinFeeB,
+	// Temporarily set TxFee to 0 to calculate size without fee
+	originalFee := tmpTx.Body.TxFee
+	tmpTx.Body.TxFee = 0
+	txBytes, err := cbor.Encode(tmpTx.Body)
+	tmpTx.Body.TxFee = originalFee
+	if err != nil {
+		return 0, err
+	}
+	minFee := common.CalculateMinFee(
+		len(txBytes),
+		tmpPparams.MinFeeA,
+		tmpPparams.MinFeeB,
 	)
 	return minFee, nil
 }

--- a/ledger/babbage/rules_test.go
+++ b/ledger/babbage/rules_test.go
@@ -195,14 +195,11 @@ func TestUtxoValidateInputSetEmptyUtxo(t *testing.T) {
 }
 
 func TestUtxoValidateFeeTooSmallUtxo(t *testing.T) {
-	var testExactFee uint64 = 74
-	var testBelowFee uint64 = 73
-	var testAboveFee uint64 = 75
-	// NOTE: this is length 4, but 3 will be used in the calculations
+	// NOTE: this is length 4, but body size will be used
 	testTxCbor, _ := hex.DecodeString("abcdef01")
 	testTx := &babbage.BabbageTransaction{
 		Body: babbage.BabbageTransactionBody{
-			TxFee: testExactFee,
+			TxFee: 0, // Set to 0 to calculate minFee
 		},
 	}
 	testTx.SetCbor(testTxCbor)
@@ -210,6 +207,14 @@ func TestUtxoValidateFeeTooSmallUtxo(t *testing.T) {
 		MinFeeA: 7,
 		MinFeeB: 53,
 	}
+	// Calculate minFee dynamically
+	minFee, err := babbage.MinFeeTx(testTx, testProtocolParams)
+	if err != nil {
+		t.Fatalf("failed to calculate minFee: %v", err)
+	}
+	var testExactFee uint64 = minFee
+	var testBelowFee uint64 = minFee - 1
+	var testAboveFee uint64 = minFee + 1
 	testLedgerState := test.MockLedgerState{}
 	testSlot := uint64(0)
 	// Test helper function

--- a/ledger/common/rewards_test.go
+++ b/ledger/common/rewards_test.go
@@ -79,20 +79,20 @@ func TestCalculateRewards(t *testing.T) {
 	snapshot := RewardSnapshot{
 		TotalActiveStake: 50000000, // 50 million ADA total active stake (delegated to pools)
 		PoolStake: map[PoolKeyHash]uint64{
-			PoolKeyHash{1}: 30000000, // Pool 1: 30 million ADA
-			PoolKeyHash{2}: 20000000, // Pool 2: 20 million ADA
+			{1}: 30000000, // Pool 1: 30 million ADA
+			{2}: 20000000, // Pool 2: 20 million ADA
 		},
 		DelegatorStake: map[PoolKeyHash]map[AddrKeyHash]uint64{
-			PoolKeyHash{1}: {
+			{1}: {
 				AddrKeyHash{1}: 25000000, // Delegator 1: 25 million ADA
 				AddrKeyHash{2}: 5000000,  // Delegator 2: 5 million ADA
 			},
-			PoolKeyHash{2}: {
+			{2}: {
 				AddrKeyHash{3}: 20000000, // Delegator 3: 20 million ADA
 			},
 		},
 		PoolParams: map[PoolKeyHash]*PoolRegistrationCertificate{
-			Blake2b224{1}: {
+			{1}: {
 				Cost:   50000,                   // 50k ADA fixed cost
 				Margin: createGenesisRat(1, 20), // 5% margin
 				Pledge: 1000000,                 // 1M ADA pledge
@@ -101,7 +101,7 @@ func TestCalculateRewards(t *testing.T) {
 					{2}, // Owner 2
 				},
 			},
-			Blake2b224{2}: {
+			{2}: {
 				Cost:   30000,                   // 30k ADA fixed cost
 				Margin: createGenesisRat(1, 10), // 10% margin
 				Pledge: 500000,                  // 500k ADA pledge
@@ -111,8 +111,8 @@ func TestCalculateRewards(t *testing.T) {
 			},
 		},
 		StakeRegistrations: map[AddrKeyHash]bool{
-			Blake2b224{1}: true,
-			Blake2b224{2}: true,
+			{1}: true,
+			{2}: true,
 			{3}: true,
 		},
 		PoolBlocks: map[PoolKeyHash]uint32{
@@ -230,20 +230,20 @@ func TestRewardServiceIntegration(t *testing.T) {
 	snapshot := RewardSnapshot{
 		TotalActiveStake: 50000000, // 50 million ADA total active stake
 		PoolStake: map[PoolKeyHash]uint64{
-			Blake2b224{1}: 30000000, // Pool 1: 30 million ADA
-			Blake2b224{2}: 20000000, // Pool 2: 20 million ADA
+			{1}: 30000000, // Pool 1: 30 million ADA
+			{2}: 20000000, // Pool 2: 20 million ADA
 		},
 		DelegatorStake: map[PoolKeyHash]map[AddrKeyHash]uint64{
-			Blake2b224{1}: {
+			{1}: {
 				AddrKeyHash{1}: 25000000, // Delegator 1: 25 million ADA
 				AddrKeyHash{2}: 5000000,  // Delegator 2: 5 million ADA
 			},
-			Blake2b224{2}: {
+			{2}: {
 				AddrKeyHash{3}: 20000000, // Delegator 3: 20 million ADA
 			},
 		},
 		PoolParams: map[PoolKeyHash]*PoolRegistrationCertificate{
-			Blake2b224{1}: {
+			{1}: {
 				Cost:   50000,                   // 50k ADA fixed cost
 				Margin: createGenesisRat(1, 20), // 5% margin
 				Pledge: 1000000,                 // 1M ADA pledge
@@ -252,7 +252,7 @@ func TestRewardServiceIntegration(t *testing.T) {
 					{2}, // Owner 2
 				},
 			},
-			Blake2b224{2}: {
+			{2}: {
 				Cost:   30000,                   // 30k ADA fixed cost
 				Margin: createGenesisRat(1, 10), // 10% margin
 				Pledge: 500000,                  // 500k ADA pledge
@@ -262,8 +262,8 @@ func TestRewardServiceIntegration(t *testing.T) {
 			},
 		},
 		StakeRegistrations: map[AddrKeyHash]bool{
-			Blake2b224{1}: true,
-			Blake2b224{2}: true,
+			{1}: true,
+			{2}: true,
 			{3}: true,
 		},
 		PoolBlocks: map[PoolKeyHash]uint32{

--- a/ledger/common/rules.go
+++ b/ledger/common/rules.go
@@ -15,3 +15,9 @@
 package common
 
 type UtxoValidationRuleFunc func(Transaction, uint64, LedgerState, ProtocolParameters) error
+
+// CalculateMinFee computes the minimum fee for a transaction body given its CBOR-encoded size
+// and the protocol parameters MinFeeA and MinFeeB
+func CalculateMinFee(bodySize int, minFeeA uint, minFeeB uint) uint64 {
+	return uint64(minFeeA*uint(bodySize) + minFeeB) //nolint:gosec
+}

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -66,7 +66,7 @@ func (b *ConwayBlock) UnmarshalCBOR(cborData []byte) error {
 		BlockHeader            *ConwayBlockHeader
 		TransactionBodies      []ConwayTransactionBody
 		TransactionWitnessSets []ConwayTransactionWitnessSet
-		TransactionMetadataSet map[uint]*cbor.LazyValue
+		TransactionMetadataSet common.TransactionMetadataSet
 		InvalidTransactions    []any
 	}
 
@@ -115,20 +115,7 @@ func (b *ConwayBlock) UnmarshalCBOR(cborData []byte) error {
 	b.BlockHeader = tmp.BlockHeader
 	b.TransactionBodies = tmp.TransactionBodies
 	b.TransactionWitnessSets = tmp.TransactionWitnessSets
-	// Decode TransactionMetadataSet from LazyValue to TransactionMetadatum
-	b.TransactionMetadataSet = make(
-		common.TransactionMetadataSet,
-		len(tmp.TransactionMetadataSet),
-	)
-	for k, lv := range tmp.TransactionMetadataSet {
-		if lv != nil {
-			md, err := common.DecodeMetadatumRaw(lv.Cbor())
-			if err != nil {
-				return fmt.Errorf("decode metadata for index %d: %w", k, err)
-			}
-			b.TransactionMetadataSet[k] = md
-		}
-	}
+	b.TransactionMetadataSet = tmp.TransactionMetadataSet
 
 	b.SetCbor(cborData)
 	return nil
@@ -200,10 +187,12 @@ func (b *ConwayBlock) Transactions() []common.Transaction {
 	ret := make([]common.Transaction, len(b.TransactionBodies))
 	// #nosec G115
 	for idx := range b.TransactionBodies {
+		// Note: Ignoring the presence flag; if distinguishing "missing" vs "present but empty/failed decode" is needed, plumb the second return value through
+		txMetadata, _ := b.TransactionMetadataSet.GetMetadata(uint(idx))
 		ret[idx] = &ConwayTransaction{
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],
-			TxMetadata: b.TransactionMetadataSet[uint(idx)],
+			TxMetadata: txMetadata,
 			TxIsValid:  !invalidTxMap[uint(idx)],
 		}
 	}

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -511,6 +511,7 @@ func UtxoValidateTooManyCollateralInputs(
 }
 
 // MinFeeTx calculates the minimum required fee for a transaction based on protocol parameters
+// Fee is calculated using the transaction body CBOR size as per Cardano protocol
 func MinFeeTx(
 	tx common.Transaction,
 	pparams common.ProtocolParameters,
@@ -519,22 +520,22 @@ func MinFeeTx(
 	if !ok {
 		return 0, errors.New("pparams are not expected type")
 	}
-	txBytes := tx.Cbor()
-	if len(txBytes) == 0 {
-		var err error
-		txBytes, err = cbor.Encode(tx)
-		if err != nil {
-			return 0, err
-		}
+	tmpTx, ok := tx.(*ConwayTransaction)
+	if !ok {
+		return 0, errors.New("tx is not expected type")
 	}
-	// We calculate fee based on the pre-Alonzo TX format, which does not include the 'valid' field
-	// Instead of having a separate helper to build the CBOR in the custom format, we subtract 1 since
-	// a boolean is always represented by a single byte in CBOR
-	txSize := max(0, len(txBytes)-1)
-	minFee := uint64(
-		// The TX size can never be negative, so casting to uint is safe
-		//nolint:gosec
-		(tmpPparams.MinFeeA * uint(txSize)) + tmpPparams.MinFeeB,
+	// Temporarily set TxFee to 0 to calculate size without fee
+	originalFee := tmpTx.Body.TxFee
+	tmpTx.Body.TxFee = 0
+	txBytes, err := cbor.Encode(tmpTx.Body)
+	tmpTx.Body.TxFee = originalFee
+	if err != nil {
+		return 0, err
+	}
+	minFee := common.CalculateMinFee(
+		len(txBytes),
+		tmpPparams.MinFeeA,
+		tmpPparams.MinFeeB,
 	)
 	return minFee, nil
 }

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -196,14 +196,11 @@ func TestUtxoValidateInputSetEmptyUtxo(t *testing.T) {
 }
 
 func TestUtxoValidateFeeTooSmallUtxo(t *testing.T) {
-	var testExactFee uint64 = 74
-	var testBelowFee uint64 = 73
-	var testAboveFee uint64 = 75
-	// NOTE: this is length 4, but 3 will be used in the calculations
+	// NOTE: this is length 4, but body size will be used
 	testTxCbor, _ := hex.DecodeString("abcdef01")
 	testTx := &conway.ConwayTransaction{
 		Body: conway.ConwayTransactionBody{
-			TxFee: testExactFee,
+			TxFee: 0, // Set to 0 to calculate minFee
 		},
 	}
 	testTx.SetCbor(testTxCbor)
@@ -211,6 +208,14 @@ func TestUtxoValidateFeeTooSmallUtxo(t *testing.T) {
 		MinFeeA: 7,
 		MinFeeB: 53,
 	}
+	// Calculate minFee dynamically
+	minFee, err := conway.MinFeeTx(testTx, testProtocolParams)
+	if err != nil {
+		t.Fatalf("failed to calculate minFee: %v", err)
+	}
+	var testExactFee uint64 = minFee
+	var testBelowFee uint64 = minFee - 1
+	var testAboveFee uint64 = minFee + 1
 	testLedgerState := test.MockLedgerState{}
 	testSlot := uint64(0)
 	// Test helper function

--- a/ledger/leios/leios.go
+++ b/ledger/leios/leios.go
@@ -251,10 +251,12 @@ func (b *LeiosRankingBlock) Transactions() []common.Transaction {
 	ret := make([]common.Transaction, len(b.TransactionBodies))
 	// #nosec G115
 	for idx := range b.TransactionBodies {
+		// Note: Ignoring the presence flag; if distinguishing "missing" vs "present but empty/failed decode" is needed, plumb the second return value through
+		txMetadata, _ := b.TransactionMetadataSet.GetMetadata(uint(idx))
 		ret[idx] = &conway.ConwayTransaction{
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],
-			TxMetadata: b.TransactionMetadataSet[uint(idx)],
+			TxMetadata: txMetadata,
 			TxIsValid:  !invalidTxMap[uint(idx)],
 		}
 	}

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -117,10 +117,12 @@ func (b *MaryBlock) Transactions() []common.Transaction {
 	ret := make([]common.Transaction, len(b.TransactionBodies))
 	// #nosec G115
 	for idx := range b.TransactionBodies {
+		// Note: Ignoring the presence flag; if distinguishing "missing" vs "present but empty/failed decode" is needed, plumb the second return value through
+		txMetadata, _ := b.TransactionMetadataSet.GetMetadata(uint(idx))
 		ret[idx] = &MaryTransaction{
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],
-			TxMetadata: b.TransactionMetadataSet[uint(idx)],
+			TxMetadata: txMetadata,
 		}
 	}
 	return ret

--- a/ledger/mary/rules.go
+++ b/ledger/mary/rules.go
@@ -256,6 +256,7 @@ func UtxoValidateMaxTxSizeUtxo(
 }
 
 // MinFeeTx calculates the minimum required fee for a transaction based on protocol parameters
+// Fee is calculated using the transaction body CBOR size as per Cardano protocol
 func MinFeeTx(
 	tx common.Transaction,
 	pparams common.ProtocolParameters,
@@ -264,18 +265,22 @@ func MinFeeTx(
 	if !ok {
 		return 0, errors.New("pparams are not expected type")
 	}
-	txBytes := tx.Cbor()
-	if len(txBytes) == 0 {
-		var err error
-		txBytes, err = cbor.Encode(tx)
-		if err != nil {
-			return 0, err
-		}
+	tmpTx, ok := tx.(*MaryTransaction)
+	if !ok {
+		return 0, errors.New("tx is not expected type")
 	}
-	minFee := uint64(
-		// The TX size can never be negative, so casting to uint is safe
-		//nolint:gosec
-		(tmpPparams.MinFeeA * uint(len(txBytes))) + tmpPparams.MinFeeB,
+	// Temporarily set TxFee to 0 to calculate size without fee
+	originalFee := tmpTx.Body.TxFee
+	tmpTx.Body.TxFee = 0
+	txBytes, err := cbor.Encode(tmpTx.Body)
+	tmpTx.Body.TxFee = originalFee
+	if err != nil {
+		return 0, err
+	}
+	minFee := common.CalculateMinFee(
+		len(txBytes),
+		tmpPparams.MinFeeA,
+		tmpPparams.MinFeeB,
 	)
 	return minFee, nil
 }

--- a/ledger/mary/rules_test.go
+++ b/ledger/mary/rules_test.go
@@ -193,13 +193,10 @@ func TestUtxoValidateInputSetEmptyUtxo(t *testing.T) {
 }
 
 func TestUtxoValidateFeeTooSmallUtxo(t *testing.T) {
-	var testExactFee uint64 = 74
-	var testBelowFee uint64 = 73
-	var testAboveFee uint64 = 75
 	testTxCbor, _ := hex.DecodeString("abcdef")
 	testTx := &mary.MaryTransaction{
 		Body: mary.MaryTransactionBody{
-			TxFee: testExactFee,
+			TxFee: 0, // Set to 0 to calculate minFee
 		},
 	}
 	testTx.SetCbor(testTxCbor)
@@ -207,6 +204,14 @@ func TestUtxoValidateFeeTooSmallUtxo(t *testing.T) {
 		MinFeeA: 7,
 		MinFeeB: 53,
 	}
+	// Calculate minFee dynamically
+	minFee, err := mary.MinFeeTx(testTx, testProtocolParams)
+	if err != nil {
+		t.Fatalf("failed to calculate minFee: %v", err)
+	}
+	var testExactFee uint64 = minFee
+	var testBelowFee uint64 = minFee - 1
+	var testAboveFee uint64 = minFee + 1
 	testLedgerState := test.MockLedgerState{}
 	testSlot := uint64(0)
 	// Test helper function

--- a/ledger/shelley/rules_test.go
+++ b/ledger/shelley/rules_test.go
@@ -190,13 +190,10 @@ func TestUtxoValidateInputSetEmptyUtxo(t *testing.T) {
 }
 
 func TestUtxoValidateFeeTooSmallUtxo(t *testing.T) {
-	var testExactFee uint64 = 74
-	var testBelowFee uint64 = 73
-	var testAboveFee uint64 = 75
 	testTxCbor, _ := hex.DecodeString("abcdef")
 	testTx := &shelley.ShelleyTransaction{
 		Body: shelley.ShelleyTransactionBody{
-			TxFee: testExactFee,
+			TxFee: 0, // Set to 0 to calculate minFee
 		},
 	}
 	testTx.SetCbor(testTxCbor)
@@ -204,6 +201,14 @@ func TestUtxoValidateFeeTooSmallUtxo(t *testing.T) {
 		MinFeeA: 7,
 		MinFeeB: 53,
 	}
+	// Calculate minFee dynamically
+	minFee, err := shelley.MinFeeTx(testTx, testProtocolParams)
+	if err != nil {
+		t.Fatalf("failed to calculate minFee: %v", err)
+	}
+	var testExactFee uint64 = minFee
+	var testBelowFee uint64 = minFee - 1
+	var testAboveFee uint64 = minFee + 1
 	testLedgerState := test.MockLedgerState{}
 	testSlot := uint64(0)
 	// Test helper function

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -107,10 +107,12 @@ func (b *ShelleyBlock) Transactions() []common.Transaction {
 	ret := make([]common.Transaction, len(b.TransactionBodies))
 	// #nosec G115
 	for idx := range b.TransactionBodies {
+		// Note: Ignoring the presence flag; if distinguishing "missing" vs "present but empty/failed decode" is needed, plumb the second return value through
+		txMetadata, _ := b.TransactionMetadataSet.GetMetadata(uint(idx))
 		ret[idx] = &ShelleyTransaction{
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],
-			TxMetadata: b.TransactionMetadataSet[uint(idx)],
+			TxMetadata: txMetadata,
 		}
 	}
 	return ret


### PR DESCRIPTION



















<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored transaction metadata to support polymorphic auxiliary data across all eras. Metadata is now decoded consistently and accessed via a single API.

- **Refactors**
  - Introduced TransactionMetadataSet struct with raw CBOR storage and a decoded metadata cache.
  - Centralized decoding for auxiliary data and map key variants (uint, int, text, bytes, array [metadata, scripts], tagged map #6.259).
  - Updated era blocks to use GetMetadata instead of direct map indexing.
  - Simplified marshal/unmarshal and adjusted tests to build a raw metadata map and unmarshal once.
  - Aligned MinFeeTx across eras to use transaction body CBOR size via a shared CalculateMinFee helper; tests now compute fees dynamically.

<sup>Written for commit 8dbc9719f5fd6b11b4c59fbd92d638af71c09da8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





















<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified per-transaction metadata handling across eras for consistent decoding and safer access; standardized invalid-transaction validation.

* **API**
  * Added a public metadata accessor and reinstated a transaction conversion helper with clearer error messaging; updated some public block fields to use validated types.

* **Behavior**
  * Min-fee is now computed from transaction body encoding size, changing fee boundary calculations.

* **Tests**
  * Updated tests and fixtures to use the new metadata flow and dynamic min-fee calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->