### PR TITLE
feat(ledger): isvalid, collateral redeemer, and cost model checks

### DIFF
--- a/ledger/alonzo/errors.go
+++ b/ledger/alonzo/errors.go
@@ -100,3 +100,5 @@ type ExtraneousPlutusScriptWitnessesError struct{}
 func (ExtraneousPlutusScriptWitnessesError) Error() string {
 	return "extraneous Plutus script witnesses"
 }
+
+// Cost model and IsValid flag errors moved to ledger/common/era_errors.go

--- a/ledger/babbage/errors.go
+++ b/ledger/babbage/errors.go
@@ -81,3 +81,5 @@ type ExtraneousPlutusScriptWitnessesError struct{}
 func (ExtraneousPlutusScriptWitnessesError) Error() string {
 	return "extraneous Plutus script witnesses"
 }
+
+// Cost model and IsValid flag errors moved to ledger/common/era_errors.go

--- a/ledger/babbage/errors_test.go
+++ b/ledger/babbage/errors_test.go
@@ -1,0 +1,69 @@
+package babbage
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+func TestCostModelsPresent_UnresolvedReferenceInputReturnsError(t *testing.T) {
+	// Create a BabbageTransaction with a single reference input so the lookup is attempted
+	var slot uint64 = 0
+	ls := &common.MockLedgerStateRefFail{}
+	var pp common.ProtocolParameters = &BabbageProtocolParameters{}
+
+	input := shelley.NewShelleyTransactionInput(
+		"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		0,
+	)
+	tmpTx := &BabbageTransaction{}
+	tmpTx.Body.TxReferenceInputs = cbor.NewSetType(
+		[]shelley.ShelleyTransactionInput{input},
+		false,
+	)
+	var tx common.Transaction = tmpTx
+
+	err := UtxoValidateCostModelsPresent(tx, slot, ls, pp)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, common.ErrReferenceInputResolution) {
+		t.Fatalf("expected ErrReferenceInputResolution, got %v", err)
+	}
+}
+
+func TestCostModelsPresent_UnresolvedReferenceInputUnwraps(t *testing.T) {
+	// Create a BabbageTransaction with a single reference input so the lookup is attempted
+	var slot uint64 = 0
+	ls := &common.MockLedgerStateRefFail{}
+	var pp common.ProtocolParameters = &BabbageProtocolParameters{}
+
+	input := shelley.NewShelleyTransactionInput(
+		"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		0,
+	)
+	tmpTx := &BabbageTransaction{}
+	tmpTx.Body.TxReferenceInputs = cbor.NewSetType(
+		[]shelley.ShelleyTransactionInput{input},
+		false,
+	)
+	var tx common.Transaction = tmpTx
+
+	err := UtxoValidateCostModelsPresent(tx, slot, ls, pp)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var refErr common.ReferenceInputResolutionError
+	if !errors.As(err, &refErr) {
+		t.Fatalf(
+			"expected ReferenceInputResolutionError via errors.As, got %T",
+			err,
+		)
+	}
+	if refErr.Err == nil || refErr.Err.Error() != "utxo not found" {
+		t.Fatalf("expected inner error 'utxo not found', got %v", refErr.Err)
+	}
+}

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -27,8 +27,11 @@ import (
 
 var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateMetadata,
+	UtxoValidateIsValidFlag,
 	UtxoValidateRequiredVKeyWitnesses,
+	UtxoValidateCollateralVKeyWitnesses,
 	UtxoValidateRedeemerAndScriptWitnesses,
+	UtxoValidateCostModelsPresent,
 	UtxoValidateOutsideValidityIntervalUtxo,
 	UtxoValidateInputSetEmptyUtxo,
 	UtxoValidateFeeTooSmallUtxo,
@@ -57,6 +60,31 @@ func UtxoValidateOutsideValidityIntervalUtxo(
 	return allegra.UtxoValidateOutsideValidityIntervalUtxo(tx, slot, ls, pp)
 }
 
+// UtxoValidateIsValidFlag ensures transactions marked invalid have Plutus scripts
+func UtxoValidateIsValidFlag(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	// If IsValid is true, no check needed
+	if tx.IsValid() {
+		return nil
+	}
+
+	// If IsValid is false, transaction must have redeemers (indicating phase-2 validation)
+	w := tx.Witnesses()
+	if w != nil && w.Redeemers() != nil {
+		for range w.Redeemers().Iter() {
+			// Has at least one redeemer
+			return nil
+		}
+	}
+
+	// IsValid=false but no redeemers present
+	return common.InvalidIsValidFlagError{}
+}
+
 // UtxoValidateRequiredVKeyWitnesses ensures required signers are accompanied by vkey witnesses
 func UtxoValidateRequiredVKeyWitnesses(
 	tx common.Transaction,
@@ -83,6 +111,16 @@ func UtxoValidateRequiredVKeyWitnesses(
 		}
 	}
 	return nil
+}
+
+// UtxoValidateCollateralVKeyWitnesses ensures collateral inputs are backed by vkey witnesses
+func UtxoValidateCollateralVKeyWitnesses(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return common.ValidateCollateralVKeyWitnesses(tx, ls)
 }
 
 // UtxoValidateRedeemerAndScriptWitnesses performs lightweight UTXOW checks for presence/absence of scripts vs redeemers
