### PR TITLE
fix: solve chainsync pipeline deadlock with default configuration

### DIFF
--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -33,7 +33,7 @@ import (
 const maxMessagesPerSegment = 20
 
 // DefaultRecvQueueSize is the default capacity for the recv queue channel
-const DefaultRecvQueueSize = 50
+const DefaultRecvQueueSize = 55
 
 // Protocol implements the base functionality of an Ouroboros mini-protocol
 type Protocol struct {
@@ -150,7 +150,7 @@ func (p *Protocol) Start() {
 		}
 
 		// Create channels
-		p.sendQueueChan = make(chan Message, 50)
+		p.sendQueueChan = make(chan Message, 80)
 		p.recvQueueChan = make(chan Message, p.config.RecvQueueSize)
 		p.recvReadyChan = make(chan bool, 1)
 		p.sendReadyChan = make(chan bool, 1)


### PR DESCRIPTION
ref:
- #1299 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised protocol queue capacities to prevent a deadlock in the chainsync pipeline under the default configuration: recv queue 50→55, send queue 50→80.

<sup>Written for commit ba7a9064931b8ba46b28fac387880e9c93452fd1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal queue capacity settings to optimize message handling performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->