### PR TITLE
feat(ledger): add witness validation rules and tests

### DIFF
--- a/ledger/allegra/allegra.go
+++ b/ledger/allegra/allegra.go
@@ -284,7 +284,8 @@ func (t *AllegraTransaction) UnmarshalCBOR(cborData []byte) error {
 	}
 	// Handle metadata (component 3, index 2) - always present, but may be CBOR nil
 	// Store raw auxiliary data bytes (including any scripts)
-	if len(txArray) > 2 && len(txArray[2]) > 0 && txArray[2][0] != 0xF6 { // 0xF6 is CBOR null
+	if len(txArray) > 2 && len(txArray[2]) > 0 &&
+		txArray[2][0] != 0xF6 { // 0xF6 is CBOR null
 		t.RawAuxData = []byte(txArray[2])
 		// Also extract metadata
 		metadata, err := common.DecodeAuxiliaryDataToMetadata(txArray[2])

--- a/ledger/allegra/rules.go
+++ b/ledger/allegra/rules.go
@@ -23,6 +23,7 @@ import (
 
 var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateMetadata,
+	UtxoValidateRequiredVKeyWitnesses,
 	UtxoValidateOutsideValidityIntervalUtxo,
 	UtxoValidateInputSetEmptyUtxo,
 	UtxoValidateFeeTooSmallUtxo,
@@ -33,6 +34,15 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateOutputTooSmallUtxo,
 	UtxoValidateOutputBootAddrAttrsTooBig,
 	UtxoValidateMaxTxSizeUtxo,
+}
+
+func UtxoValidateRequiredVKeyWitnesses(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return shelley.UtxoValidateRequiredVKeyWitnesses(tx, slot, ls, pp)
 }
 
 // UtxoValidateOutsideValidityIntervalUtxo ensures that the current tip slot has reached the specified validity interval

--- a/ledger/alonzo/errors.go
+++ b/ledger/alonzo/errors.go
@@ -66,3 +66,37 @@ func (NoCollateralInputsError) Error() string {
 }
 
 // Metadata validation errors are in the common package; use directly
+
+// Witness validation errors
+type MissingVKeyWitnessesError struct{}
+
+func (MissingVKeyWitnessesError) Error() string {
+	return "missing required vkey witnesses"
+}
+
+type MissingRequiredVKeyWitnessForSignerError struct {
+	Signer common.Blake2b224
+}
+
+func (e MissingRequiredVKeyWitnessForSignerError) Error() string {
+	return "missing required vkey witness for required signer"
+}
+
+// Plutus script/redeemer relationship errors
+type MissingRedeemersForScriptDataHashError struct{}
+
+func (MissingRedeemersForScriptDataHashError) Error() string {
+	return "missing redeemers for script data hash"
+}
+
+type MissingPlutusScriptWitnessesError struct{}
+
+func (MissingPlutusScriptWitnessesError) Error() string {
+	return "missing Plutus script witnesses for redeemers"
+}
+
+type ExtraneousPlutusScriptWitnessesError struct{}
+
+func (ExtraneousPlutusScriptWitnessesError) Error() string {
+	return "extraneous Plutus script witnesses"
+}

--- a/ledger/babbage/errors.go
+++ b/ledger/babbage/errors.go
@@ -16,6 +16,8 @@ package babbage
 
 import (
 	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
 type TooManyCollateralInputsError struct {
@@ -45,3 +47,37 @@ func (e IncorrectTotalCollateralFieldError) Error() string {
 }
 
 // Metadata validation errors are in the common package; use directly
+
+// Witness validation errors
+type MissingVKeyWitnessesError struct{}
+
+func (MissingVKeyWitnessesError) Error() string {
+	return "missing required vkey witnesses"
+}
+
+type MissingRequiredVKeyWitnessForSignerError struct {
+	Signer common.Blake2b224
+}
+
+func (e MissingRequiredVKeyWitnessForSignerError) Error() string {
+	return "missing required vkey witness for required signer"
+}
+
+// Plutus script/redeemer relationship errors
+type MissingRedeemersForScriptDataHashError struct{}
+
+func (MissingRedeemersForScriptDataHashError) Error() string {
+	return "missing redeemers for script data hash"
+}
+
+type MissingPlutusScriptWitnessesError struct{}
+
+func (MissingPlutusScriptWitnessesError) Error() string {
+	return "missing Plutus script witnesses for redeemers"
+}
+
+type ExtraneousPlutusScriptWitnessesError struct{}
+
+func (ExtraneousPlutusScriptWitnessesError) Error() string {
+	return "extraneous Plutus script witnesses"
+}

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -27,6 +27,8 @@ import (
 
 var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateMetadata,
+	UtxoValidateRequiredVKeyWitnesses,
+	UtxoValidateRedeemerAndScriptWitnesses,
 	UtxoValidateOutsideValidityIntervalUtxo,
 	UtxoValidateInputSetEmptyUtxo,
 	UtxoValidateFeeTooSmallUtxo,
@@ -53,6 +55,76 @@ func UtxoValidateOutsideValidityIntervalUtxo(
 	pp common.ProtocolParameters,
 ) error {
 	return allegra.UtxoValidateOutsideValidityIntervalUtxo(tx, slot, ls, pp)
+}
+
+// UtxoValidateRequiredVKeyWitnesses ensures required signers are accompanied by vkey witnesses
+func UtxoValidateRequiredVKeyWitnesses(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	required := tx.RequiredSigners()
+	if len(required) == 0 {
+		return nil
+	}
+	w := tx.Witnesses()
+	if w == nil || len(w.Vkey()) == 0 {
+		return MissingVKeyWitnessesError{}
+	}
+	// Build a set of vkey hashes for exact matching
+	vkeyHashes := make(map[common.Blake2b224]struct{})
+	for _, vw := range w.Vkey() {
+		vkeyHashes[common.Blake2b224Hash(vw.Vkey)] = struct{}{}
+	}
+	for _, req := range required {
+		if _, ok := vkeyHashes[req]; !ok {
+			return MissingRequiredVKeyWitnessForSignerError{Signer: req}
+		}
+	}
+	return nil
+}
+
+// UtxoValidateRedeemerAndScriptWitnesses performs lightweight UTXOW checks for presence/absence of scripts vs redeemers
+func UtxoValidateRedeemerAndScriptWitnesses(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	// Consider Plutus scripts only for redeemer relationship checks.
+	// Native scripts do not require redeemers.
+	wits := tx.Witnesses()
+	redeemerCount := 0
+	if wits != nil {
+		if r := wits.Redeemers(); r != nil {
+			for range r.Iter() {
+				redeemerCount++
+			}
+		}
+	}
+	hasPlutus := false
+	if wits != nil {
+		hasPlutus = len(wits.PlutusV1Scripts()) > 0 ||
+			len(wits.PlutusV2Scripts()) > 0
+	}
+
+	// If the body carries a script data hash, redeemers must be present
+	if tx.ScriptDataHash() != nil && redeemerCount == 0 {
+		return MissingRedeemersForScriptDataHashError{}
+	}
+
+	// If redeemers are present, we expect at least one script witness available
+	if redeemerCount > 0 && !hasPlutus {
+		return MissingPlutusScriptWitnessesError{}
+	}
+
+	// If no redeemers are present but script witnesses are supplied, treat as extraneous
+	if redeemerCount == 0 && hasPlutus {
+		return ExtraneousPlutusScriptWitnessesError{}
+	}
+
+	return nil
 }
 
 func UtxoValidateInputSetEmptyUtxo(

--- a/ledger/conway/errors.go
+++ b/ledger/conway/errors.go
@@ -33,3 +33,37 @@ func (e NonDisjointRefInputsError) Error() string {
 }
 
 // Metadata validation errors are in the common package; use directly
+
+// Witness validation errors
+type MissingVKeyWitnessesError struct{}
+
+func (MissingVKeyWitnessesError) Error() string {
+	return "missing required vkey witnesses"
+}
+
+type MissingRequiredVKeyWitnessForSignerError struct {
+	Signer common.Blake2b224
+}
+
+func (e MissingRequiredVKeyWitnessForSignerError) Error() string {
+	return "missing required vkey witness for required signer"
+}
+
+// Plutus script/redeemer relationship errors
+type MissingRedeemersForScriptDataHashError struct{}
+
+func (MissingRedeemersForScriptDataHashError) Error() string {
+	return "missing redeemers for script data hash"
+}
+
+type MissingPlutusScriptWitnessesError struct{}
+
+func (MissingPlutusScriptWitnessesError) Error() string {
+	return "missing Plutus script witnesses for redeemers"
+}
+
+type ExtraneousPlutusScriptWitnessesError struct{}
+
+func (ExtraneousPlutusScriptWitnessesError) Error() string {
+	return "extraneous Plutus script witnesses"
+}

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -28,6 +28,8 @@ import (
 
 var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateMetadata,
+	UtxoValidateRequiredVKeyWitnesses,
+	UtxoValidateRedeemerAndScriptWitnesses,
 	UtxoValidateDisjointRefInputs,
 	UtxoValidateOutsideValidityIntervalUtxo,
 	UtxoValidateInputSetEmptyUtxo,
@@ -69,6 +71,76 @@ func UtxoValidateDisjointRefInputs(
 	return NonDisjointRefInputsError{
 		Inputs: commonInputs,
 	}
+}
+
+// UtxoValidateRequiredVKeyWitnesses ensures required signers are accompanied by vkey witnesses
+func UtxoValidateRequiredVKeyWitnesses(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	required := tx.RequiredSigners()
+	if len(required) == 0 {
+		return nil
+	}
+	w := tx.Witnesses()
+	if w == nil || len(w.Vkey()) == 0 {
+		return MissingVKeyWitnessesError{}
+	}
+	vkeyHashes := make(map[common.Blake2b224]struct{})
+	for _, vw := range w.Vkey() {
+		vkeyHashes[common.Blake2b224Hash(vw.Vkey)] = struct{}{}
+	}
+	for _, req := range required {
+		if _, ok := vkeyHashes[req]; !ok {
+			return MissingRequiredVKeyWitnessForSignerError{Signer: req}
+		}
+	}
+	return nil
+}
+
+// UtxoValidateRedeemerAndScriptWitnesses performs lightweight UTXOW checks for presence/absence of scripts vs redeemers
+func UtxoValidateRedeemerAndScriptWitnesses(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	// Redeemer/script relation applies only to Plutus scripts. Native scripts
+	// do NOT require redeemers.
+	wits := tx.Witnesses()
+	redeemerCount := 0
+	if wits != nil {
+		if r := wits.Redeemers(); r != nil {
+			for range r.Iter() {
+				redeemerCount++
+			}
+		}
+	}
+	hasPlutus := false
+	if wits != nil {
+		hasPlutus = len(wits.PlutusV1Scripts()) > 0 ||
+			len(wits.PlutusV2Scripts()) > 0 ||
+			len(wits.PlutusV3Scripts()) > 0
+	}
+
+	// If the body carries a script data hash, redeemers must be present
+	if tx.ScriptDataHash() != nil && redeemerCount == 0 {
+		return MissingRedeemersForScriptDataHashError{}
+	}
+
+	// If redeemers are present, we expect at least one script witness available
+	if redeemerCount > 0 && !hasPlutus {
+		return MissingPlutusScriptWitnessesError{}
+	}
+
+	// If no redeemers are present but script witnesses are supplied, treat as extraneous
+	if redeemerCount == 0 && hasPlutus {
+		return ExtraneousPlutusScriptWitnessesError{}
+	}
+
+	return nil
 }
 
 func UtxoValidateOutsideValidityIntervalUtxo(

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -317,7 +317,8 @@ func (t *MaryTransaction) UnmarshalCBOR(cborData []byte) error {
 	}
 
 	// Handle metadata (component 3, index 2) - always present, but may be CBOR nil
-	if len(txArray) > 2 && len(txArray[2]) > 0 && txArray[2][0] != 0xF6 { // 0xF6 is CBOR null
+	if len(txArray) > 2 && len(txArray[2]) > 0 &&
+		txArray[2][0] != 0xF6 { // 0xF6 is CBOR null
 		t.RawAuxData = []byte(txArray[2])
 		metadata, err := common.DecodeAuxiliaryDataToMetadata(txArray[2])
 		if err == nil && metadata != nil {

--- a/ledger/mary/rules.go
+++ b/ledger/mary/rules.go
@@ -29,6 +29,7 @@ const (
 
 var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateMetadata,
+	UtxoValidateRequiredVKeyWitnesses,
 	UtxoValidateOutsideValidityIntervalUtxo,
 	UtxoValidateInputSetEmptyUtxo,
 	UtxoValidateFeeTooSmallUtxo,
@@ -40,6 +41,15 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateOutputTooBigUtxo,
 	UtxoValidateOutputBootAddrAttrsTooBig,
 	UtxoValidateMaxTxSizeUtxo,
+}
+
+func UtxoValidateRequiredVKeyWitnesses(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return shelley.UtxoValidateRequiredVKeyWitnesses(tx, slot, ls, pp)
 }
 
 // UtxoValidateOutputTooBigUtxo ensures that transaction output values are not too large

--- a/ledger/shelley/errors.go
+++ b/ledger/shelley/errors.go
@@ -164,3 +164,18 @@ type (
 	MissingTransactionAuxiliaryDataHashError = common.MissingTransactionAuxiliaryDataHashError
 	ConflictingMetadataHashError             = common.ConflictingMetadataHashError
 )
+
+// Witness validation errors
+type MissingVKeyWitnessesError struct{}
+
+func (MissingVKeyWitnessesError) Error() string {
+	return "missing required vkey witnesses"
+}
+
+type MissingRequiredVKeyWitnessForSignerError struct {
+	Signer common.Blake2b224
+}
+
+func (e MissingRequiredVKeyWitnessForSignerError) Error() string {
+	return "missing required vkey witness for required signer"
+}

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -598,7 +598,8 @@ func (t *ShelleyTransaction) UnmarshalCBOR(cborData []byte) error {
 	}
 
 	// Handle metadata (component 3, index 2) - always present, but may be CBOR nil
-	if len(txArray) > 2 && len(txArray[2]) > 0 && txArray[2][0] != 0xF6 { // 0xF6 is CBOR null
+	if len(txArray) > 2 && len(txArray[2]) > 0 &&
+		txArray[2][0] != 0xF6 { // 0xF6 is CBOR null
 		t.rawAuxData = []byte(txArray[2])
 		metadata, err := common.DecodeAuxiliaryDataToMetadata(txArray[2])
 		if err == nil && metadata != nil {


### PR DESCRIPTION










<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds witness validation to UTXO rules across Shelley→Conway. Requires vkey witnesses when RequiredSigners is set and enforces Plutus script/redeemer consistency where applicable.

- **New Features**
  - Required vkey witness check added across Shelley, Mary, Allegra, Alonzo, Babbage, Conway.
  - Plutus script/redeemer checks added in Alonzo, Babbage, Conway:
    - ScriptDataHash requires redeemers.
    - Redeemers require a Plutus script witness.
    - Plutus scripts without redeemers are rejected.
  - Era coverage: Plutus V1 (Alonzo), V1/V2 (Babbage), V1/V2/V3 (Conway).

- **Tests**
  - Added unit tests for witness rules in Shelley, Alonzo, Babbage, and Conway.

<sup>Written for commit dc0a39a3ed019dc9a1ab80825ecb267d3987e462. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Strengthened transaction validation across multiple ledger eras: required-signature checks and redeemer/script witness consistency to better detect and reject malformed transactions; more specific validation outcomes for witness-related failures.
* **Tests**
  * Added comprehensive unit tests covering new witness and redeemer/script validation scenarios across eras.
* **Style**
  * Minor formatting tweaks with no behavioral changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->