### PR TITLE
fix(ledger): custom cbor marshal for nativescript

### DIFF
--- a/ledger/common/metadata.go
+++ b/ledger/common/metadata.go
@@ -254,7 +254,10 @@ func decodeMapGeneric(b []byte) (TransactionMetadatum, bool, error) {
 		}
 		val, err := DecodeMetadatumRaw(rv)
 		if err != nil {
-			errors = append(errors, fmt.Errorf("decode map(generic) value for key %v: %w", k, err))
+			errors = append(
+				errors,
+				fmt.Errorf("decode map(generic) value for key %v: %w", k, err),
+			)
 			continue
 		}
 		pairs = append(pairs, MetaPair{Key: keyMd, Value: val})
@@ -263,7 +266,10 @@ func decodeMapGeneric(b []byte) (TransactionMetadatum, bool, error) {
 		return MetaMap{Pairs: pairs}, true, nil
 	}
 	if len(errors) > 0 {
-		return nil, true, fmt.Errorf("failed to decode all map pairs: %v", errors)
+		return nil, true, fmt.Errorf(
+			"failed to decode all map pairs: %v",
+			errors,
+		)
 	}
 	return MetaMap{Pairs: pairs}, true, nil
 }

--- a/ledger/common/script.go
+++ b/ledger/common/script.go
@@ -273,6 +273,16 @@ func (s NativeScript) RawScriptBytes() []byte {
 	return s.Cbor()
 }
 
+func (n NativeScript) MarshalCBOR() ([]byte, error) {
+	if raw := n.Cbor(); len(raw) > 0 {
+		return raw, nil
+	}
+	if n.item == nil {
+		return nil, errors.New("native script has no backing item")
+	}
+	return cbor.Encode(n.item)
+}
+
 type NativeScriptPubkey struct {
 	cbor.StructAsArray
 	Type uint

--- a/ledger/mary/block_test.go
+++ b/ledger/mary/block_test.go
@@ -48,6 +48,8 @@ func TestMaryBlock_CborRoundTrip_UsingCborEncode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to unmarshal CBOR data into MaryBlock: %v", err)
 	}
+	// Reset stored CBOR to nil
+	block.SetCbor(nil)
 
 	// Re-encode using the cbor Encode function
 	encoded, err := cbor.Encode(block)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a custom CBOR marshaler for NativeScript so encoding uses stored raw bytes when present and falls back to the backing item. This fixes incorrect CBOR output and stabilizes round-trips.

- **Bug Fixes**
  - Implemented NativeScript.MarshalCBOR: prefer cached Cbor(), else encode n.item; error if item is nil.
  - Updated Mary block test to clear cached CBOR before re-encoding to verify proper marshal behavior.
  - Cleaned up metadata map decode error aggregation for clearer messages.

<sup>Written for commit 4410e2ba6ea49a7faab5dcbc9232bd24c388c157. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled CBOR serialization for script objects, improving data interchange capabilities.

* **Tests**
  * Improved serialization testing with proper cache management during round-trip validation.

* **Style**
  * Reformatted error handling code for better readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->