### PR TITLE
fix(cmd): use chainsync pipeline limit 10

### DIFF
--- a/cmd/gouroboros/chainsync.go
+++ b/cmd/gouroboros/chainsync.go
@@ -128,6 +128,7 @@ func buildChainSyncConfig() chainsync.Config {
 	return chainsync.NewConfig(
 		chainsync.WithRollBackwardFunc(chainSyncRollBackwardHandler),
 		chainsync.WithRollForwardFunc(chainSyncRollForwardHandler),
+		chainsync.WithPipelineLimit(10),
 	)
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set ChainSync pipeline limit to 10 to control concurrency and avoid over-buffering. This reduces memory usage and stabilizes sync during roll-forward/backward events.

<sup>Written for commit 98b8c112dddffc1fe621b6fd0309fc4bd799a2d1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized chain synchronization by introducing a pipeline limit to the chainsync configuration, enhancing performance and resource management during blockchain data synchronization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->