### PR TITLE
refactor(ledger): centralize validation errors

### DIFF
--- a/ledger/alonzo/errors.go
+++ b/ledger/alonzo/errors.go
@@ -67,38 +67,23 @@ func (NoCollateralInputsError) Error() string {
 
 // Metadata validation errors are in the common package; use directly
 
-// Witness validation errors
-type MissingVKeyWitnessesError struct{}
+// Witness validation errors (alias to common types)
+type MissingVKeyWitnessesError = common.MissingVKeyWitnessesError
 
-func (MissingVKeyWitnessesError) Error() string {
-	return "missing required vkey witnesses"
-}
+type MissingRequiredVKeyWitnessForSignerError = common.MissingRequiredVKeyWitnessForSignerError
 
-type MissingRequiredVKeyWitnessForSignerError struct {
-	Signer common.Blake2b224
-}
+type MissingRedeemersForScriptDataHashError = common.MissingRedeemersForScriptDataHashError
 
-func (e MissingRequiredVKeyWitnessForSignerError) Error() string {
-	return "missing required vkey witness for required signer"
-}
+type MissingPlutusScriptWitnessesError = common.MissingPlutusScriptWitnessesError
 
-// Plutus script/redeemer relationship errors
-type MissingRedeemersForScriptDataHashError struct{}
+type ExtraneousPlutusScriptWitnessesError = common.ExtraneousPlutusScriptWitnessesError
 
-func (MissingRedeemersForScriptDataHashError) Error() string {
-	return "missing redeemers for script data hash"
-}
+// Metadata / cost model / IsValid aliases
+type MissingTransactionMetadataError = common.MissingTransactionMetadataError
 
-type MissingPlutusScriptWitnessesError struct{}
-
-func (MissingPlutusScriptWitnessesError) Error() string {
-	return "missing Plutus script witnesses for redeemers"
-}
-
-type ExtraneousPlutusScriptWitnessesError struct{}
-
-func (ExtraneousPlutusScriptWitnessesError) Error() string {
-	return "extraneous Plutus script witnesses"
-}
-
-// Cost model and IsValid flag errors moved to ledger/common/era_errors.go
+type (
+	MissingTransactionAuxiliaryDataHashError = common.MissingTransactionAuxiliaryDataHashError
+	ConflictingMetadataHashError             = common.ConflictingMetadataHashError
+	MissingCostModelError                    = common.MissingCostModelError
+	InvalidIsValidFlagError                  = common.InvalidIsValidFlagError
+)

--- a/ledger/alonzo/rules.go
+++ b/ledger/alonzo/rules.go
@@ -156,27 +156,7 @@ func UtxoValidateRequiredVKeyWitnesses(
 	ls common.LedgerState,
 	pp common.ProtocolParameters,
 ) error {
-	required := tx.RequiredSigners()
-	if len(required) == 0 {
-		return nil
-	}
-	w := tx.Witnesses()
-	if w == nil || len(w.Vkey()) == 0 {
-		return MissingVKeyWitnessesError{}
-	}
-	// Build a map of vkey hashes from the witness set
-	vkeyHashes := make(map[common.Blake2b224]struct{})
-	for _, vw := range w.Vkey() {
-		h := common.Blake2b224Hash(vw.Vkey)
-		vkeyHashes[h] = struct{}{}
-	}
-	// Verify each required signer has a matching vkey witness
-	for _, req := range required {
-		if _, ok := vkeyHashes[req]; !ok {
-			return MissingRequiredVKeyWitnessForSignerError{Signer: req}
-		}
-	}
-	return nil
+	return common.ValidateRequiredVKeyWitnesses(tx)
 }
 
 // UtxoValidateCollateralVKeyWitnesses ensures collateral inputs are backed by vkey witnesses
@@ -196,38 +176,7 @@ func UtxoValidateRedeemerAndScriptWitnesses(
 	ls common.LedgerState,
 	pp common.ProtocolParameters,
 ) error {
-	// Redeemer validation applies to Plutus scripts only. Native scripts
-	// (native multisig, timelocks) do not require redeemers.
-	wits := tx.Witnesses()
-	redeemerCount := 0
-	if wits != nil {
-		if r := wits.Redeemers(); r != nil {
-			for range r.Iter() {
-				redeemerCount++
-			}
-		}
-	}
-	hasPlutus := false
-	if wits != nil {
-		hasPlutus = len(wits.PlutusV1Scripts()) > 0
-	}
-
-	// If the body carries a script data hash, redeemers must be present
-	if tx.ScriptDataHash() != nil && redeemerCount == 0 {
-		return MissingRedeemersForScriptDataHashError{}
-	}
-
-	// If redeemers are present, we expect at least one script witness available
-	if redeemerCount > 0 && !hasPlutus {
-		return MissingPlutusScriptWitnessesError{}
-	}
-
-	// If no redeemers are present but script witnesses are supplied, treat as extraneous
-	if redeemerCount == 0 && hasPlutus {
-		return ExtraneousPlutusScriptWitnessesError{}
-	}
-
-	return nil
+	return common.ValidateRedeemerAndScriptWitnesses(tx)
 }
 
 // UtxoValidateCostModelsPresent ensures Plutus scripts have cost models in protocol parameters

--- a/ledger/babbage/errors.go
+++ b/ledger/babbage/errors.go
@@ -48,38 +48,23 @@ func (e IncorrectTotalCollateralFieldError) Error() string {
 
 // Metadata validation errors are in the common package; use directly
 
-// Witness validation errors
-type MissingVKeyWitnessesError struct{}
+// Witness validation errors (alias to common types)
+type MissingVKeyWitnessesError = common.MissingVKeyWitnessesError
 
-func (MissingVKeyWitnessesError) Error() string {
-	return "missing required vkey witnesses"
-}
+type MissingRequiredVKeyWitnessForSignerError = common.MissingRequiredVKeyWitnessForSignerError
 
-type MissingRequiredVKeyWitnessForSignerError struct {
-	Signer common.Blake2b224
-}
+type MissingRedeemersForScriptDataHashError = common.MissingRedeemersForScriptDataHashError
 
-func (e MissingRequiredVKeyWitnessForSignerError) Error() string {
-	return "missing required vkey witness for required signer"
-}
+type MissingPlutusScriptWitnessesError = common.MissingPlutusScriptWitnessesError
 
-// Plutus script/redeemer relationship errors
-type MissingRedeemersForScriptDataHashError struct{}
+type ExtraneousPlutusScriptWitnessesError = common.ExtraneousPlutusScriptWitnessesError
 
-func (MissingRedeemersForScriptDataHashError) Error() string {
-	return "missing redeemers for script data hash"
-}
+// Metadata / cost model / IsValid aliases
+type MissingTransactionMetadataError = common.MissingTransactionMetadataError
 
-type MissingPlutusScriptWitnessesError struct{}
-
-func (MissingPlutusScriptWitnessesError) Error() string {
-	return "missing Plutus script witnesses for redeemers"
-}
-
-type ExtraneousPlutusScriptWitnessesError struct{}
-
-func (ExtraneousPlutusScriptWitnessesError) Error() string {
-	return "extraneous Plutus script witnesses"
-}
-
-// Cost model and IsValid flag errors moved to ledger/common/era_errors.go
+type (
+	MissingTransactionAuxiliaryDataHashError = common.MissingTransactionAuxiliaryDataHashError
+	ConflictingMetadataHashError             = common.ConflictingMetadataHashError
+	MissingCostModelError                    = common.MissingCostModelError
+	InvalidIsValidFlagError                  = common.InvalidIsValidFlagError
+)

--- a/ledger/common/mock.go
+++ b/ledger/common/mock.go
@@ -1,8 +1,24 @@
+// Copyright 2025 Blink Labs Software
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
 import (
 	"errors"
 	"time"
+
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
 
 // MockLedgerStateRefFail is a shared test helper that fails UtxoById lookups
@@ -61,3 +77,58 @@ func (m *MockLedgerStateRefFail) GetRewardSnapshot(
 	return RewardSnapshot{}, nil
 }
 func (m *MockLedgerStateRefFail) NetworkId() uint { return 0 }
+
+// MockLedgerStateRules is a lightweight mock of LedgerState used by some
+// unit tests (previously defined locally in verify_rules_test.go).
+type MockLedgerStateRules struct{}
+
+func (m *MockLedgerStateRules) UtxoById(input TransactionInput) (Utxo, error) {
+	return Utxo{}, nil
+}
+
+func (m *MockLedgerStateRules) StakeRegistration(
+	key []byte,
+) ([]StakeRegistrationCertificate, error) {
+	return nil, nil
+}
+
+func (m *MockLedgerStateRules) SlotToTime(
+	slot uint64,
+) (time.Time, error) {
+	return time.Time{}, nil
+}
+
+func (m *MockLedgerStateRules) TimeToSlot(
+	t time.Time,
+) (uint64, error) {
+	return 0, nil
+}
+
+func (m *MockLedgerStateRules) PoolCurrentState(
+	poolKeyHash PoolKeyHash,
+) (*PoolRegistrationCertificate, *uint64, error) {
+	return nil, nil, nil
+}
+
+func (m *MockLedgerStateRules) CalculateRewards(
+	pots AdaPots,
+	snapshot RewardSnapshot,
+	params RewardParameters,
+) (*RewardCalculationResult, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *MockLedgerStateRules) GetAdaPots() AdaPots              { return AdaPots{} }
+func (m *MockLedgerStateRules) UpdateAdaPots(pots AdaPots) error { return nil }
+
+func (m *MockLedgerStateRules) GetRewardSnapshot(
+	epoch uint64,
+) (RewardSnapshot, error) {
+	return RewardSnapshot{}, nil
+}
+func (m *MockLedgerStateRules) NetworkId() uint { return 0 }
+
+// MockProtocolParamsRules is a simple protocol params provider used in tests.
+type MockProtocolParamsRules struct{}
+
+func (m *MockProtocolParamsRules) Utxorpc() (*cardano.PParams, error) { return nil, nil }

--- a/ledger/common/rules.go
+++ b/ledger/common/rules.go
@@ -1,5 +1,5 @@
 // Copyright 2025 Blink Labs Software
-//
+
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -23,9 +23,8 @@ type UtxoValidationRuleFunc func(
 	protocolParams ProtocolParameters,
 ) error
 
-// VerifyTransaction validates a transaction against the given validation rules.
-// It runs all provided UtxoValidationRuleFunc functions and returns the first error encountered,
-// or nil if all validations pass.
+// VerifyTransaction runs the provided validation rules in order and wraps
+// the first error encountered into a ValidationError.
 func VerifyTransaction(
 	tx Transaction,
 	slot uint64,
@@ -35,10 +34,7 @@ func VerifyTransaction(
 ) error {
 	for i, rule := range validationRules {
 		if err := rule(tx, slot, ledgerState, protocolParams); err != nil {
-			details := map[string]any{
-				"rule_index": i,
-				"slot":       slot,
-			}
+			details := map[string]any{"rule_index": i, "slot": slot}
 			if tx != nil {
 				details["tx_hash"] = tx.Hash().String()
 			}
@@ -54,7 +50,88 @@ func VerifyTransaction(
 }
 
 // CalculateMinFee computes the minimum fee for a transaction body given its CBOR-encoded size
-// and the protocol parameters MinFeeA and MinFeeB
+// and the protocol parameters MinFeeA and MinFeeB.
 func CalculateMinFee(bodySize int, minFeeA uint, minFeeB uint) uint64 {
 	return uint64(minFeeA*uint(bodySize) + minFeeB) //nolint:gosec
+}
+
+// Common witness-related error types for lightweight UTXOW checks.
+type MissingVKeyWitnessesError struct{}
+
+func (MissingVKeyWitnessesError) Error() string { return "missing required vkey witnesses" }
+
+type MissingRequiredVKeyWitnessForSignerError struct{ Signer Blake2b224 }
+
+func (MissingRequiredVKeyWitnessForSignerError) Error() string {
+	return "missing required vkey witness for required signer"
+}
+
+type MissingRedeemersForScriptDataHashError struct{}
+
+func (MissingRedeemersForScriptDataHashError) Error() string {
+	return "missing redeemers for script data hash"
+}
+
+type MissingPlutusScriptWitnessesError struct{}
+
+func (MissingPlutusScriptWitnessesError) Error() string {
+	return "missing Plutus script witnesses for redeemers"
+}
+
+type ExtraneousPlutusScriptWitnessesError struct{}
+
+func (ExtraneousPlutusScriptWitnessesError) Error() string {
+	return "extraneous Plutus script witnesses"
+}
+
+// ValidateRequiredVKeyWitnesses checks that all required signers have a vkey witness.
+func ValidateRequiredVKeyWitnesses(tx Transaction) error {
+	required := tx.RequiredSigners()
+	if len(required) == 0 {
+		return nil
+	}
+	w := tx.Witnesses()
+	if w == nil || len(w.Vkey()) == 0 {
+		return MissingVKeyWitnessesError{}
+	}
+	vkeyHashes := make(map[Blake2b224]struct{})
+	for _, vw := range w.Vkey() {
+		vkeyHashes[Blake2b224Hash(vw.Vkey)] = struct{}{}
+	}
+	for _, req := range required {
+		if _, ok := vkeyHashes[req]; !ok {
+			return MissingRequiredVKeyWitnessForSignerError{Signer: req}
+		}
+	}
+	return nil
+}
+
+// ValidateRedeemerAndScriptWitnesses performs lightweight checks between redeemers and Plutus scripts.
+func ValidateRedeemerAndScriptWitnesses(tx Transaction) error {
+	wits := tx.Witnesses()
+	redeemerCount := 0
+	if wits != nil {
+		if r := wits.Redeemers(); r != nil {
+			for range r.Iter() {
+				redeemerCount++
+			}
+		}
+	}
+	hasPlutus := false
+	if wits != nil {
+		if len(wits.PlutusV1Scripts()) > 0 || len(wits.PlutusV2Scripts()) > 0 ||
+			len(wits.PlutusV3Scripts()) > 0 {
+			hasPlutus = true
+		}
+	}
+	if tx.ScriptDataHash() != nil && redeemerCount == 0 {
+		return MissingRedeemersForScriptDataHashError{}
+	}
+	if redeemerCount > 0 && !hasPlutus {
+		return MissingPlutusScriptWitnessesError{}
+	}
+	if redeemerCount == 0 && hasPlutus {
+		return ExtraneousPlutusScriptWitnessesError{}
+	}
+	return nil
 }

--- a/ledger/conway/errors.go
+++ b/ledger/conway/errors.go
@@ -34,40 +34,23 @@ func (e NonDisjointRefInputsError) Error() string {
 
 // Metadata validation errors are in the common package; use directly
 
-// Witness validation errors
-type MissingVKeyWitnessesError struct{}
+// Witness validation errors (alias to common types)
+type MissingVKeyWitnessesError = common.MissingVKeyWitnessesError
 
-func (MissingVKeyWitnessesError) Error() string {
-	return "missing required vkey witnesses"
-}
+type MissingRequiredVKeyWitnessForSignerError = common.MissingRequiredVKeyWitnessForSignerError
 
-type MissingRequiredVKeyWitnessForSignerError struct {
-	Signer common.Blake2b224
-}
+type MissingRedeemersForScriptDataHashError = common.MissingRedeemersForScriptDataHashError
 
-func (e MissingRequiredVKeyWitnessForSignerError) Error() string {
-	return "missing required vkey witness for required signer"
-}
+type MissingPlutusScriptWitnessesError = common.MissingPlutusScriptWitnessesError
 
-// Plutus script/redeemer relationship errors
-type MissingRedeemersForScriptDataHashError struct{}
+type ExtraneousPlutusScriptWitnessesError = common.ExtraneousPlutusScriptWitnessesError
 
-func (MissingRedeemersForScriptDataHashError) Error() string {
-	return "missing redeemers for script data hash"
-}
+// Metadata / cost model / IsValid aliases
+type MissingTransactionMetadataError = common.MissingTransactionMetadataError
 
-type MissingPlutusScriptWitnessesError struct{}
-
-func (MissingPlutusScriptWitnessesError) Error() string {
-	return "missing Plutus script witnesses for redeemers"
-}
-
-type ExtraneousPlutusScriptWitnessesError struct{}
-
-func (ExtraneousPlutusScriptWitnessesError) Error() string {
-	return "extraneous Plutus script witnesses"
-}
-
-// Cost model and IsValid flag errors moved to ledger/common/era_errors.go
-
-// Reference input resolution errors moved to ledger/common/reference_errors.go
+type (
+	MissingTransactionAuxiliaryDataHashError = common.MissingTransactionAuxiliaryDataHashError
+	ConflictingMetadataHashError             = common.ConflictingMetadataHashError
+	MissingCostModelError                    = common.MissingCostModelError
+	InvalidIsValidFlagError                  = common.InvalidIsValidFlagError
+)

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -108,24 +108,7 @@ func UtxoValidateRequiredVKeyWitnesses(
 	ls common.LedgerState,
 	pp common.ProtocolParameters,
 ) error {
-	required := tx.RequiredSigners()
-	if len(required) == 0 {
-		return nil
-	}
-	w := tx.Witnesses()
-	if w == nil || len(w.Vkey()) == 0 {
-		return MissingVKeyWitnessesError{}
-	}
-	vkeyHashes := make(map[common.Blake2b224]struct{})
-	for _, vw := range w.Vkey() {
-		vkeyHashes[common.Blake2b224Hash(vw.Vkey)] = struct{}{}
-	}
-	for _, req := range required {
-		if _, ok := vkeyHashes[req]; !ok {
-			return MissingRequiredVKeyWitnessForSignerError{Signer: req}
-		}
-	}
-	return nil
+	return common.ValidateRequiredVKeyWitnesses(tx)
 }
 
 // UtxoValidateCollateralVKeyWitnesses ensures collateral inputs are backed by vkey witnesses

--- a/ledger/mary/errors.go
+++ b/ledger/mary/errors.go
@@ -33,3 +33,13 @@ func (e OutputTooBigUtxoError) Error() string {
 	}
 	return "output value too large: " + strings.Join(tmpOutputs, ", ")
 }
+
+// Metadata / cost model / IsValid aliases
+type MissingTransactionMetadataError = common.MissingTransactionMetadataError
+
+type (
+	MissingTransactionAuxiliaryDataHashError = common.MissingTransactionAuxiliaryDataHashError
+	ConflictingMetadataHashError             = common.ConflictingMetadataHashError
+	MissingCostModelError                    = common.MissingCostModelError
+	InvalidIsValidFlagError                  = common.InvalidIsValidFlagError
+)

--- a/ledger/shelley/errors.go
+++ b/ledger/shelley/errors.go
@@ -165,17 +165,7 @@ type (
 	ConflictingMetadataHashError             = common.ConflictingMetadataHashError
 )
 
-// Witness validation errors
-type MissingVKeyWitnessesError struct{}
+// Witness validation errors (alias to common types)
+type MissingVKeyWitnessesError = common.MissingVKeyWitnessesError
 
-func (MissingVKeyWitnessesError) Error() string {
-	return "missing required vkey witnesses"
-}
-
-type MissingRequiredVKeyWitnessForSignerError struct {
-	Signer common.Blake2b224
-}
-
-func (e MissingRequiredVKeyWitnessForSignerError) Error() string {
-	return "missing required vkey witness for required signer"
-}
+type MissingRequiredVKeyWitnessForSignerError = common.MissingRequiredVKeyWitnessForSignerError


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Centralized UTXOW validation errors and witness checks in ledger/common to remove duplication and ensure consistent behavior across eras. Updated era rules to call shared validators and standardized error types via aliases.

- **Refactors**
  - Moved witness-related error types to ledger/common and aliased them in era packages.
  - Added common.ValidateRequiredVKeyWitnesses and common.ValidateRedeemerAndScriptWitnesses; era rules now call these helpers.
  - Standardized metadata, cost model, and IsValid errors via common aliases across Shelley, Mary, Alonzo, Babbage, and Conway.
  - Updated VerifyTransaction to wrap the first failure in a ValidationError with rule index, slot, and tx hash.
  - Added reusable mocks in ledger/common and updated tests to use the centralized helpers.

<sup>Written for commit 64b0898d20ae82561139867170fe4d6f0c152ed8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified error handling across multiple ledger implementations for improved consistency.
  * Centralized transaction validation logic across different ledger versions to reduce code duplication.

* **Tests**
  * Added mock implementations for ledger state and protocol parameter testing to enhance test coverage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->