@@ -122,6 +160,65 @@ func UtxoValidateRedeemerAndScriptWitnesses(
 	// If no redeemers are present but script witnesses are supplied, treat as extraneous
 	if redeemerCount == 0 && hasPlutus {
 		return ExtraneousPlutusScriptWitnessesError{}
+	}
+
+	return nil
+}
+
+// UtxoValidateCostModelsPresent ensures Plutus scripts have cost models in protocol parameters
+func UtxoValidateCostModelsPresent(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	tmpPparams, ok := pp.(*BabbageProtocolParameters)
+	if !ok {
+		return errors.New("pparams are not expected type")
+	}
+	tmpTx, ok := tx.(*BabbageTransaction)
+	if !ok {
+		return errors.New("transaction is not expected type")
+	}
+
+	required := map[uint]struct{}{}
+	wits := tmpTx.WitnessSet
+	if len(wits.WsPlutusV1Scripts) > 0 {
+		required[0] = struct{}{}
+	}
+	if len(wits.WsPlutusV2Scripts) > 0 {
+		required[1] = struct{}{}
+	}
+	// Include reference scripts on reference inputs
+	for _, refInput := range tmpTx.ReferenceInputs() {
+		utxo, err := ls.UtxoById(refInput)
+		if err != nil {
+			return common.ReferenceInputResolutionError{
+				Input: refInput,
+				Err:   err,
+			}
+		}
+		script := utxo.Output.ScriptRef()
+		if script == nil {
+			continue
+		}
+		switch script.(type) {
+		case common.PlutusV1Script:
+			required[0] = struct{}{}
+		case common.PlutusV2Script:
+			required[1] = struct{}{}
+		}
+	}
+
+	if len(required) == 0 {
+		return nil
+	}
+
+	for version := range required {
+		model, ok := tmpPparams.CostModels[version]
+		if !ok || len(model) == 0 {
+			return common.MissingCostModelError{Version: version}
+		}
 	}
 
 	return nil

--- a/ledger/common/errors.go
+++ b/ledger/common/errors.go
@@ -1,0 +1,61 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"errors"
+	"fmt"
+)
+
+// InvalidIsValidFlagError indicates a tx marked invalid but lacking Plutus scripts
+type InvalidIsValidFlagError struct{}
+
+func (InvalidIsValidFlagError) Error() string {
+	return "transaction marked as invalid but has no Plutus scripts requiring phase-2 validation"
+}
+
+// MissingCostModelError indicates a missing cost model for a Plutus version
+type MissingCostModelError struct {
+	Version uint
+}
+
+func (e MissingCostModelError) Error() string {
+	return fmt.Sprintf("missing cost model for Plutus v%d", e.Version+1)
+}
+
+// ReferenceInputResolutionError indicates a failure to resolve a reference input UTxO
+type ReferenceInputResolutionError struct {
+	Input TransactionInput
+	Err   error
+}
+
+func (e ReferenceInputResolutionError) Error() string {
+	return fmt.Sprintf(
+		"failed to resolve reference input %s: %v",
+		e.Input.String(),
+		e.Err,
+	)
+}
+
+func (e ReferenceInputResolutionError) Unwrap() error { return e.Err }
+
+// Sentinel error for reference input resolution failures so callers can use errors.Is
+var ErrReferenceInputResolution = errors.New(
+	"reference input resolution failed",
+)
+
+func (ReferenceInputResolutionError) Is(target error) bool {
+	return target == ErrReferenceInputResolution
+}

