### PR TITLE
fix(protocol): do not ignore cbor errors

### DIFF
--- a/protocol/handshake/messages.go
+++ b/protocol/handshake/messages.go
@@ -69,8 +69,10 @@ func NewMsgProposeVersions(
 ) *MsgProposeVersions {
 	rawVersionMap := map[uint16]cbor.RawMessage{}
 	for version, versionData := range versionMap {
-		// This should never fail with our known VersionData types
-		cborData, _ := cbor.Encode(&versionData)
+		cborData, err := cbor.Encode(&versionData)
+		if err != nil {
+			continue
+		}
 		rawVersionMap[version] = cbor.RawMessage(cborData)
 	}
 	m := &MsgProposeVersions{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop ignoring CBOR encode errors when building handshake version proposals. This avoids malformed messages and ensures the query reply flow is validated in tests.

- **Bug Fixes**
  - NewMsgProposeVersions: check cbor.Encode errors and skip invalid versions instead of inserting bad RawMessage data.
  - client_test.go: add async error listener and verify protocol version (0, nil) after the query reply.

<sup>Written for commit cb295a30b238dbb42e5d0aca67ce2bf50c7b8c28. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in message encoding to gracefully skip invalid entries instead of silently continuing.
  * Enhanced async error detection with faster failure notification on errors.

* **Tests**
  * Added protocol version validation after connection closure to ensure proper state handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->