### PR TITLE
fix(muxer): fix race condition in muxer readLoop causing panic on shutdown

### DIFF
--- a/muxer/muxer.go
+++ b/muxer/muxer.go
@@ -393,6 +393,10 @@ func (m *Muxer) readLoop() {
 			)
 			return
 		}
-		recvChan <- msg
+		select {
+		case <-m.doneChan:
+			return
+		case recvChan <- msg:
+		}
 	}
 }


### PR DESCRIPTION
Closes #1335 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in the muxer readLoop that could panic during shutdown. The loop now exits when shutdown starts instead of sending to recvChan.

- **Bug Fixes**
  - Guarded sends with a select on m.doneChan to avoid writing to recvChan during shutdown and prevent panic.

<sup>Written for commit e1885b631853d7b43d927324f9da275155879d45. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced shutdown robustness by implementing shutdown-aware message forwarding. The muxer now properly monitors shutdown signals during message transmission, ensuring graceful termination and preventing potential issues that could occur when messages are actively being processed during system shutdown.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->