### PR TITLE
chore(deps): plutigo 0.0.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.1
 require (
 	filippo.io/edwards25519 v1.1.0
 	github.com/blinklabs-io/ouroboros-mock v0.4.0
-	github.com/blinklabs-io/plutigo v0.0.14
+	github.com/blinklabs-io/plutigo v0.0.15
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/fxamacker/cbor/v2 v2.9.0
 	github.com/jinzhu/copier v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/bits-and-blooms/bitset v1.20.0 h1:2F+rfL86jE2d/bmw7OhqUg2Sj/1rURkBn3M
 github.com/bits-and-blooms/bitset v1.20.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blinklabs-io/ouroboros-mock v0.4.0 h1:ppOcTMnC/2f5rYYSlvNqcGfAQOIpMCSDUrNh9K6a4mY=
 github.com/blinklabs-io/ouroboros-mock v0.4.0/go.mod h1:e+Kck8bmdOuaN7IfkbVvbqAVlskXNXB95oHI3YlFG5g=
-github.com/blinklabs-io/plutigo v0.0.14 h1:K45/tQpZwJFdCcrhigepbdSPQG/+0pp99cCrbJdSl44=
-github.com/blinklabs-io/plutigo v0.0.14/go.mod h1:W4TnQiGhc6da5G+jXAW3O/Q/tgqG9QoITRJ1FCXd260=
+github.com/blinklabs-io/plutigo v0.0.15 h1:j81S4/ESphJMplBTXBIgPL+fch10FvHOK08tYztaaNs=
+github.com/blinklabs-io/plutigo v0.0.15/go.mod h1:aT3mJAh1s8JJ8C42ygd8OyGDQZ8f+w8Uge2+C/9BLug=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=

--- a/ledger/common/script.go
+++ b/ledger/common/script.go
@@ -206,8 +206,8 @@ func (s PlutusV3Script) Evaluate(
 		Function: program.Term,
 		Argument: contextTerm,
 	}
-	// Execute wrapped program
-	machine := cek.NewMachine[syn.DeBruijn](200)
+	// Execute wrapped program (1.2.0 is Plutus V3)
+	machine := cek.NewMachine[syn.DeBruijn]([3]uint32{1, 2, 0}, 200)
 	machine.ExBudget = machineBudget
 	_, err = machine.Run(wrappedProgram)
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade plutigo to v0.0.15 and update Plutus V3 evaluation to initialize the CEK machine with version [1, 2, 0]. This aligns the script runner with the new API and ensures correct V3 execution.

<sup>Written for commit ccc7bd791400c1f60baba4496c626140780b5bed. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plutigo dependency to v0.0.15

* **Refactor**
  * Updated Plutus V3 script execution configuration for enhanced resource handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->