### PR TITLE
fix(ledger): use unique output pointers

### DIFF
--- a/ledger/allegra/allegra.go
+++ b/ledger/allegra/allegra.go
@@ -187,9 +187,9 @@ func (b *AllegraTransactionBody) Inputs() []common.TransactionInput {
 }
 
 func (b *AllegraTransactionBody) Outputs() []common.TransactionOutput {
-	ret := []common.TransactionOutput{}
-	for _, output := range b.TxOutputs {
-		ret = append(ret, &output)
+	ret := make([]common.TransactionOutput, len(b.TxOutputs))
+	for i := range b.TxOutputs {
+		ret[i] = &b.TxOutputs[i]
 	}
 	return ret
 }

--- a/ledger/byron/byron.go
+++ b/ledger/byron/byron.go
@@ -194,9 +194,9 @@ func (t *ByronTransaction) Inputs() []common.TransactionInput {
 }
 
 func (t *ByronTransaction) Outputs() []common.TransactionOutput {
-	ret := []common.TransactionOutput{}
-	for _, output := range t.TxOutputs {
-		ret = append(ret, &output)
+	ret := make([]common.TransactionOutput, len(t.TxOutputs))
+	for i := range t.TxOutputs {
+		ret[i] = &t.TxOutputs[i]
 	}
 	return ret
 }

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -488,9 +488,9 @@ func (b *ConwayTransactionBody) Inputs() []common.TransactionInput {
 }
 
 func (b *ConwayTransactionBody) Outputs() []common.TransactionOutput {
-	ret := []common.TransactionOutput{}
-	for _, output := range b.TxOutputs {
-		ret = append(ret, &output)
+	ret := make([]common.TransactionOutput, len(b.TxOutputs))
+	for i := range b.TxOutputs {
+		ret[i] = &b.TxOutputs[i]
 	}
 	return ret
 }
@@ -555,9 +555,10 @@ func (b *ConwayTransactionBody) ScriptDataHash() *common.Blake2b256 {
 }
 
 func (b *ConwayTransactionBody) ReferenceInputs() []common.TransactionInput {
-	ret := []common.TransactionInput{}
-	for _, input := range b.TxReferenceInputs.Items() {
-		ret = append(ret, &input)
+	items := b.TxReferenceInputs.Items()
+	ret := make([]common.TransactionInput, len(items))
+	for i := range items {
+		ret[i] = &items[i]
 	}
 	return ret
 }

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -209,9 +209,9 @@ func (b *MaryTransactionBody) Inputs() []common.TransactionInput {
 }
 
 func (b *MaryTransactionBody) Outputs() []common.TransactionOutput {
-	ret := []common.TransactionOutput{}
-	for _, output := range b.TxOutputs {
-		ret = append(ret, &output)
+	ret := make([]common.TransactionOutput, len(b.TxOutputs))
+	for i := range b.TxOutputs {
+		ret[i] = &b.TxOutputs[i]
 	}
 	return ret
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Outputs() and ReferenceInputs() to return unique pointers, preventing all items from referencing the same range variable. This avoids incorrect data reads and shared pointers in ledger transaction builders.

- **Bug Fixes**
  - Use indexed loops to take addresses of slice elements instead of the range variable.
  - Updated Outputs() for Allegra, Byron, Mary, Conway; and ReferenceInputs() for Conway.

<sup>Written for commit df3ac5c70a5e9cb1777e0ac3c5e89a6ed564de3a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed transaction output handling in multiple ledger implementations (Allegra, Byron, Conway, Mary) to ensure outputs are correctly referenced and processed.
* Improved reference input handling in Conway ledger implementation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->