### PR TITLE
fix(ledger): use tx body for size calculations

### DIFF
--- a/ledger/alonzo/rules.go
+++ b/ledger/alonzo/rules.go
@@ -370,10 +370,14 @@ func UtxoValidateMaxTxSizeUtxo(
 	if !ok {
 		return errors.New("pparams are not expected type")
 	}
-	txBytes := tx.Cbor()
+	tmpTx, ok := tx.(*AlonzoTransaction)
+	if !ok {
+		return errors.New("transaction is not expected type")
+	}
+	txBytes := tmpTx.Body.Cbor()
 	if len(txBytes) == 0 {
 		var err error
-		txBytes, err = cbor.Encode(tx)
+		txBytes, err = cbor.Encode(tmpTx.Body)
 		if err != nil {
 			return err
 		}

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -389,7 +389,11 @@ func UtxoValidateMaxTxSizeUtxo(
 	if !ok {
 		return errors.New("pparams are not expected type")
 	}
-	txBytes, err := cbor.Encode(tx)
+	tmpTx, ok := tx.(*BabbageTransaction)
+	if !ok {
+		return errors.New("transaction is not expected type")
+	}
+	txBytes, err := cbor.Encode(tmpTx.Body)
 	if err != nil {
 		return err
 	}

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -455,7 +455,11 @@ func UtxoValidateMaxTxSizeUtxo(
 	if !ok {
 		return errors.New("pparams are not expected type")
 	}
-	txBytes, err := cbor.Encode(tx)
+	tmpTx, ok := tx.(*ConwayTransaction)
+	if !ok {
+		return errors.New("transaction is not expected type")
+	}
+	txBytes, err := cbor.Encode(tmpTx.Body)
 	if err != nil {
 		return err
 	}

--- a/ledger/mary/rules.go
+++ b/ledger/mary/rules.go
@@ -238,10 +238,14 @@ func UtxoValidateMaxTxSizeUtxo(
 	if !ok {
 		return errors.New("pparams are not expected type")
 	}
-	txBytes := tx.Cbor()
+	tmpTx, ok := tx.(*MaryTransaction)
+	if !ok {
+		return errors.New("transaction is not expected type")
+	}
+	txBytes := tmpTx.Body.Cbor()
 	if len(txBytes) == 0 {
 		var err error
-		txBytes, err = cbor.Encode(tx)
+		txBytes, err = cbor.Encode(tmpTx.Body)
 		if err != nil {
 			return err
 		}

--- a/ledger/shelley/rules.go
+++ b/ledger/shelley/rules.go
@@ -283,10 +283,14 @@ func UtxoValidateMaxTxSizeUtxo(
 	if !ok {
 		return errors.New("pparams are not expected type")
 	}
-	txBytes := tx.Cbor()
+	tmpTx, ok := tx.(*ShelleyTransaction)
+	if !ok {
+		return errors.New("transaction is not expected type")
+	}
+	txBytes := tmpTx.Body.Cbor()
 	if len(txBytes) == 0 {
 		var err error
-		txBytes, err = cbor.Encode(tx)
+		txBytes, err = cbor.Encode(tmpTx.Body)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix max transaction size validation to measure the CBOR-encoded transaction body instead of the whole transaction across all eras. This prevents incorrect size checks and aligns validation with protocol parameters.

- **Bug Fixes**
  - Updated UtxoValidateMaxTxSizeUtxo in Shelley, Mary, Allegra, Alonzo, Babbage, and Conway to use Body.Cbor (fallback to cbor.Encode(body)).
  - Added era-specific type assertions and consistent error reporting when TxSize exceeds MaxTxSize.

<sup>Written for commit 996bdbb30da20fd7657db9f9b004b46e1640004a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Enhanced transaction validation logic to ensure correct type checking and more accurate size calculations across all ledger implementations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->