### PR TITLE
fix: adjust block-fetch timeouts and limits to match spec

### DIFF
--- a/protocol/blockfetch/blockfetch.go
+++ b/protocol/blockfetch/blockfetch.go
@@ -49,8 +49,7 @@ var StateDone = protocol.NewState(4, "Done")
 var StateMap = protocol.StateMap{
 	StateIdle: protocol.StateMapEntry{
 		Agency:                  protocol.AgencyClient,
-		PendingMessageByteLimit: MaxPendingMessageBytes,
-		Timeout:                 IdleTimeout, // Timeout for client to send block range request
+		PendingMessageByteLimit: IdleBusyMaxPendingMessageBytes,
 		Transitions: []protocol.StateTransition{
 			{
 				MsgType:  MessageTypeRequestRange,
@@ -64,7 +63,7 @@ var StateMap = protocol.StateMap{
 	},
 	StateBusy: protocol.StateMapEntry{
 		Agency:                  protocol.AgencyServer,
-		PendingMessageByteLimit: MaxPendingMessageBytes,
+		PendingMessageByteLimit: IdleBusyMaxPendingMessageBytes,
 		Timeout:                 BusyTimeout, // Timeout for server to start batch or respond no blocks
 		Transitions: []protocol.StateTransition{
 			{
@@ -79,7 +78,7 @@ var StateMap = protocol.StateMap{
 	},
 	StateStreaming: protocol.StateMapEntry{
 		Agency:                  protocol.AgencyServer,
-		PendingMessageByteLimit: MaxPendingMessageBytes,
+		PendingMessageByteLimit: StreamingMaxPendingMessageBytes,
 		Timeout:                 StreamingTimeout, // Timeout for server to send next block in batch
 		Transitions: []protocol.StateTransition{
 			{
@@ -93,8 +92,7 @@ var StateMap = protocol.StateMap{
 		},
 	},
 	StateDone: protocol.StateMapEntry{
-		Agency:                  protocol.AgencyNone,
-		PendingMessageByteLimit: MaxPendingMessageBytes,
+		Agency: protocol.AgencyNone,
 	},
 }
 
@@ -122,14 +120,14 @@ const MaxRecvQueueSize = 512
 // DefaultRecvQueueSize is the default receive queue size.
 const DefaultRecvQueueSize = 384
 
-// MaxPendingMessageBytes is the maximum allowed pending message bytes (5MB).
-const MaxPendingMessageBytes = 5242880
+// StreamingMaxPendingMessageBytes is the maximum allowed pending message bytes when in the Streaming state
+const StreamingMaxPendingMessageBytes = 2500000
 
-// IdleTimeout is the timeout for the client to send a block range request.
-const IdleTimeout = 60 * time.Second
+// IdleBusyMaxPendingMessageBytes is the maximum allowed pending message bytes when in the Idle or Busy state.
+const IdleBusyMaxPendingMessageBytes = 65535
 
 // BusyTimeout is the timeout for the server to start a batch or respond no blocks.
-const BusyTimeout = 5 * time.Second
+const BusyTimeout = 60 * time.Second
 
 // StreamingTimeout is the timeout for the server to send the next block in a batch.
 const StreamingTimeout = 60 * time.Second

--- a/protocol/limits_test.go
+++ b/protocol/limits_test.go
@@ -204,10 +204,16 @@ func TestBlockFetchLimitsAreDefined(t *testing.T) {
 			blockfetch.DefaultRecvQueueSize,
 		)
 	}
-	if blockfetch.MaxPendingMessageBytes <= 0 {
+	if blockfetch.IdleBusyMaxPendingMessageBytes <= 0 {
 		t.Errorf(
-			"MaxPendingMessageBytes must be positive, got %d",
-			blockfetch.MaxPendingMessageBytes,
+			"IdleBusyMaxPendingMessageBytes must be positive, got %d",
+			blockfetch.IdleBusyMaxPendingMessageBytes,
+		)
+	}
+	if blockfetch.StreamingMaxPendingMessageBytes <= 0 {
+		t.Errorf(
+			"StreamingMaxPendingMessageBytes must be positive, got %d",
+			blockfetch.StreamingMaxPendingMessageBytes,
 		)
 	}
 
@@ -220,19 +226,16 @@ func TestBlockFetchLimitsAreDefined(t *testing.T) {
 			blockfetch.MaxRecvQueueSize,
 		)
 	}
-	expectedMaxBytes := 5242880
-	if blockfetch.MaxPendingMessageBytes != expectedMaxBytes {
+	expectedMaxBytes := 2500000
+	if blockfetch.StreamingMaxPendingMessageBytes != expectedMaxBytes {
 		t.Errorf(
-			"MaxPendingMessageBytes should be %d, got %d",
+			"StreamingMaxPendingMessageBytes should be %d, got %d",
 			expectedMaxBytes,
-			blockfetch.MaxPendingMessageBytes,
+			blockfetch.StreamingMaxPendingMessageBytes,
 		)
 	}
 
 	// Test timeout constants
-	if blockfetch.IdleTimeout <= 0 {
-		t.Errorf("IdleTimeout must be positive, got %v", blockfetch.IdleTimeout)
-	}
 	if blockfetch.BusyTimeout <= 0 {
 		t.Errorf("BusyTimeout must be positive, got %v", blockfetch.BusyTimeout)
 	}
@@ -553,12 +556,6 @@ func TestProtocolStateTimeouts(t *testing.T) {
 
 	t.Run("BlockFetch timeouts", func(t *testing.T) {
 		// Test that all timeout constants are positive
-		if blockfetch.IdleTimeout <= 0 {
-			t.Errorf(
-				"IdleTimeout must be positive, got %v",
-				blockfetch.IdleTimeout,
-			)
-		}
 		if blockfetch.BusyTimeout <= 0 {
 			t.Errorf(
 				"BusyTimeout must be positive, got %v",
@@ -574,7 +571,6 @@ func TestProtocolStateTimeouts(t *testing.T) {
 
 		// Test that timeout values are reasonable
 		timeouts := map[string]time.Duration{
-			"IdleTimeout":      blockfetch.IdleTimeout,
 			"BusyTimeout":      blockfetch.BusyTimeout,
 			"StreamingTimeout": blockfetch.StreamingTimeout,
 		}
@@ -843,19 +839,9 @@ func TestStateMapTimeouts(t *testing.T) {
 	})
 
 	t.Run("BlockFetch StateMap timeouts", func(t *testing.T) {
-		stateIdle := protocol.NewState(1, "Idle")
 		stateBusy := protocol.NewState(2, "Busy")
 		stateStreaming := protocol.NewState(3, "Streaming")
 
-		if entry, exists := blockfetch.StateMap[stateIdle]; exists {
-			if entry.Timeout != blockfetch.IdleTimeout {
-				t.Errorf(
-					"StateIdle timeout should be %v, got %v",
-					blockfetch.IdleTimeout,
-					entry.Timeout,
-				)
-			}
-		}
 		if entry, exists := blockfetch.StateMap[stateBusy]; exists {
 			if entry.Timeout != blockfetch.BusyTimeout {
 				t.Errorf(


### PR DESCRIPTION
Fixes #1336





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adjust block-fetch timeouts and pending message byte limits to match the protocol spec. Prevents premature timeouts and oversized buffers during block streaming.

- **Bug Fixes**
  - Removed Idle state timeout.
  - Increased Busy state timeout from 5s to 60s.
  - Replaced global 5MB pending-message limit with state-specific limits:
    - 65,535 bytes in Idle/Busy.
    - 2,500,000 bytes in Streaming.

<sup>Written for commit bd2da200a52fd19c70c41b8529fb3c169a853fdf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Block fetch now uses state-specific pending-message size limits instead of a single global cap; busy timeout increased from 5s to 60s. Streaming timeout unchanged.
* **Tests**
  * Updated tests to reflect the new per-state size limits and removed idle-timeout expectations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->