### PR TITLE
fix: use any instead of interface{}

### DIFF
--- a/ledger/common/metadata.go
+++ b/ledger/common/metadata.go
@@ -233,7 +233,7 @@ func decodeMapBytes(b []byte) (TransactionMetadatum, bool, error) {
 
 func decodeMapGeneric(b []byte) (TransactionMetadatum, bool, error) {
 	// Try to decode as a generic map to handle unsupported key types
-	var m map[interface{}]cbor.RawMessage
+	var m map[any]cbor.RawMessage
 	if _, err := cbor.Decode(b, &m); err != nil {
 		return nil, false, nil //nolint:nilerr // not this shape
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replace map[interface{}] with map[any] in decodeMapGeneric to modernize the type and match Go 1.18+ conventions.
No behavior change; improves readability and aligns with linter preferences.

<sup>Written for commit f5908b0364779b80b85ebc017fc90146c8de62b7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved metadata processing to better handle various key types in data structures, enhancing robustness and compatibility across different data formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->