### PR TITLE
feat(ledger): validate metadata during rule checks

### DIFF
--- a/ledger/allegra/errors.go
+++ b/ledger/allegra/errors.go
@@ -30,3 +30,5 @@ func (e OutsideValidityIntervalUtxoError) Error() string {
 		e.Slot,
 	)
 }
+
+// Metadata validation errors are in the common package; use directly

--- a/ledger/allegra/rules.go
+++ b/ledger/allegra/rules.go
@@ -22,6 +22,7 @@ import (
 )
 
 var UtxoValidationRules = []common.UtxoValidationRuleFunc{
+	UtxoValidateMetadata,
 	UtxoValidateOutsideValidityIntervalUtxo,
 	UtxoValidateInputSetEmptyUtxo,
 	UtxoValidateFeeTooSmallUtxo,
@@ -166,4 +167,13 @@ func UtxoValidateMaxTxSizeUtxo(
 		ls,
 		tmpPparams,
 	)
+}
+
+func UtxoValidateMetadata(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return shelley.UtxoValidateMetadata(tx, slot, ls, pp)
 }

--- a/ledger/alonzo/errors.go
+++ b/ledger/alonzo/errors.go
@@ -64,3 +64,5 @@ type NoCollateralInputsError struct{}
 func (NoCollateralInputsError) Error() string {
 	return "no collateral inputs"
 }
+
+// Metadata validation errors are in the common package; use directly

