### PR TITLE
fix(ledger): mutate body copy not original

### DIFF
--- a/ledger/alonzo/rules.go
+++ b/ledger/alonzo/rules.go
@@ -401,11 +401,10 @@ func MinFeeTx(
 	if !ok {
 		return 0, errors.New("tx is not expected type")
 	}
-	// Temporarily set TxFee to 0 to calculate size without fee
-	originalFee := tmpTx.Body.TxFee
-	tmpTx.Body.TxFee = 0
-	txBytes, err := cbor.Encode(tmpTx.Body)
-	tmpTx.Body.TxFee = originalFee
+	// Encode a local copy of the body with TxFee set to 0 to calculate size without fee
+	body := tmpTx.Body
+	body.TxFee = 0
+	txBytes, err := cbor.Encode(body)
 	if err != nil {
 		return 0, err
 	}

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -468,11 +468,10 @@ func MinFeeTx(
 	if !ok {
 		return 0, errors.New("tx is not expected type")
 	}
-	// Temporarily set TxFee to 0 to calculate size without fee
-	originalFee := tmpTx.Body.TxFee
-	tmpTx.Body.TxFee = 0
-	txBytes, err := cbor.Encode(tmpTx.Body)
-	tmpTx.Body.TxFee = originalFee
+	// Encode a local copy of the body with TxFee set to 0 to calculate size without fee
+	body := tmpTx.Body
+	body.TxFee = 0
+	txBytes, err := cbor.Encode(body)
 	if err != nil {
 		return 0, err
 	}

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -524,11 +524,10 @@ func MinFeeTx(
 	if !ok {
 		return 0, errors.New("tx is not expected type")
 	}
-	// Temporarily set TxFee to 0 to calculate size without fee
-	originalFee := tmpTx.Body.TxFee
-	tmpTx.Body.TxFee = 0
-	txBytes, err := cbor.Encode(tmpTx.Body)
-	tmpTx.Body.TxFee = originalFee
+	// Encode a local copy of the body with TxFee set to 0 to calculate size without fee
+	body := tmpTx.Body
+	body.TxFee = 0
+	txBytes, err := cbor.Encode(body)
 	if err != nil {
 		return 0, err
 	}

--- a/ledger/mary/rules.go
+++ b/ledger/mary/rules.go
@@ -269,11 +269,10 @@ func MinFeeTx(
 	if !ok {
 		return 0, errors.New("tx is not expected type")
 	}
-	// Temporarily set TxFee to 0 to calculate size without fee
-	originalFee := tmpTx.Body.TxFee
-	tmpTx.Body.TxFee = 0
-	txBytes, err := cbor.Encode(tmpTx.Body)
-	tmpTx.Body.TxFee = originalFee
+	// Encode a local copy of the body with TxFee set to 0 to calculate size without fee
+	body := tmpTx.Body
+	body.TxFee = 0
+	txBytes, err := cbor.Encode(body)
 	if err != nil {
 		return 0, err
 	}

--- a/ledger/shelley/rules.go
+++ b/ledger/shelley/rules.go
@@ -314,11 +314,10 @@ func MinFeeTx(
 	if !ok {
 		return 0, errors.New("tx is not expected type")
 	}
-	// Temporarily set TxFee to 0 to calculate size without fee
-	originalFee := tmpTx.Body.TxFee
-	tmpTx.Body.TxFee = 0
-	txBytes, err := cbor.Encode(tmpTx.Body)
-	tmpTx.Body.TxFee = originalFee
+	// Encode a local copy of the body with TxFee set to 0 to calculate size without fee
+	body := tmpTx.Body
+	body.TxFee = 0
+	txBytes, err := cbor.Encode(body)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Calculate min fee without mutating the original transaction body by encoding a local copy with TxFee set to 0 across all ledger eras (Shelley, Mary, Alonzo, Babbage, Conway). This prevents unintended side effects during fee size estimation and makes MinFeeTx safer.

<sup>Written for commit b2713f44c4f6fc5e017df5983cd8d9b6b824eb91. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated transaction fee calculation implementation across multiple ledger versions to improve processing efficiency while maintaining existing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->