### PR TITLE
feat(protocol): distributed message queue (CIP-0137)

### DIFF
--- a/protocol/common/authentication.go
+++ b/protocol/common/authentication.go
@@ -1,0 +1,533 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"golang.org/x/crypto/blake2b"
+)
+
+// MessageAuthenticator handles DMQ message authentication verification per CIP-0137.
+// It verifies message signatures, operational certificates, SPO pool registration,
+// and KES period rotation to prevent replay attacks and unauthorized messages.
+type MessageAuthenticator struct {
+	logger *slog.Logger
+	// protect maps with mutex
+	mu sync.RWMutex
+
+	// When true, all authentication checks are skipped. Intended for testing or
+	// environments that explicitly opt out; use NewNoOpAuthenticator to create.
+	disableValidation bool
+
+	// SPO stake distribution and registration info
+	spoPoolIDs map[string]bool // poolID -> active
+
+	// KES period tracking from opcerts. No automatic eviction; callers running long-lived
+	// nodes should remove inactive pool entries (see RemoveKESOpCertCacheEntry) or wrap
+	// this with their own TTL/LRU policy to avoid unbounded growth.
+	kesOpCertCache map[string]uint64 // poolID -> latest opcert number
+
+	// Slots per KES period used for ledger KES verification. Default is Cardano standard.
+	slotsPerKesPeriod uint64
+	// AllowInsecureKES when true will accept KES signatures without running
+	// a real KES verification (for tests or environments without ledger verifier).
+	// This must be false in production.
+	AllowInsecureKES bool
+	// kesVerifier holds the optional KES verifier callback. If set, it will be used to verify KES signatures.
+	// Signature: func(wrappedPayload []byte, signature []byte, vkey []byte, kesPeriod uint64, slot uint64, slotsPerKesPeriod uint64) (bool, error)
+	// Uses atomic.Value for race-free concurrent access (typically set once at init, read many times).
+	kesVerifier atomic.Value // stores func([]byte,[]byte,[]byte,uint64,uint64,uint64)(bool,error) or nil
+}
+
+// package-level default KES verifier used when set by application startup.
+// defaultKESVerifier holds an optional package-level KES verifier used when set by application startup.
+// Use atomic.Value to allow concurrent, race-free access.
+var defaultKESVerifier atomic.Value // stores func([]byte,[]byte,[]byte,uint64,uint64,uint64)(bool,error)
+
+// SetDefaultKESVerifier sets a package-level default KES verifier. Callers (e.g. main)
+// can set this once at startup to avoid per-constructor imports of ledger.
+func SetDefaultKESVerifier(
+	v func([]byte, []byte, []byte, uint64, uint64, uint64) (bool, error),
+) {
+	defaultKESVerifier.Store(v)
+}
+
+// ApplyDefaultKESVerifier applies the package-level default KES verifier to the provided
+// authenticator if a default has been set.
+func ApplyDefaultKESVerifier(auth *MessageAuthenticator) {
+	if auth == nil {
+		return
+	}
+	// Load via atomic.Value and type-assert
+	if val := defaultKESVerifier.Load(); val != nil {
+		if fn, ok := val.(func([]byte, []byte, []byte, uint64, uint64, uint64) (bool, error)); ok {
+			auth.SetKESVerifier(fn)
+		}
+	}
+}
+
+// NewMessageAuthenticator creates a new message authenticator.
+func NewMessageAuthenticator(logger *slog.Logger) *MessageAuthenticator {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return &MessageAuthenticator{
+		logger:         logger,
+		spoPoolIDs:     make(map[string]bool),
+		kesOpCertCache: make(map[string]uint64),
+		// Default Cardano slots per KES period (standard mainnet value)
+		slotsPerKesPeriod: 129600,
+	}
+}
+
+// NewNoOpAuthenticator returns an authenticator that performs no validation.
+// Suitable for testing or trusted environments where authentication is
+// intentionally disabled.
+func NewNoOpAuthenticator(logger *slog.Logger) *MessageAuthenticator {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &MessageAuthenticator{
+		logger:            logger,
+		spoPoolIDs:        make(map[string]bool),
+		kesOpCertCache:    make(map[string]uint64),
+		slotsPerKesPeriod: 129600,
+		disableValidation: true,
+	}
+}
+
+// SetKESVerifier sets a custom KES verifier function used by VerifyMessage.
+// This avoids hard dependency on the ledger package in the protocol/common package
+// and lets callers inject the ledger verifier when available.
+// Thread-safe; uses atomic.Value for concurrent access.
+func (m *MessageAuthenticator) SetKESVerifier(
+	v func([]byte, []byte, []byte, uint64, uint64, uint64) (bool, error),
+) {
+	m.kesVerifier.Store(v)
+}
+
+// RegisterSPOPool adds an SPO pool ID to the known active pools.
+func (m *MessageAuthenticator) RegisterSPOPool(poolID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.spoPoolIDs[poolID] = true
+}
+
+// UnregisterSPOPool removes an SPO pool ID from known pools.
+func (m *MessageAuthenticator) UnregisterSPOPool(poolID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.spoPoolIDs, poolID)
+}
+
+// IsSPOPoolRegistered returns whether a poolID is known and registered.
+// This provides a stable public API for tests and callers instead of
+// accessing internal maps directly.
+func (m *MessageAuthenticator) IsSPOPoolRegistered(poolID string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.spoPoolIDs[poolID]
+}
+
+// VerifyMessage performs complete message authentication as per CIP-0137.
+// It verifies: operational certificate, KES signature, SPO pool registration,
+// message ID, and KES period rotation. Returns error if verification fails
+// (which is a protocol violation and should result in peer disconnection).
+// VerifyMessage verifies a message using no explicit slot (slot==0). Use VerifyMessageWithSlot
+// when the caller has an explicit slot value to supply.
+func (m *MessageAuthenticator) VerifyMessage(msg *DmqMessage) error {
+	return m.verifyMessageInternal(msg, 0)
+}
+
+// VerifyMessageWithSlot verifies a message using an explicit slot value. When available,
+// callers should supply the slot (e.g., from the block header) so KES period/current period
+// checks are accurate.
+func (m *MessageAuthenticator) VerifyMessageWithSlot(
+	msg *DmqMessage,
+	slot uint64,
+) error {
+	return m.verifyMessageInternal(msg, slot)
+}
+
+// verifyMessageInternal contains the core verification logic. If slot==0, the verifier
+// will compute a slot based on kesPeriod * slotsPerKesPeriod as a fallback.
+func (m *MessageAuthenticator) verifyMessageInternal(
+	msg *DmqMessage,
+	slot uint64,
+) error {
+	if m.disableValidation {
+		return nil
+	}
+
+	if msg == nil {
+		return errors.New("message is nil")
+	}
+
+	// Step 1: Verify operational certificate validity
+	if err := m.verifyOperationalCertificate(&msg.OperationalCertificate, msg.ColdVerificationKey); err != nil {
+		return fmt.Errorf(
+			"operational certificate verification failed: %w",
+			err,
+		)
+	}
+
+	// Step 2: Verify KES signature over message payload
+	if err := m.verifyKESSignature(msg, slot); err != nil {
+		return fmt.Errorf("KES signature verification failed: %w", err)
+	}
+
+	// Step 3: Compute SPO pool ID from cold key and verify it's registered and active
+	poolID := m.computePoolID(msg.ColdVerificationKey)
+	m.mu.RLock()
+	registered := m.spoPoolIDs[poolID]
+	m.mu.RUnlock()
+	if !registered {
+		return fmt.Errorf("SPO pool %s is not registered or not active", poolID)
+	}
+
+	// Step 4: Verify message ID format and size constraints
+	if err := m.verifyMessageID(msg); err != nil {
+		return fmt.Errorf("message ID verification failed: %w", err)
+	}
+
+	// Step 5: Verify KES period rotation (opcert number doesn't go backwards)
+	if err := m.verifyKESPeriodRotation(poolID, &msg.OperationalCertificate); err != nil {
+		return fmt.Errorf("KES period rotation verification failed: %w", err)
+	}
+
+	return nil
+}
+
+// verifyOperationalCertificate verifies the operational certificate signature by the cold key.
+func (m *MessageAuthenticator) verifyOperationalCertificate(
+	opcert *OperationalCertificate,
+	coldVerificationKey []byte,
+) error {
+	if opcert == nil {
+		return errors.New("operational certificate is nil")
+	}
+
+	if len(coldVerificationKey) != 32 {
+		return fmt.Errorf(
+			"cold verification key must be 32 bytes, got %d",
+			len(coldVerificationKey),
+		)
+	}
+
+	if len(opcert.ColdSignature) != 64 {
+		return fmt.Errorf(
+			"cold signature must be 64 bytes, got %d",
+			len(opcert.ColdSignature),
+		)
+	}
+
+	// Create the message to verify: [KES vkey, issue number, KES period]
+	certData := []any{
+		opcert.KESVerificationKey,
+		opcert.IssueNumber,
+		opcert.KESPeriod,
+	}
+
+	certCbor, err := cbor.Encode(certData)
+	if err != nil {
+		return fmt.Errorf("failed to encode certificate data: %w", err)
+	}
+
+	// Verify signature using cold verification key
+	pubKey := ed25519.PublicKey(coldVerificationKey)
+	if !ed25519.Verify(pubKey, certCbor, opcert.ColdSignature) {
+		return errors.New("cold signature verification failed")
+	}
+
+	return nil
+}
+
+// verifyKESSignature verifies the KES signature over the message payload (CBOR encoded).
+// If slot==0, a fallback slot will be computed from the KES period and configured
+// slots per KES period.
+func (m *MessageAuthenticator) verifyKESSignature(
+	msg *DmqMessage,
+	slot uint64,
+) error {
+	if len(msg.KESSignature) != 448 {
+		return fmt.Errorf(
+			"KES signature must be 448 bytes, got %d",
+			len(msg.KESSignature),
+		)
+	}
+
+	// Create CBOR encoding of the message payload as required by spec
+	payload := []any{
+		msg.Payload.MessageID,
+		msg.Payload.MessageBody,
+		msg.Payload.KESPeriod,
+		msg.Payload.ExpiresAt,
+	}
+
+	payloadCbor, err := cbor.Encode(payload)
+	if err != nil {
+		return fmt.Errorf("failed to encode payload: %w", err)
+	}
+
+	// Wrap payloadCbor into a CBOR byte string (bstr .cbor messagePayload).
+	// Encoding the raw payloadCbor bytes will produce a CBOR byte string containing
+	// the original CBOR-encoded payload (bstr), which matches the spec.
+	wrappedCbor, err := cbor.Encode(payloadCbor)
+	if err != nil {
+		return fmt.Errorf("failed to encode wrapped payload as bstr: %w", err)
+	}
+
+	// KES signature verification with KES verification key
+	// Note: Real KES verification would be more complex and require the KES scheme implementation
+	// For now, we verify the basic structure
+	if len(msg.OperationalCertificate.KESVerificationKey) != 32 {
+		return errors.New("KES verification key must be 32 bytes")
+	}
+
+	// If a KES verifier has been injected, use it.
+	kesVerifierVal := m.kesVerifier.Load()
+	if kesVerifierVal != nil {
+		kesVerifier, ok := kesVerifierVal.(func([]byte, []byte, []byte, uint64, uint64, uint64) (bool, error))
+		if ok {
+			kesPeriod := msg.Payload.KESPeriod
+			computedSlot := slot
+			if computedSlot == 0 {
+				computedSlot = kesPeriod * m.slotsPerKesPeriod
+			}
+			// Log the slot used for verification to aid debugging
+			m.logger.Debug(
+				"KES verification using slot",
+				"slot",
+				computedSlot,
+				"kes_period",
+				kesPeriod,
+			)
+			valid, err := kesVerifier(
+				wrappedCbor,
+				msg.KESSignature,
+				msg.OperationalCertificate.KESVerificationKey,
+				kesPeriod,
+				computedSlot,
+				m.slotsPerKesPeriod,
+			)
+			if err != nil {
+				return fmt.Errorf("KES verification failed: %w", err)
+			}
+			if !valid {
+				return errors.New("KES signature verification failed")
+			}
+			m.logger.Debug(
+				"KES signature verified",
+				"payload_size",
+				len(wrappedCbor),
+			)
+			return nil
+		}
+	}
+
+	// No verifier injected: either allow insecure bypass (tests/dev) or error.
+	if m.AllowInsecureKES {
+		m.logger.Warn(
+			"Insecure KES bypass enabled: accepting KES signature without cryptographic verification",
+			"payload_size",
+			len(wrappedCbor),
+		)
+		return nil
+	}
+
+	// Strong failure: production should set a real verifier
+	m.logger.Error("No KES verifier available and insecure bypass disabled")
+	return errors.New(
+		"KES verification not implemented: no verifier injected and AllowInsecureKES is false",
+	)
+}
+
+// verifyMessageID verifies the message ID format and size constraints.
+func (m *MessageAuthenticator) verifyMessageID(msg *DmqMessage) error {
+	if len(msg.Payload.MessageID) == 0 {
+		return errors.New("message ID cannot be empty")
+	}
+
+	if len(msg.Payload.MessageID) > 256 {
+		return fmt.Errorf(
+			"message ID is too long: %d bytes",
+			len(msg.Payload.MessageID),
+		)
+	}
+
+	// In the actual implementation, message ID should be computed as a hash of the message
+	// For now, we just verify it exists and has reasonable size
+	return nil
+}
+
+// computePoolID computes the SPO pool ID from the cold verification key.
+// Pool ID = blake2b-256(coldVerificationKey)
+func (m *MessageAuthenticator) computePoolID(
+	coldVerificationKey []byte,
+) string {
+	hash := blake2b.Sum256(coldVerificationKey)
+	// Convert to hex string for use as pool ID
+	return hex.EncodeToString(hash[:])
+}
+
+// verifyKESPeriodRotation verifies that the opcert number doesn't go backwards for each pool,
+// preventing replay attacks with stale credentials.
+func (m *MessageAuthenticator) verifyKESPeriodRotation(
+	poolID string,
+	opcert *OperationalCertificate,
+) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	lastOpCertNumber, exists := m.kesOpCertCache[poolID]
+
+	// If we've seen this pool before, opcert number must be >= previous
+	if exists && opcert.IssueNumber < lastOpCertNumber {
+		return fmt.Errorf(
+			"opcert number went backwards: previous=%d, current=%d",
+			lastOpCertNumber,
+			opcert.IssueNumber,
+		)
+	}
+
+	// Update cache with latest opcert number
+	m.kesOpCertCache[poolID] = opcert.IssueNumber
+
+	return nil
+}
+
+// RemoveKESOpCertCacheEntry removes a pool entry from the KES opcert cache.
+// The cache does not evict automatically, so long-running nodes should call
+// this (or wrap the authenticator with their own TTL/LRU policy) when pools
+// are unregistered or otherwise inactive to avoid unbounded growth.
+func (m *MessageAuthenticator) RemoveKESOpCertCacheEntry(poolID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.kesOpCertCache, poolID)
+}
+
+// TTLValidator enforces message time-to-live (TTL) constraints per CIP-0137.
+// It validates that messages have not expired and rejects messages with
+// expiration timestamps too far in the future.
+type TTLValidator struct {
+	maxAllowedTTL time.Duration
+	logger        *slog.Logger
+	disabled      bool
+}
+
+// NewTTLValidator creates a new TTL validator with configurable max TTL.
+// If maxAllowedTTL is 0, defaults to 30 minutes per CIP-0137.
+// Negative values are clamped to 0.
+func NewTTLValidator(
+	maxAllowedTTL time.Duration,
+	logger *slog.Logger,
+) *TTLValidator {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	if maxAllowedTTL < 0 {
+		maxAllowedTTL = 0
+	}
+
+	if maxAllowedTTL == 0 {
+		// Default to 30 minutes as per CIP-0137
+		maxAllowedTTL = 30 * time.Minute
+	}
+
+	return &TTLValidator{
+		maxAllowedTTL: maxAllowedTTL,
+		logger:        logger,
+	}
+}
+
+// NewNoOpTTLValidator returns a validator that performs no TTL checks. Intended
+// for trusted/testing environments where TTL enforcement is explicitly disabled.
+func NewNoOpTTLValidator(logger *slog.Logger) *TTLValidator {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &TTLValidator{disabled: true, logger: logger}
+}
+
+// ValidateMessageTTL checks if a message's expiration is valid (not expired and not too far in future).
+func (v *TTLValidator) ValidateMessageTTL(msg *DmqMessage) error {
+	if v.disabled {
+		return nil
+	}
+	if msg == nil {
+		return errors.New("message is nil")
+	}
+
+	// #nosec G115 -- Unix timestamp will not overflow uint32 until year 2106
+	now := uint32(time.Now().Unix())
+	expiresAt := msg.Payload.ExpiresAt
+
+	// Check if message has already expired
+	if now > expiresAt {
+		return fmt.Errorf(
+			"message has expired: now=%d, expiresAt=%d",
+			now,
+			expiresAt,
+		)
+	}
+
+	// Check if expiration is too far in the future (protocol violation).
+	// Compute in uint64 to avoid overflow when adding TTL seconds to current time.
+	maxAllowedTTLSeconds := uint64(v.maxAllowedTTL.Seconds())
+	nowUint64 := uint64(now)
+	maxAllowedExpirationUint64 := min(
+		nowUint64+maxAllowedTTLSeconds,
+		math.MaxUint32,
+	)
+	// #nosec G115 -- overflow prevented by clamping to MaxUint32 above
+	maxAllowedExpiration := uint32(maxAllowedExpirationUint64)
+	if expiresAt > maxAllowedExpiration {
+		return fmt.Errorf(
+			"message expiration too far in future: now=%d, expiresAt=%d, max_allowed=%d",
+			now,
+			expiresAt,
+			maxAllowedExpiration,
+		)
+	}
+
+	return nil
+}
+
+// GetTimeUntilExpiration returns the time remaining before message expires, or 0 if already expired.
+func (v *TTLValidator) GetTimeUntilExpiration(msg *DmqMessage) time.Duration {
+	if msg == nil {
+		return 0
+	}
+
+	// #nosec G115 -- Unix timestamp will not overflow uint32 until year 2106
+	now := uint32(time.Now().Unix())
+	if now >= msg.Payload.ExpiresAt {
+		return 0
+	}
+
+	secondsLeft := msg.Payload.ExpiresAt - now
+	return time.Duration(secondsLeft) * time.Second
+}

