### PR TITLE
test: correct allegra wrong network utxo error type

### DIFF
--- a/ledger/allegra/rules_test.go
+++ b/ledger/allegra/rules_test.go
@@ -391,7 +391,7 @@ func TestUtxoValidateWrongNetwork(t *testing.T) {
 		"correct network",
 		func(t *testing.T) {
 			testTx.Body.TxOutputs[0].OutputAddress = testCorrectNetworkAddr
-			err := allegra.UtxoValidateBadInputsUtxo(
+			err := allegra.UtxoValidateWrongNetwork(
 				testTx,
 				testSlot,
 				testLedgerState,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the Allegra UTXO network validation test to call allegra.UtxoValidateWrongNetwork instead of UtxoValidateBadInputsUtxo. This ensures the test checks the correct wrong-network error type and avoids misleading results.

<sup>Written for commit c26057219f04d0dc3f653ee2f5fcf4a9ca4a0fb6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Corrected test logic to ensure proper validation scenarios are being tested, improving test accuracy and reliability of the validation suite.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->