### PR TITLE
feat(ledger): structured errors for validation failures

### DIFF
--- a/ledger/common/rules_test.go
+++ b/ledger/common/rules_test.go
@@ -51,8 +51,19 @@ func TestVerifyTransaction(t *testing.T) {
 		}
 
 		err := VerifyTransaction(tx, slot, ledgerState, protocolParams, rules)
-		if err != expectedErr {
-			t.Errorf("expected error %v, got %v", expectedErr, err)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var validationErr *ValidationError
+		if !errors.As(err, &validationErr) {
+			t.Fatalf("expected ValidationError, got %T", err)
+		}
+		if validationErr.Cause != expectedErr {
+			t.Errorf(
+				"expected cause %v, got %v",
+				expectedErr,
+				validationErr.Cause,
+			)
 		}
 	})
 
@@ -65,8 +76,19 @@ func TestVerifyTransaction(t *testing.T) {
 		}
 
 		err := VerifyTransaction(tx, slot, ledgerState, protocolParams, rules)
-		if err != expectedErr {
-			t.Errorf("expected error %v, got %v", expectedErr, err)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var validationErr *ValidationError
+		if !errors.As(err, &validationErr) {
+			t.Fatalf("expected ValidationError, got %T", err)
+		}
+		if validationErr.Cause != expectedErr {
+			t.Errorf(
+				"expected cause %v, got %v",
+				expectedErr,
+				validationErr.Cause,
+			)
 		}
 	})
 
@@ -78,8 +100,19 @@ func TestVerifyTransaction(t *testing.T) {
 		}
 
 		err := VerifyTransaction(tx, slot, ledgerState, protocolParams, rules)
-		if err != expectedErr {
-			t.Errorf("expected error %v, got %v", expectedErr, err)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		var validationErr *ValidationError
+		if !errors.As(err, &validationErr) {
+			t.Fatalf("expected ValidationError, got %T", err)
+		}
+		if validationErr.Cause != expectedErr {
+			t.Errorf(
+				"expected cause %v, got %v",
+				expectedErr,
+				validationErr.Cause,
+			)
 		}
 	})
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduces structured validation errors across ledger verification to make failures typed and self-describing. VerifyTransaction and VerifyBlock now return ValidationError with type, message, and details like era, slot, block number, and tx hash.

- **New Features**
  - Added ValidationError and ValidationErrorType (body_hash, transaction, stake_pool, vrf, kes, protocol, configuration).
  - Wrapped errors in VerifyTransaction and VerifyBlock with contextual details; clearer messages for mismatches and unsupported types.
  - Updated tests to assert ValidationError and cover transaction and stake pool validation paths.

- **Migration**
  - Use errors.As(err, *ValidationError) to inspect type and details.
  - Use err.Unwrap() to access the original cause when needed.

<sup>Written for commit a0ef043d8d61ae2ce5ed71840e1d5e68879daee2. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CalculateMinFee function for computing minimum transaction fees.

* **Bug Fixes**
  * Enhanced validation error reporting with structured error types and comprehensive contextual details.
  * Improved error messages for block and transaction validation failures with additional metadata for debugging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->