--- a/protocol/common/authentication_test.go
+++ b/protocol/common/authentication_test.go
@@ -1,0 +1,543 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMessageAuthenticatorCreation tests authenticator creation
+func TestMessageAuthenticatorCreation(t *testing.T) {
+	auth := NewMessageAuthenticator(nil)
+	assert.NotNil(t, auth)
+}
+
+// TestRegisterUnregisterSPOPool tests SPO pool registration
+func TestRegisterUnregisterSPOPool(t *testing.T) {
+	auth := NewMessageAuthenticator(nil)
+
+	poolID := "test-pool-123"
+	auth.RegisterSPOPool(poolID)
+	assert.True(t, auth.IsSPOPoolRegistered(poolID))
+
+	auth.UnregisterSPOPool(poolID)
+	assert.False(t, auth.IsSPOPoolRegistered(poolID))
+}
+
+// TestVerifyMessageNil tests nil message verification
+func TestVerifyMessageNil(t *testing.T) {
+	auth := NewMessageAuthenticator(nil)
+	err := auth.VerifyMessage(nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "message is nil")
+}
+
+// TestVerifyMessageInvalidCertificate tests verification with invalid cert
+func TestVerifyMessageInvalidCertificate(t *testing.T) {
+	auth := NewMessageAuthenticator(nil)
+
+	msg := &DmqMessage{
+		Payload: DmqMessagePayload{
+			MessageID:   []byte("test-id"),
+			MessageBody: []byte("test-body"),
+			KESPeriod:   100,
+			ExpiresAt:   uint32(time.Now().Add(time.Hour).Unix()),
+		},
+		KESSignature: make([]byte, 448),
+		OperationalCertificate: OperationalCertificate{
+			KESVerificationKey: make([]byte, 32), // All zeros - invalid key
+			IssueNumber:        1,
+			KESPeriod:          100,
+			ColdSignature: make(
+				[]byte,
+				64,
+			), // All zeros - invalid signature
+		},
+		ColdVerificationKey: make([]byte, 32),
+	}
+
+	err := auth.VerifyMessage(msg)
+	assert.Error(t, err)
+}
+
+// TestComputePoolID tests pool ID computation from cold key
+// Note: This test uses unexported computePoolID method to verify internal hash logic
+func TestComputePoolID(t *testing.T) {
+	auth := NewMessageAuthenticator(nil)
+
+	coldKey1 := make([]byte, 32)
+	coldKey1[0] = 0x01
+
+	coldKey2 := make([]byte, 32)
+	coldKey2[0] = 0x02
+
+	poolID1 := auth.computePoolID(coldKey1)
+	poolID2 := auth.computePoolID(coldKey2)
+
+	assert.NotEmpty(t, poolID1)
+	assert.NotEmpty(t, poolID2)
+	assert.NotEqual(t, poolID1, poolID2)
+}
+
+// TestVerifyKESPeriodRotation tests KES period rotation verification
+func TestVerifyKESPeriodRotation(t *testing.T) {
+	auth := NewMessageAuthenticator(nil)
+
+	poolID := "test-pool"
+	opcert1 := &OperationalCertificate{
+		IssueNumber: 1,
+	}
+
+	// First time should succeed
+	err := auth.verifyKESPeriodRotation(poolID, opcert1)
+	assert.NoError(t, err)
+
+	// Same number should succeed
+	err = auth.verifyKESPeriodRotation(poolID, opcert1)
+	assert.NoError(t, err)
+
+	// Higher number should succeed
+	opcert2 := &OperationalCertificate{
+		IssueNumber: 2,
+	}
+	err = auth.verifyKESPeriodRotation(poolID, opcert2)
+	assert.NoError(t, err)
+
+	// Lower number should fail
+	opcert3 := &OperationalCertificate{
+		IssueNumber: 1,
+	}
+	err = auth.verifyKESPeriodRotation(poolID, opcert3)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "went backwards")
+}
+
+// TestTTLValidatorCreation tests TTL validator creation
+func TestTTLValidatorCreation(t *testing.T) {
+	validator := NewTTLValidator(0, nil)
+	assert.NotNil(t, validator)
+	// Default should be 30 minutes
+	assert.Equal(t, 30*time.Minute, validator.maxAllowedTTL)
+}
+
+// TestTTLValidatorCustomTTL tests TTL validator with custom TTL
+func TestTTLValidatorCustomTTL(t *testing.T) {
+	customTTL := 1 * time.Hour
+	validator := NewTTLValidator(customTTL, nil)
+	assert.Equal(t, customTTL, validator.maxAllowedTTL)
+}
+
+// TestValidateMessageTTLExpired tests expired message validation
+func TestValidateMessageTTLExpired(t *testing.T) {
+	validator := NewTTLValidator(30*time.Minute, nil)
+
+	msg := &DmqMessage{
+		Payload: DmqMessagePayload{
+			MessageID:   []byte("test-id"),
+			MessageBody: []byte("test-body"),
+			KESPeriod:   100,
+			ExpiresAt: uint32(
+				time.Now().Add(-1 * time.Minute).Unix(),
+			), // Expired 1 minute ago
+		},
+	}
+
+	err := validator.ValidateMessageTTL(msg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "expired")
+}
+
+// TestValidateMessageTTLValid tests valid message TTL
+func TestValidateMessageTTLValid(t *testing.T) {
+	validator := NewTTLValidator(30*time.Minute, nil)
+
+	msg := &DmqMessage{
+		Payload: DmqMessagePayload{
+			MessageID:   []byte("test-id"),
+			MessageBody: []byte("test-body"),
+			KESPeriod:   100,
+			ExpiresAt: uint32(
+				time.Now().Add(10 * time.Minute).Unix(),
+			), // Expires in 10 minutes
+		},
+	}
+
+	err := validator.ValidateMessageTTL(msg)
+	assert.NoError(t, err)
+}
+
+// TestValidateMessageTTLTooFar tests message with expiration too far in future
+func TestValidateMessageTTLTooFar(t *testing.T) {
+	validator := NewTTLValidator(30*time.Minute, nil)
+
+	msg := &DmqMessage{
+		Payload: DmqMessagePayload{
+			MessageID:   []byte("test-id"),
+			MessageBody: []byte("test-body"),
+			KESPeriod:   100,
+			ExpiresAt: uint32(
+				time.Now().Add(2 * time.Hour).Unix(),
+			), // Expires too far in future
+		},
+	}
+
+	err := validator.ValidateMessageTTL(msg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "too far in future")
+}
+
+// TestValidateMessageTTLNil tests nil message validation
+func TestValidateMessageTTLNil(t *testing.T) {
+	validator := NewTTLValidator(30*time.Minute, nil)
+	err := validator.ValidateMessageTTL(nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "nil")
+}
+
+// TestGetTimeUntilExpiration tests time until expiration calculation
+func TestGetTimeUntilExpiration(t *testing.T) {
+	validator := NewTTLValidator(30*time.Minute, nil)
+
+	// Message expiring in 5 minutes
+	expiresAt := uint32(time.Now().Add(5 * time.Minute).Unix())
+	msg := &DmqMessage{
+		Payload: DmqMessagePayload{
+			MessageID:   []byte("test-id"),
+			MessageBody: []byte("test-body"),
+			KESPeriod:   100,
+			ExpiresAt:   expiresAt,
+		},
+	}
+
+	timeLeft := validator.GetTimeUntilExpiration(msg)
+	assert.Greater(t, timeLeft, 4*time.Minute)
+	assert.Less(t, timeLeft, 6*time.Minute)
+}
+
+// TestGetTimeUntilExpirationExpired tests time calculation for expired message
+func TestGetTimeUntilExpirationExpired(t *testing.T) {
+	validator := NewTTLValidator(30*time.Minute, nil)
+
+	msg := &DmqMessage{
+		Payload: DmqMessagePayload{
+			MessageID:   []byte("test-id"),
+			MessageBody: []byte("test-body"),
+			KESPeriod:   100,
+			ExpiresAt: uint32(
+				time.Now().Add(-1 * time.Minute).Unix(),
+			), // Already expired
+		},
+	}
+
+	timeLeft := validator.GetTimeUntilExpiration(msg)
+	assert.Equal(t, time.Duration(0), timeLeft)
+}
+
+// TestGetTimeUntilExpirationNil tests time calculation for nil message
+func TestGetTimeUntilExpirationNil(t *testing.T) {
+	validator := NewTTLValidator(30*time.Minute, nil)
+	timeLeft := validator.GetTimeUntilExpiration(nil)
+	assert.Equal(t, time.Duration(0), timeLeft)
+}
+
+// TestMessageAuthenticatorWithLogger tests authenticator with custom logger
+func TestMessageAuthenticatorWithLogger(t *testing.T) {
+	logger := slog.Default()
+	auth := NewMessageAuthenticator(logger)
+	assert.NotNil(t, auth)
+	assert.NotNil(t, auth.logger)
+}
+
+// TestMessageIsValid tests message validity check
+func TestMessageIsValid(t *testing.T) {
+	// Valid message (expires in future)
+	validMsg := &DmqMessage{
+		Payload: DmqMessagePayload{
+			ExpiresAt: uint32(time.Now().Add(time.Hour).Unix()),
+		},
+	}
+	assert.True(t, validMsg.IsValid())
+
+	// Expired message
+	expiredMsg := &DmqMessage{
+		Payload: DmqMessagePayload{
+			ExpiresAt: uint32(time.Now().Add(-time.Hour).Unix()),
+		},
+	}
+	assert.False(t, expiredMsg.IsValid())
+}
+
+// TestVerifyOperationalCertificateInvalidColdKeySize tests cert verification with invalid cold key size
+func TestVerifyOperationalCertificateInvalidColdKeySize(t *testing.T) {
+	auth := NewMessageAuthenticator(nil)
+
+	opcert := &OperationalCertificate{
+		KESVerificationKey: make([]byte, 32),
+		IssueNumber:        1,
+		KESPeriod:          100,
+		ColdSignature:      make([]byte, 64),
+	}
+
+	err := auth.verifyOperationalCertificate(
+		opcert,
+		make([]byte, 16),
+	) // Wrong cold key size
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "32 bytes")
+}
+
+// TestVerifyOperationalCertificateInvalidSignatureSize tests cert verification with invalid signature size
+func TestVerifyOperationalCertificateInvalidSignatureSize(t *testing.T) {
+	auth := NewMessageAuthenticator(nil)
+
+	opcert := &OperationalCertificate{
+		KESVerificationKey: make([]byte, 32),
+		IssueNumber:        1,
+		KESPeriod:          100,
+		ColdSignature:      make([]byte, 32), // Wrong size
+	}
+
+	err := auth.verifyOperationalCertificate(opcert, make([]byte, 32))
+	assert.Error(t, err)
+}
+
+// TestVerifyMessageIDInvalid tests message ID verification with invalid ID
+func TestVerifyMessageIDInvalid(t *testing.T) {
+	auth := NewMessageAuthenticator(nil)
+
+	msg := &DmqMessage{
+		Payload: DmqMessagePayload{
+			MessageID: []byte{}, // Empty ID
+		},
+	}
+
+	err := auth.verifyMessageID(msg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}
+
+// TestVerifyMessageIDTooLong tests message ID verification with too long ID
+func TestVerifyMessageIDTooLong(t *testing.T) {
+	auth := NewMessageAuthenticator(nil)
+
+	msg := &DmqMessage{
+		Payload: DmqMessagePayload{
+			MessageID: make([]byte, 300), // Too long
+		},
+	}
+
+	err := auth.verifyMessageID(msg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "too long")
+}
+
+// TestVerifyKESSignatureInvalidSize tests KES signature verification with invalid size
+func TestVerifyKESSignatureInvalidSize(t *testing.T) {
+	auth := NewMessageAuthenticator(nil)
+	// Generate an ed25519 keypair for a valid cold key and sign the opcert
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	assert.NoError(t, err)
+
+	opcert := OperationalCertificate{
+		KESVerificationKey: make([]byte, 32),
+		IssueNumber:        1,
+		KESPeriod:          1,
+	}
+
+	certData := []any{
+		opcert.KESVerificationKey,
+		opcert.IssueNumber,
+		opcert.KESPeriod,
+	}
+	certCbor, err := cbor.Encode(certData)
+	assert.NoError(t, err)
+
+	sig := ed25519.Sign(priv, certCbor)
+	opcert.ColdSignature = sig
+
+	msg := &DmqMessage{
+		KESSignature: make(
+			[]byte,
+			256,
+		), // Wrong size triggers KES check
+		OperationalCertificate: opcert,
+		ColdVerificationKey:    []byte(pub),
+		Payload: DmqMessagePayload{
+			MessageID:   []byte("test-id"),
+			MessageBody: []byte("body"),
+			KESPeriod:   1,
+			ExpiresAt:   uint32(time.Now().Add(time.Minute).Unix()),
+		},
+	}
+
+	err = auth.VerifyMessage(msg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "448 bytes")
+}
+
+// helper to build a minimal valid Message suitable for KES verification tests
+func buildTestMessage(t *testing.T) *DmqMessage {
+	// generate cold keypair
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate ed25519 key: %v", err)
+	}
+
+	// create opcert with a 32-byte KES vkey (zeros are fine for these tests)
+	opcert := OperationalCertificate{
+		KESVerificationKey: make([]byte, 32),
+		IssueNumber:        1,
+		KESPeriod:          100,
+	}
+
+	// build cert cbor and sign it with cold key
+	certData := []any{
+		opcert.KESVerificationKey,
+		opcert.IssueNumber,
+		opcert.KESPeriod,
+	}
+	certCbor, err := cbor.Encode(certData)
+	if err != nil {
+		t.Fatalf("failed to encode cert cbor: %v", err)
+	}
+	opcert.ColdSignature = ed25519.Sign(priv, certCbor)
+
+	msg := &DmqMessage{
+		Payload: DmqMessagePayload{
+			MessageID:   []byte("test-id"),
+			MessageBody: []byte("hello"),
+			KESPeriod:   100,
+			ExpiresAt:   uint32(time.Now().Add(time.Hour).Unix()),
+		},
+		KESSignature:           make([]byte, 448),
+		OperationalCertificate: opcert,
+		ColdVerificationKey:    pub,
+	}
+
+	return msg
+}
+
+func TestVerifyMessageWithSlot_CallsInjectedVerifier_Success(t *testing.T) {
+	auth := NewMessageAuthenticator(nil)
+	msg := buildTestMessage(t)
+
+	// register poolID so SPO check passes
+	poolID := auth.computePoolID(msg.ColdVerificationKey)
+	auth.RegisterSPOPool(poolID)
+
+	called := false
+	var gotKesPeriod uint64
+	var gotSlot uint64
+	var gotSignature []byte
+	var gotVkey []byte
+
+	auth.SetKESVerifier(
+		func(wrappedPayload []byte, signature []byte, vkey []byte, kesPeriod uint64, slot uint64, slotsPerKesPeriod uint64) (bool, error) {
+			called = true
+			gotKesPeriod = kesPeriod
+			gotSlot = slot
+			gotSignature = signature
+			gotVkey = vkey
+			return true, nil
+		},
+	)
+
+	// call verification with explicit slot
+	err := auth.VerifyMessageWithSlot(msg, 12345)
+	assert.NoError(t, err)
+	assert.True(t, called, "expected verifier to be called")
+	assert.Equal(t, uint64(msg.Payload.KESPeriod), gotKesPeriod)
+	assert.Equal(t, uint64(12345), gotSlot)
+	assert.Equal(t, msg.KESSignature, gotSignature)
+	assert.Equal(t, msg.OperationalCertificate.KESVerificationKey, gotVkey)
+}
+
+func TestVerifyMessageWithSlot_VerifierRejects(t *testing.T) {
+	auth := NewMessageAuthenticator(nil)
+	msg := buildTestMessage(t)
+	poolID := auth.computePoolID(msg.ColdVerificationKey)
+	auth.RegisterSPOPool(poolID)
+
+	auth.SetKESVerifier(
+		func(_ []byte, _ []byte, _ []byte, _ uint64, _ uint64, _ uint64) (bool, error) {
+			return false, nil
+		},
+	)
+
+	err := auth.VerifyMessageWithSlot(msg, 0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "KES signature verification failed")
+}
+
+func TestVerifyMessageWithSlot_VerifierError(t *testing.T) {
+	auth := NewMessageAuthenticator(nil)
+	msg := buildTestMessage(t)
+	poolID := auth.computePoolID(msg.ColdVerificationKey)
+	auth.RegisterSPOPool(poolID)
+
+	auth.SetKESVerifier(
+		func(_ []byte, _ []byte, _ []byte, _ uint64, _ uint64, _ uint64) (bool, error) {
+			return false, errors.New("boom")
+		},
+	)
+
+	err := auth.VerifyMessageWithSlot(msg, 0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "KES verification failed")
+}
+
+func TestDefaultKESVerifier_IsAppliedAndCalled(t *testing.T) {
+	// set package-level default verifier to a mock
+	called := false
+	pcommonVerifier := func(wrappedPayload []byte, signature []byte, vkey []byte, kesPeriod uint64, slot uint64, slotsPerKesPeriod uint64) (bool, error) {
+		called = true
+		return true, nil
+	}
+
+	// Use SetDefaultKESVerifier from this package (same package)
+	// Save previous default and restore after test to avoid package-level state pollution
+	prev := defaultKESVerifier.Load()
+	SetDefaultKESVerifier(pcommonVerifier)
+	defer func() {
+		// Restore previous default verifier (nil or func); defaultKESVerifier only stores this concrete type.
+		if fn, ok := prev.(func([]byte, []byte, []byte, uint64, uint64, uint64) (bool, error)); ok {
+			SetDefaultKESVerifier(fn)
+			return
+		}
+		SetDefaultKESVerifier(nil)
+	}()
+
+	auth := NewMessageAuthenticator(nil)
+	// apply default verifier to auth
+	ApplyDefaultKESVerifier(auth)
+
+	// build message and register pool
+	msg := buildTestMessage(t)
+	poolID := auth.computePoolID(msg.ColdVerificationKey)
+	auth.RegisterSPOPool(poolID)
+
+	// call verification which should trigger default verifier
+	err := auth.VerifyMessageWithSlot(msg, 0)
+	assert.NoError(t, err)
+	assert.True(t, called, "expected default verifier to be called")
+}

--- a/protocol/common/dmq.go
+++ b/protocol/common/dmq.go
@@ -1,0 +1,239 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+)
+
+// DMQ Message structures following CIP-0137 specification
+// https://github.com/cardano-foundation/CIPs/tree/master/CIP-0137
+
+// DmqMessagePayload represents the unsigned message payload for DMQ messages.
+type DmqMessagePayload struct {
+	cbor.StructAsArray
+	// MessageID is the unique identifier for the message
+	MessageID []byte
+	// MessageBody contains the actual message data
+	MessageBody []byte
+	// KESPeriod is the KES key evolution step period
+	KESPeriod uint64
+	// ExpiresAt is the Unix timestamp when the message expires
+	ExpiresAt uint32
+}
+
+// OperationalCertificate represents an SPO's operational certificate used for message authentication.
+type OperationalCertificate struct {
+	cbor.StructAsArray
+	// KESVerificationKey is the 32-byte KES public key
+	KESVerificationKey []byte
+	// IssueNumber is the certificate issue number (for rotation tracking)
+	IssueNumber uint64
+	// KESPeriod is the KES period at certificate creation
+	KESPeriod uint64
+	// ColdSignature is the 64-byte signature by the cold key
+	ColdSignature []byte
+}
+
+// DmqMessage represents a complete authenticated DMQ message with cryptographic proofs.
+type DmqMessage struct {
+	cbor.StructAsArray
+	// Payload is the unsigned message payload
+	Payload DmqMessagePayload
+	// KESSignature is the 448-byte KES signature over the payload
+	KESSignature []byte
+	// OperationalCertificate contains the KES certificate and cold signature
+	OperationalCertificate OperationalCertificate
+	// ColdVerificationKey is the 32-byte SPO cold public key
+	ColdVerificationKey []byte
+}
+
+// MessageIDAndSize represents a message identifier with its serialized size in bytes.
+type MessageIDAndSize struct {
+	cbor.StructAsArray
+	// MessageID is the unique message identifier
+	MessageID []byte
+	// SizeInBytes is the total size of the serialized message
+	SizeInBytes uint32
+}
+
+// IsValid checks if a message has not yet expired by comparing its expiration time
+// against the current Unix timestamp.
+func (m *DmqMessage) IsValid() bool {
+	// Delegate to IsValidAt using current time for testability
+	// #nosec G115 -- Unix timestamp will not overflow uint32 until year 2106
+	return m.IsValidAt(time.Now())
+}
+
+// IsValidAt checks if a message has not yet expired when evaluated at the provided time.
+// This variant is provided for testability so callers can validate expiration behavior
+// deterministically by passing a specific timestamp.
+func (m *DmqMessage) IsValidAt(t time.Time) bool {
+	// #nosec G115 -- Unix timestamp will not overflow uint32 until year 2106
+	return uint32(t.Unix()) <= m.Payload.ExpiresAt
+}
+
+// RejectReason provides information about why a submitted message was rejected.
+// Implementations must support the following reason types via RejectReasonType().
+type RejectReason interface {
+	// RejectReasonType returns the reason code (0-3)
+	RejectReasonType() uint8
+}
+
+// InvalidReason indicates the message failed validation checks.
+type InvalidReason struct {
+	// Message describes the validation error
+	Message string
+}
+
+// RejectReasonType returns 0 for invalid reason
+func (r InvalidReason) RejectReasonType() uint8 {
+	return 0
+}
+
+// AlreadyReceivedReason indicates the message was already received and processed.
+type AlreadyReceivedReason struct{}
+
+// RejectReasonType returns 1 for already received reason
+func (r AlreadyReceivedReason) RejectReasonType() uint8 {
+	return 1
+}
+
+// ExpiredReason indicates the message's TTL has passed.
+type ExpiredReason struct{}
+
+// RejectReasonType returns 2 for expired reason
+func (r ExpiredReason) RejectReasonType() uint8 {
+	return 2
+}
+
+// OtherReason indicates some other rejection cause not covered by the standard reasons.
+type OtherReason struct {
+	// Message describes the other rejection reason
+	Message string
+}
+
+// RejectReasonType returns 3 for other reason
+func (r OtherReason) RejectReasonType() uint8 {
+	return 3
+}
+
+// RejectReasonData is a concrete, CBOR-marshalable representation of a reject reason.
+// It encodes as an array [type, message?] where type is 0..3 and message is optional.
+type RejectReasonData struct {
+	cbor.StructAsArray
+	Type    uint8
+	Message string
+}
+
+// RejectReasonType implements the RejectReason interface.
+func (r RejectReasonData) RejectReasonType() uint8 {
+	return r.Type
+}
+
+// ToRejectReasonData converts any RejectReason implementation into a concrete RejectReasonData.
+func ToRejectReasonData(rr RejectReason) RejectReasonData {
+	if rr == nil {
+		return RejectReasonData{Type: 3}
+	}
+	switch v := rr.(type) {
+	case InvalidReason:
+		return RejectReasonData{Type: 0, Message: v.Message}
+	case AlreadyReceivedReason:
+		return RejectReasonData{Type: 1}
+	case ExpiredReason:
+		return RejectReasonData{Type: 2}
+	case OtherReason:
+		return RejectReasonData{Type: 3, Message: v.Message}
+	case RejectReasonData:
+		return v
+	default:
+		// Fallback: encode as OtherReason with type 3
+		return RejectReasonData{Type: 3}
+	}
+}
+
+// MarshalCBOR encodes RejectReasonData as an array [type, message?] for deterministic wire format.
+func (r RejectReasonData) MarshalCBOR() ([]byte, error) {
+	// Encode as array [type, message]
+	// If message is empty, it still appears in the array (empty string) to keep structure consistent
+	data := []any{r.Type, r.Message}
+	return cbor.Encode(data)
+}
+
+// UnmarshalCBOR decodes a CBOR array [type, message?] back into RejectReasonData.
+func (r *RejectReasonData) UnmarshalCBOR(data []byte) error {
+	if r == nil {
+		return errors.New("cannot unmarshal CBOR into nil RejectReasonData")
+	}
+	// Decode as a CBOR array
+	var arr []any
+	if _, err := cbor.Decode(data, &arr); err != nil {
+		return fmt.Errorf("failed to decode RejectReasonData: %w", err)
+	}
+
+	if len(arr) < 1 {
+		return fmt.Errorf(
+			"RejectReasonData array must have at least 1 element (type), got %d",
+			len(arr),
+		)
+	}
+
+	// Extract type (first element)
+	typeVal, ok := arr[0].(uint64)
+	if !ok {
+		return fmt.Errorf("RejectReasonData type must be uint, got %T", arr[0])
+	}
+	if typeVal > 3 {
+		return fmt.Errorf("RejectReasonData type out of range: %d", typeVal)
+	}
+	r.Type = uint8(typeVal)
+
+	// Extract message (second element, if present)
+	r.Message = ""
+	if len(arr) > 1 && arr[1] != nil {
+		msg, ok := arr[1].(string)
+		if !ok {
+			return fmt.Errorf(
+				"RejectReasonData message must be string or nil, got %T",
+				arr[1],
+			)
+		}
+		r.Message = msg
+	}
+
+	return nil
+}
+
+// FromRejectReasonData converts RejectReasonData back to a concrete public API type.
+// This is used during decoding to reconstruct the public RejectReason interface type.
+func FromRejectReasonData(data RejectReasonData) RejectReason {
+	switch data.Type {
+	case 0:
+		return InvalidReason{Message: data.Message}
+	case 1:
+		return AlreadyReceivedReason{}
+	case 2:
+		return ExpiredReason{}
+	case 3:
+		return OtherReason{Message: data.Message}
+	default:
+		return OtherReason{Message: data.Message}
+	}
+}

