### PR TITLE
fix(ledger): use raw bytes for metadata

### DIFF
--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -118,6 +118,17 @@ func (b *BabbageBlock) UnmarshalCBOR(cborData []byte) error {
 	b.TransactionMetadataSet = tmp.TransactionMetadataSet
 
 	b.SetCbor(cborData)
+
+	// Extract and store CBOR for each component
+	if err := common.ExtractAndSetTransactionCbor(
+		cborData,
+		func(i int, data []byte) { b.TransactionBodies[i].SetCbor(data) },
+		func(i int, data []byte) { b.TransactionWitnessSets[i].SetCbor(data) },
+		len(b.TransactionBodies),
+		len(b.TransactionWitnessSets),
+	); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -187,14 +198,15 @@ func (b *BabbageBlock) Transactions() []common.Transaction {
 	ret := make([]common.Transaction, len(b.TransactionBodies))
 	// #nosec G115
 	for idx := range b.TransactionBodies {
-		// Note: Ignoring the presence flag; if distinguishing "missing" vs "present but empty/failed decode" is needed, plumb the second return value through
-		txMetadata, _ := b.TransactionMetadataSet.GetMetadata(uint(idx))
-		ret[idx] = &BabbageTransaction{
+		tx := &BabbageTransaction{
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],
-			TxMetadata: txMetadata,
 			TxIsValid:  !invalidTxMap[uint(idx)],
 		}
+		if metadata, ok := b.TransactionMetadataSet.GetMetadata(uint(idx)); ok {
+			tx.TxMetadata = metadata
+		}
+		ret[idx] = tx
 	}
 	return ret
 }
@@ -877,14 +889,50 @@ type BabbageTransaction struct {
 }
 
 func (t *BabbageTransaction) UnmarshalCBOR(cborData []byte) error {
-	type tBabbageTransaction BabbageTransaction
-	var tmp tBabbageTransaction
-	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+	// Decode as raw array to preserve metadata bytes
+	var txArray []cbor.RawMessage
+	if _, err := cbor.Decode(cborData, &txArray); err != nil {
 		return err
 	}
-	*t = BabbageTransaction(tmp)
+
+	// Ensure we have exactly 4 components (body, witness, isValid, metadata)
+	if len(txArray) != 4 {
+		return fmt.Errorf(
+			"invalid transaction: expected exactly 4 components, got %d",
+			len(txArray),
+		)
+	}
+
+	// Decode body
+	if _, err := cbor.Decode([]byte(txArray[0]), &t.Body); err != nil {
+		return fmt.Errorf("failed to decode transaction body: %w", err)
+	}
+
+	// Decode witness set
+	if _, err := cbor.Decode([]byte(txArray[1]), &t.WitnessSet); err != nil {
+		return fmt.Errorf("failed to decode transaction witness set: %w", err)
+	}
+
+	// Decode TxIsValid flag
+	if _, err := cbor.Decode([]byte(txArray[2]), &t.TxIsValid); err != nil {
+		return fmt.Errorf("failed to decode TxIsValid: %w", err)
+	}
+
+	// Handle metadata (component 4, always present - either data or CBOR nil)
+	// DecodeAuxiliaryDataToMetadata already preserves raw bytes via DecodeMetadatumRaw
+	if len(txArray[3]) > 0 {
+		metadata, err := common.DecodeAuxiliaryDataToMetadata(txArray[3])
+		if err == nil && metadata != nil {
+			t.TxMetadata = metadata
+		}
+	}
+
 	t.SetCbor(cborData)
 	return nil
+}
+
+func (t *BabbageTransaction) Metadata() common.TransactionMetadatum {
+	return t.TxMetadata
 }
 
 func (BabbageTransaction) Type() int {
@@ -987,10 +1035,6 @@ func (t BabbageTransaction) Donation() uint64 {
 	return t.Body.Donation()
 }
 
-func (t BabbageTransaction) Metadata() common.TransactionMetadatum {
-	return t.TxMetadata
-}
-
 func (t BabbageTransaction) IsValid() bool {
 	return t.TxIsValid
 }
@@ -1036,6 +1080,26 @@ func (t BabbageTransaction) Witnesses() common.TransactionWitnessSet {
 	return t.WitnessSet
 }
 
+func (t *BabbageTransaction) MarshalCBOR() ([]byte, error) {
+	// If we have stored CBOR (from decode), return it to preserve metadata bytes
+	cborData := t.DecodeStoreCbor.Cbor()
+	if cborData != nil {
+		return cborData, nil
+	}
+	// Otherwise, construct and encode
+	tmpObj := []any{
+		t.Body,
+		t.WitnessSet,
+		t.TxIsValid,
+	}
+	if t.TxMetadata != nil {
+		tmpObj = append(tmpObj, cbor.RawMessage(t.TxMetadata.Cbor()))
+	} else {
+		tmpObj = append(tmpObj, nil)
+	}
+	return cbor.Encode(tmpObj)
+}
+
 func (t *BabbageTransaction) Cbor() []byte {
 	// Return stored CBOR if we have any
 	cborData := t.DecodeStoreCbor.Cbor()
@@ -1046,20 +1110,8 @@ func (t *BabbageTransaction) Cbor() []byte {
 	if t.Body.Cbor() == nil {
 		return nil
 	}
-	// Generate our own CBOR
-	// This is necessary when a transaction is put together from pieces stored separately in a block
-	tmpObj := []any{
-		cbor.RawMessage(t.Body.Cbor()),
-		cbor.RawMessage(t.WitnessSet.Cbor()),
-		t.TxIsValid,
-	}
-	if t.TxMetadata != nil {
-		tmpObj = append(tmpObj, t.TxMetadata)
-	} else {
-		tmpObj = append(tmpObj, nil)
-	}
-	// This should never fail, since we're only encoding a list and a bool value
-	cborData, err := cbor.Encode(&tmpObj)
+	// Delegate to MarshalCBOR which handles encoding
+	cborData, err := t.MarshalCBOR()
 	if err != nil {
 		panic("CBOR encoding that should never fail has failed: " + err.Error())
 	}

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -118,6 +118,17 @@ func (b *ConwayBlock) UnmarshalCBOR(cborData []byte) error {
 	b.TransactionMetadataSet = tmp.TransactionMetadataSet
 
 	b.SetCbor(cborData)
+
+	// Extract and store CBOR for each component
+	if err := common.ExtractAndSetTransactionCbor(
+		cborData,
+		func(i int, data []byte) { b.TransactionBodies[i].SetCbor(data) },
+		func(i int, data []byte) { b.TransactionWitnessSets[i].SetCbor(data) },
+		len(b.TransactionBodies),
+		len(b.TransactionWitnessSets),
+	); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -187,14 +198,15 @@ func (b *ConwayBlock) Transactions() []common.Transaction {
 	ret := make([]common.Transaction, len(b.TransactionBodies))
 	// #nosec G115
 	for idx := range b.TransactionBodies {
-		// Note: Ignoring the presence flag; if distinguishing "missing" vs "present but empty/failed decode" is needed, plumb the second return value through
-		txMetadata, _ := b.TransactionMetadataSet.GetMetadata(uint(idx))
-		ret[idx] = &ConwayTransaction{
+		tx := &ConwayTransaction{
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],
-			TxMetadata: txMetadata,
 			TxIsValid:  !invalidTxMap[uint(idx)],
 		}
+		if metadata, ok := b.TransactionMetadataSet.GetMetadata(uint(idx)); ok {
+			tx.TxMetadata = metadata
+		}
+		ret[idx] = tx
 	}
 	return ret
 }
@@ -601,14 +613,50 @@ type ConwayTransaction struct {
 }
 
 func (t *ConwayTransaction) UnmarshalCBOR(cborData []byte) error {
-	type tConwayTransaction ConwayTransaction
-	var tmp tConwayTransaction
-	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+	// Decode as raw array to preserve metadata bytes
+	var txArray []cbor.RawMessage
+	if _, err := cbor.Decode(cborData, &txArray); err != nil {
 		return err
 	}
-	*t = ConwayTransaction(tmp)
+
+	// Ensure we have exactly 4 components (body, witness, isValid, metadata)
+	if len(txArray) != 4 {
+		return fmt.Errorf(
+			"invalid transaction: expected exactly 4 components, got %d",
+			len(txArray),
+		)
+	}
+
+	// Decode body
+	if _, err := cbor.Decode([]byte(txArray[0]), &t.Body); err != nil {
+		return fmt.Errorf("failed to decode transaction body: %w", err)
+	}
+
+	// Decode witness set
+	if _, err := cbor.Decode([]byte(txArray[1]), &t.WitnessSet); err != nil {
+		return fmt.Errorf("failed to decode transaction witness set: %w", err)
+	}
+
+	// Decode TxIsValid flag
+	if _, err := cbor.Decode([]byte(txArray[2]), &t.TxIsValid); err != nil {
+		return fmt.Errorf("failed to decode TxIsValid: %w", err)
+	}
+
+	// Handle metadata (component 4, always present - either data or CBOR nil)
+	// DecodeAuxiliaryDataToMetadata already preserves raw bytes via DecodeMetadatumRaw
+	if len(txArray) > 3 && len(txArray[3]) > 0 {
+		metadata, err := common.DecodeAuxiliaryDataToMetadata(txArray[3])
+		if err == nil && metadata != nil {
+			t.TxMetadata = metadata
+		}
+	}
+
 	t.SetCbor(cborData)
 	return nil
+}
+
+func (t *ConwayTransaction) Metadata() common.TransactionMetadatum {
+	return t.TxMetadata
 }
 
 func (ConwayTransaction) Type() int {
@@ -711,10 +759,6 @@ func (t ConwayTransaction) Donation() uint64 {
 	return t.Body.Donation()
 }
 
-func (t ConwayTransaction) Metadata() common.TransactionMetadatum {
-	return t.TxMetadata
-}
-
 func (t ConwayTransaction) IsValid() bool {
 	return t.TxIsValid
 }
@@ -760,6 +804,26 @@ func (t ConwayTransaction) Witnesses() common.TransactionWitnessSet {
 	return t.WitnessSet
 }
 
+func (t *ConwayTransaction) MarshalCBOR() ([]byte, error) {
+	// If we have stored CBOR (from decode), return it to preserve metadata bytes
+	cborData := t.DecodeStoreCbor.Cbor()
+	if cborData != nil {
+		return cborData, nil
+	}
+	// Otherwise, construct and encode
+	tmpObj := []any{
+		t.Body,
+		t.WitnessSet,
+		t.TxIsValid,
+	}
+	if t.TxMetadata != nil {
+		tmpObj = append(tmpObj, cbor.RawMessage(t.TxMetadata.Cbor()))
+	} else {
+		tmpObj = append(tmpObj, nil)
+	}
+	return cbor.Encode(tmpObj)
+}
+
 func (t *ConwayTransaction) Cbor() []byte {
 	// Return stored CBOR if we have any
 	cborData := t.DecodeStoreCbor.Cbor()
@@ -770,20 +834,8 @@ func (t *ConwayTransaction) Cbor() []byte {
 	if t.Body.Cbor() == nil {
 		return nil
 	}
-	// Generate our own CBOR
-	// This is necessary when a transaction is put together from pieces stored separately in a block
-	tmpObj := []any{
-		cbor.RawMessage(t.Body.Cbor()),
-		cbor.RawMessage(t.WitnessSet.Cbor()),
-		t.TxIsValid,
-	}
-	if t.TxMetadata != nil {
-		tmpObj = append(tmpObj, t.TxMetadata)
-	} else {
-		tmpObj = append(tmpObj, nil)
-	}
-	// This should never fail, since we're only encoding a list and a bool value
-	cborData, err := cbor.Encode(&tmpObj)
+	// Delegate to MarshalCBOR which handles encoding
+	cborData, err := t.MarshalCBOR()
 	if err != nil {
 		panic("CBOR encoding that should never fail has failed: " + err.Error())
 	}

--- a/ledger/leios/leios.go
+++ b/ledger/leios/leios.go
@@ -251,8 +251,15 @@ func (b *LeiosRankingBlock) Transactions() []common.Transaction {
 	ret := make([]common.Transaction, len(b.TransactionBodies))
 	// #nosec G115
 	for idx := range b.TransactionBodies {
-		// Note: Ignoring the presence flag; if distinguishing "missing" vs "present but empty/failed decode" is needed, plumb the second return value through
-		txMetadata, _ := b.TransactionMetadataSet.GetMetadata(uint(idx))
+		txMetadataRaw, _ := b.TransactionMetadataSet.GetRawMetadata(uint(idx))
+		var txMetadata common.TransactionMetadatum
+		if len(txMetadataRaw) > 0 {
+			var err error
+			txMetadata, err = common.DecodeAuxiliaryDataToMetadata(
+				txMetadataRaw,
+			)
+			_ = err // ignore error, txMetadata will be nil if decoding failed
+		}
 		ret[idx] = &conway.ConwayTransaction{
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -57,6 +57,7 @@ type ShelleyBlock struct {
 }
 
 func (b *ShelleyBlock) UnmarshalCBOR(cborData []byte) error {
+	// First, decode the block structure normally
 	type tShelleyBlock ShelleyBlock
 	var tmp tShelleyBlock
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
@@ -64,6 +65,21 @@ func (b *ShelleyBlock) UnmarshalCBOR(cborData []byte) error {
 	}
 	*b = ShelleyBlock(tmp)
 	b.SetCbor(cborData)
+
+	// Extract and store CBOR for each component (bodies, witnesses, metadata)
+	// This ensures tx.Body.Cbor(), tx.WitnessSet.Cbor(), etc. return the original bytes
+	if err := common.ExtractAndSetTransactionCbor(
+		cborData,
+		func(i int, data []byte) { b.TransactionBodies[i].SetCbor(data) },
+		func(i int, data []byte) { b.TransactionWitnessSets[i].SetCbor(data) },
+		len(b.TransactionBodies),
+		len(b.TransactionWitnessSets),
+	); err != nil {
+		return err
+	}
+
+	// Note: Metadata is stored in TransactionMetadataSet with raw CBOR already preserved
+
 	return nil
 }
 
@@ -107,13 +123,14 @@ func (b *ShelleyBlock) Transactions() []common.Transaction {
 	ret := make([]common.Transaction, len(b.TransactionBodies))
 	// #nosec G115
 	for idx := range b.TransactionBodies {
-		// Note: Ignoring the presence flag; if distinguishing "missing" vs "present but empty/failed decode" is needed, plumb the second return value through
-		txMetadata, _ := b.TransactionMetadataSet.GetMetadata(uint(idx))
-		ret[idx] = &ShelleyTransaction{
+		tx := &ShelleyTransaction{
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],
-			TxMetadata: txMetadata,
 		}
+		if metadata, ok := b.TransactionMetadataSet.GetMetadata(uint(idx)); ok {
+			tx.TxMetadata = metadata
+		}
+		ret[idx] = tx
 	}
 	return ret
 }
@@ -555,14 +572,45 @@ type ShelleyTransaction struct {
 }
 
 func (t *ShelleyTransaction) UnmarshalCBOR(cborData []byte) error {
-	type tShelleyTransaction ShelleyTransaction
-	var tmp tShelleyTransaction
-	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+	// Decode as raw array to preserve metadata bytes
+	var txArray []cbor.RawMessage
+	if _, err := cbor.Decode(cborData, &txArray); err != nil {
 		return err
 	}
-	*t = ShelleyTransaction(tmp)
+
+	// Ensure we have at least 3 components (body, witness, metadata)
+	if len(txArray) < 3 {
+		return fmt.Errorf(
+			"invalid transaction: expected at least 3 components, got %d",
+			len(txArray),
+		)
+	}
+
+	// Decode body
+	if _, err := cbor.Decode([]byte(txArray[0]), &t.Body); err != nil {
+		return fmt.Errorf("failed to decode transaction body: %w", err)
+	}
+
+	// Decode witness set
+	if _, err := cbor.Decode([]byte(txArray[1]), &t.WitnessSet); err != nil {
+		return fmt.Errorf("failed to decode transaction witness set: %w", err)
+	}
+
+	// Handle metadata (component 3, index 2) - always present, but may be CBOR nil
+	// DecodeAuxiliaryDataToMetadata already preserves raw bytes via DecodeMetadatumRaw
+	if len(txArray) > 2 && len(txArray[2]) > 0 {
+		metadata, err := common.DecodeAuxiliaryDataToMetadata(txArray[2])
+		if err == nil && metadata != nil {
+			t.TxMetadata = metadata
+		}
+	}
+
 	t.SetCbor(cborData)
 	return nil
+}
+
+func (t *ShelleyTransaction) Metadata() common.TransactionMetadatum {
+	return t.TxMetadata
 }
 
 func (ShelleyTransaction) Type() int {
@@ -661,10 +709,6 @@ func (t ShelleyTransaction) Donation() uint64 {
 	return t.Body.Donation()
 }
 
-func (t ShelleyTransaction) Metadata() common.TransactionMetadatum {
-	return t.TxMetadata
-}
-
 func (t ShelleyTransaction) IsValid() bool {
 	return true
 }
@@ -703,6 +747,25 @@ func (t *ShelleyTransaction) ProtocolParameterUpdates() (uint64, map[common.Blak
 	return t.Body.ProtocolParameterUpdates()
 }
 
+func (t *ShelleyTransaction) MarshalCBOR() ([]byte, error) {
+	// If we have stored CBOR (from decode), return it to preserve metadata bytes
+	cborData := t.DecodeStoreCbor.Cbor()
+	if cborData != nil {
+		return cborData, nil
+	}
+	// Otherwise, construct and encode
+	tmpObj := []any{
+		t.Body,
+		t.WitnessSet,
+	}
+	if t.TxMetadata != nil {
+		tmpObj = append(tmpObj, cbor.RawMessage(t.TxMetadata.Cbor()))
+	} else {
+		tmpObj = append(tmpObj, nil)
+	}
+	return cbor.Encode(tmpObj)
+}
+
 func (t *ShelleyTransaction) Cbor() []byte {
 	// Return stored CBOR if we have any
 	cborData := t.DecodeStoreCbor.Cbor()
@@ -713,19 +776,8 @@ func (t *ShelleyTransaction) Cbor() []byte {
 	if t.Body.Cbor() == nil {
 		return nil
 	}
-	// Generate our own CBOR
-	// This is necessary when a transaction is put together from pieces stored separately in a block
-	tmpObj := []any{
-		cbor.RawMessage(t.Body.Cbor()),
-		cbor.RawMessage(t.WitnessSet.Cbor()),
-	}
-	if t.TxMetadata != nil {
-		tmpObj = append(tmpObj, t.TxMetadata)
-	} else {
-		tmpObj = append(tmpObj, nil)
-	}
-	// This should never fail, since we're only encoding a list and a bool value
-	cborData, err := cbor.Encode(&tmpObj)
+	// Delegate to MarshalCBOR which handles encoding
+	cborData, err := cbor.Encode(t)
 	if err != nil {
 		panic("CBOR encoding that should never fail has failed: " + err.Error())
 	}

--- a/ledger/verify_kes.go
+++ b/ledger/verify_kes.go
@@ -140,7 +140,7 @@ func (s Sum0KesSig) Verify(
 }
 
 func extractKesFieldsShelleyAlonzo(
-	header interface{},
+	header any,
 ) (bodyCbor []byte, sig []byte, hotVkey []byte, kesPeriod uint64, slot uint64, err error) {
 	switch h := header.(type) {
 	case *shelley.ShelleyBlockHeader:
@@ -173,7 +173,7 @@ func extractKesFieldsShelleyAlonzo(
 }
 
 func extractKesFieldsBabbagePlus(
-	header interface{},
+	header any,
 ) (bodyCbor []byte, sig []byte, hotVkey []byte, kesPeriod uint64, slot uint64, err error) {
 	switch h := header.(type) {
 	case *babbage.BabbageBlockHeader:


### PR DESCRIPTION












































<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve raw CBOR bytes for transaction metadata and for tx bodies/witness sets across eras to keep exact bytes and round-trip encoding. Metadata is decoded only when needed.

- **Bug Fixes**
  - Store metadata raw bytes and decode on demand where used (incl. tx array metadata and Leios).
  - Add TransactionMetadataSet.GetRawMetadata and use it in Leios Transactions().
  - Decode transactions as raw arrays across eras; preserve metadata bytes; parse TxIsValid where needed (Alonzo, Babbage, Conway).
  - Add MarshalCBOR and use cbor.RawMessage for metadata; Cbor() delegates to preserve original bytes.
  - On block unmarshal, set raw CBOR for each tx body and witness set using common.ExtractAndSetTransactionCbor (Shelley→Conway).
  - Expose Cbor() on TransactionMetadatum and export DecodeAuxiliaryDataToMetadata.

<sup>Written for commit d443a43e1e5574fafeb7fc32c2a3d43983ade4cb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->













































<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Transactions across eras now preserve original per-item CBOR and carry per-transaction metadata for reliable round‑tripping.

* **New Features**
  * Added public auxiliary-data decoder and metadatum CBOR accessor; transactions expose CBOR/encoding methods and pointer-based metadata accessors.
  * Block decoding now captures per-transaction body/witness CBOR for accurate reconstruction.

* **Bug Fixes**
  * Stronger validation of transaction CBOR structure and clearer error reporting for missing or malformed components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->