--- a/ledger/common/mock.go
+++ b/ledger/common/mock.go
@@ -1,0 +1,63 @@
+package common
+
+import (
+	"errors"
+	"time"
+)
+
+// MockLedgerStateRefFail is a shared test helper that fails UtxoById lookups
+// This file is intentionally non-_test.go so other package tests can import it.
+type MockLedgerStateRefFail struct{}
+
+func (m *MockLedgerStateRefFail) UtxoById(
+	input TransactionInput,
+) (Utxo, error) {
+	return Utxo{}, errors.New("utxo not found")
+}
+
+func (m *MockLedgerStateRefFail) StakeRegistration(
+	key []byte,
+) ([]StakeRegistrationCertificate, error) {
+	return nil, nil
+}
+
+func (m *MockLedgerStateRefFail) SlotToTime(
+	slot uint64,
+) (time.Time, error) {
+	return time.Time{}, nil
+}
+
+func (m *MockLedgerStateRefFail) TimeToSlot(
+	t time.Time,
+) (uint64, error) {
+	return 0, nil
+}
+
+func (m *MockLedgerStateRefFail) PoolCurrentState(
+	poolKeyHash PoolKeyHash,
+) (*PoolRegistrationCertificate, *uint64, error) {
+	return nil, nil, nil
+}
+
+func (m *MockLedgerStateRefFail) CalculateRewards(
+	pots AdaPots,
+	snapshot RewardSnapshot,
+	params RewardParameters,
+) (*RewardCalculationResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *MockLedgerStateRefFail) GetAdaPots() AdaPots { return AdaPots{} }
+
+func (m *MockLedgerStateRefFail) UpdateAdaPots(
+	pots AdaPots,
+) error {
+	return nil
+}
+
+func (m *MockLedgerStateRefFail) GetRewardSnapshot(
+	epoch uint64,
+) (RewardSnapshot, error) {
+	return RewardSnapshot{}, nil
+}
+func (m *MockLedgerStateRefFail) NetworkId() uint { return 0 }

--- a/ledger/conway/errors.go
+++ b/ledger/conway/errors.go
@@ -67,3 +67,7 @@ type ExtraneousPlutusScriptWitnessesError struct{}
 func (ExtraneousPlutusScriptWitnessesError) Error() string {
 	return "extraneous Plutus script witnesses"
 }
+
+// Cost model and IsValid flag errors moved to ledger/common/era_errors.go
+
+// Reference input resolution errors moved to ledger/common/reference_errors.go

--- a/ledger/conway/errors_test.go
+++ b/ledger/conway/errors_test.go
@@ -1,0 +1,71 @@
+package conway
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+func TestConway_CostModelsPresent_UnresolvedReferenceInputReturnsError(
+	t *testing.T,
+) {
+	var slot uint64 = 0
+	ls := &common.MockLedgerStateRefFail{}
+	var pp common.ProtocolParameters = &ConwayProtocolParameters{}
+
+	input := shelley.NewShelleyTransactionInput(
+		"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		0,
+	)
+	tmpTx := &ConwayTransaction{}
+	tmpTx.Body.TxReferenceInputs = cbor.NewSetType(
+		[]shelley.ShelleyTransactionInput{input},
+		false,
+	)
+	var tx common.Transaction = tmpTx
+
+	err := UtxoValidateCostModelsPresent(tx, slot, ls, pp)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, common.ErrReferenceInputResolution) {
+		t.Fatalf("expected ErrReferenceInputResolution, got %v", err)
+	}
+}
+
+func TestConway_CostModelsPresent_UnresolvedReferenceInputUnwraps(
+	t *testing.T,
+) {
+	var slot uint64 = 0
+	ls := &common.MockLedgerStateRefFail{}
+	var pp common.ProtocolParameters = &ConwayProtocolParameters{}
+
+	input := shelley.NewShelleyTransactionInput(
+		"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		0,
+	)
+	tmpTx := &ConwayTransaction{}
+	tmpTx.Body.TxReferenceInputs = cbor.NewSetType(
+		[]shelley.ShelleyTransactionInput{input},
+		false,
+	)
+	var tx common.Transaction = tmpTx
+
+	err := UtxoValidateCostModelsPresent(tx, slot, ls, pp)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var refErr common.ReferenceInputResolutionError
+	if !errors.As(err, &refErr) {
+		t.Fatalf(
+			"expected ReferenceInputResolutionError via errors.As, got %T",
+			err,
+		)
+	}
+	if refErr.Err == nil || refErr.Err.Error() != "utxo not found" {
+		t.Fatalf("expected inner error 'utxo not found', got %v", refErr.Err)
+	}
+}


### PR DESCRIPTION












<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds new UTXO validation checks for IsValid flags, collateral payment key witnesses, and Plutus cost model presence across Alonzo, Babbage, and Conway. Improves script/redeemer checks to consider reference scripts where applicable.

- **New Features**
  - Enforce IsValid=false requires at least one redeemer; otherwise InvalidIsValidFlagError.
  - Require vkey witnesses for each collateral input and ensure collateral is key-locked (shared helper in ledger/common, used by all eras).
  - Verify protocol parameters include cost models for each Plutus version used by witnesses or reference scripts; raises MissingCostModelError and explicit ReferenceInputResolutionError when a reference input UTxO cannot be resolved.

<sup>Written for commit 8c9582b8510356a234871d07a430d98a422e8da1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->













<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stronger transaction validation across eras: IsValid flag enforcement, collateral vkey witness checks, and required Plutus cost-model verification (handles explicit and reference scripts).

* **Bug Fixes / Diagnostics**
  * New structured errors for invalid IsValid usage, missing cost models, and reference-input resolution to improve error clarity.

* **Tests**
  * Added unit tests covering unresolved reference-input error behavior.

* **Chores**
  * Added a reusable failing-ledger-state test helper to support testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->