--- a/protocol/localmessagenotification/client.go
+++ b/protocol/localmessagenotification/client.go
@@ -1,0 +1,203 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localmessagenotification
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/protocol"
+)
+
+// Client implements the LocalMessageNotification client
+type Client struct {
+	*protocol.Protocol
+	config          *Config
+	callbackContext CallbackContext
+	onceStart       sync.Once
+	onceStop        sync.Once
+	stopErr         error
+}
+
+// NewClient returns a new LocalMessageNotification client object
+func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
+	if cfg == nil {
+		tmpCfg := NewConfig()
+		cfg = &tmpCfg
+	}
+	c := &Client{
+		config: cfg,
+	}
+	c.callbackContext = CallbackContext{
+		Client:       c,
+		ConnectionId: protoOptions.ConnectionId,
+	}
+
+	// Update state map with timeouts for blocking requests
+	stateMapCopy := stateMap.Copy()
+	if entry, ok := stateMapCopy[protocolStateBusyBlock]; ok {
+		// Set timeout for blocking request state to the configured timeout
+		entry.Timeout = cfg.BlockingRequestTimeout
+		stateMapCopy[protocolStateBusyBlock] = entry
+	}
+
+	// Configure underlying Protocol
+	protoConfig := protocol.ProtocolConfig{
+		Name:                ProtocolName,
+		ProtocolId:          ProtocolID,
+		Muxer:               protoOptions.Muxer,
+		Logger:              protoOptions.Logger,
+		ErrorChan:           protoOptions.ErrorChan,
+		Mode:                protoOptions.Mode,
+		Role:                protocol.ProtocolRoleClient,
+		MessageHandlerFunc:  c.messageHandler,
+		MessageFromCborFunc: NewMsgFromCbor,
+		StateMap:            stateMapCopy,
+		InitialState:        protocolStateIdle,
+	}
+	c.Protocol = protocol.New(protoConfig)
+	return c
+}
+
+// Start begins protocol operation
+func (c *Client) Start() {
+	c.onceStart.Do(func() {
+		c.Protocol.Logger().
+			Debug("starting client protocol",
+				"component", "network",
+				"protocol", ProtocolName,
+				"connection_id", c.callbackContext.ConnectionId.String(),
+			)
+		c.Protocol.Start()
+	})
+}
+
+// Stop transitions the protocol to the Done state
+func (c *Client) Stop() error {
+	c.onceStop.Do(func() {
+		c.Protocol.Logger().
+			Debug("stopping client protocol",
+				"component", "network",
+				"protocol", ProtocolName,
+				"connection_id", c.callbackContext.ConnectionId.String(),
+			)
+		msg := NewMsgClientDone()
+		c.stopErr = c.SendMessage(msg)
+	})
+	return c.stopErr
+}
+
+// RequestMessagesNonBlocking sends a non-blocking request for messages
+func (c *Client) RequestMessagesNonBlocking() error {
+	msg := NewMsgRequestMessages(false)
+	return c.SendMessage(msg)
+}
+
+// RequestMessagesBlocking sends a blocking request for messages
+func (c *Client) RequestMessagesBlocking() error {
+	msg := NewMsgRequestMessages(true)
+	return c.SendMessage(msg)
+}
+
+// RequestMessagesBlockingValidateTimeout sends a blocking request for messages and validates
+// that the provided timeout matches the pre-configured BlockingRequestTimeout.
+// This is a validation helper, not a dynamic timeout API. The actual timeout is controlled
+// by the protocol state machine and configured via WithBlockingRequestTimeout.
+// Dynamic timeout changes after client creation are not supported.
+// Pass the expected timeout to verify configuration matches expectations, or use
+// RequestMessagesBlocking() if validation is not needed.
+func (c *Client) RequestMessagesBlockingValidateTimeout(
+	expectedTimeout time.Duration,
+) error {
+	// If expectedTimeout is 0, validation is skipped and only a blocking request is sent.
+	// This allows callers to bypass validation when they do not wish to assert a specific timeout.
+	// Validate that the caller's expected timeout matches the configured BlockingRequestTimeout
+	// to catch configuration mismatches. This prevents silent timeout misalignments that could
+	// lead to hard-to-debug protocol hangs or unexpected behavior.
+	if expectedTimeout != 0 && c.config != nil &&
+		c.config.BlockingRequestTimeout != 0 &&
+		expectedTimeout != c.config.BlockingRequestTimeout {
+		return fmt.Errorf(
+			"timeout mismatch: configured=%s, expected=%s; dynamic timeout changes are not supported",
+			c.config.BlockingRequestTimeout.String(),
+			expectedTimeout.String(),
+		)
+	}
+
+	msg := NewMsgRequestMessages(true)
+	return c.SendMessage(msg)
+}
+
+func (c *Client) messageHandler(msg protocol.Message) error {
+	var err error
+	switch msg.Type() {
+	case MessageTypeReplyMessagesNonBlocking:
+		err = c.handleReplyMessagesNonBlocking(msg)
+	case MessageTypeReplyMessagesBlocking:
+		err = c.handleReplyMessagesBlocking(msg)
+	default:
+		err = fmt.Errorf(
+			"%s: received unexpected message type %d",
+			ProtocolName,
+			msg.Type(),
+		)
+	}
+	return err
+}
+
+func (c *Client) handleReplyMessagesNonBlocking(msg protocol.Message) error {
+	msgReply, ok := msg.(*MsgReplyMessagesNonBlocking)
+	if !ok {
+		return fmt.Errorf("%s: unexpected message type %T", ProtocolName, msg)
+	}
+	c.Protocol.Logger().
+		Debug("received non-blocking reply",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "client",
+			"connection_id", c.callbackContext.ConnectionId.String(),
+			"message_count", len(msgReply.Messages),
+			"has_more", msgReply.HasMore,
+		)
+	if c.config.ReplyMessagesFunc != nil {
+		c.config.ReplyMessagesFunc(
+			c.callbackContext,
+			msgReply.Messages,
+			msgReply.HasMore,
+		)
+	}
+	return nil
+}
+
+func (c *Client) handleReplyMessagesBlocking(msg protocol.Message) error {
+	msgReply, ok := msg.(*MsgReplyMessagesBlocking)
+	if !ok {
+		return fmt.Errorf("%s: unexpected message type %T", ProtocolName, msg)
+	}
+	c.Protocol.Logger().
+		Debug("received blocking reply",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "client",
+			"connection_id", c.callbackContext.ConnectionId.String(),
+			"message_count", len(msgReply.Messages),
+		)
+	if c.config.ReplyMessagesFunc != nil {
+		// For blocking replies, hasMore is always false (waiting until at least one message available)
+		c.config.ReplyMessagesFunc(c.callbackContext, msgReply.Messages, false)
+	}
+	return nil
+}

--- a/protocol/localmessagenotification/localmessagenotification.go
+++ b/protocol/localmessagenotification/localmessagenotification.go
@@ -1,0 +1,226 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package localmessagenotification implements the Ouroboros local-message-notification protocol (CIP-0137)
+package localmessagenotification
+
+import (
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+const (
+	ProtocolName = "LocalMessageNotification"
+	ProtocolID   = 19
+)
+
+// State timeouts for Local Message Notification protocol
+const (
+	IdleTimeout            = 300 * time.Second // Timeout for client to send RequestMessages when idle
+	BusyNonblockingTimeout = 0 * time.Second   // Non-blocking returns immediately, no timeout
+	BusyBlockingTimeout    = 0 * time.Second   // Blocking waits indefinitely for messages, no timeout
+)
+
+// State machine states for Local Message Notification protocol
+const (
+	stateIdleId         = 1
+	stateBusyNonBlockId = 2
+	stateBusyBlockId    = 3
+	stateDoneId         = 4
+)
+
+var (
+	protocolStateIdle         = protocol.NewState(stateIdleId, "idle")
+	protocolStateBusyNonBlock = protocol.NewState(
+		stateBusyNonBlockId,
+		"busyNonBlocking",
+	)
+	protocolStateBusyBlock = protocol.NewState(
+		stateBusyBlockId,
+		"busyBlocking",
+	)
+	protocolStateDone = protocol.NewState(stateDoneId, "done")
+	stateMap          = protocol.StateMap{
+		protocolStateIdle: protocol.StateMapEntry{
+			Agency:                  protocol.AgencyClient,
+			PendingMessageByteLimit: 0,
+			Timeout:                 IdleTimeout,
+			Transitions: []protocol.StateTransition{
+				{
+					MsgType:  MessageTypeRequestMessages,
+					NewState: protocolStateBusyNonBlock,
+					MatchFunc: func(_ any, msg protocol.Message) bool {
+						msgReq := msg.(*MsgRequestMessages)
+						return !msgReq.IsBlocking
+					},
+				},
+				{
+					MsgType:  MessageTypeRequestMessages,
+					NewState: protocolStateBusyBlock,
+					MatchFunc: func(_ any, msg protocol.Message) bool {
+						msgReq := msg.(*MsgRequestMessages)
+						return msgReq.IsBlocking
+					},
+				},
+				{
+					MsgType:  MessageTypeClientDone,
+					NewState: protocolStateDone,
+				},
+			},
+		},
+		protocolStateBusyNonBlock: protocol.StateMapEntry{
+			Agency:                  protocol.AgencyServer,
+			PendingMessageByteLimit: 0,
+			Timeout:                 BusyNonblockingTimeout,
+			Transitions: []protocol.StateTransition{
+				{
+					MsgType:  MessageTypeReplyMessagesNonBlocking,
+					NewState: protocolStateIdle,
+				},
+			},
+		},
+		protocolStateBusyBlock: protocol.StateMapEntry{
+			Agency:                  protocol.AgencyServer,
+			PendingMessageByteLimit: 0,
+			Timeout:                 BusyBlockingTimeout,
+			Transitions: []protocol.StateTransition{
+				{
+					MsgType:  MessageTypeReplyMessagesBlocking,
+					NewState: protocolStateIdle,
+				},
+			},
+		},
+		protocolStateDone: protocol.StateMapEntry{
+			Agency:                  protocol.AgencyNone,
+			PendingMessageByteLimit: 0,
+		},
+	}
+)
+
+// LocalMessageNotification is a wrapper object that holds the client and server instances
+type LocalMessageNotification struct {
+	Client *Client
+	Server *Server
+}
+
+// Config is used to configure the LocalMessageNotification protocol instance
+type Config struct {
+	// Client callbacks
+	ReplyMessagesFunc ReplyMessagesFunc
+
+	// Server configuration
+	MaxQueueSize int
+
+	// Client timeouts
+	BlockingRequestTimeout time.Duration
+
+	// Shared configuration
+	Authenticator *pcommon.MessageAuthenticator
+	TTLValidator  *pcommon.TTLValidator
+}
+
+// CallbackContext provides context for callback functions
+type CallbackContext struct {
+	ConnectionId connection.ConnectionId
+	Client       *Client
+	Server       *Server
+}
+
+// Callback function types
+type ReplyMessagesFunc func(CallbackContext, []pcommon.DmqMessage, bool)
+
+// New returns a new LocalMessageNotification object
+func New(
+	protoOptions protocol.ProtocolOptions,
+	cfg *Config,
+) *LocalMessageNotification {
+	l := &LocalMessageNotification{
+		Client: NewClient(protoOptions, cfg),
+		Server: NewServer(protoOptions, cfg),
+	}
+	return l
+}
+
+// LocalMessageNotificationOptionFunc represents a function used to modify the LocalMessageNotification protocol config
+type LocalMessageNotificationOptionFunc func(*Config)
+
+// NewConfig returns a new LocalMessageNotification config object with the provided options
+func NewConfig(options ...LocalMessageNotificationOptionFunc) Config {
+	c := Config{
+		MaxQueueSize: 100,
+	}
+	// Apply provided options functions
+	for _, option := range options {
+		option(&c)
+	}
+	// Set defaults
+	if c.Authenticator == nil {
+		c.Authenticator = pcommon.NewMessageAuthenticator(nil)
+		pcommon.ApplyDefaultKESVerifier(c.Authenticator)
+	}
+	if c.TTLValidator == nil {
+		c.TTLValidator = pcommon.NewTTLValidator(0, nil)
+	}
+	// Note: The above applies defaults when Authenticator or TTLValidator are
+	// nil. Explicitly setting these fields to nil via option functions will be
+	// overridden by defaults here. To explicitly opt out, use the provided no-op
+	// helpers: common.NewNoOpAuthenticator() and common.NewNoOpTTLValidator().
+	return c
+}
+
+// WithReplyMessagesFunc specifies the callback function when messages are received when acting as a client
+func WithReplyMessagesFunc(
+	replyMessagesFunc ReplyMessagesFunc,
+) LocalMessageNotificationOptionFunc {
+	return func(c *Config) {
+		c.ReplyMessagesFunc = replyMessagesFunc
+	}
+}
+
+// WithMaxQueueSize specifies the maximum queue size for the server
+func WithMaxQueueSize(maxQueueSize int) LocalMessageNotificationOptionFunc {
+	return func(c *Config) {
+		c.MaxQueueSize = maxQueueSize
+	}
+}
+
+// WithBlockingRequestTimeout specifies the timeout for blocking message requests when acting as a client
+func WithBlockingRequestTimeout(
+	timeout time.Duration,
+) LocalMessageNotificationOptionFunc {
+	return func(c *Config) {
+		c.BlockingRequestTimeout = timeout
+	}
+}
+
+// WithAuthenticator specifies the message authenticator to use for message verification
+func WithAuthenticator(
+	authenticator *pcommon.MessageAuthenticator,
+) LocalMessageNotificationOptionFunc {
+	return func(c *Config) {
+		c.Authenticator = authenticator
+	}
+}
+
+// WithTTLValidator specifies the TTL validator to use for message TTL validation
+func WithTTLValidator(
+	ttlValidator *pcommon.TTLValidator,
+) LocalMessageNotificationOptionFunc {
+	return func(c *Config) {
+		c.TTLValidator = ttlValidator
+	}
+}

--- a/protocol/localmessagenotification/messages.go
+++ b/protocol/localmessagenotification/messages.go
@@ -1,0 +1,147 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localmessagenotification
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// Message type constants following CIP-0137 CDDL specification
+const (
+	MessageTypeRequestMessages          = 0
+	MessageTypeReplyMessagesNonBlocking = 1
+	MessageTypeReplyMessagesBlocking    = 2
+	MessageTypeClientDone               = 3
+)
+
+// MsgRequestMessages represents a request for messages (blocking or non-blocking)
+type MsgRequestMessages struct {
+	protocol.MessageBase
+	IsBlocking bool
+}
+
+// NewMsgRequestMessages creates a new MsgRequestMessages
+func NewMsgRequestMessages(isBlocking bool) *MsgRequestMessages {
+	return &MsgRequestMessages{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeRequestMessages,
+		},
+		IsBlocking: isBlocking,
+	}
+}
+
+// MsgReplyMessagesNonBlocking represents a reply with available messages (non-blocking)
+type MsgReplyMessagesNonBlocking struct {
+	protocol.MessageBase
+	Messages []pcommon.DmqMessage
+	HasMore  bool
+}
+
+// NewMsgReplyMessagesNonBlocking creates a new MsgReplyMessagesNonBlocking
+func NewMsgReplyMessagesNonBlocking(
+	messages []pcommon.DmqMessage,
+	hasMore bool,
+) *MsgReplyMessagesNonBlocking {
+	return &MsgReplyMessagesNonBlocking{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeReplyMessagesNonBlocking,
+		},
+		Messages: messages,
+		HasMore:  hasMore,
+	}
+}
+
+// MsgReplyMessagesBlocking represents a reply with available messages (blocking)
+type MsgReplyMessagesBlocking struct {
+	protocol.MessageBase
+	Messages []pcommon.DmqMessage
+}
+
+// NewMsgReplyMessagesBlocking creates a new MsgReplyMessagesBlocking
+func NewMsgReplyMessagesBlocking(
+	messages []pcommon.DmqMessage,
+) *MsgReplyMessagesBlocking {
+	return &MsgReplyMessagesBlocking{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeReplyMessagesBlocking,
+		},
+		Messages: messages,
+	}
+}
+
+// MsgClientDone represents the protocol completion message from client
+type MsgClientDone struct {
+	protocol.MessageBase
+}
+
+// NewMsgClientDone creates a new MsgClientDone message
+func NewMsgClientDone() *MsgClientDone {
+	return &MsgClientDone{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeClientDone,
+		},
+	}
+}
+
+// NewMsgFromCbor parses a Local Message Notification message from CBOR
+func NewMsgFromCbor(msgType uint, data []byte) (protocol.Message, error) {
+	var ret protocol.Message
+	switch msgType {
+	case MessageTypeRequestMessages:
+		ret = &MsgRequestMessages{}
+	case MessageTypeReplyMessagesNonBlocking:
+		ret = &MsgReplyMessagesNonBlocking{}
+	case MessageTypeReplyMessagesBlocking:
+		ret = &MsgReplyMessagesBlocking{}
+	case MessageTypeClientDone:
+		ret = &MsgClientDone{}
+	default:
+		return nil, fmt.Errorf(
+			"%s: unknown message type: %d",
+			ProtocolName,
+			msgType,
+		)
+	}
+	if _, err := cbor.Decode(data, ret); err != nil {
+		return nil, fmt.Errorf("%s: decode error: %w", ProtocolName, err)
+	}
+	// Store the raw message CBOR (ret is always non-nil for handled types)
+	ret.SetCbor(data)
+	return ret, nil
+}
+
+// Type returns the message type
+func (m *MsgRequestMessages) Type() uint8 {
+	return MessageTypeRequestMessages
+}
+
+// Type returns the message type
+func (m *MsgReplyMessagesNonBlocking) Type() uint8 {
+	return MessageTypeReplyMessagesNonBlocking
+}
+
+// Type returns the message type
+func (m *MsgReplyMessagesBlocking) Type() uint8 {
+	return MessageTypeReplyMessagesBlocking
+}
+
+// Type returns the message type
+func (m *MsgClientDone) Type() uint8 {
+	return MessageTypeClientDone
+}