--- a/ledger/alonzo/rules.go
+++ b/ledger/alonzo/rules.go
@@ -25,6 +25,7 @@ import (
 )
 
 var UtxoValidationRules = []common.UtxoValidationRuleFunc{
+	UtxoValidateMetadata,
 	UtxoValidateOutsideValidityIntervalUtxo,
 	UtxoValidateInputSetEmptyUtxo,
 	UtxoValidateFeeTooSmallUtxo,
@@ -427,4 +428,13 @@ func MinCoinTxOut(
 	}
 	minCoinTxOut := uint64(tmpPparams.MinUtxoValue)
 	return minCoinTxOut, nil
+}
+
+func UtxoValidateMetadata(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return shelley.UtxoValidateMetadata(tx, slot, ls, pp)
 }

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -886,6 +886,7 @@ type BabbageTransaction struct {
 	WitnessSet BabbageTransactionWitnessSet
 	TxIsValid  bool
 	TxMetadata common.TransactionMetadatum
+	rawAuxData []byte
 }
 
 func (t *BabbageTransaction) UnmarshalCBOR(cborData []byte) error {
@@ -919,8 +920,8 @@ func (t *BabbageTransaction) UnmarshalCBOR(cborData []byte) error {
 	}
 
 	// Handle metadata (component 4, always present - either data or CBOR nil)
-	// DecodeAuxiliaryDataToMetadata already preserves raw bytes via DecodeMetadatumRaw
-	if len(txArray[3]) > 0 {
+	if len(txArray[3]) > 0 && txArray[3][0] != 0xF6 { // 0xF6 is CBOR null
+		t.rawAuxData = []byte(txArray[3])
 		metadata, err := common.DecodeAuxiliaryDataToMetadata(txArray[3])
 		if err == nil && metadata != nil {
 			t.TxMetadata = metadata
@@ -933,6 +934,10 @@ func (t *BabbageTransaction) UnmarshalCBOR(cborData []byte) error {
 
 func (t *BabbageTransaction) Metadata() common.TransactionMetadatum {
 	return t.TxMetadata
+}
+
+func (t *BabbageTransaction) RawAuxiliaryData() []byte {
+	return t.rawAuxData
 }
 
 func (BabbageTransaction) Type() int {

--- a/ledger/babbage/errors.go
+++ b/ledger/babbage/errors.go
@@ -43,3 +43,5 @@ func (e IncorrectTotalCollateralFieldError) Error() string {
 		e.TotalCollateral,
 	)
 }
+
+// Metadata validation errors are in the common package; use directly

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -26,6 +26,7 @@ import (
 )
 
 var UtxoValidationRules = []common.UtxoValidationRuleFunc{
+	UtxoValidateMetadata,
 	UtxoValidateOutsideValidityIntervalUtxo,
 	UtxoValidateInputSetEmptyUtxo,
 	UtxoValidateFeeTooSmallUtxo,
@@ -498,4 +499,13 @@ func MinCoinTxOut(
 	}
 	minCoinTxOut := tmpPparams.AdaPerUtxoByte * uint64(len(txOutBytes))
 	return minCoinTxOut, nil
+}
+
+func UtxoValidateMetadata(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return shelley.UtxoValidateMetadata(tx, slot, ls, pp)
 }

--- a/ledger/byron/byron.go
+++ b/ledger/byron/byron.go
@@ -292,6 +292,10 @@ func (t *ByronTransaction) Metadata() common.TransactionMetadatum {
 	return nil
 }
 
+func (t *ByronTransaction) RawAuxiliaryData() []byte {
+	return nil
+}
+
 func (t *ByronTransaction) LeiosHash() common.Blake2b256 {
 	if t.hash == nil {
 		tmpHash := common.Blake2b256Hash(t.Cbor())

--- a/ledger/common/common.go
+++ b/ledger/common/common.go
@@ -612,3 +612,39 @@ func ExtractAndSetTransactionCbor(
 
 	return nil
 }
+
+// Metadata validation errors
+type MissingTransactionMetadataError struct {
+	Hash Blake2b256
+}
+
+func (e MissingTransactionMetadataError) Error() string {
+	return fmt.Sprintf(
+		"missing transaction metadata: body declares hash %x but no metadata provided",
+		e.Hash,
+	)
+}
+
+type MissingTransactionAuxiliaryDataHashError struct {
+	Hash Blake2b256
+}
+
+func (e MissingTransactionAuxiliaryDataHashError) Error() string {
+	return fmt.Sprintf(
+		"missing transaction auxiliary data hash: metadata provided with hash %x but body has no hash",
+		e.Hash,
+	)
+}
+
+type ConflictingMetadataHashError struct {
+	Supplied Blake2b256
+	Expected Blake2b256
+}
+
+func (e ConflictingMetadataHashError) Error() string {
+	return fmt.Sprintf(
+		"conflicting metadata hash: body declares %x, actual metadata hash is %x",
+		e.Supplied,
+		e.Expected,
+	)
+}

--- a/ledger/common/tx.go
+++ b/ledger/common/tx.go
@@ -29,6 +29,7 @@ type Transaction interface {
 	Hash() Blake2b256
 	LeiosHash() Blake2b256
 	Metadata() TransactionMetadatum
+	RawAuxiliaryData() []byte
 	IsValid() bool
 	Consumed() []TransactionInput
 	Produced() []Utxo

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -610,6 +610,7 @@ type ConwayTransaction struct {
 	WitnessSet ConwayTransactionWitnessSet
 	TxIsValid  bool
 	TxMetadata common.TransactionMetadatum
+	rawAuxData []byte
 }
 
 func (t *ConwayTransaction) UnmarshalCBOR(cborData []byte) error {
@@ -643,8 +644,8 @@ func (t *ConwayTransaction) UnmarshalCBOR(cborData []byte) error {
 	}
 
 	// Handle metadata (component 4, always present - either data or CBOR nil)
-	// DecodeAuxiliaryDataToMetadata already preserves raw bytes via DecodeMetadatumRaw
-	if len(txArray) > 3 && len(txArray[3]) > 0 {
+	if len(txArray[3]) > 0 && txArray[3][0] != 0xF6 { // 0xF6 is CBOR null
+		t.rawAuxData = []byte(txArray[3])
 		metadata, err := common.DecodeAuxiliaryDataToMetadata(txArray[3])
 		if err == nil && metadata != nil {
 			t.TxMetadata = metadata
@@ -657,6 +658,10 @@ func (t *ConwayTransaction) UnmarshalCBOR(cborData []byte) error {
 
 func (t *ConwayTransaction) Metadata() common.TransactionMetadatum {
 	return t.TxMetadata
+}
+
+func (t *ConwayTransaction) RawAuxiliaryData() []byte {
+	return t.rawAuxData
 }
 
 func (ConwayTransaction) Type() int {

--- a/ledger/conway/errors.go
+++ b/ledger/conway/errors.go
@@ -31,3 +31,5 @@ func (e NonDisjointRefInputsError) Error() string {
 	}
 	return "non-disjoint reference inputs: " + strings.Join(tmpInputs, ", ")
 }
+
+// Metadata validation errors are in the common package; use directly

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -27,6 +27,7 @@ import (
 )
 
 var UtxoValidationRules = []common.UtxoValidationRuleFunc{
+	UtxoValidateMetadata,
 	UtxoValidateDisjointRefInputs,
 	UtxoValidateOutsideValidityIntervalUtxo,
 	UtxoValidateInputSetEmptyUtxo,
@@ -564,4 +565,13 @@ func MinCoinTxOut(
 	}
 	minCoinTxOut := tmpPparams.AdaPerUtxoByte * uint64(len(txOutBytes))
 	return minCoinTxOut, nil
+}
+
+func UtxoValidateMetadata(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return shelley.UtxoValidateMetadata(tx, slot, ls, pp)
 }

--- a/ledger/mary/errors.go
+++ b/ledger/mary/errors.go
@@ -20,6 +20,8 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
+// Metadata validation errors are in the common package; use directly
+
 type OutputTooBigUtxoError struct {
 	Outputs []common.TransactionOutput
 }

--- a/ledger/mary/rules.go
+++ b/ledger/mary/rules.go
@@ -28,6 +28,7 @@ const (
 )
 
 var UtxoValidationRules = []common.UtxoValidationRuleFunc{
+	UtxoValidateMetadata,
 	UtxoValidateOutsideValidityIntervalUtxo,
 	UtxoValidateInputSetEmptyUtxo,
 	UtxoValidateFeeTooSmallUtxo,
@@ -295,4 +296,13 @@ func MinCoinTxOut(
 	}
 	minCoinTxOut := uint64(tmpPparams.MinUtxoValue)
 	return minCoinTxOut, nil
+}
+
+func UtxoValidateMetadata(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return shelley.UtxoValidateMetadata(tx, slot, ls, pp)
 }

--- a/ledger/shelley/errors.go
+++ b/ledger/shelley/errors.go
@@ -156,3 +156,11 @@ func (e InvalidCertificateDepositError) Error() string {
 		e.Amount,
 	)
 }
+
+// Metadata validation errors are now in common package
+// Type aliases for backward compatibility
+type (
+	MissingTransactionMetadataError          = common.MissingTransactionMetadataError
+	MissingTransactionAuxiliaryDataHashError = common.MissingTransactionAuxiliaryDataHashError
+	ConflictingMetadataHashError             = common.ConflictingMetadataHashError
+)


### PR DESCRIPTION
















<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a metadata validation rule to all eras to verify auxiliary data and the transaction body’s auxiliary data hash. This catches missing or mismatched metadata early and returns clear errors.

- **New Features**
  - Added UtxoValidateMetadata to UtxoValidationRules across Shelley, Mary, Allegra, Alonzo, Babbage, and Conway; runs before other checks.
  - Verifies body hash and metadata align: none+none (OK), hash without metadata, metadata without hash, and mismatch.
  - New errors: MissingTransactionMetadataError, MissingTransactionAuxiliaryDataHashError, ConflictingMetadataHashError.
  - Transactions now expose RawAuxiliaryData; raw aux bytes are stored and used for hashing where available to ensure accurate matching.

<sup>Written for commit eb5d9bb7ae4309aa7661d2fef30b5990bb597a50. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

















<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transactions now preserve and expose raw auxiliary data (original metadata bytes) across ledger types for retrieval.
  * A metadata validation check has been added early in transaction prevalidation to ensure metadata/hash consistency.

* **Bug Fixes / UX**
  * Validation now returns clearer, specific errors for missing metadata, missing auxiliary-data hash, or conflicting metadata hashes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->