### PR TITLE
feat(handshake): implement query reply message handling and version d…

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -350,7 +350,7 @@ func (c *Connection) setupConnection() error {
 			func(ctx handshake.CallbackContext, version uint16, versionData protocol.VersionData) error {
 				c.handshakeVersion = version
 				c.handshakeVersionData = versionData
-				if c.useNodeToNodeProto {
+				if c.useNodeToNodeProto && versionData != nil {
 					if versionData.DiffusionMode() == protocol.DiffusionModeInitiatorAndResponder {
 						handshakeFullDuplex = true
 					}

--- a/protocol/handshake/handshake.go
+++ b/protocol/handshake/handshake.go
@@ -64,6 +64,10 @@ var StateMap = protocol.StateMap{
 				MsgType:  MessageTypeRefuse,
 				NewState: stateDone,
 			},
+			{
+				MsgType:  MessageTypeQueryReply,
+				NewState: stateDone,
+			},
 		},
 	},
 	stateDone: protocol.StateMapEntry{
@@ -81,6 +85,7 @@ type Handshake struct {
 type Config struct {
 	ProtocolVersionMap protocol.ProtocolVersionMap
 	FinishedFunc       FinishedFunc
+	QueryReplyFunc     QueryReplyFunc
 	Timeout            time.Duration
 }
 
@@ -93,6 +98,8 @@ type CallbackContext struct {
 
 // Callback function types
 type FinishedFunc func(CallbackContext, uint16, protocol.VersionData) error
+
+type QueryReplyFunc func(CallbackContext, protocol.ProtocolVersionMap) error
 
 // New returns a new Handshake object
 func New(protoOptions protocol.ProtocolOptions, cfg *Config) *Handshake {
@@ -138,5 +145,12 @@ func WithFinishedFunc(finishedFunc FinishedFunc) HandshakeOptionFunc {
 func WithTimeout(timeout time.Duration) HandshakeOptionFunc {
 	return func(c *Config) {
 		c.Timeout = timeout
+	}
+}
+
+// WithQueryReplyFunc specifies the QueryReply callback function
+func WithQueryReplyFunc(queryReplyFunc QueryReplyFunc) HandshakeOptionFunc {
+	return func(c *Config) {
+		c.QueryReplyFunc = queryReplyFunc
 	}
 }

--- a/protocol/versiondata.go
+++ b/protocol/versiondata.go
@@ -39,7 +39,7 @@ const (
 
 type VersionData interface {
 	NetworkMagic() uint32
-	// Query() bool
+	Query() bool
 	// NtN only
 	DiffusionMode() bool
 	PeerSharing() bool
@@ -62,6 +62,10 @@ func (v VersionDataNtC9to14) DiffusionMode() bool {
 }
 
 func (v VersionDataNtC9to14) PeerSharing() bool {
+	return false
+}
+
+func (v VersionDataNtC9to14) Query() bool {
 	return false
 }
 
@@ -89,6 +93,10 @@ func (v VersionDataNtC15andUp) PeerSharing() bool {
 	return false
 }
 
+func (v VersionDataNtC15andUp) Query() bool {
+	return v.CborQuery
+}
+
 type VersionDataNtN7to10 struct {
 	cbor.StructAsArray
 	CborNetworkMagic                       uint32
@@ -110,6 +118,10 @@ func (v VersionDataNtN7to10) DiffusionMode() bool {
 }
 
 func (v VersionDataNtN7to10) PeerSharing() bool {
+	return false
+}
+
+func (v VersionDataNtN7to10) Query() bool {
 	return false
 }
 
@@ -139,6 +151,10 @@ func (v VersionDataNtN11to12) PeerSharing() bool {
 	return v.CborPeerSharing >= PeerSharingModeV11PeerSharingPublic
 }
 
+func (v VersionDataNtN11to12) Query() bool {
+	return v.CborQuery
+}
+
 // NOTE: the format stays the same, but the values for PeerSharing change
 type VersionDataNtN13andUp struct {
 	VersionDataNtN11to12
@@ -152,4 +168,8 @@ func NewVersionDataNtN13andUpFromCbor(cborData []byte) (VersionData, error) {
 
 func (v VersionDataNtN13andUp) PeerSharing() bool {
 	return v.CborPeerSharing >= PeerSharingModePeerSharingPublic
+}
+
+func (v VersionDataNtN13andUp) Query() bool {
+	return v.VersionDataNtN11to12.Query()
 }


### PR DESCRIPTION
…ata query support





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added handshake query mode. The server now replies with supported versions via QueryReply, and the client processes it through a callback for version discovery without completing a full handshake.

- **New Features**
  - Added MessageTypeQueryReply with CBOR encode/decode.
  - Client handles QueryReply, calls optional QueryReplyFunc, then FinishedFunc.
  - Server detects proposed versions with Query() and responds with QueryReply, then closes the connection.
  - Introduced Query() on VersionData for NtC/NtN versions and a WithQueryReplyFunc option.
  - Added client and server tests for query mode.

- **Bug Fixes**
  - Guarded NtN diffusion mode check with a nil versionData check to avoid a panic.

<sup>Written for commit d2285def9c7921144f1a730c98a728b516fce2df. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added handshake query mode allowing servers to request per-version client data.
  * Added QueryReply message handling and a configurable callback to process replies.
  * Exposed query capability on version data so versions can indicate query behavior.

* **Bug Fixes**
  * Avoided a potential nil-related issue during handshake completion when version data is missing.

* **Tests**
  * Added client and server tests covering the new query/reply handshake flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->