--- a/protocol/localmessagenotification/messages_test.go
+++ b/protocol/localmessagenotification/messages_test.go
@@ -1,0 +1,232 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localmessagenotification
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMsgRequestMessagesNonBlocking tests MsgRequestMessages non-blocking variant
+func TestMsgRequestMessagesNonBlocking(t *testing.T) {
+	msg := &MsgRequestMessages{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeRequestMessages,
+		},
+		IsBlocking: false,
+	}
+
+	assert.Equal(t, uint8(MessageTypeRequestMessages), msg.Type())
+	assert.False(t, msg.IsBlocking)
+	// CBOR round-trip and field preservation
+	data, err := cbor.Encode(msg)
+	assert.NoError(t, err)
+	parsed, err := NewMsgFromCbor(uint(MessageTypeRequestMessages), data)
+	require.NoError(t, err)
+	decoded, ok := parsed.(*MsgRequestMessages)
+	assert.True(t, ok)
+	assert.Equal(t, msg.IsBlocking, decoded.IsBlocking)
+	reencoded, err := cbor.Encode(decoded)
+	assert.NoError(t, err)
+	assert.Equal(t, data, reencoded)
+}
+
+// TestMsgRequestMessagesBlocking tests MsgRequestMessages blocking variant
+func TestMsgRequestMessagesBlocking(t *testing.T) {
+	msg := &MsgRequestMessages{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeRequestMessages,
+		},
+		IsBlocking: true,
+	}
+
+	assert.Equal(t, uint8(MessageTypeRequestMessages), msg.Type())
+	assert.True(t, msg.IsBlocking)
+	// CBOR round-trip and field preservation
+	data, err := cbor.Encode(msg)
+	assert.NoError(t, err)
+	parsed, err := NewMsgFromCbor(uint(MessageTypeRequestMessages), data)
+	require.NoError(t, err)
+	decoded, ok := parsed.(*MsgRequestMessages)
+	assert.True(t, ok)
+	assert.Equal(t, msg.IsBlocking, decoded.IsBlocking)
+	reencoded, err := cbor.Encode(decoded)
+	assert.NoError(t, err)
+	assert.Equal(t, data, reencoded)
+}
+
+// TestMsgReplyMessagesNonBlocking tests MsgReplyMessagesNonBlocking struct creation
+func TestMsgReplyMessagesNonBlocking(t *testing.T) {
+	messages := []pcommon.DmqMessage{
+		{
+			Payload: pcommon.DmqMessagePayload{
+				MessageID:   []byte("id1"),
+				MessageBody: []byte("body1"),
+				KESPeriod:   100,
+				ExpiresAt:   2000000000,
+			},
+			KESSignature: make([]byte, 448),
+			OperationalCertificate: pcommon.OperationalCertificate{
+				KESVerificationKey: make([]byte, 32),
+				IssueNumber:        1,
+				KESPeriod:          100,
+				ColdSignature:      make([]byte, 64),
+			},
+			ColdVerificationKey: make([]byte, 32),
+		},
+	}
+
+	msg := &MsgReplyMessagesNonBlocking{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeReplyMessagesNonBlocking,
+		},
+		Messages: messages,
+		HasMore:  true,
+	}
+
+	assert.Equal(t, uint8(MessageTypeReplyMessagesNonBlocking), msg.Type())
+	assert.Equal(t, 1, len(msg.Messages))
+	assert.True(t, msg.HasMore)
+	// CBOR round-trip and field preservation
+	data, err := cbor.Encode(msg)
+	assert.NoError(t, err)
+	parsed, err := NewMsgFromCbor(
+		uint(MessageTypeReplyMessagesNonBlocking),
+		data,
+	)
+	require.NoError(t, err)
+	decoded, ok := parsed.(*MsgReplyMessagesNonBlocking)
+	assert.True(t, ok)
+	assert.Equal(t, len(msg.Messages), len(decoded.Messages))
+	assert.Equal(t, msg.HasMore, decoded.HasMore)
+	reencoded, err := cbor.Encode(decoded)
+	assert.NoError(t, err)
+	assert.Equal(t, data, reencoded)
+}
+
+// TestMsgReplyMessagesNonBlockingEmpty tests empty reply struct with HasMore flag
+func TestMsgReplyMessagesNonBlockingEmpty(t *testing.T) {
+	msg := &MsgReplyMessagesNonBlocking{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeReplyMessagesNonBlocking,
+		},
+		Messages: []pcommon.DmqMessage{},
+		HasMore:  false,
+	}
+
+	assert.Equal(t, uint8(MessageTypeReplyMessagesNonBlocking), msg.Type())
+	assert.Equal(t, 0, len(msg.Messages))
+	assert.False(t, msg.HasMore)
+	data, err := cbor.Encode(msg)
+	assert.NoError(t, err)
+	parsed, err := NewMsgFromCbor(
+		uint(MessageTypeReplyMessagesNonBlocking),
+		data,
+	)
+	require.NoError(t, err)
+	decoded, ok := parsed.(*MsgReplyMessagesNonBlocking)
+	assert.True(t, ok)
+	assert.Equal(t, msg.HasMore, decoded.HasMore)
+	reencoded, err := cbor.Encode(decoded)
+	assert.NoError(t, err)
+	assert.Equal(t, data, reencoded)
+}
+
+// TestMsgReplyMessagesBlocking tests MsgReplyMessagesBlocking struct creation
+func TestMsgReplyMessagesBlocking(t *testing.T) {
+	messages := []pcommon.DmqMessage{
+		{
+			Payload: pcommon.DmqMessagePayload{
+				MessageID:   []byte("id1"),
+				MessageBody: []byte("body1"),
+				KESPeriod:   100,
+				ExpiresAt:   2000000000,
+			},
+			KESSignature: make([]byte, 448),
+			OperationalCertificate: pcommon.OperationalCertificate{
+				KESVerificationKey: make([]byte, 32),
+				IssueNumber:        1,
+				KESPeriod:          100,
+				ColdSignature:      make([]byte, 64),
+			},
+			ColdVerificationKey: make([]byte, 32),
+		},
+		{
+			Payload: pcommon.DmqMessagePayload{
+				MessageID:   []byte("id2"),
+				MessageBody: []byte("body2"),
+				KESPeriod:   100,
+				ExpiresAt:   2000000000,
+			},
+			KESSignature: make([]byte, 448),
+			OperationalCertificate: pcommon.OperationalCertificate{
+				KESVerificationKey: make([]byte, 32),
+				IssueNumber:        1,
+				KESPeriod:          100,
+				ColdSignature:      make([]byte, 64),
+			},
+			ColdVerificationKey: make([]byte, 32),
+		},
+	}
+
+	msg := &MsgReplyMessagesBlocking{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeReplyMessagesBlocking,
+		},
+		Messages: messages,
+	}
+
+	assert.Equal(t, uint8(MessageTypeReplyMessagesBlocking), msg.Type())
+	assert.Equal(t, 2, len(msg.Messages))
+	// CBOR round-trip and field preservation
+	data, err := cbor.Encode(msg)
+	assert.NoError(t, err)
+	parsed, err := NewMsgFromCbor(uint(MessageTypeReplyMessagesBlocking), data)
+	require.NoError(t, err)
+	decoded, ok := parsed.(*MsgReplyMessagesBlocking)
+	assert.True(t, ok)
+	assert.Equal(t, len(msg.Messages), len(decoded.Messages))
+	reencoded, err := cbor.Encode(decoded)
+	assert.NoError(t, err)
+	assert.Equal(t, data, reencoded)
+}
+
+// TestMsgClientDoneEncoding tests MsgClientDone encoding
+func TestMsgClientDoneEncoding(t *testing.T) {
+	msg := &MsgClientDone{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeClientDone,
+		},
+	}
+
+	assert.Equal(t, uint8(MessageTypeClientDone), msg.Type())
+	data, err := cbor.Encode(msg)
+	assert.NoError(t, err)
+	parsed, err := NewMsgFromCbor(uint(MessageTypeClientDone), data)
+	require.NoError(t, err)
+	assert.Equal(t, uint8(MessageTypeClientDone), parsed.Type())
+}
+
+// TestNewMsgFromCborUnknownType tests handling of unknown message type
+func TestNewMsgFromCborUnknownType(t *testing.T) {
+	_, err := NewMsgFromCbor(99, []byte{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown message type")
+}

--- a/protocol/localmessagenotification/server.go
+++ b/protocol/localmessagenotification/server.go
@@ -1,0 +1,342 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localmessagenotification
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// Server implements the LocalMessageNotification server
+type Server struct {
+	*protocol.Protocol
+	config          *Config
+	callbackContext CallbackContext
+
+	// Message queue management
+	lock                   sync.Mutex
+	messageQueue           []*pcommon.DmqMessage
+	acknowledgedIDs        map[string]time.Time // Maps message ID to acknowledgment timestamp for TTL-based expiration
+	acknowledgedIDsTTL     time.Duration        // TTL for acknowledged message IDs (default: 10 minutes)
+	expirationTicker       *time.Ticker
+	expirationStopChan     chan struct{}
+	newMessageSignal       chan struct{}
+	newMessageSignalClosed bool
+	done                   chan struct{}
+}
+
+// NewServer returns a new LocalMessageNotification server object
+func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
+	if cfg == nil {
+		tmpCfg := NewConfig()
+		cfg = &tmpCfg
+	}
+	s := &Server{
+		config:             cfg,
+		messageQueue:       make([]*pcommon.DmqMessage, 0),
+		acknowledgedIDs:    make(map[string]time.Time),
+		acknowledgedIDsTTL: 10 * time.Minute, // TTL for acknowledged message IDs
+		expirationStopChan: make(chan struct{}),
+		newMessageSignal:   make(chan struct{}, 1),
+		done:               make(chan struct{}),
+	}
+	s.callbackContext = CallbackContext{
+		Server:       s,
+		ConnectionId: protoOptions.ConnectionId,
+	}
+	protoConfig := protocol.ProtocolConfig{
+		Name:                ProtocolName,
+		ProtocolId:          ProtocolID,
+		Muxer:               protoOptions.Muxer,
+		Logger:              protoOptions.Logger,
+		ErrorChan:           protoOptions.ErrorChan,
+		Mode:                protoOptions.Mode,
+		Role:                protocol.ProtocolRoleServer,
+		MessageHandlerFunc:  s.messageHandler,
+		MessageFromCborFunc: NewMsgFromCbor,
+		StateMap:            stateMap,
+		InitialState:        protocolStateIdle,
+	}
+	s.Protocol = protocol.New(protoConfig)
+	// Start background goroutine to clean up expired acknowledged IDs after Protocol is set
+	s.startExpirationCleaner()
+	return s
+}
+
+// AddMessage adds a message to the notification queue
+func (s *Server) AddMessage(msg *pcommon.DmqMessage) error {
+	// Validate message before adding to queue
+	if s.config.TTLValidator != nil {
+		if err := s.config.TTLValidator.ValidateMessageTTL(msg); err != nil {
+			return err
+		}
+	}
+	if s.config.Authenticator != nil {
+		if err := s.config.Authenticator.VerifyMessage(msg); err != nil {
+			return err
+		}
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// Check if already acknowledged (non-zero timestamp means it was acknowledged)
+	msgID := string(msg.Payload.MessageID)
+	if _, acknowledged := s.acknowledgedIDs[msgID]; acknowledged {
+		return errors.New("message already acknowledged")
+	}
+
+	// Check queue size limit
+	if len(s.messageQueue) >= s.config.MaxQueueSize {
+		return errors.New("message queue full")
+	}
+
+	s.messageQueue = append(s.messageQueue, msg)
+
+	// Signal that a new message is available (non-blocking).
+	// Check the closed flag under the lock to avoid sending to a closed channel.
+	if !s.newMessageSignalClosed {
+		select {
+		case s.newMessageSignal <- struct{}{}:
+		default:
+		}
+	}
+
+	s.Protocol.Logger().
+		Debug("message added to queue",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "server",
+			"connection_id", s.callbackContext.ConnectionId.String(),
+			"message_id", msgID,
+			"queue_size", len(s.messageQueue),
+		)
+
+	return nil
+}
+
+// WaitForMessage blocks until a message is available or timeout occurs
+func (s *Server) WaitForMessage(timeout time.Duration) error {
+	if timeout > 0 {
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		select {
+		case _, ok := <-s.newMessageSignal:
+			if !ok {
+				return errors.New("server shutting down")
+			}
+			return nil
+		case <-timer.C:
+			return errors.New("timeout waiting for message")
+		case <-s.done:
+			return errors.New("server shutting down")
+		}
+	}
+	// Wait indefinitely
+	select {
+	case _, ok := <-s.newMessageSignal:
+		if !ok {
+			return errors.New("server shutting down")
+		}
+		return nil
+	case <-s.done:
+		return errors.New("server shutting down")
+	}
+}
+
+func (s *Server) messageHandler(msg protocol.Message) error {
+	var err error
+	switch msg.Type() {
+	case MessageTypeRequestMessages:
+		err = s.handleRequestMessages(msg)
+	case MessageTypeClientDone:
+		err = s.handleClientDone()
+	default:
+		err = fmt.Errorf(
+			"%s: received unexpected message type %d",
+			ProtocolName,
+			msg.Type(),
+		)
+	}
+	return err
+}
+
+func (s *Server) handleRequestMessages(msg protocol.Message) error {
+	msgRequest := msg.(*MsgRequestMessages)
+
+	s.Protocol.Logger().
+		Debug("request messages",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "server",
+			"connection_id", s.callbackContext.ConnectionId.String(),
+			"is_blocking", msgRequest.IsBlocking,
+		)
+
+	if msgRequest.IsBlocking {
+		return s.handleBlockingRequest()
+	}
+	return s.handleNonBlockingRequest()
+}
+
+func (s *Server) handleNonBlockingRequest() error {
+	s.lock.Lock()
+
+	messages := make([]pcommon.DmqMessage, 0, len(s.messageQueue))
+	for _, msg := range s.messageQueue {
+		messages = append(messages, *msg)
+	}
+
+	// Mark all collected messages as acknowledged with current timestamp and clear the queue
+	now := time.Now()
+	for _, msg := range s.messageQueue {
+		s.acknowledgedIDs[string(msg.Payload.MessageID)] = now
+	}
+	s.messageQueue = s.messageQueue[:0]
+
+	s.lock.Unlock()
+
+	// After clearing the queue, hasMore should always be false
+	replyMsg := NewMsgReplyMessagesNonBlocking(messages, false)
+	return s.SendMessage(replyMsg)
+}
+
+func (s *Server) handleBlockingRequest() error {
+	// For blocking requests, wait until at least one message is available
+	for {
+		s.lock.Lock()
+		hasMessages := len(s.messageQueue) > 0
+		if hasMessages {
+			break
+		}
+		s.lock.Unlock()
+
+		// Wait for a message to arrive (no timeout - blocking indefinitely)
+		if err := s.WaitForMessage(0); err != nil {
+			// If we get an error (e.g., shutting down), return empty list
+			replyMsg := NewMsgReplyMessagesBlocking([]pcommon.DmqMessage{})
+			return s.SendMessage(replyMsg)
+		}
+	}
+
+	// At this point, lock is held and hasMessages is true
+
+	messages := make([]pcommon.DmqMessage, 0, len(s.messageQueue))
+	for _, msg := range s.messageQueue {
+		messages = append(messages, *msg)
+	}
+
+	// Mark all collected messages as acknowledged with current timestamp and clear the queue
+	now := time.Now()
+	for _, msg := range s.messageQueue {
+		s.acknowledgedIDs[string(msg.Payload.MessageID)] = now
+	}
+	s.messageQueue = s.messageQueue[:0]
+
+	s.lock.Unlock()
+
+	replyMsg := NewMsgReplyMessagesBlocking(messages)
+	return s.SendMessage(replyMsg)
+}
+
+//nolint:unparam
+func (s *Server) handleClientDone() error {
+	s.Protocol.Logger().
+		Debug("received client done message",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "server",
+			"connection_id", s.callbackContext.ConnectionId.String(),
+		)
+	// Close channels and signal shutdown
+	s.lock.Lock()
+	if !s.newMessageSignalClosed {
+		// Close newMessageSignal to wake up any goroutines waiting on it
+		close(s.newMessageSignal)
+		// Close done channel to signal protocol shutdown
+		close(s.done)
+		s.newMessageSignalClosed = true
+	}
+	s.lock.Unlock()
+
+	// Stop the expiration cleaner
+	s.stopExpirationCleaner()
+	return nil
+}
+
+// startExpirationCleaner starts a background goroutine that periodically cleans up expired acknowledged IDs
+func (s *Server) startExpirationCleaner() {
+	s.expirationTicker = time.NewTicker(1 * time.Minute) // Check every 1 minute
+	go func() {
+		for {
+			select {
+			case <-s.expirationTicker.C:
+				s.cleanupExpiredAcknowledgedIDs()
+			case <-s.expirationStopChan:
+				s.expirationTicker.Stop()
+				return
+			case <-s.DoneChan():
+				s.expirationTicker.Stop()
+				return
+			}
+		}
+	}()
+}
+
+// stopExpirationCleaner stops the background expiration cleanup goroutine
+func (s *Server) stopExpirationCleaner() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	select {
+	case <-s.expirationStopChan:
+		// Already closed
+	default:
+		close(s.expirationStopChan)
+	}
+}
+
+// cleanupExpiredAcknowledgedIDs removes acknowledged IDs that have exceeded their TTL
+func (s *Server) cleanupExpiredAcknowledgedIDs() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	now := time.Now()
+	expiredCount := 0
+
+	for msgID, ackTime := range s.acknowledgedIDs {
+		if now.Sub(ackTime) > s.acknowledgedIDsTTL {
+			delete(s.acknowledgedIDs, msgID)
+			expiredCount++
+		}
+	}
+
+	if expiredCount > 0 {
+		s.Protocol.Logger().
+			Debug("cleaned up expired acknowledged IDs",
+				"component", "network",
+				"protocol", ProtocolName,
+				"role", "server",
+				"connection_id", s.callbackContext.ConnectionId.String(),
+				"count", expiredCount,
+				"remaining", len(s.acknowledgedIDs),
+			)
+	}
+}

