### PR TITLE
fix: support mint/burn ADA

### DIFF
--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -276,6 +276,15 @@ func UtxoValidateValueNotConservedUtxo(
 			consumedValue += uint64(tmpPparams.KeyDeposit)
 		}
 	}
+	// Add minted/burned ADA
+	if tx.AssetMint() != nil {
+		mintedAda := tx.AssetMint().Asset(common.Blake2b224{}, []byte{})
+		if mintedAda > 0 {
+			consumedValue += uint64(mintedAda)
+		} else if mintedAda < 0 {
+			consumedValue -= uint64(-mintedAda)
+		}
+	}
 	// Calculate produced value
 	// produced = value from output(s) + fee + deposits
 	var producedValue uint64

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -798,6 +798,42 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 			)
 		},
 	)
+	// Minting
+	t.Run(
+		"minting",
+		func(t *testing.T) {
+			mintData := map[common.Blake2b224]map[cbor.ByteString]int64{
+				common.Blake2b224{}: {cbor.ByteString{}: 7000000},
+			}
+			mint := common.NewMultiAsset[common.MultiAssetTypeMint](mintData)
+			mintTx := &conway.ConwayTransaction{
+				Body: conway.ConwayTransactionBody{
+					TxInputs: conway.NewConwayTransactionInputSet([]shelley.ShelleyTransactionInput{}),
+					TxOutputs: []babbage.BabbageTransactionOutput{
+						{
+							OutputAmount: mary.MaryTransactionOutputValue{
+								Amount: 7000000,
+							},
+						},
+					},
+					TxFee:  0,
+					TxMint: &mint,
+				},
+			}
+			err := conway.UtxoValidateValueNotConservedUtxo(
+				mintTx,
+				testSlot,
+				test.MockLedgerState{},
+				testProtocolParams,
+			)
+			if err != nil {
+				t.Errorf(
+					"UtxoValidateValueNotConservedUtxo should succeed with minting\n  got error: %v",
+					err,
+				)
+			}
+		},
+	)
 }
 
 func TestUtxoValidateOutputTooSmallUtxo(t *testing.T) {


### PR DESCRIPTION
Supports treasury withdrawals, which mint tokens out of thin air, so they won't have correlating inputs.

Closes #1302 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
UTxO value conservation now accounts for ADA minted or burned. This fixes validation for treasury withdrawals and ADA mint/burn transactions.

- **Bug Fixes**
  - Include ADA from TxMint in consumed value (add on mint, subtract on burn) during UtxoValidateValueNotConservedUtxo.
  - Add a unit test verifying minting passes value conservation.

<sup>Written for commit 5b0872fcebe1206429fe18ad3dc1231082785804. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced value conservation validation to properly account for minted and burned ADA. Consumed value calculations now adjust based on minting activity, improving transaction value tracking accuracy.

* **Tests**
  * Added test case validating correct handling of minting operations in value conservation checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->