### PR TITLE
test(muxer): remove containsString helper

### DIFF
--- a/muxer/muxer_test.go
+++ b/muxer/muxer_test.go
@@ -477,7 +477,7 @@ func TestDiffusionModes(t *testing.T) {
 				select {
 				case err := <-m.ErrorChan():
 					if tt.expectError {
-						if !containsString(err.Error(), tt.errorContains) {
+						if !strings.Contains(err.Error(), tt.errorContains) {
 							t.Errorf(
 								"expected error containing %q, got: %v",
 								tt.errorContains,
@@ -530,7 +530,7 @@ func TestErrorHandling(t *testing.T) {
 		select {
 		case err := <-m.ErrorChan():
 			if err == nil ||
-				!containsString(err.Error(), "zero-byte segment payload") {
+				!strings.Contains(err.Error(), "zero-byte segment payload") {
 				t.Errorf("expected zero-byte payload error, got: %v", err)
 			}
 		default:
@@ -556,7 +556,7 @@ func TestErrorHandling(t *testing.T) {
 		select {
 		case err := <-m.ErrorChan():
 			if err == nil ||
-				!containsString(err.Error(), "unknown protocol ID") {
+				!strings.Contains(err.Error(), "unknown protocol ID") {
 				t.Errorf("expected unknown protocol error, got: %v", err)
 			}
 		default:
@@ -680,9 +680,4 @@ func createSegmentData(segment *muxer.Segment) []byte {
 	) // error ignored: Buffer.Write never fails
 	buf.Write(segment.Payload)
 	return buf.Bytes()
-}
-
-// containsString checks if a string contains a substring
-func containsString(s, substr string) bool {
-	return strings.Contains(s, substr)
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Simplified muxer tests by replacing the custom containsString helper with strings.Contains and removing the helper function.

<sup>Written for commit dc293a7392bd7108e6fc8168f563cccd828ebfa6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test code implementation by streamlining error assertion patterns to use standard library utilities instead of custom helpers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->