--- a/protocol/localmessagesubmission/client.go
+++ b/protocol/localmessagesubmission/client.go
@@ -1,0 +1,189 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localmessagesubmission
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// Client implements the LocalMessageSubmission client
+type Client struct {
+	*protocol.Protocol
+	config          *Config
+	callbackContext CallbackContext
+	onceStart       sync.Once
+	onceStop        sync.Once
+	stopErr         error
+}
+
+// NewClient returns a new LocalMessageSubmission client object
+func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
+	if cfg == nil {
+		tmpCfg := NewConfig()
+		cfg = &tmpCfg
+	}
+	c := &Client{
+		config: cfg,
+	}
+	c.callbackContext = CallbackContext{
+		Client:       c,
+		ConnectionId: protoOptions.ConnectionId,
+	}
+	// Update state map with timeout
+	stateMapCopy := stateMap.Copy()
+	if entry, ok := stateMapCopy[protocolStateBusy]; ok {
+		entry.Timeout = c.config.Timeout
+		stateMapCopy[protocolStateBusy] = entry
+	}
+	// Configure underlying Protocol
+	protoConfig := protocol.ProtocolConfig{
+		Name:                ProtocolName,
+		ProtocolId:          ProtocolID,
+		Muxer:               protoOptions.Muxer,
+		Logger:              protoOptions.Logger,
+		ErrorChan:           protoOptions.ErrorChan,
+		Mode:                protoOptions.Mode,
+		Role:                protocol.ProtocolRoleClient,
+		MessageHandlerFunc:  c.messageHandler,
+		MessageFromCborFunc: NewMsgFromCbor,
+		StateMap:            stateMapCopy,
+		InitialState:        protocolStateIdle,
+	}
+	c.Protocol = protocol.New(protoConfig)
+	return c
+}
+
+// Start begins protocol operation
+func (c *Client) Start() {
+	c.onceStart.Do(func() {
+		c.Protocol.Logger().
+			Debug("starting client protocol",
+				"component", "network",
+				"protocol", ProtocolName,
+				"connection_id", c.callbackContext.ConnectionId.String(),
+			)
+		c.Protocol.Start()
+	})
+}
+
+// Stop transitions the protocol to the Done state
+func (c *Client) Stop() error {
+	c.onceStop.Do(func() {
+		c.Protocol.Logger().
+			Debug("stopping client protocol",
+				"component", "network",
+				"protocol", ProtocolName,
+				"connection_id", c.callbackContext.ConnectionId.String(),
+			)
+		msg := NewMsgDone()
+		c.stopErr = c.SendMessage(msg)
+	})
+	return c.stopErr
+}
+
+// SubmitMessage sends a message submission request
+func (c *Client) SubmitMessage(msg *pcommon.DmqMessage) error {
+	if msg == nil {
+		return errors.New("message cannot be nil")
+	}
+
+	// Validate message before sending
+	if c.config.TTLValidator != nil {
+		if err := c.config.TTLValidator.ValidateMessageTTL(msg); err != nil {
+			return err
+		}
+	} else if !msg.IsValid() {
+		return errors.New("message has expired")
+	}
+	if c.config.Authenticator != nil {
+		if err := c.config.Authenticator.VerifyMessage(msg); err != nil {
+			return err
+		}
+	}
+
+	submitMsg := NewMsgSubmitMessage(*msg)
+	return c.SendMessage(submitMsg)
+}
+
+func (c *Client) messageHandler(msg protocol.Message) error {
+	var err error
+	switch msg.Type() {
+	case MessageTypeAcceptMessage:
+		err = c.handleAcceptMessage()
+	case MessageTypeRejectMessage:
+		err = c.handleRejectMessage(msg)
+	default:
+		err = fmt.Errorf(
+			"%s: received unexpected message type %d",
+			ProtocolName,
+			msg.Type(),
+		)
+	}
+	return err
+}
+
+//nolint:unparam
+func (c *Client) handleAcceptMessage() error {
+	c.Protocol.Logger().
+		Debug("message accepted",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "client",
+			"connection_id", c.callbackContext.ConnectionId.String(),
+		)
+	if c.config.AcceptMessageFunc != nil {
+		c.config.AcceptMessageFunc(c.callbackContext)
+	}
+	return nil
+}
+
+func (c *Client) handleRejectMessage(msg protocol.Message) error {
+	msgReject, ok := msg.(*MsgRejectMessage)
+	if !ok {
+		err := fmt.Errorf(
+			"%s: expected MsgRejectMessage but got %T",
+			ProtocolName,
+			msg,
+		)
+		c.Protocol.Logger().
+			Warn("unexpected message type in handleRejectMessage",
+				"component", "network",
+				"protocol", ProtocolName,
+				"role", "client",
+				"connection_id", c.callbackContext.ConnectionId.String(),
+				"error", err,
+			)
+		return err
+	}
+	c.Protocol.Logger().
+		Warn("message rejected",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "client",
+			"connection_id", c.callbackContext.ConnectionId.String(),
+			"reason", msgReject.Reason,
+		)
+	if c.config.RejectMessageFunc != nil {
+		// Convert concrete RejectReasonData back to a RejectReason interface expected by the callback.
+		rr := pcommon.FromRejectReasonData(msgReject.Reason)
+		c.config.RejectMessageFunc(c.callbackContext, rr)
+	}
+	return nil
+}

--- a/protocol/localmessagesubmission/localmessagesubmission.go
+++ b/protocol/localmessagesubmission/localmessagesubmission.go
@@ -1,0 +1,211 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package localmessagesubmission implements the Ouroboros local-message-submission protocol (CIP-0137)
+package localmessagesubmission
+
+import (
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+const (
+	ProtocolName = "LocalMessageSubmission"
+	ProtocolID   = 18
+)
+
+// State timeouts for Local Message Submission protocol
+const (
+	IdleTimeout = 300 * time.Second // Timeout for client to send SubmitMessage when idle
+	BusyTimeout = 30 * time.Second  // Timeout for server to reply with Accept/Reject
+)
+
+// State machine states for Local Message Submission protocol
+const (
+	stateIdleId = 1
+	stateBusyId = 2
+	stateDoneId = 3
+)
+
+var (
+	protocolStateIdle = protocol.NewState(stateIdleId, "idle")
+	protocolStateBusy = protocol.NewState(stateBusyId, "busy")
+	protocolStateDone = protocol.NewState(stateDoneId, "done")
+	stateMap          = protocol.StateMap{
+		protocolStateIdle: protocol.StateMapEntry{
+			Agency:                  protocol.AgencyClient,
+			PendingMessageByteLimit: 0,
+			Timeout:                 IdleTimeout,
+			Transitions: []protocol.StateTransition{
+				{
+					MsgType:  MessageTypeSubmitMessage,
+					NewState: protocolStateBusy,
+				},
+				{
+					MsgType:  MessageTypeDone,
+					NewState: protocolStateDone,
+				},
+			},
+		},
+		protocolStateBusy: protocol.StateMapEntry{
+			Agency:                  protocol.AgencyServer,
+			PendingMessageByteLimit: 0,
+			Timeout:                 BusyTimeout,
+			Transitions: []protocol.StateTransition{
+				{
+					MsgType:  MessageTypeAcceptMessage,
+					NewState: protocolStateIdle,
+				},
+				{
+					MsgType:  MessageTypeRejectMessage,
+					NewState: protocolStateIdle,
+				},
+			},
+		},
+		protocolStateDone: protocol.StateMapEntry{
+			Agency:                  protocol.AgencyNone,
+			PendingMessageByteLimit: 0,
+		},
+	}
+)
+
+// LocalMessageSubmission is a wrapper object that holds the client and server instances
+type LocalMessageSubmission struct {
+	Client *Client
+	Server *Server
+}
+
+// Config is used to configure the LocalMessageSubmission protocol instance
+type Config struct {
+	// Client callbacks
+	AcceptMessageFunc AcceptMessageFunc
+	RejectMessageFunc RejectMessageFunc
+
+	// Server callbacks
+	SubmitMessageFunc SubmitMessageFunc
+
+	// Shared configuration
+	Authenticator *pcommon.MessageAuthenticator
+	TTLValidator  *pcommon.TTLValidator
+	Timeout       time.Duration
+}
+
+// CallbackContext provides context for callback functions
+type CallbackContext struct {
+	ConnectionId connection.ConnectionId
+	Client       *Client
+	Server       *Server
+}
+
+// Callback function types
+type (
+	SubmitMessageFunc func(CallbackContext, *pcommon.DmqMessage) pcommon.RejectReason
+	AcceptMessageFunc func(CallbackContext)
+	RejectMessageFunc func(CallbackContext, pcommon.RejectReason)
+)
+
+// New returns a new LocalMessageSubmission object
+func New(
+	protoOptions protocol.ProtocolOptions,
+	cfg *Config,
+) *LocalMessageSubmission {
+	l := &LocalMessageSubmission{
+		Client: NewClient(protoOptions, cfg),
+		Server: NewServer(protoOptions, cfg),
+	}
+	return l
+}
+
+// LocalMessageSubmissionOptionFunc represents a function used to modify the LocalMessageSubmission protocol config
+type LocalMessageSubmissionOptionFunc func(*Config)
+
+// NewConfig returns a new LocalMessageSubmission config object with the provided options
+func NewConfig(options ...LocalMessageSubmissionOptionFunc) Config {
+	c := Config{
+		Timeout: BusyTimeout,
+	}
+	// Apply provided options functions
+	for _, option := range options {
+		option(&c)
+	}
+	// Set defaults
+	if c.Authenticator == nil {
+		c.Authenticator = pcommon.NewMessageAuthenticator(nil)
+		pcommon.ApplyDefaultKESVerifier(c.Authenticator)
+	}
+	if c.TTLValidator == nil {
+		c.TTLValidator = pcommon.NewTTLValidator(0, nil)
+	}
+	// Note: The above applies defaults when Authenticator or TTLValidator are
+	// nil. Explicitly setting these fields to nil via option functions will be
+	// overridden by defaults here; opt-out of defaults is not currently
+	// supported. If callers need to explicitly disable validation/authentication
+	// they should pass a no-op implementation instead of nil.
+	return c
+}
+
+// WithSubmitMessageFunc specifies the callback function when a message is submitted when acting as a server
+func WithSubmitMessageFunc(
+	submitMessageFunc SubmitMessageFunc,
+) LocalMessageSubmissionOptionFunc {
+	return func(c *Config) {
+		c.SubmitMessageFunc = submitMessageFunc
+	}
+}
+
+// WithAcceptMessageFunc specifies the callback function when a message is accepted when acting as a client
+func WithAcceptMessageFunc(
+	acceptMessageFunc AcceptMessageFunc,
+) LocalMessageSubmissionOptionFunc {
+	return func(c *Config) {
+		c.AcceptMessageFunc = acceptMessageFunc
+	}
+}
+
+// WithRejectMessageFunc specifies the callback function when a message is rejected when acting as a client
+func WithRejectMessageFunc(
+	rejectMessageFunc RejectMessageFunc,
+) LocalMessageSubmissionOptionFunc {
+	return func(c *Config) {
+		c.RejectMessageFunc = rejectMessageFunc
+	}
+}
+
+// WithAuthenticator specifies the message authenticator to use for message verification
+func WithAuthenticator(
+	authenticator *pcommon.MessageAuthenticator,
+) LocalMessageSubmissionOptionFunc {
+	return func(c *Config) {
+		c.Authenticator = authenticator
+	}
+}
+
+// WithTTLValidator specifies the TTL validator to use for message TTL validation
+func WithTTLValidator(
+	ttlValidator *pcommon.TTLValidator,
+) LocalMessageSubmissionOptionFunc {
+	return func(c *Config) {
+		c.TTLValidator = ttlValidator
+	}
+}
+
+// WithTimeout specifies the timeout for message submit operations when acting as a client
+func WithTimeout(timeout time.Duration) LocalMessageSubmissionOptionFunc {
+	return func(c *Config) {
+		c.Timeout = timeout
+	}
+}

--- a/protocol/localmessagesubmission/messages.go
+++ b/protocol/localmessagesubmission/messages.go
@@ -1,0 +1,138 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localmessagesubmission
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// Message type constants following CIP-0137 CDDL specification
+const (
+	MessageTypeSubmitMessage = 0
+	MessageTypeAcceptMessage = 1
+	MessageTypeRejectMessage = 2
+	MessageTypeDone          = 3
+)
+
+// MsgSubmitMessage represents a local message submission
+type MsgSubmitMessage struct {
+	protocol.MessageBase
+	Message pcommon.DmqMessage
+}
+
+// NewMsgSubmitMessage creates a new MsgSubmitMessage
+func NewMsgSubmitMessage(msg pcommon.DmqMessage) *MsgSubmitMessage {
+	return &MsgSubmitMessage{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeSubmitMessage,
+		},
+		Message: msg,
+	}
+}
+
+// MsgAcceptMessage represents acceptance of a submitted message
+type MsgAcceptMessage struct {
+	protocol.MessageBase
+}
+
+// NewMsgAcceptMessage creates a new MsgAcceptMessage
+func NewMsgAcceptMessage() *MsgAcceptMessage {
+	return &MsgAcceptMessage{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeAcceptMessage,
+		},
+	}
+}
+
+// MsgRejectMessage represents rejection of a submitted message
+type MsgRejectMessage struct {
+	protocol.MessageBase
+	Reason pcommon.RejectReasonData
+}
+
+// NewMsgRejectMessage creates a new MsgRejectMessage
+func NewMsgRejectMessage(reason pcommon.RejectReason) *MsgRejectMessage {
+	return &MsgRejectMessage{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeRejectMessage,
+		},
+		Reason: pcommon.ToRejectReasonData(reason),
+	}
+}
+
+// MsgDone represents the protocol completion message
+type MsgDone struct {
+	protocol.MessageBase
+}
+
+// NewMsgDone creates a new MsgDone message
+func NewMsgDone() *MsgDone {
+	return &MsgDone{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeDone,
+		},
+	}
+}
+
+// NewMsgFromCbor parses a Local Message Submission message from CBOR
+func NewMsgFromCbor(msgType uint, data []byte) (protocol.Message, error) {
+	var ret protocol.Message
+	switch msgType {
+	case MessageTypeSubmitMessage:
+		ret = &MsgSubmitMessage{}
+	case MessageTypeAcceptMessage:
+		ret = &MsgAcceptMessage{}
+	case MessageTypeRejectMessage:
+		ret = &MsgRejectMessage{}
+	case MessageTypeDone:
+		ret = &MsgDone{}
+	default:
+		return nil, fmt.Errorf(
+			"%s: unknown message type: %d",
+			ProtocolName,
+			msgType,
+		)
+	}
+	if _, err := cbor.Decode(data, ret); err != nil {
+		return nil, fmt.Errorf("%s: decode error: %w", ProtocolName, err)
+	}
+	// Store the raw message CBOR (ret is always non-nil for handled types)
+	ret.SetCbor(data)
+	return ret, nil
+}
+
+// Type returns the message type
+func (m *MsgSubmitMessage) Type() uint8 {
+	return MessageTypeSubmitMessage
+}
+
+// Type returns the message type
+func (m *MsgAcceptMessage) Type() uint8 {
+	return MessageTypeAcceptMessage
+}
+
+// Type returns the message type
+func (m *MsgRejectMessage) Type() uint8 {
+	return MessageTypeRejectMessage
+}
+
+// Type returns the message type
+func (m *MsgDone) Type() uint8 {
+	return MessageTypeDone
+}

