### PR TITLE
feat(leios): update based on latest CIP-0164

### DIFF
--- a/ledger/leios/leios_test.go
+++ b/ledger/leios/leios_test.go
@@ -121,9 +121,9 @@ func TestLeiosRankingBlock_Era(t *testing.T) {
 func TestLeiosEndorserBlock_Hash(t *testing.T) {
 	block := &LeiosEndorserBlock{
 		Body: &LeiosEndorserBlockBody{
-			TxReferences: map[common.Blake2b256]uint16{
-				{0x01, 0x02}: 100,
-				{0x03, 0x04}: 200,
+			TxReferences: []TxReference{
+				{TxHash: common.Blake2b256{0x01, 0x02}, TxSize: 100},
+				{TxHash: common.Blake2b256{0x03, 0x04}, TxSize: 200},
 			},
 		},
 	}
@@ -164,9 +164,9 @@ func TestLeiosBlockHeader_Hash(t *testing.T) {
 func TestLeiosEndorserBlock_CborRoundTrip(t *testing.T) {
 	original := &LeiosEndorserBlock{
 		Body: &LeiosEndorserBlockBody{
-			TxReferences: map[common.Blake2b256]uint16{
-				{0x01, 0x02}: 100,
-				{0x03, 0x04}: 200,
+			TxReferences: []TxReference{
+				{TxHash: common.Blake2b256{0x01, 0x02}, TxSize: 100},
+				{TxHash: common.Blake2b256{0x03, 0x04}, TxSize: 200},
 			},
 		},
 	}
@@ -194,14 +194,10 @@ func TestLeiosEndorserBlock_CborRoundTrip(t *testing.T) {
 			len(decoded.Body.TxReferences),
 		)
 	}
-	for hash, size := range original.Body.TxReferences {
-		if decoded.Body.TxReferences[hash] != size {
-			t.Errorf(
-				"TxReference mismatch for hash %x: expected %d, got %d",
-				hash,
-				size,
-				decoded.Body.TxReferences[hash],
-			)
+	for i := range original.Body.TxReferences {
+		if decoded.Body.TxReferences[i].TxHash != original.Body.TxReferences[i].TxHash ||
+			decoded.Body.TxReferences[i].TxSize != original.Body.TxReferences[i].TxSize {
+			t.Errorf("TxReference mismatch at index %d", i)
 		}
 	}
 }

--- a/protocol/leiosfetch/client.go
+++ b/protocol/leiosfetch/client.go
@@ -137,13 +137,13 @@ func (c *Client) BlockRequest(
 	return resp, nil
 }
 
-// BlockTxsRequest fetches the requested TXs identified by the slot, Leios hash, and TX bitmap
+// BlockTxsRequest fetches the requested TXs identified by the slot, Leios hash, and TX bitmaps
 func (c *Client) BlockTxsRequest(
 	slot uint64,
 	hash []byte,
-	txBitmap [8]byte,
+	bitmaps map[uint16][8]byte,
 ) (protocol.Message, error) {
-	msg := NewMsgBlockTxsRequest(slot, hash, txBitmap)
+	msg := NewMsgBlockTxsRequest(slot, hash, bitmaps)
 	if err := c.SendMessage(msg); err != nil {
 		return nil, err
 	}

--- a/protocol/leiosfetch/leiosfetch.go
+++ b/protocol/leiosfetch/leiosfetch.go
@@ -130,7 +130,7 @@ type CallbackContext struct {
 // Callback function types
 type (
 	BlockRequestFunc      func(CallbackContext, uint64, []byte) (protocol.Message, error)
-	BlockTxsRequestFunc   func(CallbackContext, uint64, []byte, [8]byte) (protocol.Message, error)
+	BlockTxsRequestFunc   func(CallbackContext, uint64, []byte, map[uint16][8]byte) (protocol.Message, error)
 	VotesRequestFunc      func(CallbackContext, []MsgVotesRequestVoteId) (protocol.Message, error)
 	BlockRangeRequestFunc func(CallbackContext, pcommon.Point, pcommon.Point) error
 )

--- a/protocol/leiosfetch/messages.go
+++ b/protocol/leiosfetch/messages.go
@@ -17,6 +17,7 @@ package leiosfetch
 import (
 	"bytes"
 	"fmt"
+	"maps"
 	"slices"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -106,23 +107,26 @@ func NewMsgBlock(block cbor.RawMessage) *MsgBlock {
 
 type MsgBlockTxsRequest struct {
 	protocol.MessageBase
-	Slot     uint64
-	Hash     []byte
-	TxBitmap [8]byte
+	Slot uint64
+	Hash []byte
+	// Bitmaps identifies which transactions to fetch using a map
+	// from 16-bit index to a 64-bit bitmap (8 bytes) per CIP-0164.
+	// The offset of the first transaction bit is 64*index.
+	Bitmaps map[uint16][8]byte
 }
 
 func NewMsgBlockTxsRequest(
 	slot uint64,
 	hash []byte,
-	txBitmap [8]byte,
+	bitmaps map[uint16][8]byte,
 ) *MsgBlockTxsRequest {
 	m := &MsgBlockTxsRequest{
 		MessageBase: protocol.MessageBase{
 			MessageType: MessageTypeBlockTxsRequest,
 		},
-		Slot:     slot,
-		Hash:     bytes.Clone(hash),
-		TxBitmap: txBitmap,
+		Slot:    slot,
+		Hash:    bytes.Clone(hash),
+		Bitmaps: maps.Clone(bitmaps),
 	}
 	return m
 }

--- a/protocol/leiosfetch/server.go
+++ b/protocol/leiosfetch/server.go
@@ -133,7 +133,7 @@ func (s *Server) handleBlockTxsRequest(msg protocol.Message) error {
 		s.callbackContext,
 		msgBlockTxsRequest.Slot,
 		msgBlockTxsRequest.Hash,
-		msgBlockTxsRequest.TxBitmap,
+		msgBlockTxsRequest.Bitmaps,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
Update with the latest information on Leios per https://github.com/cardano-foundation/CIPs/pull/1078







<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Leios structures and leiosfetch with the latest CIP-0164. Adds optional header fields, ordered EB transaction references, BLS signature validation, and segmented bitmap requests.

- New Features
  - Header body decode supports optional announced_eb (hash32, size) and certified_eb.
  - Endorser block encodes transaction references as an ordered list of [hash32, uint16]; empty EBs are rejected.
  - Validates 48-byte BLS signatures for aggregated vote and nonpersistent voter sigs in LeiosEbCertificate.
  - BlockTxsRequest uses segmented bitmaps: map[uint16][8]byte; client, server, and callbacks updated.

- Migration
  - Replace AggregateVoteSig with AggregatedVoteSig and use Get/SetAggregatedVoteSig; AggregateEligSig is removed.
  - Update EB construction to use []TxReference instead of map[hash]size and ensure it’s non-empty.
  - Update BlockTxsRequest usage and callbacks to pass map[uint16][8]byte bitmaps.

<sup>Written for commit 3de7d75c05a845487113c911f3d9fe5718b9a0ec. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced 48-byte BLS signature validation for aggregated vote signatures and individual nonpersistent voter signatures (CIP-0164).

* **Updates**
  * Transaction references now preserve insertion order for deterministic serialization.
  * Block headers accept optional CIP-0164 fields.
  * Block transaction requests now use per-index TX bitmaps (map) instead of a single fixed bitmap.

* **API**
  * Public accessors for aggregated vote signature updated to reflect new naming and shape.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->