### PR TITLE
fix(ledger): prevent panic calling IssuserVkey on Byron EBB

### DIFF
--- a/ledger/byron/byron.go
+++ b/ledger/byron/byron.go
@@ -732,7 +732,7 @@ func (h *ByronEpochBoundaryBlockHeader) SlotNumber() uint64 {
 
 func (h *ByronEpochBoundaryBlockHeader) IssuerVkey() common.IssuerVkey {
 	// Byron blocks don't have an issuer
-	return common.IssuerVkey([]byte{})
+	return common.IssuerVkey{}
 }
 
 func (h *ByronEpochBoundaryBlockHeader) BlockBodySize() uint64 {


### PR DESCRIPTION
Closes #701 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent a panic when calling IssuerVkey on Byron Epoch Boundary Block headers. Return a zero-value IssuerVkey instead of an empty byte slice, since Byron blocks have no issuer.

<sup>Written for commit 3298c7051baa98af84aaaa4928fd2855a95f9e1e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal implementation refinement to ensure consistent behavior in utility components. No user-facing changes or new functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->