### PR TITLE
chore: fix comments for golangci-lint

### DIFF
--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -280,10 +280,10 @@ func UtxoValidateValueNotConservedUtxo(
 	if tx.AssetMint() != nil {
 		mintedAda := tx.AssetMint().Asset(common.Blake2b224{}, []byte{})
 		if mintedAda > 0 {
-			consumedValue += uint64(mintedAda) //nolint:gosec,G115
+			consumedValue += uint64(mintedAda) //nolint:gosec // G115
 		} else if mintedAda < 0 {
 			burned := -mintedAda
-			consumedValue -= uint64(burned) //nolint:gosec,G115
+			consumedValue -= uint64(burned) //nolint:gosec // G115
 		}
 	}
 	// Calculate produced value


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix golangci-lint comments in ledger/conway/rules.go so the linter parses suppressions correctly. No logic changes; only comment formatting for gosec and G115 around uint64 casts.

<sup>Written for commit edd77aace896ee870bc8132a93a10f9451adc30f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor formatting adjustments to internal code comments.

**Note:** This release contains no user-facing changes or functional updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->