### PR TITLE
chore: use lcommon and pcommon aliases consistently

### DIFF
--- a/cmd/gouroboros/query.go
+++ b/cmd/gouroboros/query.go
@@ -25,6 +25,7 @@ import (
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
 )
 
@@ -180,13 +181,13 @@ func testQuery(f *globalFlags) {
 		}
 		fmt.Printf("genesis-config: %#v\n", *genesisConfig)
 	case "pool-params":
-		var tmpPools []ledger.PoolId
+		var tmpPools []lcommon.PoolId
 		if len(queryFlags.flagset.Args()) <= 1 {
 			fmt.Println("No pools specified")
 			os.Exit(1)
 		}
 		for _, pool := range queryFlags.flagset.Args()[1:] {
-			tmpPoolId, err := ledger.NewPoolIdFromBech32(pool)
+			tmpPoolId, err := lcommon.NewPoolIdFromBech32(pool)
 			if err != nil {
 				fmt.Printf("Invalid bech32 pool ID %q: %s", pool, err)
 				os.Exit(1)
@@ -202,13 +203,13 @@ func testQuery(f *globalFlags) {
 		}
 		fmt.Printf("pool-params: %#v\n", *poolParams)
 	case "utxos-by-address":
-		var tmpAddrs []ledger.Address
+		var tmpAddrs []lcommon.Address
 		if len(queryFlags.flagset.Args()) <= 1 {
 			fmt.Println("No addresses specified")
 			os.Exit(1)
 		}
 		for _, addr := range queryFlags.flagset.Args()[1:] {
-			tmpAddr, err := ledger.NewAddress(addr)
+			tmpAddr, err := lcommon.NewAddress(addr)
 			if err != nil {
 				fmt.Printf("Invalid address %q: %s", addr, err)
 				os.Exit(1)
@@ -234,7 +235,7 @@ func testQuery(f *globalFlags) {
 			}
 		}
 	case "utxos-by-txin":
-		var tmpTxIns []ledger.TransactionInput
+		var tmpTxIns []lcommon.TransactionInput
 		if len(queryFlags.flagset.Args()) <= 1 {
 			fmt.Println("No UTxO IDs specified")
 			os.Exit(1)

--- a/ledger/common/gov.go
+++ b/ledger/common/gov.go
@@ -55,11 +55,21 @@ func encodeCip129Voter(
 	copy(data[1:], hash)
 	convData, err := bech32.ConvertBits(data, 8, 5, true)
 	if err != nil {
-		panic(fmt.Sprintf("unexpected error converting voter data to base32: %s", err))
+		panic(
+			fmt.Sprintf(
+				"unexpected error converting voter data to base32: %s",
+				err,
+			),
+		)
 	}
 	encoded, err := bech32.Encode(prefix, convData)
 	if err != nil {
-		panic(fmt.Sprintf("unexpected error encoding voter data as bech32: %s", err))
+		panic(
+			fmt.Sprintf(
+				"unexpected error encoding voter data as bech32: %s",
+				err,
+			),
+		)
 	}
 	return encoded
 }

--- a/protocol/blockfetch/blockfetch.go
+++ b/protocol/blockfetch/blockfetch.go
@@ -24,7 +24,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/protocol"
-	"github.com/blinklabs-io/gouroboros/protocol/common"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 // ProtocolName is the name of the Block Fetch protocol.
@@ -151,7 +151,7 @@ type BlockRawFunc func(CallbackContext, uint, []byte) error
 type BatchDoneFunc func(CallbackContext) error
 
 // RequestRangeFunc is a callback for handling block range requests.
-type RequestRangeFunc func(CallbackContext, common.Point, common.Point) error
+type RequestRangeFunc func(CallbackContext, pcommon.Point, pcommon.Point) error
 
 // New creates a new BlockFetch instance with the given protocol options and configuration.
 func New(protoOptions protocol.ProtocolOptions, cfg *Config) *BlockFetch {

--- a/protocol/blockfetch/client.go
+++ b/protocol/blockfetch/client.go
@@ -23,7 +23,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/protocol"
-	"github.com/blinklabs-io/gouroboros/protocol/common"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 // Client implements the Block Fetch protocol client, which requests blocks from a server.
@@ -122,7 +122,7 @@ func (c *Client) Stop() error {
 
 // GetBlockRange starts an async process to fetch all blocks in the specified range (inclusive).
 // The provided callbacks are used for each block and when the batch is done.
-func (c *Client) GetBlockRange(start common.Point, end common.Point) error {
+func (c *Client) GetBlockRange(start pcommon.Point, end pcommon.Point) error {
 	c.Protocol.Logger().
 		Debug(
 			fmt.Sprintf("calling GetBlockRange(start: {Slot: %d, Hash: %x}, end: {Slot: %d, Hash: %x})",
@@ -158,7 +158,7 @@ func (c *Client) GetBlockRange(start common.Point, end common.Point) error {
 
 // GetBlock requests and returns a single block specified by the provided point.
 // This is a synchronous call that returns the block or an error.
-func (c *Client) GetBlock(point common.Point) (ledger.Block, error) {
+func (c *Client) GetBlock(point pcommon.Point) (ledger.Block, error) {
 	c.Protocol.Logger().
 		Debug(
 			fmt.Sprintf("calling GetBlock(point: {Slot: %d, Hash: %x})", point.Slot, point.Hash),

--- a/protocol/blockfetch/client_test.go
+++ b/protocol/blockfetch/client_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	"github.com/blinklabs-io/gouroboros/protocol/blockfetch"
-	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
 	"go.uber.org/goleak"
 )
@@ -151,7 +151,7 @@ func TestGetBlock(t *testing.T) {
 		conversation,
 		func(t *testing.T, oConn *ouroboros.Connection) {
 			blk, err := oConn.BlockFetch().Client.GetBlock(
-				ocommon.NewPoint(
+				pcommon.NewPoint(
 					testBlockSlot,
 					testBlockHash,
 				),
@@ -197,7 +197,7 @@ func TestGetBlockNoBlocks(t *testing.T) {
 		conversation,
 		func(t *testing.T, oConn *ouroboros.Connection) {
 			_, err := oConn.BlockFetch().Client.GetBlock(
-				ocommon.NewPoint(
+				pcommon.NewPoint(
 					12345,
 					test.DecodeHexString("abcdef0123456789"),
 				),

--- a/protocol/blockfetch/messages.go
+++ b/protocol/blockfetch/messages.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/protocol"
-	"github.com/blinklabs-io/gouroboros/protocol/common"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 // MessageTypeRequestRange is the message type for requesting a range of blocks.
@@ -70,12 +70,15 @@ func NewMsgFromCbor(msgType uint, data []byte) (protocol.Message, error) {
 // MsgRequestRange represents a request for a range of blocks.
 type MsgRequestRange struct {
 	protocol.MessageBase
-	Start common.Point // Start point of the range
-	End   common.Point // End point of the range
+	Start pcommon.Point // Start point of the range
+	End   pcommon.Point // End point of the range
 }
 
 // NewMsgRequestRange creates a new MsgRequestRange with the given start and end points.
-func NewMsgRequestRange(start common.Point, end common.Point) *MsgRequestRange {
+func NewMsgRequestRange(
+	start pcommon.Point,
+	end pcommon.Point,
+) *MsgRequestRange {
 	m := &MsgRequestRange{
 		MessageBase: protocol.MessageBase{
 			MessageType: MessageTypeRequestRange,

--- a/protocol/chainsync/chainsync.go
+++ b/protocol/chainsync/chainsync.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/protocol"
-	"github.com/blinklabs-io/gouroboros/protocol/common"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 // Protocol identifiers
@@ -246,13 +246,13 @@ type CallbackContext struct {
 
 // Callback function types
 type (
-	RollBackwardFunc   func(CallbackContext, common.Point, Tip) error
+	RollBackwardFunc   func(CallbackContext, pcommon.Point, Tip) error
 	RollForwardFunc    func(CallbackContext, uint, any, Tip) error
 	RollForwardRawFunc func(CallbackContext, uint, []byte, Tip) error
 )
 
 type (
-	FindIntersectFunc func(CallbackContext, []common.Point) (common.Point, Tip, error)
+	FindIntersectFunc func(CallbackContext, []pcommon.Point) (pcommon.Point, Tip, error)
 	RequestNextFunc   func(CallbackContext) error
 )
 

--- a/protocol/chainsync/client_test.go
+++ b/protocol/chainsync/client_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	"github.com/blinklabs-io/gouroboros/protocol/chainsync"
-	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
 	"go.uber.org/goleak"
 )
@@ -117,7 +117,7 @@ func TestIntersectNotFound(t *testing.T) {
 					chainsync.Tip{
 						// NOTE: these values don't matter
 						BlockNumber: 12345,
-						Point:       ocommon.NewPointOrigin(),
+						Point:       pcommon.NewPointOrigin(),
 					},
 				),
 			},
@@ -128,7 +128,7 @@ func TestIntersectNotFound(t *testing.T) {
 		conversation,
 		func(t *testing.T, oConn *ouroboros.Connection) {
 			// Start sync with "bad" intersect points
-			err := oConn.ChainSync().Client.Sync([]ocommon.Point{})
+			err := oConn.ChainSync().Client.Sync([]pcommon.Point{})
 			if err == nil {
 				t.Fatalf("did not receive expected error")
 			}
@@ -149,7 +149,7 @@ func TestIntersectNotFound(t *testing.T) {
 func TestGetCurrentTip(t *testing.T) {
 	expectedTip := chainsync.Tip{
 		BlockNumber: 12345,
-		Point: ocommon.NewPoint(
+		Point: pcommon.NewPoint(
 			23456,
 			test.DecodeHexString("0123456789abcdef"),
 		),
@@ -187,13 +187,13 @@ func TestGetCurrentTip(t *testing.T) {
 }
 
 func TestGetAvailableBlockRange(t *testing.T) {
-	expectedIntersect := ocommon.NewPoint(
+	expectedIntersect := pcommon.NewPoint(
 		20001,
 		test.DecodeHexString("123456789abcdef0"),
 	)
 	expectedTip := chainsync.Tip{
 		BlockNumber: 12345,
-		Point: ocommon.NewPoint(
+		Point: pcommon.NewPoint(
 			23456,
 			test.DecodeHexString("0123456789abcdef"),
 		),
@@ -213,7 +213,7 @@ func TestGetAvailableBlockRange(t *testing.T) {
 	if _, err := cbor.Decode(blockCbor, &testBlock); err != nil {
 		t.Fatalf("received unexpected error: %s", err)
 	}
-	expectedStart := ocommon.NewPoint(
+	expectedStart := pcommon.NewPoint(
 		testBlock.SlotNumber(),
 		testBlock.Hash().Bytes(),
 	)
@@ -264,7 +264,7 @@ func TestGetAvailableBlockRange(t *testing.T) {
 		conversation,
 		func(t *testing.T, oConn *ouroboros.Connection) {
 			start, end, err := oConn.ChainSync().Client.GetAvailableBlockRange(
-				[]ocommon.Point{expectedIntersect},
+				[]pcommon.Point{expectedIntersect},
 			)
 			if err != nil {
 				t.Fatalf("received unexpected error: %s", err)

--- a/protocol/chainsync/messages.go
+++ b/protocol/chainsync/messages.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/protocol"
-	"github.com/blinklabs-io/gouroboros/protocol/common"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 // Message types
@@ -200,11 +200,11 @@ func NewMsgRollForwardNtN(
 
 type MsgRollBackward struct {
 	protocol.MessageBase
-	Point common.Point
+	Point pcommon.Point
 	Tip   Tip
 }
 
-func NewMsgRollBackward(point common.Point, tip Tip) *MsgRollBackward {
+func NewMsgRollBackward(point pcommon.Point, tip Tip) *MsgRollBackward {
 	m := &MsgRollBackward{
 		MessageBase: protocol.MessageBase{
 			MessageType: MessageTypeRollBackward,
@@ -217,10 +217,10 @@ func NewMsgRollBackward(point common.Point, tip Tip) *MsgRollBackward {
 
 type MsgFindIntersect struct {
 	protocol.MessageBase
-	Points []common.Point
+	Points []pcommon.Point
 }
 
-func NewMsgFindIntersect(points []common.Point) *MsgFindIntersect {
+func NewMsgFindIntersect(points []pcommon.Point) *MsgFindIntersect {
 	m := &MsgFindIntersect{
 		MessageBase: protocol.MessageBase{
 			MessageType: MessageTypeFindIntersect,
@@ -232,11 +232,11 @@ func NewMsgFindIntersect(points []common.Point) *MsgFindIntersect {
 
 type MsgIntersectFound struct {
 	protocol.MessageBase
-	Point common.Point
+	Point pcommon.Point
 	Tip   Tip
 }
 
-func NewMsgIntersectFound(point common.Point, tip Tip) *MsgIntersectFound {
+func NewMsgIntersectFound(point pcommon.Point, tip Tip) *MsgIntersectFound {
 	m := &MsgIntersectFound{
 		MessageBase: protocol.MessageBase{
 			MessageType: MessageTypeIntersectFound,
@@ -276,4 +276,4 @@ func NewMsgDone() *MsgDone {
 }
 
 // Tip is an alias to keep historical code from breaking after moving this elsewhere
-type Tip = common.Tip
+type Tip = pcommon.Tip

--- a/protocol/chainsync/messages_test.go
+++ b/protocol/chainsync/messages_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/protocol"
-	"github.com/blinklabs-io/gouroboros/protocol/common"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 type testDefinition struct {
@@ -149,7 +149,7 @@ func TestMsgRollForwardNodeToNode(t *testing.T) {
 				ledger.BlockHeaderTypeByron,
 				"testdata/byron_ebb_testnet_8f8602837f7c6f8b8867dd1cbc1842cf51a27eaed2c70ef48325d00f8efb320f.hex",
 				Tip{
-					Point: common.Point{
+					Point: pcommon.Point{
 						Slot: 55740899,
 						Hash: hexDecode(
 							"C89E652408EC269379751C8B2BF0137297BF9F5D0FB2E76E19ACF63D783C3A66",
@@ -173,7 +173,7 @@ func TestMsgRollForwardNodeToNode(t *testing.T) {
 				ledger.BlockHeaderTypeShelley,
 				"testdata/shelley_block_testnet_02b1c561715da9e540411123a6135ee319b02f60b9a11a603d3305556c04329f.hex",
 				Tip{
-					Point: common.Point{
+					Point: pcommon.Point{
 						Slot: 55770176,
 						Hash: hexDecode(
 							"EA90218C8606AAD58B90C2AD51E37FC35ED6D4C40D8944DF0BC60D22F1E6DD65",
@@ -197,7 +197,7 @@ func TestMsgRollForwardNodeToNode_CorruptedCBOR(t *testing.T) {
 		0,
 		badCBOR,
 		Tip{
-			Point: common.Point{
+			Point: pcommon.Point{
 				Slot: 1,
 				Hash: []byte{0xDE, 0xAD, 0xBE, 0xEF},
 			},
@@ -234,7 +234,7 @@ func TestMsgRollForwardNodeToClient(t *testing.T) {
 				0,
 				"testdata/byron_ebb_testnet_8f8602837f7c6f8b8867dd1cbc1842cf51a27eaed2c70ef48325d00f8efb320f.hex",
 				Tip{
-					Point: common.Point{
+					Point: pcommon.Point{
 						Slot: 49055,
 						Hash: hexDecode(
 							"7C288E72BB8C10439308901F379C2821945ED58BD1058578E8376F959078B321",
@@ -258,7 +258,7 @@ func TestMsgRollForwardNodeToClient(t *testing.T) {
 				1,
 				"testdata/byron_main_block_testnet_f38aa5e8cf0b47d1ffa8b2385aa2d43882282db2ffd5ac0e3dadec1a6f2ecf08.hex",
 				Tip{
-					Point: common.Point{
+					Point: pcommon.Point{
 						Slot: 49055,
 						Hash: hexDecode(
 							"7C288E72BB8C10439308901F379C2821945ED58BD1058578E8376F959078B321",
@@ -282,7 +282,7 @@ func TestMsgRollForwardNodeToClient(t *testing.T) {
 				2,
 				"testdata/shelley_block_testnet_02b1c561715da9e540411123a6135ee319b02f60b9a11a603d3305556c04329f.hex",
 				Tip{
-					Point: common.Point{
+					Point: pcommon.Point{
 						Slot: 55829927,
 						Hash: hexDecode(
 							"2809888408DD6F499ECDC868E10F635FA550AF3EBC3B5165C9DACC023D1F52C5",
@@ -303,9 +303,9 @@ func TestMsgRollBackward(t *testing.T) {
 		{
 			CborHex: "83038082821a03520ff458201979d7dd2c7211cb7ce393c83aceca09675ec7786741620676e16c3ad3ac81031a00351333",
 			Message: NewMsgRollBackward(
-				common.Point{},
+				pcommon.Point{},
 				Tip{
-					Point: common.Point{
+					Point: pcommon.Point{
 						Slot: 55709684,
 						Hash: hexDecode(
 							"1979D7DD2C7211CB7CE393C83ACECA09675EC7786741620676E16C3AD3AC8103",
@@ -326,7 +326,7 @@ func TestMsgFindIntersect(t *testing.T) {
 		{
 			CborHex: "82048180",
 			Message: NewMsgFindIntersect(
-				[]common.Point{
+				[]pcommon.Point{
 					{},
 				},
 			),
@@ -336,7 +336,7 @@ func TestMsgFindIntersect(t *testing.T) {
 		{
 			CborHex: "820481821a001863bf58207e16781b40ebf8b6da18f7b5e8ade855d6738095ef2f1c58c77e88b6e45997a4",
 			Message: NewMsgFindIntersect(
-				[]common.Point{
+				[]pcommon.Point{
 					{
 						Slot: 1598399,
 						Hash: hexDecode(
@@ -356,9 +356,9 @@ func TestMsgIntersectFound(t *testing.T) {
 		{
 			CborHex: "83058082821a03520ff458201979d7dd2c7211cb7ce393c83aceca09675ec7786741620676e16c3ad3ac81031a00351333",
 			Message: NewMsgIntersectFound(
-				common.Point{},
+				pcommon.Point{},
 				Tip{
-					Point: common.Point{
+					Point: pcommon.Point{
 						Slot: 55709684,
 						Hash: hexDecode(
 							"1979D7DD2C7211CB7CE393C83ACECA09675EC7786741620676E16C3AD3AC8103",
@@ -379,7 +379,7 @@ func TestMsgIntersectNotFound(t *testing.T) {
 			CborHex: "820682821a03520ff458201979d7dd2c7211cb7ce393c83aceca09675ec7786741620676e16c3ad3ac81031a00351333",
 			Message: NewMsgIntersectNotFound(
 				Tip{
-					Point: common.Point{
+					Point: pcommon.Point{
 						Slot: 55709684,
 						Hash: hexDecode(
 							"1979D7DD2C7211CB7CE393C83ACECA09675EC7786741620676E16C3AD3AC8103",

--- a/protocol/chainsync/server.go
+++ b/protocol/chainsync/server.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/protocol"
-	"github.com/blinklabs-io/gouroboros/protocol/common"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 // Server implements the ChainSync server
@@ -81,7 +81,7 @@ func (s *Server) initProtocol() {
 	s.Protocol = protocol.New(protoConfig)
 }
 
-func (s *Server) RollBackward(point common.Point, tip Tip) error {
+func (s *Server) RollBackward(point pcommon.Point, tip Tip) error {
 	s.Protocol.Logger().
 		Debug(
 			fmt.Sprintf("calling RollBackward(point: {Slot: %d, Hash: %x}, tip: {Point: {Slot: %d, Hash: %x}, BlockNumber: %d})",

--- a/protocol/localstatequery/client.go
+++ b/protocol/localstatequery/client.go
@@ -23,7 +23,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/protocol"
-	"github.com/blinklabs-io/gouroboros/protocol/common"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 // Client implements the LocalStateQuery client
@@ -114,7 +114,7 @@ func (c *Client) Start() {
 }
 
 // Acquire starts the acquire process for the specified chain point
-func (c *Client) Acquire(point *common.Point) error {
+func (c *Client) Acquire(point *pcommon.Point) error {
 	// Use volatile tip if no point provided
 	if point == nil {
 		return c.AcquireVolatileTip()
@@ -240,7 +240,7 @@ func (c *Client) GetChainBlockNo() (int64, error) {
 }
 
 // GetChainPoint returns the current chain tip
-func (c *Client) GetChainPoint() (*common.Point, error) {
+func (c *Client) GetChainPoint() (*pcommon.Point, error) {
 	c.Protocol.Logger().
 		Debug("calling GetChainPoint()",
 			"component", "network",
@@ -253,7 +253,7 @@ func (c *Client) GetChainPoint() (*common.Point, error) {
 	query := buildQuery(
 		QueryTypeChainPoint,
 	)
-	var result common.Point
+	var result pcommon.Point
 	if err := c.runQuery(query, &result); err != nil {
 		return nil, err
 	}

--- a/protocol/localstatequery/client_test.go
+++ b/protocol/localstatequery/client_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/internal/test"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/protocol"
-	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
 	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
 	"go.uber.org/goleak"
@@ -146,7 +146,7 @@ func TestGetCurrentEra(t *testing.T) {
 }
 
 func TestGetChainPoint(t *testing.T) {
-	expectedPoint := ocommon.NewPoint(123, []byte{0xa, 0xb, 0xc})
+	expectedPoint := pcommon.NewPoint(123, []byte{0xa, 0xb, 0xc})
 	cborData, err := cbor.Encode(expectedPoint)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)

--- a/protocol/localstatequery/localstatequery.go
+++ b/protocol/localstatequery/localstatequery.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/protocol"
-	"github.com/blinklabs-io/gouroboros/protocol/common"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 // Protocol identifiers
@@ -133,7 +133,7 @@ type AcquireTarget interface {
 }
 
 type AcquireSpecificPoint struct {
-	Point common.Point
+	Point pcommon.Point
 }
 
 func (AcquireSpecificPoint) isAcquireTarget() {}

--- a/protocol/localstatequery/messages.go
+++ b/protocol/localstatequery/messages.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/protocol"
-	"github.com/blinklabs-io/gouroboros/protocol/common"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 // Message types
@@ -85,10 +85,10 @@ func NewMsgFromCbor(msgType uint, data []byte) (protocol.Message, error) {
 
 type MsgAcquire struct {
 	protocol.MessageBase
-	Point common.Point
+	Point pcommon.Point
 }
 
-func NewMsgAcquire(point common.Point) *MsgAcquire {
+func NewMsgAcquire(point pcommon.Point) *MsgAcquire {
 	m := &MsgAcquire{
 		MessageBase: protocol.MessageBase{
 			MessageType: MessageTypeAcquire,
@@ -199,10 +199,10 @@ func NewMsgRelease() *MsgRelease {
 
 type MsgReAcquire struct {
 	protocol.MessageBase
-	Point common.Point
+	Point pcommon.Point
 }
 
-func NewMsgReAcquire(point common.Point) *MsgReAcquire {
+func NewMsgReAcquire(point pcommon.Point) *MsgReAcquire {
 	m := &MsgReAcquire{
 		MessageBase: protocol.MessageBase{
 			MessageType: MessageTypeReacquire,

--- a/protocol/localstatequery/messages_test.go
+++ b/protocol/localstatequery/messages_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/protocol"
-	"github.com/blinklabs-io/gouroboros/protocol/common"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 type testDefinition struct {
@@ -37,7 +37,7 @@ type testDefinition struct {
 var tests = []testDefinition{
 	{
 		CborHex:     "820080",
-		Message:     NewMsgAcquire(common.Point{}),
+		Message:     NewMsgAcquire(pcommon.Point{}),
 		MessageType: MessageTypeAcquire,
 	},
 	{
@@ -78,7 +78,7 @@ var tests = []testDefinition{
 	},
 	{
 		CborHex:     "820680",
-		Message:     NewMsgReAcquire(common.Point{}),
+		Message:     NewMsgReAcquire(pcommon.Point{}),
 		MessageType: MessageTypeReacquire,
 	},
 	{

--- a/protocol/localstatequery/queries.go
+++ b/protocol/localstatequery/queries.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
-	"github.com/blinklabs-io/gouroboros/ledger/common"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
 // Query types
@@ -271,7 +271,7 @@ type ShelleyStakeDistributionQuery struct {
 type ShelleyUtxoByAddressQuery struct {
 	cbor.StructAsArray
 	Type  int
-	Addrs []ledger.Address
+	Addrs []lcommon.Address
 }
 
 type ShelleyUtxoWholeQuery struct {
@@ -522,7 +522,7 @@ type CurrentProtocolParamsResult interface {
 		any
 }
 
-type ProposedProtocolParamsUpdatesResult map[common.GenesisHash]common.ProtocolParameterUpdate
+type ProposedProtocolParamsUpdatesResult map[lcommon.GenesisHash]lcommon.ProtocolParameterUpdate
 
 type StakeDistributionResult struct {
 	cbor.StructAsArray


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized import aliases across the codebase: lcommon for ledger/common and pcommon for protocol/common. This improves readability and consistency with no behavior changes.

- **Refactors**
  - Replaced common.Point with pcommon.Point across ChainSync, BlockFetch, LocalStateQuery, and CLI.
  - Updated message structs and callbacks to use pcommon types (e.g., Tip, Point).
  - Switched ledger/common types to lcommon where used (e.g., Address, PoolId, TransactionInput).
  - Adjusted tests to match new aliases.
  - Minor formatting cleanup in CIP-129 voter encoding error messages.

<sup>Written for commit e9f8d50c860621c8873b6b3da912892b8b0e5a69. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

- Consolidated and reorganized internal type structures across protocol and ledger components to enhance code consistency and maintainability. Updated internal type references throughout chain synchronization, block fetching, and state query modules. These internal improvements do not affect functionality or user-facing APIs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->