--- a/protocol/localmessagesubmission/messages_test.go
+++ b/protocol/localmessagesubmission/messages_test.go
@@ -1,0 +1,250 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localmessagesubmission
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMsgSubmitMessageType tests MsgSubmitMessage type and field access
+func TestMsgSubmitMessageType(t *testing.T) {
+	msg := &MsgSubmitMessage{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeSubmitMessage,
+		},
+		Message: pcommon.DmqMessage{
+			Payload: pcommon.DmqMessagePayload{
+				MessageID:   []byte("test-id"),
+				MessageBody: []byte("test-body"),
+				KESPeriod:   100,
+				ExpiresAt:   2000000000,
+			},
+			KESSignature: make([]byte, 448),
+			OperationalCertificate: pcommon.OperationalCertificate{
+				KESVerificationKey: make([]byte, 32),
+				IssueNumber:        1,
+				KESPeriod:          100,
+				ColdSignature:      make([]byte, 64),
+			},
+			ColdVerificationKey: make([]byte, 32),
+		},
+	}
+
+	assert.Equal(t, uint8(MessageTypeSubmitMessage), msg.Type())
+	assert.Equal(t, []byte("test-id"), msg.Message.Payload.MessageID)
+}
+
+// TestMsgSubmitMessageCBORRoundTrip tests encode/decode round-trip for MsgSubmitMessage
+func TestMsgSubmitMessageCBORRoundTrip(t *testing.T) {
+	msg := &MsgSubmitMessage{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeSubmitMessage,
+		},
+		Message: pcommon.DmqMessage{
+			Payload: pcommon.DmqMessagePayload{
+				MessageID:   []byte("test-id"),
+				MessageBody: []byte("test-body"),
+				KESPeriod:   100,
+				ExpiresAt:   2000000000,
+			},
+			KESSignature: make([]byte, 448),
+			OperationalCertificate: pcommon.OperationalCertificate{
+				KESVerificationKey: make([]byte, 32),
+				IssueNumber:        1,
+				KESPeriod:          100,
+				ColdSignature:      make([]byte, 64),
+			},
+			ColdVerificationKey: make([]byte, 32),
+		},
+	}
+
+	data, err := cbor.Encode(msg)
+	assert.NoError(t, err)
+
+	parsed, err := NewMsgFromCbor(uint(MessageTypeSubmitMessage), data)
+	assert.NoError(t, err)
+
+	// Type assertion and deep field equality checks
+	parsedMsg, ok := parsed.(*MsgSubmitMessage)
+	if !ok {
+		t.Fatalf("expected *MsgSubmitMessage, got %T", parsed)
+	}
+	assert.Equal(t, msg.Type(), parsedMsg.Type())
+	assert.Equal(
+		t,
+		msg.Message.Payload.MessageID,
+		parsedMsg.Message.Payload.MessageID,
+	)
+	assert.Equal(
+		t,
+		msg.Message.Payload.MessageBody,
+		parsedMsg.Message.Payload.MessageBody,
+	)
+	assert.Equal(
+		t,
+		msg.Message.Payload.KESPeriod,
+		parsedMsg.Message.Payload.KESPeriod,
+	)
+	assert.Equal(
+		t,
+		msg.Message.Payload.ExpiresAt,
+		parsedMsg.Message.Payload.ExpiresAt,
+	)
+	assert.Equal(
+		t,
+		len(msg.Message.KESSignature),
+		len(parsedMsg.Message.KESSignature),
+	)
+	assert.Equal(
+		t,
+		msg.Message.OperationalCertificate.IssueNumber,
+		parsedMsg.Message.OperationalCertificate.IssueNumber,
+	)
+	assert.Equal(
+		t,
+		msg.Message.OperationalCertificate.KESPeriod,
+		parsedMsg.Message.OperationalCertificate.KESPeriod,
+	)
+	assert.Equal(
+		t,
+		len(msg.Message.OperationalCertificate.KESVerificationKey),
+		len(parsedMsg.Message.OperationalCertificate.KESVerificationKey),
+	)
+	assert.Equal(
+		t,
+		len(msg.Message.OperationalCertificate.ColdSignature),
+		len(parsedMsg.Message.OperationalCertificate.ColdSignature),
+	)
+	assert.Equal(
+		t,
+		len(msg.Message.ColdVerificationKey),
+		len(parsedMsg.Message.ColdVerificationKey),
+	)
+
+	// Deterministic re-encode
+	reencoded, err := cbor.Encode(parsedMsg)
+	assert.NoError(t, err)
+	assert.Equal(t, data, reencoded)
+}
+
+// TestMsgAcceptMessageEncoding tests MsgAcceptMessage encoding
+func TestMsgAcceptMessageEncoding(t *testing.T) {
+	msg := &MsgAcceptMessage{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeAcceptMessage,
+		},
+	}
+
+	assert.Equal(t, uint8(MessageTypeAcceptMessage), msg.Type())
+	data, err := cbor.Encode(msg)
+	assert.NoError(t, err)
+	parsed, err := NewMsgFromCbor(uint(MessageTypeAcceptMessage), data)
+	assert.NoError(t, err)
+	assert.Equal(t, uint8(MessageTypeAcceptMessage), parsed.Type())
+}
+
+// TestMsgRejectMessageEncoding tests MsgRejectMessage encoding with different reasons
+func TestMsgRejectMessageEncoding(t *testing.T) {
+	invalidReason := pcommon.InvalidReason{
+		Message: "Invalid signature",
+	}
+
+	msg := NewMsgRejectMessage(invalidReason)
+
+	assert.Equal(t, uint8(MessageTypeRejectMessage), msg.Type())
+	assert.NotNil(t, msg.Reason)
+	assert.Equal(t, uint8(0), msg.Reason.RejectReasonType())
+
+	// Verify deterministic encoding: two equivalent messages should encode identically.
+	data, err := cbor.Encode(msg)
+	assert.NoError(t, err)
+	// Recreate the same message and re-encode
+	msg2 := NewMsgRejectMessage(invalidReason)
+	data2, err := cbor.Encode(msg2)
+	assert.NoError(t, err)
+	assert.Equal(t, data, data2)
+
+	// Verify decode round-trip preserves Reason
+	parsed, err := NewMsgFromCbor(uint(MessageTypeRejectMessage), data)
+	assert.NoError(t, err)
+	parsedMsg, ok := parsed.(*MsgRejectMessage)
+	if !ok {
+		t.Fatalf("expected *MsgRejectMessage, got %T", parsed)
+	}
+	// Convert back to public API type and check fields
+	rr := pcommon.FromRejectReasonData(parsedMsg.Reason)
+	inv, ok := rr.(pcommon.InvalidReason)
+	if !ok {
+		t.Fatalf("expected InvalidReason, got %T", rr)
+	}
+	assert.Equal(t, invalidReason.Message, inv.Message)
+}
+
+// TestMsgRejectMessageAlreadyReceived tests rejection with AlreadyReceivedReason
+func TestMsgRejectMessageAlreadyReceived(t *testing.T) {
+	reason := pcommon.AlreadyReceivedReason{}
+
+	msg := NewMsgRejectMessage(reason)
+
+	assert.Equal(t, uint8(1), msg.Reason.RejectReasonType())
+}
+
+// TestMsgRejectMessageExpired tests rejection with ExpiredReason
+func TestMsgRejectMessageExpired(t *testing.T) {
+	reason := pcommon.ExpiredReason{}
+
+	msg := NewMsgRejectMessage(reason)
+
+	assert.Equal(t, uint8(2), msg.Reason.RejectReasonType())
+}
+
+// TestMsgRejectMessageOther tests rejection with OtherReason
+func TestMsgRejectMessageOther(t *testing.T) {
+	reason := pcommon.OtherReason{
+		Message: "Some other reason",
+	}
+
+	msg := NewMsgRejectMessage(reason)
+
+	assert.Equal(t, uint8(3), msg.Reason.RejectReasonType())
+}
+
+// TestMsgDoneEncoding tests MsgDone encoding
+func TestMsgDoneEncoding(t *testing.T) {
+	msg := &MsgDone{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeDone,
+		},
+	}
+
+	assert.Equal(t, uint8(MessageTypeDone), msg.Type())
+	data, err := cbor.Encode(msg)
+	assert.NoError(t, err)
+	parsed, err := NewMsgFromCbor(uint(MessageTypeDone), data)
+	assert.NoError(t, err)
+	assert.Equal(t, uint8(MessageTypeDone), parsed.Type())
+}
+
+// TestNewMsgFromCborUnknownType tests handling of unknown message type
+func TestNewMsgFromCborUnknownType(t *testing.T) {
+	_, err := NewMsgFromCbor(99, []byte{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown message type")
+}

--- a/protocol/localmessagesubmission/server.go
+++ b/protocol/localmessagesubmission/server.go
@@ -1,0 +1,193 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localmessagesubmission
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// Server implements the LocalMessageSubmission server
+type Server struct {
+	*protocol.Protocol
+	config          *Config
+	callbackContext CallbackContext
+}
+
+// NewServer returns a new LocalMessageSubmission server object
+func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
+	if cfg == nil {
+		tmpCfg := NewConfig()
+		cfg = &tmpCfg
+	}
+	s := &Server{
+		config: cfg,
+	}
+	s.callbackContext = CallbackContext{
+		Server:       s,
+		ConnectionId: protoOptions.ConnectionId,
+	}
+	protoConfig := protocol.ProtocolConfig{
+		Name:                ProtocolName,
+		ProtocolId:          ProtocolID,
+		Muxer:               protoOptions.Muxer,
+		Logger:              protoOptions.Logger,
+		ErrorChan:           protoOptions.ErrorChan,
+		Mode:                protoOptions.Mode,
+		Role:                protocol.ProtocolRoleServer,
+		MessageHandlerFunc:  s.messageHandler,
+		MessageFromCborFunc: NewMsgFromCbor,
+		StateMap:            stateMap,
+		InitialState:        protocolStateIdle,
+	}
+	s.Protocol = protocol.New(protoConfig)
+	return s
+}
+
+func (s *Server) messageHandler(msg protocol.Message) error {
+	var err error
+	switch msg.Type() {
+	case MessageTypeSubmitMessage:
+		err = s.handleSubmitMessage(msg)
+	case MessageTypeDone:
+		err = s.handleDone()
+	default:
+		err = fmt.Errorf(
+			"%s: received unexpected message type %d",
+			ProtocolName,
+			msg.Type(),
+		)
+	}
+	return err
+}
+
+func (s *Server) handleSubmitMessage(msg protocol.Message) error {
+	msgSubmit, ok := msg.(*MsgSubmitMessage)
+	if !ok {
+		err := fmt.Errorf(
+			"%s: expected MsgSubmitMessage but got %T",
+			ProtocolName,
+			msg,
+		)
+		s.Protocol.Logger().
+			Warn("unexpected message type in handleSubmitMessage",
+				"component", "network",
+				"protocol", ProtocolName,
+				"role", "server",
+				"connection_id", s.callbackContext.ConnectionId.String(),
+				"error", err,
+			)
+		return err
+	}
+
+	s.Protocol.Logger().
+		Debug("submit message",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "server",
+			"connection_id", s.callbackContext.ConnectionId.String(),
+		)
+
+	if s.config.SubmitMessageFunc == nil {
+		err := errors.New(
+			"received local-message-submission SubmitMessage message but no callback function is defined",
+		)
+		s.Protocol.Logger().
+			Warn("submit message callback not configured",
+				"component", "network",
+				"protocol", ProtocolName,
+				"role", "server",
+				"connection_id", s.callbackContext.ConnectionId.String(),
+				"error", err,
+			)
+		rejectMsg := NewMsgRejectMessage(
+			pcommon.OtherReason{Message: err.Error()},
+		)
+		return s.SendMessage(rejectMsg)
+	}
+
+	// Validate inbound message before invoking handler
+	if s.config.TTLValidator != nil {
+		if err := s.config.TTLValidator.ValidateMessageTTL(&msgSubmit.Message); err != nil {
+			s.Protocol.Logger().
+				Warn("message validation failed",
+					"component", "network",
+					"protocol", ProtocolName,
+					"role", "server",
+					"connection_id", s.callbackContext.ConnectionId.String(),
+					"error", err,
+				)
+			rejectMsg := NewMsgRejectMessage(
+				pcommon.InvalidReason{Message: err.Error()},
+			)
+			return s.SendMessage(rejectMsg)
+		}
+	}
+	if s.config.Authenticator != nil {
+		if err := s.config.Authenticator.VerifyMessage(&msgSubmit.Message); err != nil {
+			s.Protocol.Logger().
+				Warn("message authentication failed",
+					"component", "network",
+					"protocol", ProtocolName,
+					"role", "server",
+					"connection_id", s.callbackContext.ConnectionId.String(),
+					"error", err,
+				)
+			rejectMsg := NewMsgRejectMessage(
+				pcommon.InvalidReason{Message: err.Error()},
+			)
+			return s.SendMessage(rejectMsg)
+		}
+	}
+
+	// Call the user callback function and send Accept/RejectMessage based on result
+	reason := s.config.SubmitMessageFunc(s.callbackContext, &msgSubmit.Message)
+	if reason == nil {
+		acceptMsg := NewMsgAcceptMessage()
+		if err := s.SendMessage(acceptMsg); err != nil {
+			return err
+		}
+	} else {
+		// Log rejection reason for observability
+		s.Protocol.Logger().
+			Warn("message rejected by handler",
+				"component", "network",
+				"protocol", ProtocolName,
+				"role", "server",
+				"connection_id", s.callbackContext.ConnectionId.String(),
+				"reason", reason,
+			)
+		rejectMsg := NewMsgRejectMessage(reason)
+		if err := s.SendMessage(rejectMsg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+//nolint:unparam
+func (s *Server) handleDone() error {
+	s.Protocol.Logger().
+		Debug("received done message",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "server",
+			"connection_id", s.callbackContext.ConnectionId.String(),
+		)
+	return nil
+}

--- a/protocol/messagesubmission/client.go
+++ b/protocol/messagesubmission/client.go
@@ -1,0 +1,301 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messagesubmission
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// Client implements the MessageSubmission client
+type Client struct {
+	*protocol.Protocol
+	config          *Config
+	callbackContext CallbackContext
+
+	// Client-side state for message ID tracking
+	lock              sync.Mutex
+	pendingMessageIDs [][]byte
+	onceStart         sync.Once
+	onceStop          sync.Once
+	// stopErr caches the error returned by the first Stop() call so
+	// subsequent Stop() calls return the same result instead of nil.
+	stopErr error
+}
+
+// NewClient returns a new MessageSubmission client object
+func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
+	if cfg == nil {
+		tmpCfg := NewConfig()
+		cfg = &tmpCfg
+	}
+	c := &Client{
+		config:            cfg,
+		pendingMessageIDs: [][]byte{},
+	}
+	c.callbackContext = CallbackContext{
+		Client:       c,
+		ConnectionId: protoOptions.ConnectionId,
+	}
+
+	// Update state map with configurable timeouts
+	stateMapCopy := stateMap.Copy()
+	if entry, ok := stateMapCopy[protocolStateInit]; ok {
+		entry.Timeout = c.config.InitTimeout
+		stateMapCopy[protocolStateInit] = entry
+	}
+	if entry, ok := stateMapCopy[protocolStateIdle]; ok {
+		entry.Timeout = c.config.IdleTimeout
+		stateMapCopy[protocolStateIdle] = entry
+	}
+	if entry, ok := stateMapCopy[protocolStateMessageIdsBlock]; ok {
+		entry.Timeout = c.config.MessageIdsBlockingTimeout
+		stateMapCopy[protocolStateMessageIdsBlock] = entry
+	}
+	if entry, ok := stateMapCopy[protocolStateMessageIdsNonBlk]; ok {
+		entry.Timeout = c.config.MessageIdsNonblockingTimeout
+		stateMapCopy[protocolStateMessageIdsNonBlk] = entry
+	}
+	if entry, ok := stateMapCopy[protocolStateMessages]; ok {
+		entry.Timeout = c.config.MessagesTimeout
+		stateMapCopy[protocolStateMessages] = entry
+	}
+	// Done state has no timeout
+
+	// Configure underlying Protocol
+	protoConfig := protocol.ProtocolConfig{
+		Name:                ProtocolName,
+		ProtocolId:          ProtocolID,
+		Muxer:               protoOptions.Muxer,
+		Logger:              protoOptions.Logger,
+		ErrorChan:           protoOptions.ErrorChan,
+		Mode:                protoOptions.Mode,
+		Role:                protocol.ProtocolRoleClient,
+		MessageHandlerFunc:  c.messageHandler,
+		MessageFromCborFunc: NewMsgFromCbor,
+		StateMap:            stateMapCopy,
+		InitialState:        protocolStateInit,
+	}
+	c.Protocol = protocol.New(protoConfig)
+	return c
+}
+
+// Start begins protocol operation
+func (c *Client) Start() {
+	c.onceStart.Do(func() {
+		c.Protocol.Logger().
+			Debug("starting client protocol",
+				"component", "network",
+				"protocol", ProtocolName,
+				"connection_id", c.callbackContext.ConnectionId.String(),
+			)
+		c.Protocol.Start()
+	})
+}
+
+// Stop transitions the protocol to the Done state
+func (c *Client) Stop() error {
+	c.onceStop.Do(func() {
+		c.Protocol.Logger().
+			Debug("stopping client protocol",
+				"component", "network",
+				"protocol", ProtocolName,
+				"connection_id", c.callbackContext.ConnectionId.String(),
+			)
+		msg := NewMsgDone()
+		c.stopErr = c.SendMessage(msg)
+	})
+	return c.stopErr
+}
+
+// Init sends the initialization message to start the protocol
+func (c *Client) Init() error {
+	msg := NewMsgInit()
+	if err := c.SendMessage(msg); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ReplyMessageIds sends a reply with message IDs and sizes
+func (c *Client) ReplyMessageIds(messages []pcommon.MessageIDAndSize) error {
+	// Prepare the outgoing message first and attempt send before mutating internal state.
+	msg := NewMsgReplyMessageIds(messages)
+	if err := c.SendMessage(msg); err != nil {
+		return err
+	}
+
+	// On successful send, update pendingMessageIDs under lock. Deep-copy inner byte slices
+	// to avoid external mutation affecting internal state.
+	ids := make([][]byte, len(messages))
+	for i, m := range messages {
+		if m.MessageID == nil {
+			ids[i] = nil
+			continue
+		}
+		ids[i] = make([]byte, len(m.MessageID))
+		copy(ids[i], m.MessageID)
+	}
+
+	c.lock.Lock()
+	c.pendingMessageIDs = ids
+	c.lock.Unlock()
+
+	return nil
+}
+
+// ReplyMessages sends a reply with full messages
+func (c *Client) ReplyMessages(messages []pcommon.DmqMessage) error {
+	msg := NewMsgReplyMessages(messages)
+	if err := c.SendMessage(msg); err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetPendingMessageIDs returns the list of message IDs that are currently pending
+func (c *Client) GetPendingMessageIDs() [][]byte {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	// Return a deep copy to prevent external modification of inner byte slices
+	ids := make([][]byte, len(c.pendingMessageIDs))
+	for i, b := range c.pendingMessageIDs {
+		if b == nil {
+			ids[i] = nil
+			continue
+		}
+		ids[i] = make([]byte, len(b))
+		copy(ids[i], b)
+	}
+	return ids
+}
+
+func (c *Client) messageHandler(msg protocol.Message) error {
+	var err error
+	switch msg.Type() {
+	case MessageTypeRequestMessageIds:
+		err = c.handleRequestMessageIds(msg)
+	case MessageTypeRequestMessages:
+		err = c.handleRequestMessages(msg)
+	case MessageTypeDone:
+		err = c.handleDone()
+	default:
+		err = fmt.Errorf(
+			"%s: received unexpected message type %d",
+			ProtocolName,
+			msg.Type(),
+		)
+	}
+	return err
+}
+
+func (c *Client) handleRequestMessageIds(msg protocol.Message) error {
+	msgRequest, ok := msg.(*MsgRequestMessageIds)
+	if !ok {
+		return fmt.Errorf("%s: unexpected message type %T", ProtocolName, msg)
+	}
+
+	c.Protocol.Logger().
+		Debug("request message IDs",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "client",
+			"connection_id", c.callbackContext.ConnectionId.String(),
+			"is_blocking", msgRequest.IsBlocking,
+			"ack_count", msgRequest.AckCount,
+			"request_count", msgRequest.RequestCount,
+		)
+
+	// Acknowledge previously sent IDs
+	c.lock.Lock()
+	if msgRequest.AckCount > 0 {
+		if int(msgRequest.AckCount) <= len(c.pendingMessageIDs) {
+			c.pendingMessageIDs = c.pendingMessageIDs[int(msgRequest.AckCount):]
+		} else {
+			c.Protocol.Logger().Warn("AckCount greater than pendingMessageIDs; clearing all",
+				"ack_count", msgRequest.AckCount,
+				"pending", len(c.pendingMessageIDs))
+			c.pendingMessageIDs = nil
+		}
+	}
+
+	// Validate blocking/non-blocking protocol invariants
+	if msgRequest.IsBlocking && len(c.pendingMessageIDs) > 0 {
+		c.lock.Unlock()
+		return errors.New(
+			"cannot accept blocking request when pending IDs exist",
+		)
+	}
+	if !msgRequest.IsBlocking && len(c.pendingMessageIDs) == 0 {
+		c.lock.Unlock()
+		return errors.New(
+			"cannot accept non-blocking request when no pending IDs",
+		)
+	}
+	c.lock.Unlock()
+
+	// Invoke callback to get available message IDs
+	if c.config.RequestMessageIdsFunc != nil {
+		c.config.RequestMessageIdsFunc(
+			c.callbackContext,
+			msgRequest.IsBlocking,
+			msgRequest.AckCount,
+			msgRequest.RequestCount,
+		)
+	}
+
+	return nil
+}
+
+func (c *Client) handleRequestMessages(msg protocol.Message) error {
+	msgRequest, ok := msg.(*MsgRequestMessages)
+	if !ok {
+		return fmt.Errorf("%s: unexpected message type %T", ProtocolName, msg)
+	}
+
+	c.Protocol.Logger().
+		Debug("request messages",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "client",
+			"connection_id", c.callbackContext.ConnectionId.String(),
+			"message_count", len(msgRequest.MessageIDs),
+		)
+
+	// Invoke callback to get the requested messages
+	if c.config.RequestMessagesFunc != nil {
+		c.config.RequestMessagesFunc(c.callbackContext, msgRequest.MessageIDs)
+	}
+
+	return nil
+}
+
+func (c *Client) handleDone() error {
+	c.Protocol.Logger().
+		Debug("received done message",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "client",
+			"connection_id", c.callbackContext.ConnectionId.String(),
+		)
+	if c.config != nil && c.config.DoneFunc != nil {
+		return c.config.DoneFunc(c.callbackContext)
+	}
+	return nil
+}

--- a/protocol/messagesubmission/messages.go
+++ b/protocol/messagesubmission/messages.go
@@ -1,0 +1,195 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messagesubmission
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// Message type constants following CIP-0137 CDDL specification
+const (
+	MessageTypeInit              = 0
+	MessageTypeRequestMessageIds = 1
+	MessageTypeReplyMessageIds   = 2
+	MessageTypeRequestMessages   = 3
+	MessageTypeReplyMessages     = 4
+	MessageTypeDone              = 5
+)
+
+// MsgInit represents the initialization message
+type MsgInit struct {
+	protocol.MessageBase
+}
+
+// NewMsgInit creates a new MsgInit
+func NewMsgInit() *MsgInit {
+	return &MsgInit{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeInit,
+		},
+	}
+}
+
+// MsgRequestMessageIds represents a request for message IDs (blocking or non-blocking)
+type MsgRequestMessageIds struct {
+	protocol.MessageBase
+	IsBlocking   bool
+	AckCount     uint16
+	RequestCount uint16
+}
+
+// NewMsgRequestMessageIds creates a new MsgRequestMessageIds
+func NewMsgRequestMessageIds(
+	isBlocking bool,
+	ackCount, requestCount uint16,
+) *MsgRequestMessageIds {
+	return &MsgRequestMessageIds{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeRequestMessageIds,
+		},
+		IsBlocking:   isBlocking,
+		AckCount:     ackCount,
+		RequestCount: requestCount,
+	}
+}
+
+// MsgReplyMessageIds represents the reply with message IDs and sizes
+type MsgReplyMessageIds struct {
+	protocol.MessageBase
+	Messages []pcommon.MessageIDAndSize
+}
+
+// NewMsgReplyMessageIds creates a new MsgReplyMessageIds
+func NewMsgReplyMessageIds(
+	messages []pcommon.MessageIDAndSize,
+) *MsgReplyMessageIds {
+	return &MsgReplyMessageIds{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeReplyMessageIds,
+		},
+		Messages: messages,
+	}
+}
+
+// MsgRequestMessages represents a request for specific messages
+type MsgRequestMessages struct {
+	protocol.MessageBase
+	MessageIDs [][]byte
+}
+
+// NewMsgRequestMessages creates a new MsgRequestMessages
+func NewMsgRequestMessages(messageIDs [][]byte) *MsgRequestMessages {
+	return &MsgRequestMessages{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeRequestMessages,
+		},
+		MessageIDs: messageIDs,
+	}
+}
+
+// MsgReplyMessages represents the reply with full messages
+type MsgReplyMessages struct {
+	protocol.MessageBase
+	Messages []pcommon.DmqMessage
+}
+
+// NewMsgReplyMessages creates a new MsgReplyMessages
+func NewMsgReplyMessages(messages []pcommon.DmqMessage) *MsgReplyMessages {
+	return &MsgReplyMessages{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeReplyMessages,
+		},
+		Messages: messages,
+	}
+}
+
+// MsgDone represents the protocol completion message
+type MsgDone struct {
+	protocol.MessageBase
+}
+
+// NewMsgDone creates a new MsgDone message
+func NewMsgDone() *MsgDone {
+	return &MsgDone{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeDone,
+		},
+	}
+}
+
+// NewMsgFromCbor parses a Message Submission message from CBOR
+func NewMsgFromCbor(msgType uint, data []byte) (protocol.Message, error) {
+	var ret protocol.Message
+	switch msgType {
+	case MessageTypeInit:
+		ret = &MsgInit{}
+	case MessageTypeRequestMessageIds:
+		ret = &MsgRequestMessageIds{}
+	case MessageTypeReplyMessageIds:
+		ret = &MsgReplyMessageIds{}
+	case MessageTypeRequestMessages:
+		ret = &MsgRequestMessages{}
+	case MessageTypeReplyMessages:
+		ret = &MsgReplyMessages{}
+	case MessageTypeDone:
+		ret = &MsgDone{}
+	default:
+		return nil, fmt.Errorf(
+			"%s: unknown message type: %d",
+			ProtocolName,
+			msgType,
+		)
+	}
+	if _, err := cbor.Decode(data, ret); err != nil {
+		return nil, fmt.Errorf("%s: decode error: %w", ProtocolName, err)
+	}
+	// Store the raw message CBOR (ret is always non-nil for handled types)
+	ret.SetCbor(data)
+	return ret, nil
+}
+
+// Type returns the message type
+func (m *MsgInit) Type() uint8 {
+	return MessageTypeInit
+}
+
+// Type returns the message type
+func (m *MsgRequestMessageIds) Type() uint8 {
+	return MessageTypeRequestMessageIds
+}
+
+// Type returns the message type
+func (m *MsgReplyMessageIds) Type() uint8 {
+	return MessageTypeReplyMessageIds
+}
+
+// Type returns the message type
+func (m *MsgRequestMessages) Type() uint8 {
+	return MessageTypeRequestMessages
+}
+
+// Type returns the message type
+func (m *MsgReplyMessages) Type() uint8 {
+	return MessageTypeReplyMessages
+}
+
+// Type returns the message type
+func (m *MsgDone) Type() uint8 {
+	return MessageTypeDone
+}

