### PR TITLE
feat(network): support public roots in named networks

### DIFF
--- a/networks.go
+++ b/networks.go
@@ -83,19 +83,41 @@ var (
 				Port:    5521,
 			},
 		},
+		PublicRoots: []NetworkPublicRoot{
+			{
+				AccessPoints: []NetworkAccessPoint{
+					{
+						Address: "relay-g1.prime.mainnet.apexfusion.org",
+						Port:    5521,
+					},
+					{
+						Address: "relay-g2.prime.mainnet.apexfusion.org",
+						Port:    5521,
+					},
+				},
+				Advertise: true,
+				Valency:   1,
+			},
+		},
 	}
 	NetworkPrimeTestnet = Network{
 		Id:           common.AddressNetworkTestnet,
 		Name:         "prime-testnet",
 		NetworkMagic: 3311,
-		BootstrapPeers: []NetworkBootstrapPeer{
+		PublicRoots: []NetworkPublicRoot{
 			{
-				Address: "relay-0.prime.testnet.apexfusion.org",
-				Port:    5521,
-			},
-			{
-				Address: "relay-1.prime.testnet.apexfusion.org",
-				Port:    5521,
+				AccessPoints: []NetworkAccessPoint{
+					{
+						Address: "relay-0.prime.testnet.apexfusion.org",
+						Port:    5521,
+					},
+					{
+						Address: "relay-1.prime.testnet.apexfusion.org",
+						Port:    5521,
+					},
+				},
+				Advertise: true,
+				Valency:   1,
 			},
 		},
 	}
@@ -160,9 +182,21 @@ type Network struct {
 	Name           string
 	NetworkMagic   uint32
 	BootstrapPeers []NetworkBootstrapPeer
+	PublicRoots    []NetworkPublicRoot
 }
 
 type NetworkBootstrapPeer struct {
+	Address string
+	Port    uint
+}
+
+type NetworkPublicRoot struct {
+	AccessPoints []NetworkAccessPoint
+	Advertise    bool
+	Valency      int
+}
+
+type NetworkAccessPoint struct {
 	Address string
 	Port    uint
 }


### PR DESCRIPTION
Closes #1246 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added support for configuring public root nodes in named networks to improve discovery and connectivity. Updated prime mainnet and migrated prime testnet from bootstrap peers to public roots.

- **New Features**
  - Added Network.PublicRoots with NetworkPublicRoot and NetworkAccessPoint types.
  - Configured public roots for mainnet and testnet with two relay access points each (advertise=true, valency=1).

- **Migration**
  - If you rely on prime-testnet BootstrapPeers, switch to PublicRoots.

<sup>Written for commit 0e80f39e82b4b192e8f38857e782baa575fa7d08. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

