### PR TITLE
test(cbor): encode indef length map

### DIFF
--- a/cbor/encode_test.go
+++ b/cbor/encode_test.go
@@ -91,6 +91,26 @@ func TestEncodeIndefLengthByteString(t *testing.T) {
 	}
 }
 
+func TestEncodeIndefLengthMap(t *testing.T) {
+	expectedCborHex := "bf616101616202ff"
+	tmpData := cbor.IndefLengthMap{
+		"a": 1,
+		"b": 2,
+	}
+	cborData, err := cbor.Encode(tmpData)
+	if err != nil {
+		t.Fatalf("failed to encode object to CBOR: %s", err)
+	}
+	cborHex := hex.EncodeToString(cborData)
+	if cborHex != expectedCborHex {
+		t.Fatalf(
+			"object did not encode to expected CBOR\n  got %s\n  wanted: %s",
+			cborHex,
+			expectedCborHex,
+		)
+	}
+}
+
 func BenchmarkEncode(b *testing.B) {
 	obj := []any{1, 2, 3}
 	b.ResetTimer()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a unit test for encoding an indefinite-length CBOR map to improve coverage and verify encoder correctness. Confirms the output hex is bf616101616202ff for {"a": 1, "b": 2}.

<sup>Written for commit d0b6a5448ab1da0e85aed7a00ee04b4550ee2f9d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for indefinite-length data structure encoding.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->