### PR TITLE
feat(ledger): stake pool validation

### DIFF
--- a/ledger/common/rules_test.go
+++ b/ledger/common/rules_test.go
@@ -1,0 +1,149 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+func TestVerifyTransaction(t *testing.T) {
+	// Mock transaction - we don't need a real one for this test
+	var tx Transaction
+
+	slot := uint64(1000)
+	ledgerState := &mockLedgerStateRules{}
+	protocolParams := &mockProtocolParamsRules{}
+
+	t.Run("all_rules_pass", func(t *testing.T) {
+		rules := []UtxoValidationRuleFunc{
+			func(Transaction, uint64, LedgerState, ProtocolParameters) error { return nil },
+			func(Transaction, uint64, LedgerState, ProtocolParameters) error { return nil },
+			func(Transaction, uint64, LedgerState, ProtocolParameters) error { return nil },
+		}
+
+		err := VerifyTransaction(tx, slot, ledgerState, protocolParams, rules)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("first_rule_fails", func(t *testing.T) {
+		expectedErr := errors.New("first rule failed")
+		rules := []UtxoValidationRuleFunc{
+			func(Transaction, uint64, LedgerState, ProtocolParameters) error { return expectedErr },
+			func(Transaction, uint64, LedgerState, ProtocolParameters) error { return nil },
+		}
+
+		err := VerifyTransaction(tx, slot, ledgerState, protocolParams, rules)
+		if err != expectedErr {
+			t.Errorf("expected error %v, got %v", expectedErr, err)
+		}
+	})
+
+	t.Run("middle_rule_fails", func(t *testing.T) {
+		expectedErr := errors.New("middle rule failed")
+		rules := []UtxoValidationRuleFunc{
+			func(Transaction, uint64, LedgerState, ProtocolParameters) error { return nil },
+			func(Transaction, uint64, LedgerState, ProtocolParameters) error { return expectedErr },
+			func(Transaction, uint64, LedgerState, ProtocolParameters) error { return nil },
+		}
+
+		err := VerifyTransaction(tx, slot, ledgerState, protocolParams, rules)
+		if err != expectedErr {
+			t.Errorf("expected error %v, got %v", expectedErr, err)
+		}
+	})
+
+	t.Run("last_rule_fails", func(t *testing.T) {
+		expectedErr := errors.New("last rule failed")
+		rules := []UtxoValidationRuleFunc{
+			func(Transaction, uint64, LedgerState, ProtocolParameters) error { return nil },
+			func(Transaction, uint64, LedgerState, ProtocolParameters) error { return expectedErr },
+		}
+
+		err := VerifyTransaction(tx, slot, ledgerState, protocolParams, rules)
+		if err != expectedErr {
+			t.Errorf("expected error %v, got %v", expectedErr, err)
+		}
+	})
+
+	t.Run("empty_rules", func(t *testing.T) {
+		rules := []UtxoValidationRuleFunc{}
+
+		err := VerifyTransaction(tx, slot, ledgerState, protocolParams, rules)
+		if err != nil {
+			t.Errorf("expected no error with empty rules, got %v", err)
+		}
+	})
+}
+
+// Mock types for testing
+type mockLedgerStateRules struct{}
+
+func (m *mockLedgerStateRules) UtxoById(
+	input TransactionInput,
+) (Utxo, error) {
+	return Utxo{}, nil
+}
+
+func (m *mockLedgerStateRules) StakeRegistration(
+	key []byte,
+) ([]StakeRegistrationCertificate, error) {
+	return nil, nil
+}
+
+func (m *mockLedgerStateRules) SlotToTime(
+	slot uint64,
+) (time.Time, error) {
+	return time.Time{}, nil
+}
+
+func (m *mockLedgerStateRules) TimeToSlot(
+	t time.Time,
+) (uint64, error) {
+	return 0, nil
+}
+
+func (m *mockLedgerStateRules) PoolCurrentState(
+	poolKeyHash PoolKeyHash,
+) (*PoolRegistrationCertificate, *uint64, error) {
+	return nil, nil, nil
+}
+
+func (m *mockLedgerStateRules) CalculateRewards(
+	pots AdaPots,
+	snapshot RewardSnapshot,
+	params RewardParameters,
+) (*RewardCalculationResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockLedgerStateRules) GetAdaPots() AdaPots              { return AdaPots{} }
+func (m *mockLedgerStateRules) UpdateAdaPots(pots AdaPots) error { return nil }
+
+func (m *mockLedgerStateRules) GetRewardSnapshot(
+	epoch uint64,
+) (RewardSnapshot, error) {
+	return RewardSnapshot{}, nil
+}
+func (m *mockLedgerStateRules) NetworkId() uint { return 0 }
+
+type mockProtocolParamsRules struct{}
+
+func (m *mockProtocolParamsRules) Utxorpc() (*cardano.PParams, error) { return nil, nil }

--- a/ledger/common/verify_config.go
+++ b/ledger/common/verify_config.go
@@ -26,13 +26,17 @@ import (
 // Default values favor safety; tests or specific flows can opt out.
 type VerifyConfig struct {
 	// SkipBodyHashValidation disables body hash verification in VerifyBlock().
+	// When false (default), full block CBOR must be available for validation.
 	// Useful for scenarios where full block CBOR is unavailable.
 	SkipBodyHashValidation bool
 	// SkipTransactionValidation disables transaction validation in VerifyBlock().
 	// When false (default), LedgerState and ProtocolParameters must be set.
 	SkipTransactionValidation bool
+	// SkipStakePoolValidation disables stake pool registration validation in VerifyBlock().
+	// When false (default), LedgerState must be set.
+	SkipStakePoolValidation bool
 	// LedgerState provides the current ledger state for transaction validation.
-	// Required if SkipTransactionValidation is false.
+	// Required if SkipTransactionValidation or SkipStakePoolValidation is false.
 	LedgerState LedgerState
 	// ProtocolParameters provides the current protocol parameters for transaction validation.
 	// Required if SkipTransactionValidation is false.

--- a/ledger/verify_block_test.go
+++ b/ledger/verify_block_test.go
@@ -26,12 +26,13 @@ var eraNameMap = map[uint]string{
 	BlockTypeConway:  conway.EraNameConway,
 }
 
-// testSkipAllValidationConfig returns a VerifyConfig that skips both body hash and transaction validation.
+// testSkipAllValidationConfig returns a VerifyConfig that skips body hash, stake pool, and transaction validation.
 // Useful for tests that don't provide full CBOR or ledger state.
 func testSkipAllValidationConfig() common.VerifyConfig {
 	return common.VerifyConfig{
 		SkipBodyHashValidation:    true,
 		SkipTransactionValidation: true,
+		SkipStakePoolValidation:   true,
 	}
 }
 


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add stake pool validation to VerifyBlock to ensure blocks are produced by a registered pool with a matching VRF key. Adds a config flag to optionally skip this check.

- **New Features**
  - Validates pool registration by hashing the issuer vkey to a poolKeyHash and querying LedgerState.PoolCurrentState.
  - Verifies the header VRF key by comparing its Blake2b-256 hash to the registered pool’s VRF key hash.
  - Supports Shelley through Conway block headers.
  - Adds VerifyConfig.SkipStakePoolValidation and clarifies config requirements.

- **Migration**
  - When stake pool validation is enabled, provide LedgerState; otherwise set SkipStakePoolValidation to true.
  - If transaction validation is enabled, continue providing ProtocolParameters.

<sup>Written for commit 8586122f356cded4b2b56d268535eba4459f2c33. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stake-pool validation during block verification to confirm pool registration and VRF key consistency.
  * Added a configuration option to skip stake-pool validation when desired.

* **Tests**
  * Added comprehensive tests for transaction verification rules covering all-pass, first/middle/last-rule failures, and empty-rule scenarios.
  * Updated validation tests to account for the new skip option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->