### PR TITLE
refactor(ledger): verify config struct vs env variable

### DIFF
--- a/ledger/verify_config.go
+++ b/ledger/verify_config.go
@@ -1,0 +1,46 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import "sync"
+
+// VerifyConfig holds runtime verification toggles.
+// Default values favor safety; tests or specific flows can opt out.
+type VerifyConfig struct {
+	// SkipBodyHashValidation disables body hash verification in VerifyBlock().
+	// Useful for scenarios where full block CBOR is unavailable.
+	SkipBodyHashValidation bool
+}
+
+var (
+	verifyConfig   VerifyConfig
+	verifyConfigMu sync.RWMutex
+)
+
+// SetVerifyConfig sets global verification configuration.
+// Safe for concurrent use.
+func SetVerifyConfig(cfg VerifyConfig) {
+	verifyConfigMu.Lock()
+	defer verifyConfigMu.Unlock()
+	verifyConfig = cfg
+}
+
+// GetVerifyConfig returns current verification configuration.
+// Safe for concurrent use.
+func GetVerifyConfig() VerifyConfig {
+	verifyConfigMu.RLock()
+	defer verifyConfigMu.RUnlock()
+	return verifyConfig
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored block verification to use a thread-safe VerifyConfig instead of an env variable to control body hash checks. Defaults stay secure; tests or constrained environments can explicitly opt out.

- **Refactors**
  - Added VerifyConfig with SetVerifyConfig/GetVerifyConfig (ledger/verify_config.go).
  - Removed allowMissingCbor and GOUROBOROS_TEST_ALLOW_MISSING_CBOR usage.
  - VerifyBlock now errors on missing CBOR unless SkipBodyHashValidation is set.
  - Updated tests to use SetVerifyConfig and added coverage for the skip path.

<sup>Written for commit 6a37f268acf9fdf5ec847cfeef613a5c411f0a1b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced configuration-driven control for block body hash validation behavior, allowing selective skipping for non-Byron eras.

* **Refactoring**
  * Replaced environment variable-based verification controls with a thread-safe configuration system for improved reliability and maintainability.

* **Tests**
  * Added test coverage for body hash validation skipping functionality.
  * Updated test infrastructure to use programmatic configuration instead of environment variables.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->