### PR TITLE
fix: update verify config to be per-caller

### DIFF
--- a/ledger/verify_block.go
+++ b/ledger/verify_block.go
@@ -124,6 +124,7 @@ func VerifyBlock(
 	block Block,
 	eta0Hex string,
 	slotsPerKesPeriod uint64,
+	config VerifyConfig,
 ) (bool, string, uint64, uint64, error) {
 	isValid := false
 	vrfHex := ""
@@ -293,7 +294,7 @@ func VerifyBlock(
 	// VerifyConfig{SkipBodyHashValidation:true} to bypass this check.
 	expectedBodyHash := block.BlockBodyHash()
 	isBodyValid := true
-	if block.Era() != byron.EraByron && !GetVerifyConfig().SkipBodyHashValidation {
+	if block.Era() != byron.EraByron && !config.SkipBodyHashValidation {
 		rawCbor := block.Cbor()
 		if len(rawCbor) == 0 {
 			return false, "", 0, 0, errors.New(

--- a/ledger/verify_block_test.go
+++ b/ledger/verify_block_test.go
@@ -108,8 +108,7 @@ func decodeTransactionMetadataSet(
 
 func TestVerifyBlockBody(t *testing.T) {
 	// Enable skipping body hash validation for tests that use blocks without stored CBOR
-	SetVerifyConfig(VerifyConfig{SkipBodyHashValidation: true})
-	t.Cleanup(func() { SetVerifyConfig(VerifyConfig{}) })
+	config := VerifyConfig{SkipBodyHashValidation: true}
 
 	testCases := []struct {
 		name          string
@@ -314,6 +313,7 @@ func TestVerifyBlockBody(t *testing.T) {
 				block,
 				tc.blockHexCbor.Eta0,
 				uint64(tc.blockHexCbor.Spk),
+				config,
 			)
 			if tc.expectedValid != isValid {
 				t.Errorf(
@@ -335,8 +335,7 @@ func TestVerifyBlockBody(t *testing.T) {
 
 func TestVerifyBlock_SkipBodyHashValidation(t *testing.T) {
 	// Enable skipping body hash validation
-	SetVerifyConfig(VerifyConfig{SkipBodyHashValidation: true})
-	t.Cleanup(func() { SetVerifyConfig(VerifyConfig{}) })
+	config := VerifyConfig{SkipBodyHashValidation: true}
 
 	// This test is lightweight: it constructs a minimal Shelley header/body
 	// and a block with empty CBOR to simulate missing CBOR scenario.
@@ -350,7 +349,7 @@ func TestVerifyBlock_SkipBodyHashValidation(t *testing.T) {
 	header := &shelley.ShelleyBlockHeader{}
 	block := &shelley.ShelleyBlock{BlockHeader: header}
 	// Call VerifyBlock and ensure it doesn't fail because of body hash/CBOR
-	_, _, _, _, err := VerifyBlock(block, eta0Hex, slotsPerKesPeriod)
+	_, _, _, _, err := VerifyBlock(block, eta0Hex, slotsPerKesPeriod, config)
 	if err != nil {
 		if strings.Contains(err.Error(), "block CBOR is required for body hash verification") {
 			t.Fatalf("SkipBodyHashValidation should bypass body CBOR requirement, got: %v", err)

--- a/ledger/verify_config.go
+++ b/ledger/verify_config.go
@@ -14,33 +14,10 @@
 
 package ledger
 
-import "sync"
-
 // VerifyConfig holds runtime verification toggles.
 // Default values favor safety; tests or specific flows can opt out.
 type VerifyConfig struct {
 	// SkipBodyHashValidation disables body hash verification in VerifyBlock().
 	// Useful for scenarios where full block CBOR is unavailable.
 	SkipBodyHashValidation bool
-}
-
-var (
-	verifyConfig   VerifyConfig
-	verifyConfigMu sync.RWMutex
-)
-
-// SetVerifyConfig sets global verification configuration.
-// Safe for concurrent use.
-func SetVerifyConfig(cfg VerifyConfig) {
-	verifyConfigMu.Lock()
-	defer verifyConfigMu.Unlock()
-	verifyConfig = cfg
-}
-
-// GetVerifyConfig returns current verification configuration.
-// Safe for concurrent use.
-func GetVerifyConfig() VerifyConfig {
-	verifyConfigMu.RLock()
-	defer verifyConfigMu.RUnlock()
-	return verifyConfig
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch verification config to be per-call. VerifyBlock now accepts a VerifyConfig, removing the global config and fixing a race in concurrent verification.

- **Refactors**
  - Add VerifyConfig parameter to VerifyBlock.
  - Remove global config, mutex, and Set/Get helpers.
  - Update tests to pass config directly.

- **Migration**
  - Pass VerifyConfig to VerifyBlock at your call sites.
  - Remove any use of SetVerifyConfig/GetVerifyConfig.

<sup>Written for commit 5dfa353919c6362c73e573ecd54ff10b2f952e07. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified block verification configuration handling to use per-call settings instead of global state, enabling more flexible and thread-safe verification operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->