### PR TITLE
fix(ledger): include era in verify error output

### DIFF
--- a/ledger/verify_block.go
+++ b/ledger/verify_block.go
@@ -483,7 +483,7 @@ func VerifyBlock(
 					map[string]any{
 						"block_slot":   slot,
 						"block_number": blockNo,
-						"era":          block.Era().Name,
+						"era":          era,
 					},
 					err,
 				)
@@ -517,6 +517,7 @@ func VerifyBlock(
 					"pool_key_hash": poolKeyHash.String(),
 					"block_slot":    slot,
 					"block_number":  blockNo,
+					"era":           era,
 				},
 				err,
 			)
@@ -529,6 +530,7 @@ func VerifyBlock(
 					"pool_key_hash": poolKeyHash.String(),
 					"block_slot":    slot,
 					"block_number":  blockNo,
+					"era":           era,
 				},
 				nil,
 			)
@@ -547,6 +549,7 @@ func VerifyBlock(
 					"block_vrf_hash":      expectedVrfKeyHash.String(),
 					"block_slot":          slot,
 					"block_number":        blockNo,
+					"era":                 era,
 				},
 				nil,
 			)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds the era to VerifyBlock error outputs to improve troubleshooting and consistency across eras. Uses the resolved era value and includes it in general verification, pool key hash, and VRF hash error contexts.

<sup>Written for commit 4883952789e163460cebb588ea03d3719919813f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error reporting consistency in block verification by streamlining how era information is included in error contexts across transaction validation, stake pool queries, and VRF mismatch reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->