--- a/protocol/messagesubmission/messages_test.go
+++ b/protocol/messagesubmission/messages_test.go
@@ -1,0 +1,340 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messagesubmission
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMsgInitEncoding tests MsgInit message encoding
+func TestMsgInitEncoding(t *testing.T) {
+	msg := &MsgInit{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeInit,
+		},
+	}
+
+	assert.Equal(t, uint8(MessageTypeInit), msg.Type())
+	// CBOR encode/decode round-trip
+	data, err := cbor.Encode(msg)
+	assert.NoError(t, err)
+	parsed, err := NewMsgFromCbor(uint(MessageTypeInit), data)
+	assert.NoError(t, err)
+	assert.Equal(t, uint8(MessageTypeInit), parsed.Type())
+}
+
+// TestMsgRequestMessageIdsEncoding tests MsgRequestMessageIds encoding
+func TestMsgRequestMessageIdsEncoding(t *testing.T) {
+	msg := &MsgRequestMessageIds{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeRequestMessageIds,
+		},
+		IsBlocking:   true,
+		AckCount:     5,
+		RequestCount: 10,
+	}
+
+	assert.Equal(t, uint8(MessageTypeRequestMessageIds), msg.Type())
+	assert.Equal(t, true, msg.IsBlocking)
+	assert.Equal(t, uint16(5), msg.AckCount)
+	assert.Equal(t, uint16(10), msg.RequestCount)
+	// CBOR encode/decode round-trip and field preservation
+	data, err := cbor.Encode(msg)
+	assert.NoError(t, err)
+	parsed, err := NewMsgFromCbor(uint(MessageTypeRequestMessageIds), data)
+	assert.NoError(t, err)
+	decoded, ok := parsed.(*MsgRequestMessageIds)
+	assert.True(t, ok)
+	assert.Equal(t, msg.IsBlocking, decoded.IsBlocking)
+	assert.Equal(t, msg.AckCount, decoded.AckCount)
+	assert.Equal(t, msg.RequestCount, decoded.RequestCount)
+	// Re-encode and assert deterministic equality
+	reencoded, err := cbor.Encode(decoded)
+	assert.NoError(t, err)
+	assert.Equal(t, data, reencoded)
+}
+
+// TestMsgReplyMessageIdsEncoding tests MsgReplyMessageIds encoding
+func TestMsgReplyMessageIdsEncoding(t *testing.T) {
+	messages := []pcommon.MessageIDAndSize{
+		{
+			MessageID:   []byte("id1"),
+			SizeInBytes: 100,
+		},
+		{
+			MessageID:   []byte("id2"),
+			SizeInBytes: 200,
+		},
+	}
+
+	msg := &MsgReplyMessageIds{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeReplyMessageIds,
+		},
+		Messages: messages,
+	}
+
+	assert.Equal(t, uint8(MessageTypeReplyMessageIds), msg.Type())
+	assert.Equal(t, 2, len(msg.Messages))
+	assert.Equal(t, []byte("id1"), msg.Messages[0].MessageID)
+	// CBOR round-trip and field preservation
+	data, err := cbor.Encode(msg)
+	assert.NoError(t, err)
+	parsed, err := NewMsgFromCbor(uint(MessageTypeReplyMessageIds), data)
+	assert.NoError(t, err)
+	decoded, ok := parsed.(*MsgReplyMessageIds)
+	assert.True(t, ok)
+	assert.Equal(t, len(msg.Messages), len(decoded.Messages))
+	assert.Equal(t, msg.Messages[0].MessageID, decoded.Messages[0].MessageID)
+	// Re-encode deterministic equality
+	reencoded, err := cbor.Encode(decoded)
+	assert.NoError(t, err)
+	assert.Equal(t, data, reencoded)
+}
+
+// TestMsgRequestMessagesEncoding tests MsgRequestMessages encoding
+func TestMsgRequestMessagesEncoding(t *testing.T) {
+	messageIDs := [][]byte{
+		[]byte("id1"),
+		[]byte("id2"),
+		[]byte("id3"),
+	}
+
+	msg := &MsgRequestMessages{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeRequestMessages,
+		},
+		MessageIDs: messageIDs,
+	}
+
+	assert.Equal(t, uint8(MessageTypeRequestMessages), msg.Type())
+	assert.Equal(t, 3, len(msg.MessageIDs))
+	// CBOR round-trip and field preservation
+	data, err := cbor.Encode(msg)
+	assert.NoError(t, err)
+	parsed, err := NewMsgFromCbor(uint(MessageTypeRequestMessages), data)
+	assert.NoError(t, err)
+	decoded, ok := parsed.(*MsgRequestMessages)
+	assert.True(t, ok)
+	assert.Equal(t, len(msg.MessageIDs), len(decoded.MessageIDs))
+	for i := range msg.MessageIDs {
+		assert.Equal(t, msg.MessageIDs[i], decoded.MessageIDs[i])
+	}
+	reencoded, err := cbor.Encode(decoded)
+	assert.NoError(t, err)
+	assert.Equal(t, data, reencoded)
+}
+
+// TestMsgReplyMessagesEncoding tests MsgReplyMessages encoding
+func TestMsgReplyMessagesEncoding(t *testing.T) {
+	messages := []pcommon.DmqMessage{
+		{
+			Payload: pcommon.DmqMessagePayload{
+				MessageID:   []byte("id1"),
+				MessageBody: []byte("body1"),
+				KESPeriod:   100,
+				ExpiresAt:   2000000000,
+			},
+			KESSignature: make([]byte, 448),
+			OperationalCertificate: pcommon.OperationalCertificate{
+				KESVerificationKey: make([]byte, 32),
+				IssueNumber:        1,
+				KESPeriod:          100,
+				ColdSignature:      make([]byte, 64),
+			},
+			ColdVerificationKey: make([]byte, 32),
+		},
+	}
+
+	msg := &MsgReplyMessages{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeReplyMessages,
+		},
+		Messages: messages,
+	}
+
+	assert.Equal(t, uint8(MessageTypeReplyMessages), msg.Type())
+	assert.Equal(t, 1, len(msg.Messages))
+	// CBOR round-trip and field preservation
+	data, err := cbor.Encode(msg)
+	assert.NoError(t, err)
+	parsed, err := NewMsgFromCbor(uint(MessageTypeReplyMessages), data)
+	assert.NoError(t, err)
+	decoded, ok := parsed.(*MsgReplyMessages)
+	assert.True(t, ok)
+	assert.Equal(t, len(msg.Messages), len(decoded.Messages))
+	assert.Equal(
+		t,
+		msg.Messages[0].Payload.MessageID,
+		decoded.Messages[0].Payload.MessageID,
+	)
+	// Re-encode deterministic equality
+	reencoded, err := cbor.Encode(decoded)
+	assert.NoError(t, err)
+	assert.Equal(t, data, reencoded)
+}
+
+// TestMsgDoneEncoding tests MsgDone encoding
+func TestMsgDoneEncoding(t *testing.T) {
+	msg := &MsgDone{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeDone,
+		},
+	}
+
+	assert.Equal(t, uint8(MessageTypeDone), msg.Type())
+	data, err := cbor.Encode(msg)
+	assert.NoError(t, err)
+	parsed, err := NewMsgFromCbor(uint(MessageTypeDone), data)
+	assert.NoError(t, err)
+	assert.Equal(t, uint8(MessageTypeDone), parsed.Type())
+}
+
+// TestNewMsgFromCborInit tests parsing MsgInit from CBOR
+func TestNewMsgFromCborInit(t *testing.T) {
+	msg := &MsgInit{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeInit,
+		},
+	}
+	data, err := cbor.Encode(msg)
+	assert.NoError(t, err)
+	parsed, err := NewMsgFromCbor(uint(MessageTypeInit), data)
+	assert.NoError(t, err)
+	assert.Equal(t, uint8(MessageTypeInit), parsed.Type())
+}
+
+// TestNewMsgFromCborUnknownType tests handling of unknown message type
+func TestNewMsgFromCborUnknownType(t *testing.T) {
+	_, err := NewMsgFromCbor(99, []byte{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown message type")
+}
+
+// Positive CBOR round-trip tests for message types
+// Note: This comprehensive round-trip test intentionally overlaps with individual
+// encoding tests to provide broader regression coverage across types. Keeping
+// redundancy here ensures future changes don't break CBOR parsing semantics.
+func TestNewMsgFromCborRoundTrip(t *testing.T) {
+	// MsgInit
+	initMsg := &MsgInit{
+		MessageBase: protocol.MessageBase{MessageType: MessageTypeInit},
+	}
+	data, err := cbor.Encode(initMsg)
+	assert.NoError(t, err)
+	parsed, err := NewMsgFromCbor(uint(MessageTypeInit), data)
+	assert.NoError(t, err)
+	assert.Equal(t, uint8(MessageTypeInit), parsed.Type())
+
+	// MsgRequestMessageIds
+	req := &MsgRequestMessageIds{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeRequestMessageIds,
+		},
+		IsBlocking:   true,
+		AckCount:     1,
+		RequestCount: 2,
+	}
+	data, err = cbor.Encode(req)
+	assert.NoError(t, err)
+	parsed, err = NewMsgFromCbor(uint(MessageTypeRequestMessageIds), data)
+	assert.NoError(t, err)
+	assert.Equal(t, uint8(MessageTypeRequestMessageIds), parsed.Type())
+	// Verify decoded values match original
+	if decoded, ok := parsed.(*MsgRequestMessageIds); ok {
+		assert.Equal(t, req.IsBlocking, decoded.IsBlocking)
+		assert.Equal(t, req.AckCount, decoded.AckCount)
+		assert.Equal(t, req.RequestCount, decoded.RequestCount)
+		// Re-encode and assert deterministic equality
+		reencoded, err := cbor.Encode(decoded)
+		assert.NoError(t, err)
+		assert.Equal(t, data, reencoded)
+	} else {
+		t.Fatalf("decoded message is not *MsgRequestMessageIds: %T", parsed)
+	}
+
+	// MsgReplyMessageIds
+	msgs := []pcommon.MessageIDAndSize{
+		{MessageID: []byte("id1"), SizeInBytes: 10},
+	}
+	reply := &MsgReplyMessageIds{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeReplyMessageIds,
+		},
+		Messages: msgs,
+	}
+	data, err = cbor.Encode(reply)
+	assert.NoError(t, err)
+	parsed, err = NewMsgFromCbor(uint(MessageTypeReplyMessageIds), data)
+	assert.NoError(t, err)
+	assert.Equal(t, uint8(MessageTypeReplyMessageIds), parsed.Type())
+
+	// MsgRequestMessages
+	reqMsgs := &MsgRequestMessages{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeRequestMessages,
+		},
+		MessageIDs: [][]byte{[]byte("id1")},
+	}
+	data, err = cbor.Encode(reqMsgs)
+	assert.NoError(t, err)
+	parsed, err = NewMsgFromCbor(uint(MessageTypeRequestMessages), data)
+	assert.NoError(t, err)
+	assert.Equal(t, uint8(MessageTypeRequestMessages), parsed.Type())
+
+	// MsgReplyMessages
+	payload := pcommon.DmqMessage{
+		Payload: pcommon.DmqMessagePayload{
+			MessageID:   []byte("id1"),
+			MessageBody: []byte("body"),
+			KESPeriod:   1,
+			ExpiresAt:   2000000000,
+		},
+		KESSignature: make([]byte, 448),
+		OperationalCertificate: pcommon.OperationalCertificate{
+			KESVerificationKey: make([]byte, 32),
+			IssueNumber:        1,
+			KESPeriod:          1,
+			ColdSignature:      make([]byte, 64),
+		},
+		ColdVerificationKey: make([]byte, 32),
+	}
+	replyMsgs := &MsgReplyMessages{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeReplyMessages,
+		},
+		Messages: []pcommon.DmqMessage{payload},
+	}
+	data, err = cbor.Encode(replyMsgs)
+	assert.NoError(t, err)
+	parsed, err = NewMsgFromCbor(uint(MessageTypeReplyMessages), data)
+	assert.NoError(t, err)
+	assert.Equal(t, uint8(MessageTypeReplyMessages), parsed.Type())
+
+	// MsgDone
+	done := &MsgDone{
+		MessageBase: protocol.MessageBase{MessageType: MessageTypeDone},
+	}
+	data, err = cbor.Encode(done)
+	assert.NoError(t, err)
+	parsed, err = NewMsgFromCbor(uint(MessageTypeDone), data)
+	assert.NoError(t, err)
+	assert.Equal(t, uint8(MessageTypeDone), parsed.Type())
+}

