### PR TITLE
feat(ledger): wire up tx validation

### DIFF
--- a/ledger/common/verify_config.go
+++ b/ledger/common/verify_config.go
@@ -28,6 +28,15 @@ type VerifyConfig struct {
 	// SkipBodyHashValidation disables body hash verification in VerifyBlock().
 	// Useful for scenarios where full block CBOR is unavailable.
 	SkipBodyHashValidation bool
+	// SkipTransactionValidation disables transaction validation in VerifyBlock().
+	// When false (default), LedgerState and ProtocolParameters must be set.
+	SkipTransactionValidation bool
+	// LedgerState provides the current ledger state for transaction validation.
+	// Required if SkipTransactionValidation is false.
+	LedgerState LedgerState
+	// ProtocolParameters provides the current protocol parameters for transaction validation.
+	// Required if SkipTransactionValidation is false.
+	ProtocolParameters ProtocolParameters
 }
 
 // ValidateBlockBodyHash validates the block body hash during parsing.

--- a/ledger/verify_block.go
+++ b/ledger/verify_block.go
@@ -19,7 +19,6 @@
 package ledger
 
 import (
-	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -34,7 +33,6 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
-	"golang.org/x/crypto/blake2b"
 )
 
 const (
@@ -300,45 +298,52 @@ func VerifyBlock(
 			return false, "", 0, 0, errors.New(
 				"VerifyBlock: block CBOR is required for body hash verification",
 			)
-		} else {
-			var raw []cbor.RawMessage
-			if _, err := cbor.Decode(rawCbor, &raw); err != nil {
+		}
+		era := block.Era()
+		eraName := era.Name
+		minLength := 4
+		if era.Id >= alonzo.EraAlonzo.Id {
+			minLength = 5
+		}
+		if err := common.ValidateBlockBodyHash(rawCbor, expectedBodyHash, eraName, minLength); err != nil {
+			return false, "", 0, 0, fmt.Errorf(
+				"VerifyBlock: %w",
+				err,
+			)
+		}
+	}
+
+	// Verify transactions (can be skipped via config)
+	// Requires LedgerState and ProtocolParameters in config if enabled.
+	if block.Era() != byron.EraByron && !config.SkipTransactionValidation {
+		var validationRules []common.UtxoValidationRuleFunc
+		switch block.Era().Id {
+		case shelley.EraShelley.Id:
+			validationRules = shelley.UtxoValidationRules
+		case allegra.EraAllegra.Id:
+			validationRules = allegra.UtxoValidationRules
+		case mary.EraMary.Id:
+			validationRules = mary.UtxoValidationRules
+		case alonzo.EraAlonzo.Id:
+			validationRules = alonzo.UtxoValidationRules
+		case babbage.EraBabbage.Id:
+			validationRules = babbage.UtxoValidationRules
+		case conway.EraConway.Id:
+			validationRules = conway.UtxoValidationRules
+		default:
+			return false, "", 0, 0, fmt.Errorf(
+				"VerifyBlock: unsupported era for transaction validation %s",
+				block.Era().Name,
+			)
+		}
+		if config.LedgerState == nil || config.ProtocolParameters == nil {
+			return false, "", 0, 0, errors.New("VerifyBlock: missing required config field: LedgerState and ProtocolParameters must be set")
+		}
+		for _, tx := range block.Transactions() {
+			if err := common.VerifyTransaction(tx, slot, config.LedgerState, config.ProtocolParameters, validationRules); err != nil {
 				return false, "", 0, 0, fmt.Errorf(
-					"VerifyBlock: failed to decode block CBOR for body hash, %w",
+					"VerifyBlock: transaction validation failed: %w",
 					err,
-				)
-			}
-			if len(raw) < 4 {
-				return false, "", 0, 0, errors.New(
-					"VerifyBlock: invalid block CBOR structure for body hash",
-				)
-			}
-			// Compute body hash as per Cardano spec: blake2b_256(hash_tx || hash_wit || hash_aux || hash_invalid)
-			emptyInvalidCbor, _ := cbor.Encode(cbor.IndefLengthList([]any{}))
-			hashInvalidDefault := blake2b.Sum256(emptyInvalidCbor)
-			var bodyHashes []byte
-			hashTx := blake2b.Sum256(raw[1])
-			bodyHashes = append(bodyHashes, hashTx[:]...)
-			hashWit := blake2b.Sum256(raw[2])
-			bodyHashes = append(bodyHashes, hashWit[:]...)
-			hashAux := blake2b.Sum256(raw[3])
-			bodyHashes = append(bodyHashes, hashAux[:]...)
-			switch block.Header().(type) {
-			case *shelley.ShelleyBlockHeader, *allegra.AllegraBlockHeader, *mary.MaryBlockHeader:
-				bodyHashes = append(bodyHashes, hashInvalidDefault[:]...)
-			case *alonzo.AlonzoBlockHeader, *babbage.BabbageBlockHeader, *conway.ConwayBlockHeader:
-				hashInvalid := blake2b.Sum256(raw[4])
-				bodyHashes = append(bodyHashes, hashInvalid[:]...)
-			default:
-				return false, "", 0, 0, fmt.Errorf(
-					"VerifyBlock: unsupported block type for body hash %T",
-					block.Header(),
-				)
-			}
-			actualBodyHash := blake2b.Sum256(bodyHashes)
-			if !bytes.Equal(actualBodyHash[:], expectedBodyHash.Bytes()) {
-				return false, "", 0, 0, errors.New(
-					"VerifyBlock: block body hash mismatch",
 				)
 			}
 		}

--- a/ledger/verify_block_test.go
+++ b/ledger/verify_block_test.go
@@ -26,6 +26,15 @@ var eraNameMap = map[uint]string{
 	BlockTypeConway:  conway.EraNameConway,
 }
 
+// testSkipAllValidationConfig returns a VerifyConfig that skips both body hash and transaction validation.
+// Useful for tests that don't provide full CBOR or ledger state.
+func testSkipAllValidationConfig() common.VerifyConfig {
+	return common.VerifyConfig{
+		SkipBodyHashValidation:    true,
+		SkipTransactionValidation: true,
+	}
+}
+
 // decodeTxBodyBytes extracts transaction body bytes from either []byte or hex string
 func decodeTxBodyBytes(t *testing.T, v any) []byte {
 	t.Helper()
@@ -107,8 +116,8 @@ func decodeTransactionMetadataSet(
 }
 
 func TestVerifyBlockBody(t *testing.T) {
-	// Enable skipping body hash validation for tests that use blocks without stored CBOR
-	config := common.VerifyConfig{SkipBodyHashValidation: true}
+	// Skip body hash and transaction validation for tests that use blocks without stored CBOR and don't provide ledger state
+	config := testSkipAllValidationConfig()
 
 	testCases := []struct {
 		name          string
@@ -334,8 +343,8 @@ func TestVerifyBlockBody(t *testing.T) {
 }
 
 func TestVerifyBlock_SkipBodyHashValidation(t *testing.T) {
-	// Enable skipping body hash validation
-	config := common.VerifyConfig{SkipBodyHashValidation: true}
+	// Skip body hash and transaction validation
+	config := testSkipAllValidationConfig()
 
 	// This test is lightweight: it constructs a minimal Shelley header/body
 	// and a block with empty CBOR to simulate missing CBOR scenario.


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds transaction validation to VerifyBlock for non-Byron eras and centralizes body hash checks. This strengthens block verification and flags invalid transactions.

- **New Features**
  - Validates transactions using era-specific UTXO rules (Shelley → Conway) and includes result in block validity.
  - Adds VerifyConfig fields: SkipTransactionValidation, LedgerState, ProtocolParameters.
  - Uses common.ValidateBlockBodyHash for era-aware body hash verification.

- **Migration**
  - To enable transaction validation, set LedgerState and ProtocolParameters in VerifyConfig; otherwise set SkipTransactionValidation: true.
  - Tests now skip both body hash and transaction validation when CBOR or ledger state is missing; mirror this in your tests if needed.

<sup>Written for commit 032bcd9e6e2fcdeae06aabf4f9f8d2ef1fd2fc1a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Added transaction-level verification controls allowing optional skipping of transaction validation.
  * Block verification now uses streamlined body-hash handling and performs era-aware transaction validation when enabled, requiring ledger state and protocol parameters.
* **Tests**
  * Updated verification tests and helpers to support the new configuration options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->