--- a/protocol/messagesubmission/messagesubmission.go
+++ b/protocol/messagesubmission/messagesubmission.go
@@ -1,0 +1,351 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package messagesubmission implements the Ouroboros message-submission protocol (CIP-0137)
+package messagesubmission
+
+import (
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+const (
+	ProtocolName = "MessageSubmission"
+	ProtocolID   = 17
+)
+
+// State timeouts for Message Submission protocol
+const (
+	InitTimeout                  = 30 * time.Second  // Timeout for client to send Init
+	IdleTimeout                  = 300 * time.Second // Timeout for server to send RequestMessageIds when idle
+	MessageIdsBlockingTimeout    = 30 * time.Second  // Timeout for client to reply to blocking RequestMessageIds
+	MessageIdsNonblockingTimeout = 0 * time.Second   // Non-blocking doesn't timeout (server sends when ready)
+	MessagesTimeout              = 30 * time.Second  // Timeout for client to reply with messages
+	DoneTimeout                  = 10 * time.Second  // Timeout for Done state cleanup
+)
+
+// State machine states for Message Submission protocol
+const (
+	stateInitId               = 1
+	stateIdleId               = 2
+	stateMessageIdsBlockId    = 3
+	stateMessageIdsNonBlockId = 4
+	stateMessagesId           = 5
+	stateDoneId               = 6
+)
+
+var (
+	protocolStateInit            = protocol.NewState(stateInitId, "init")
+	protocolStateIdle            = protocol.NewState(stateIdleId, "idle")
+	protocolStateMessageIdsBlock = protocol.NewState(
+		stateMessageIdsBlockId,
+		"messageIdsBlocking",
+	)
+	protocolStateMessageIdsNonBlk = protocol.NewState(
+		stateMessageIdsNonBlockId,
+		"messageIdsNonBlocking",
+	)
+	protocolStateMessages = protocol.NewState(
+		stateMessagesId,
+		"messages",
+	)
+	protocolStateDone = protocol.NewState(stateDoneId, "done")
+	stateMap          = protocol.StateMap{
+		protocolStateInit: protocol.StateMapEntry{
+			Agency:                  protocol.AgencyClient,
+			PendingMessageByteLimit: 0,
+			Timeout:                 InitTimeout,
+			Transitions: []protocol.StateTransition{
+				{
+					MsgType:  MessageTypeInit,
+					NewState: protocolStateIdle,
+				},
+			},
+		},
+		protocolStateIdle: protocol.StateMapEntry{
+			Agency:                  protocol.AgencyServer,
+			PendingMessageByteLimit: 0,
+			Timeout:                 IdleTimeout,
+			Transitions: []protocol.StateTransition{
+				{
+					MsgType:  MessageTypeRequestMessageIds,
+					NewState: protocolStateMessageIdsBlock,
+					MatchFunc: func(_ any, msg protocol.Message) bool {
+						msgReq := msg.(*MsgRequestMessageIds)
+						return msgReq.IsBlocking
+					},
+				},
+				{
+					MsgType:  MessageTypeRequestMessageIds,
+					NewState: protocolStateMessageIdsNonBlk,
+					MatchFunc: func(_ any, msg protocol.Message) bool {
+						msgReq := msg.(*MsgRequestMessageIds)
+						return !msgReq.IsBlocking
+					},
+				},
+				{
+					MsgType:  MessageTypeRequestMessages,
+					NewState: protocolStateMessages,
+				},
+				{
+					MsgType:  MessageTypeDone,
+					NewState: protocolStateDone,
+				},
+			},
+		},
+		protocolStateMessageIdsBlock: protocol.StateMapEntry{
+			Agency:                  protocol.AgencyClient,
+			PendingMessageByteLimit: 0,
+			Timeout:                 MessageIdsBlockingTimeout,
+			Transitions: []protocol.StateTransition{
+				{
+					MsgType:  MessageTypeReplyMessageIds,
+					NewState: protocolStateIdle,
+				},
+				{
+					MsgType:  MessageTypeDone,
+					NewState: protocolStateDone,
+				},
+			},
+		},
+		protocolStateMessageIdsNonBlk: protocol.StateMapEntry{
+			Agency:                  protocol.AgencyClient,
+			PendingMessageByteLimit: 0,
+			Timeout:                 MessageIdsNonblockingTimeout,
+			Transitions: []protocol.StateTransition{
+				{
+					MsgType:  MessageTypeReplyMessageIds,
+					NewState: protocolStateIdle,
+				},
+				{
+					MsgType:  MessageTypeDone,
+					NewState: protocolStateDone,
+				},
+			},
+		},
+		protocolStateMessages: protocol.StateMapEntry{
+			Agency:                  protocol.AgencyClient,
+			PendingMessageByteLimit: 0,
+			Timeout:                 MessagesTimeout,
+			Transitions: []protocol.StateTransition{
+				{
+					MsgType:  MessageTypeReplyMessages,
+					NewState: protocolStateIdle,
+				},
+			},
+		},
+		protocolStateDone: protocol.StateMapEntry{
+			Agency:                  protocol.AgencyNone,
+			PendingMessageByteLimit: 0,
+		},
+	}
+)
+
+// MessageSubmission is a wrapper object that holds the client and server instances
+type MessageSubmission struct {
+	Client *Client
+	Server *Server
+}
+
+// Config is used to configure the MessageSubmission protocol instance
+type Config struct {
+	// Client callbacks
+	RequestMessageIdsFunc RequestMessageIdsFunc
+	RequestMessagesFunc   RequestMessagesFunc
+
+	// Server callbacks
+	ReplyMessageIdsFunc ReplyMessageIdsFunc
+	ReplyMessagesFunc   ReplyMessagesFunc
+
+	// Client timeouts (use defaults from state machine constants if not set)
+	InitTimeout                  time.Duration
+	IdleTimeout                  time.Duration
+	MessageIdsBlockingTimeout    time.Duration
+	MessageIdsNonblockingTimeout time.Duration
+	MessagesTimeout              time.Duration
+	DoneTimeout                  time.Duration
+
+	// Shared configuration
+	MaxQueueSize  int
+	Authenticator *pcommon.MessageAuthenticator
+	TTLValidator  *pcommon.TTLValidator
+	// Done callback invoked when peer sends Done
+	DoneFunc func(CallbackContext) error
+}
+
+// CallbackContext provides context for callback functions
+type CallbackContext struct {
+	ConnectionId connection.ConnectionId
+	Client       *Client
+	Server       *Server
+}
+
+// Callback function types
+type (
+	RequestMessageIdsFunc func(CallbackContext, bool, uint16, uint16)
+	RequestMessagesFunc   func(CallbackContext, [][]byte)
+	ReplyMessageIdsFunc   func(CallbackContext, []pcommon.MessageIDAndSize)
+	ReplyMessagesFunc     func(CallbackContext, []pcommon.DmqMessage)
+)
+
+// New returns a new MessageSubmission object
+func New(
+	protoOptions protocol.ProtocolOptions,
+	cfg *Config,
+) *MessageSubmission {
+	m := &MessageSubmission{
+		Client: NewClient(protoOptions, cfg),
+		Server: NewServer(protoOptions, cfg),
+	}
+	return m
+}
+
+// MessageSubmissionOptionFunc represents a function used to modify the MessageSubmission protocol config
+type MessageSubmissionOptionFunc func(*Config)
+
+// NewConfig returns a new MessageSubmission config object with the provided options
+func NewConfig(options ...MessageSubmissionOptionFunc) Config {
+	c := Config{
+		MaxQueueSize:                 100,
+		InitTimeout:                  InitTimeout,
+		IdleTimeout:                  IdleTimeout,
+		MessageIdsBlockingTimeout:    MessageIdsBlockingTimeout,
+		MessageIdsNonblockingTimeout: MessageIdsNonblockingTimeout,
+		MessagesTimeout:              MessagesTimeout,
+		DoneTimeout:                  DoneTimeout,
+	}
+	// Apply provided options functions
+	for _, option := range options {
+		option(&c)
+	}
+	// Set defaults
+	if c.Authenticator == nil {
+		c.Authenticator = pcommon.NewMessageAuthenticator(nil)
+		pcommon.ApplyDefaultKESVerifier(c.Authenticator)
+	}
+	if c.TTLValidator == nil {
+		c.TTLValidator = pcommon.NewTTLValidator(0, nil)
+	}
+	return c
+}
+
+// WithRequestMessageIdsFunc specifies the callback function when message IDs are requested when acting as a client
+func WithRequestMessageIdsFunc(
+	requestMessageIdsFunc RequestMessageIdsFunc,
+) MessageSubmissionOptionFunc {
+	return func(c *Config) {
+		c.RequestMessageIdsFunc = requestMessageIdsFunc
+	}
+}
+
+// WithRequestMessagesFunc specifies the callback function when messages are requested when acting as a client
+func WithRequestMessagesFunc(
+	requestMessagesFunc RequestMessagesFunc,
+) MessageSubmissionOptionFunc {
+	return func(c *Config) {
+		c.RequestMessagesFunc = requestMessagesFunc
+	}
+}
+
+// WithReplyMessageIdsFunc specifies the callback function when message IDs are received when acting as a server
+func WithReplyMessageIdsFunc(
+	replyMessageIdsFunc ReplyMessageIdsFunc,
+) MessageSubmissionOptionFunc {
+	return func(c *Config) {
+		c.ReplyMessageIdsFunc = replyMessageIdsFunc
+	}
+}
+
+// WithReplyMessagesFunc specifies the callback function when messages are received when acting as a server
+func WithReplyMessagesFunc(
+	replyMessagesFunc ReplyMessagesFunc,
+) MessageSubmissionOptionFunc {
+	return func(c *Config) {
+		c.ReplyMessagesFunc = replyMessagesFunc
+	}
+}
+
+// WithMaxQueueSize specifies the maximum queue size for the server
+func WithMaxQueueSize(maxQueueSize int) MessageSubmissionOptionFunc {
+	return func(c *Config) {
+		c.MaxQueueSize = maxQueueSize
+	}
+}
+
+// WithInitTimeout specifies the timeout for the Init state
+func WithInitTimeout(timeout time.Duration) MessageSubmissionOptionFunc {
+	return func(c *Config) {
+		c.InitTimeout = timeout
+	}
+}
+
+// WithIdleTimeout specifies the timeout for the Idle state
+func WithIdleTimeout(timeout time.Duration) MessageSubmissionOptionFunc {
+	return func(c *Config) {
+		c.IdleTimeout = timeout
+	}
+}
+
+// WithMessageIdsBlockingTimeout specifies the timeout for blocking MessageIds requests
+func WithMessageIdsBlockingTimeout(
+	timeout time.Duration,
+) MessageSubmissionOptionFunc {
+	return func(c *Config) {
+		c.MessageIdsBlockingTimeout = timeout
+	}
+}
+
+// WithMessageIdsNonblockingTimeout specifies the timeout for non-blocking MessageIds requests
+func WithMessageIdsNonblockingTimeout(
+	timeout time.Duration,
+) MessageSubmissionOptionFunc {
+	return func(c *Config) {
+		c.MessageIdsNonblockingTimeout = timeout
+	}
+}
+
+// WithMessagesTimeout specifies the timeout for the Messages state
+func WithMessagesTimeout(timeout time.Duration) MessageSubmissionOptionFunc {
+	return func(c *Config) {
+		c.MessagesTimeout = timeout
+	}
+}
+
+// WithDoneTimeout specifies the timeout for the Done state
+func WithDoneTimeout(timeout time.Duration) MessageSubmissionOptionFunc {
+	return func(c *Config) {
+		c.DoneTimeout = timeout
+	}
+}
+
+// WithAuthenticator specifies the message authenticator to use for message verification
+func WithAuthenticator(
+	authenticator *pcommon.MessageAuthenticator,
+) MessageSubmissionOptionFunc {
+	return func(c *Config) {
+		c.Authenticator = authenticator
+	}
+}
+
+// WithTTLValidator specifies the TTL validator to use for message TTL validation
+func WithTTLValidator(
+	ttlValidator *pcommon.TTLValidator,
+) MessageSubmissionOptionFunc {
+	return func(c *Config) {
+		c.TTLValidator = ttlValidator
+	}
+}

--- a/protocol/messagesubmission/server.go
+++ b/protocol/messagesubmission/server.go
@@ -1,0 +1,449 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messagesubmission
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// Server implements the MessageSubmission server
+type Server struct {
+	*protocol.Protocol
+	config          *Config
+	callbackContext CallbackContext
+
+	// Server-side state for message queue management
+	lock              sync.Mutex
+	messageQueue      []*pcommon.DmqMessage
+	pendingMessageIDs [][]byte
+	requestInFlight   bool // Protects against concurrent request modifications (TOCTOU)
+}
+
+// NewServer returns a new MessageSubmission server object
+func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
+	if cfg == nil {
+		tmpCfg := NewConfig()
+		cfg = &tmpCfg
+	}
+	s := &Server{
+		config:            cfg,
+		messageQueue:      make([]*pcommon.DmqMessage, 0),
+		pendingMessageIDs: [][]byte{},
+	}
+	s.callbackContext = CallbackContext{
+		Server:       s,
+		ConnectionId: protoOptions.ConnectionId,
+	}
+	protoConfig := protocol.ProtocolConfig{
+		Name:                ProtocolName,
+		ProtocolId:          ProtocolID,
+		Muxer:               protoOptions.Muxer,
+		Logger:              protoOptions.Logger,
+		ErrorChan:           protoOptions.ErrorChan,
+		Mode:                protoOptions.Mode,
+		Role:                protocol.ProtocolRoleServer,
+		MessageHandlerFunc:  s.messageHandler,
+		MessageFromCborFunc: NewMsgFromCbor,
+		StateMap:            stateMap,
+		InitialState:        protocolStateInit,
+	}
+	s.Protocol = protocol.New(protoConfig)
+	return s
+}
+
+// AddMessage adds a message to the outbound queue
+func (s *Server) AddMessage(msg *pcommon.DmqMessage) error {
+	// Validate message before adding to queue
+	if s.config.TTLValidator != nil {
+		if err := s.config.TTLValidator.ValidateMessageTTL(msg); err != nil {
+			return err
+		}
+	}
+	if s.config.Authenticator != nil {
+		if err := s.config.Authenticator.VerifyMessage(msg); err != nil {
+			return err
+		}
+	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// Check queue size limit
+	if len(s.messageQueue) >= s.config.MaxQueueSize {
+		return errors.New("message queue full")
+	}
+
+	s.messageQueue = append(s.messageQueue, msg)
+
+	s.Protocol.Logger().
+		Debug("message added to queue",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "server",
+			"connection_id", s.callbackContext.ConnectionId.String(),
+			"message_id", string(msg.Payload.MessageID),
+			"queue_size", len(s.messageQueue),
+		)
+
+	return nil
+}
+
+// RequestMessageIdsBlocking sends a blocking request for message IDs
+func (s *Server) RequestMessageIdsBlocking(
+	ackCount, requestCount uint16,
+) error {
+	s.lock.Lock()
+
+	// Protocol invariant: blocking request must be done if and only if buffer of unacknowledged ids is empty
+	if len(s.pendingMessageIDs) > 0 {
+		s.lock.Unlock()
+		return errors.New(
+			"cannot send blocking request when pending message IDs exist",
+		)
+	}
+
+	// Prevent concurrent requests
+	if s.requestInFlight {
+		s.lock.Unlock()
+		return errors.New("a request is already in flight")
+	}
+
+	if requestCount == 0 {
+		s.lock.Unlock()
+		return errors.New("cannot request 0 message IDs")
+	}
+
+	// Mark request as in-flight before releasing lock.
+	s.requestInFlight = true
+	// Prepare message
+	msg := NewMsgRequestMessageIds(true, ackCount, requestCount)
+	// Release lock before performing network I/O
+	s.lock.Unlock()
+	err := s.SendMessage(msg)
+	// Re-acquire lock to update in-flight flag on error
+	s.lock.Lock()
+	if err != nil {
+		s.requestInFlight = false
+	}
+	s.lock.Unlock()
+
+	return err
+}
+
+// RequestMessageIdsNonBlocking sends a non-blocking request for message IDs
+func (s *Server) RequestMessageIdsNonBlocking(
+	ackCount, requestCount uint16,
+) error {
+	s.lock.Lock()
+
+	// Protocol invariant: cannot request if buffer of unacknowledged ids is empty
+	if len(s.pendingMessageIDs) == 0 {
+		s.lock.Unlock()
+		return errors.New(
+			"cannot send non-blocking request when pending message IDs buffer is empty",
+		)
+	}
+
+	// Prevent concurrent requests
+	if s.requestInFlight {
+		s.lock.Unlock()
+		return errors.New("a request is already in flight")
+	}
+
+	if requestCount == 0 {
+		s.lock.Unlock()
+		return errors.New("cannot request 0 message IDs")
+	}
+
+	// Mark request as in-flight while holding the lock.
+	s.requestInFlight = true
+	// Prepare message
+	msg := NewMsgRequestMessageIds(false, ackCount, requestCount)
+	// Release lock before performing network I/O
+	s.lock.Unlock()
+	err := s.SendMessage(msg)
+	// Re-acquire lock to update in-flight flag on error
+	s.lock.Lock()
+	if err != nil {
+		s.requestInFlight = false
+	}
+	s.lock.Unlock()
+
+	return err
+}
+
+// RequestMessages sends a request for specific messages by their IDs
+func (s *Server) RequestMessages(messageIDs [][]byte) error {
+	msg := NewMsgRequestMessages(messageIDs)
+	return s.SendMessage(msg)
+}
+
+// GetAvailableMessages returns messages from the outbound queue up to maxCount
+func (s *Server) GetAvailableMessages(maxCount int) []pcommon.DmqMessage {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	var available []pcommon.DmqMessage
+	now := time.Now().Unix()
+
+	// Prune expired and gather up to maxCount
+	filtered := make([]*pcommon.DmqMessage, 0, len(s.messageQueue))
+	for _, msg := range s.messageQueue {
+		if msg == nil {
+			continue
+		}
+		// #nosec G115 -- Unix timestamp will not overflow uint32 until year 2106
+		if uint32(now) <= msg.Payload.ExpiresAt {
+			if len(available) < maxCount {
+				available = append(available, *msg)
+			} else {
+				filtered = append(filtered, msg)
+			}
+		}
+	}
+	s.messageQueue = filtered
+
+	return available
+}
+
+// GetAvailableMessageIDs returns message IDs from the queue up to count
+func (s *Server) GetAvailableMessageIDs(count int) []pcommon.MessageIDAndSize {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	// Guard: prevent overwriting pending IDs if a request is already in flight
+	if s.requestInFlight {
+		s.Protocol.Logger().
+			Debug("ignoring GetAvailableMessageIDs; request already in flight",
+				"component", "network",
+				"protocol", ProtocolName,
+				"role", "server",
+				"connection_id", s.callbackContext.ConnectionId.String(),
+			)
+		return []pcommon.MessageIDAndSize{}
+	}
+
+	ids := make([]pcommon.MessageIDAndSize, 0, count)
+	now := time.Now().Unix()
+
+	// Prune expired messages and collect IDs
+	filtered := make([]*pcommon.DmqMessage, 0, len(s.messageQueue))
+	for _, msg := range s.messageQueue {
+		if msg == nil {
+			continue
+		}
+		// #nosec G115 -- Unix timestamp will not overflow uint32 until year 2106
+		if uint32(now) > msg.Payload.ExpiresAt {
+			continue // skip expired messages, don't add to filtered
+		}
+		// #nosec G115 -- message body size bounded by protocol limits
+		if len(ids) < count {
+			ids = append(ids, pcommon.MessageIDAndSize{
+				MessageID:   msg.Payload.MessageID,
+				SizeInBytes: uint32(len(msg.Payload.MessageBody)),
+			})
+		}
+		filtered = append(filtered, msg)
+	}
+	s.messageQueue = filtered
+
+	// Append new pending IDs instead of overwriting to avoid dropping unacknowledged IDs
+	if len(ids) > 0 {
+		// Build a set of existing pending IDs to prevent duplicates across multiple calls
+		existing := make(map[string]struct{}, len(s.pendingMessageIDs))
+		for _, b := range s.pendingMessageIDs {
+			existing[string(b)] = struct{}{}
+		}
+		for _, id := range ids {
+			key := string(id.MessageID)
+			if _, seen := existing[key]; !seen {
+				s.pendingMessageIDs = append(s.pendingMessageIDs, id.MessageID)
+				existing[key] = struct{}{}
+			}
+		}
+	}
+
+	return ids
+}
+
+// GetMessagesByIDs returns messages matching the provided IDs
+func (s *Server) GetMessagesByIDs(ids [][]byte) []pcommon.DmqMessage {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	messages := make([]pcommon.DmqMessage, 0, len(ids))
+	idSet := make(map[string]struct{}, len(ids))
+	now := time.Now().Unix()
+
+	// Build a set of IDs for O(1) lookup
+	for _, id := range ids {
+		idSet[string(id)] = struct{}{}
+	}
+
+	// Check all messages once, return those matching the ID set
+	for _, msg := range s.messageQueue {
+		if msg == nil {
+			continue
+		}
+		// #nosec G115 -- Unix timestamp will not overflow uint32 until year 2106
+		if uint32(now) > msg.Payload.ExpiresAt {
+			continue
+		}
+		if _, exists := idSet[string(msg.Payload.MessageID)]; exists {
+			messages = append(messages, *msg)
+		}
+	}
+
+	return messages
+}
+
+func (s *Server) messageHandler(msg protocol.Message) error {
+	var err error
+	switch msg.Type() {
+	case MessageTypeInit:
+		err = s.handleInit()
+	case MessageTypeReplyMessageIds:
+		err = s.handleReplyMessageIds(msg)
+	case MessageTypeReplyMessages:
+		err = s.handleReplyMessages(msg)
+	case MessageTypeDone:
+		err = s.handleDone()
+	default:
+		err = fmt.Errorf(
+			"%s: received unexpected message type %d",
+			ProtocolName,
+			msg.Type(),
+		)
+	}
+	return err
+}
+
+//nolint:unparam
+func (s *Server) handleInit() error {
+	s.Protocol.Logger().
+		Debug("received init message",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "server",
+			"connection_id", s.callbackContext.ConnectionId.String(),
+		)
+	return nil
+}
+
+//nolint:unparam
+func (s *Server) handleReplyMessageIds(msg protocol.Message) error {
+	msgReply := msg.(*MsgReplyMessageIds)
+
+	s.Protocol.Logger().
+		Debug("received reply message IDs",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "server",
+			"connection_id", s.callbackContext.ConnectionId.String(),
+			"message_count", len(msgReply.Messages),
+		)
+
+	s.lock.Lock()
+	// Clear the in-flight flag now that response is received
+	s.requestInFlight = false
+	// Remove the replied IDs from pendingMessageIDs to mark them as acknowledged
+	repliedIDs := make(map[string]struct{}, len(msgReply.Messages))
+	for _, entry := range msgReply.Messages {
+		repliedIDs[string(entry.MessageID)] = struct{}{}
+	}
+	filtered := make([][]byte, 0, len(s.pendingMessageIDs))
+	for _, id := range s.pendingMessageIDs {
+		if _, replied := repliedIDs[string(id)]; !replied {
+			filtered = append(filtered, id)
+		}
+	}
+	s.pendingMessageIDs = filtered
+	s.lock.Unlock()
+
+	// Invoke callback
+	if s.config.ReplyMessageIdsFunc != nil {
+		s.config.ReplyMessageIdsFunc(s.callbackContext, msgReply.Messages)
+	}
+
+	return nil
+}
+
+func (s *Server) handleReplyMessages(msg protocol.Message) error {
+	msgReply := msg.(*MsgReplyMessages)
+
+	s.Protocol.Logger().
+		Debug("received reply messages",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "server",
+			"connection_id", s.callbackContext.ConnectionId.String(),
+			"message_count", len(msgReply.Messages),
+		)
+
+	// Validate messages before invoking callback
+	for i := range msgReply.Messages {
+		if s.config.TTLValidator != nil {
+			if err := s.config.TTLValidator.ValidateMessageTTL(&msgReply.Messages[i]); err != nil {
+				s.Protocol.Logger().
+					Warn("message validation failed",
+						"component", "network",
+						"protocol", ProtocolName,
+						"role", "server",
+						"connection_id", s.callbackContext.ConnectionId.String(),
+						"error", err,
+					)
+				return err
+			}
+		}
+		if s.config.Authenticator != nil {
+			if err := s.config.Authenticator.VerifyMessage(&msgReply.Messages[i]); err != nil {
+				s.Protocol.Logger().
+					Warn("message authentication failed",
+						"component", "network",
+						"protocol", ProtocolName,
+						"role", "server",
+						"connection_id", s.callbackContext.ConnectionId.String(),
+						"error", err,
+					)
+				return err
+			}
+		}
+	}
+
+	// Invoke callback
+	if s.config.ReplyMessagesFunc != nil {
+		s.config.ReplyMessagesFunc(s.callbackContext, msgReply.Messages)
+	}
+
+	return nil
+}
+
+//nolint:unparam
+func (s *Server) handleDone() error {
+	s.Protocol.Logger().
+		Debug("received done message",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "server",
+			"connection_id", s.callbackContext.ConnectionId.String(),
+		)
+	return nil
+}

--- a/protocol/messagesubmission/server_test.go
+++ b/protocol/messagesubmission/server_test.go
@@ -1,0 +1,78 @@
+package messagesubmission
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+func TestServerGetAvailableMessageIDs_DedupAcrossCalls(t *testing.T) {
+	cfg := NewConfig()
+	// Disable validation to simplify queueing in this unit test
+	cfg.Authenticator = pcommon.NewNoOpAuthenticator(nil)
+	cfg.TTLValidator = pcommon.NewNoOpTTLValidator(nil)
+	// Provide a non-nil ConnectionId to satisfy logging code paths
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	s := NewServer(protocol.ProtocolOptions{ConnectionId: connId}, &cfg)
+	// Add two identical messages (same ID) and one different
+	exp := uint32(time.Now().Unix() + 60)
+	msg1 := &pcommon.DmqMessage{
+		Payload: pcommon.DmqMessagePayload{
+			MessageID:   []byte("id1"),
+			MessageBody: []byte("body1"),
+			KESPeriod:   1,
+			ExpiresAt:   exp,
+		},
+	}
+	msg2 := &pcommon.DmqMessage{
+		Payload: pcommon.DmqMessagePayload{
+			MessageID:   []byte("id1"),
+			MessageBody: []byte("body1"),
+			KESPeriod:   1,
+			ExpiresAt:   exp,
+		},
+	}
+	msg3 := &pcommon.DmqMessage{
+		Payload: pcommon.DmqMessagePayload{
+			MessageID:   []byte("id2"),
+			MessageBody: []byte("body2"),
+			KESPeriod:   1,
+			ExpiresAt:   exp,
+		},
+	}
+	if err := s.AddMessage(msg1); err != nil {
+		t.Fatalf("failed to add msg1: %v", err)
+	}
+	if err := s.AddMessage(msg2); err != nil {
+		t.Fatalf("failed to add msg2: %v", err)
+	}
+	if err := s.AddMessage(msg3); err != nil {
+		t.Fatalf("failed to add msg3: %v", err)
+	}
+
+	ids1 := s.GetAvailableMessageIDs(10)
+	if len(ids1) == 0 {
+		t.Fatalf("expected some IDs, got 0")
+	}
+	// pendingMessageIDs should not contain duplicates across calls
+	seen := map[string]int{}
+	for _, b := range s.pendingMessageIDs {
+		seen[string(b)]++
+	}
+	for k, count := range seen {
+		if count > 1 {
+			t.Fatalf(
+				"duplicate pendingMessageID %s count=%d; expected deduplication",
+				k,
+				count,
+			)
+		}
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements CIP-0137 distributed message queue with node-to-node and node-to-client protocols, plus authentication and TTL checks. Enables secure message submission and notifications with blocking and non-blocking flows.

- **New Features**
  - Common DMQ types, message authentication (opcert/KES/pool registration), and TTL validation.
  - MessageSubmission (ID 17): init, request/reply for message IDs and messages, blocking/non-blocking, bounded queue.
  - LocalMessageSubmission (ID 18): submit messages; accept/reject with standard reasons; handler hook.
  - LocalMessageNotification (ID 19): request messages (blocking/non-blocking); internal queue; wait-for-message signaling.
  - CBOR encoding/decoding, protocol state machines, and timeouts per CIP-0137, with tests for authentication, TTL, and message formats.

<sup>Written for commit 75fe9f2c66518b5e7c3fff7d742f9440eea3bb8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end message authentication with configurable KES verifiers, SPO pool registration, slot-aware verification, insecure/no-op modes, cache management, and TTL enforcement.
  * Structured DMQ message model with message/operational cert payloads, reject reasons, and deterministic CBOR encoding/decoding.
  * Full CIP-0137 protocol suite: Local Message Notification, Local Message Submission, and Message Submission (clients/servers, blocking/non-blocking, timeouts, queuing, callbacks, ack handling).

* **Tests**
  * Extensive unit tests covering authentication flows, verifier injection and errors, TTL edge cases, CBOR round-trips, and protocol behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->