### PR TITLE
fix: resolve unparam linter errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,7 +40,6 @@ linters:
     - depguard
     - noctx
     - recvcheck
-    - unparam
   exclusions:
     generated: lax
     presets:

--- a/ledger/common/rewards.go
+++ b/ledger/common/rewards.go
@@ -355,20 +355,13 @@ func CalculateRewards(
 			delegatorStake = make(map[AddrKeyHash]uint64)
 		}
 
-		poolRewards, err := distributePoolRewards(
+		poolRewards := distributePoolRewards(
 			poolID,
 			totalPoolRewards,
 			delegatorStake,
 			poolParams,
 			snapshot,
 		)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"failed to distribute rewards for pool %s: %w",
-				poolID,
-				err,
-			)
-		}
 
 		result.PoolRewards[poolID] = *poolRewards
 	}
@@ -434,7 +427,7 @@ func distributePoolRewards(
 	delegatorStake map[AddrKeyHash]uint64,
 	poolParams *PoolRegistrationCertificate,
 	snapshot RewardSnapshot,
-) (*PoolRewards, error) {
+) *PoolRewards {
 	poolCost := poolParams.Cost
 	margin := marginFloat(poolParams.Margin)
 
@@ -503,7 +496,7 @@ func distributePoolRewards(
 		OperatorRewards:  operatorRewards,
 		DelegatorRewards: delegatorRewards,
 		TotalRewards:     totalPoolRewards,
-	}, nil
+	}
 }
 
 // marginFloat converts a GenesisRat margin to float64

--- a/protocol/blockfetch/server.go
+++ b/protocol/blockfetch/server.go
@@ -133,7 +133,7 @@ func (s *Server) messageHandler(msg protocol.Message) error {
 	case MessageTypeRequestRange:
 		err = s.handleRequestRange(msg)
 	case MessageTypeClientDone:
-		err = s.handleClientDone()
+		s.handleClientDone()
 	default:
 		err = fmt.Errorf(
 			"%s: received unexpected message type %d",
@@ -167,7 +167,7 @@ func (s *Server) handleRequestRange(msg protocol.Message) error {
 }
 
 // handleClientDone handles the ClientDone message from the client and restarts the protocol.
-func (s *Server) handleClientDone() error {
+func (s *Server) handleClientDone() {
 	s.Protocol.Logger().
 		Debug("client done",
 			"component", "network",
@@ -179,5 +179,4 @@ func (s *Server) handleClientDone() error {
 	s.Stop()
 	s.initProtocol()
 	s.Start()
-	return nil
 }

--- a/protocol/chainsync/client.go
+++ b/protocol/chainsync/client.go
@@ -568,15 +568,15 @@ func (c *Client) messageHandler(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeAwaitReply:
-		err = c.handleAwaitReply()
+		c.handleAwaitReply()
 	case MessageTypeRollForward:
 		err = c.handleRollForward(msg)
 	case MessageTypeRollBackward:
 		err = c.handleRollBackward(msg)
 	case MessageTypeIntersectFound:
-		err = c.handleIntersectFound(msg)
+		c.handleIntersectFound(msg)
 	case MessageTypeIntersectNotFound:
-		err = c.handleIntersectNotFound(msg)
+		c.handleIntersectNotFound(msg)
 	default:
 		err = fmt.Errorf(
 			"%s: received unexpected message type %d",
@@ -587,7 +587,7 @@ func (c *Client) messageHandler(msg protocol.Message) error {
 	return err
 }
 
-func (c *Client) handleAwaitReply() error {
+func (c *Client) handleAwaitReply() {
 	c.Protocol.Logger().
 		Debug("waiting for next reply",
 			"component", "network",
@@ -595,7 +595,6 @@ func (c *Client) handleAwaitReply() error {
 			"role", "client",
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
-	return nil
 }
 
 func (c *Client) handleRollForward(msgGeneric protocol.Message) error {
@@ -771,7 +770,7 @@ func (c *Client) handleRollBackward(msgGeneric protocol.Message) error {
 	return nil
 }
 
-func (c *Client) handleIntersectFound(msg protocol.Message) error {
+func (c *Client) handleIntersectFound(msg protocol.Message) {
 	c.Protocol.Logger().
 		Debug("chain intersect found",
 			"component", "network",
@@ -787,10 +786,9 @@ func (c *Client) handleIntersectFound(msg protocol.Message) error {
 		ch <- clientPointResult{tip: msgIntersectFound.Tip, point: msgIntersectFound.Point}
 	default:
 	}
-	return nil
 }
 
-func (c *Client) handleIntersectNotFound(msgGeneric protocol.Message) error {
+func (c *Client) handleIntersectNotFound(msgGeneric protocol.Message) {
 	c.Protocol.Logger().
 		Debug("chain intersect not found",
 			"component", "network",
@@ -806,5 +804,4 @@ func (c *Client) handleIntersectNotFound(msgGeneric protocol.Message) error {
 		ch <- clientPointResult{tip: msgIntersectNotFound.Tip, error: ErrIntersectNotFound}
 	default:
 	}
-	return nil
 }

--- a/protocol/chainsync/server.go
+++ b/protocol/chainsync/server.go
@@ -165,7 +165,7 @@ func (s *Server) messageHandler(msg protocol.Message) error {
 	case MessageTypeFindIntersect:
 		err = s.handleFindIntersect(msg)
 	case MessageTypeDone:
-		err = s.handleDone()
+		s.handleDone()
 	default:
 		err = fmt.Errorf(
 			"%s: received unexpected message type %d",
@@ -231,7 +231,7 @@ func (s *Server) handleFindIntersect(msg protocol.Message) error {
 	return nil
 }
 
-func (s *Server) handleDone() error {
+func (s *Server) handleDone() {
 	if s.Protocol != nil {
 		s.Protocol.Logger().
 			Debug("done",
@@ -245,5 +245,4 @@ func (s *Server) handleDone() error {
 	s.Stop()
 	s.initProtocol()
 	s.Start()
-	return nil
 }

--- a/protocol/leiosfetch/client.go
+++ b/protocol/leiosfetch/client.go
@@ -197,15 +197,15 @@ func (c *Client) messageHandler(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeBlock:
-		err = c.handleBlock(msg)
+		c.handleBlock(msg)
 	case MessageTypeBlockTxs:
-		err = c.handleBlockTxs(msg)
+		c.handleBlockTxs(msg)
 	case MessageTypeVotes:
-		err = c.handleVotes(msg)
+		c.handleVotes(msg)
 	case MessageTypeNextBlockAndTxsInRange:
-		err = c.handleNextBlockAndTxsInRange(msg)
+		c.handleNextBlockAndTxsInRange(msg)
 	case MessageTypeLastBlockAndTxsInRange:
-		err = c.handleLastBlockAndTxsInRange(msg)
+		c.handleLastBlockAndTxsInRange(msg)
 	default:
 		err = fmt.Errorf(
 			"%s: received unexpected message type %d",
@@ -216,27 +216,22 @@ func (c *Client) messageHandler(msg protocol.Message) error {
 	return err
 }
 
-func (c *Client) handleBlock(msg protocol.Message) error {
+func (c *Client) handleBlock(msg protocol.Message) {
 	c.blockResultChan <- msg
-	return nil
 }
 
-func (c *Client) handleBlockTxs(msg protocol.Message) error {
+func (c *Client) handleBlockTxs(msg protocol.Message) {
 	c.blockTxsResultChan <- msg
-	return nil
 }
 
-func (c *Client) handleVotes(msg protocol.Message) error {
+func (c *Client) handleVotes(msg protocol.Message) {
 	c.votesResultChan <- msg
-	return nil
 }
 
-func (c *Client) handleNextBlockAndTxsInRange(msg protocol.Message) error {
+func (c *Client) handleNextBlockAndTxsInRange(msg protocol.Message) {
 	c.blockRangeResultChan <- msg
-	return nil
 }
 
-func (c *Client) handleLastBlockAndTxsInRange(msg protocol.Message) error {
+func (c *Client) handleLastBlockAndTxsInRange(msg protocol.Message) {
 	c.blockRangeResultChan <- msg
-	return nil
 }

--- a/protocol/leiosfetch/server.go
+++ b/protocol/leiosfetch/server.go
@@ -71,7 +71,7 @@ func (s *Server) messageHandler(msg protocol.Message) error {
 	case MessageTypeBlockRangeRequest:
 		err = s.handleBlockRangeRequest(msg)
 	case MessageTypeDone:
-		err = s.handleDone()
+		s.handleDone()
 	default:
 		err = fmt.Errorf(
 			"%s: received unexpected message type %d",
@@ -206,7 +206,7 @@ func (s *Server) handleBlockRangeRequest(msg protocol.Message) error {
 	return nil
 }
 
-func (s *Server) handleDone() error {
+func (s *Server) handleDone() {
 	s.Protocol.Logger().
 		Debug("client done",
 			"component", "network",
@@ -218,5 +218,4 @@ func (s *Server) handleDone() error {
 	s.Stop()
 	s.initProtocol()
 	s.Start()
-	return nil
 }

--- a/protocol/leiosnotify/client.go
+++ b/protocol/leiosnotify/client.go
@@ -116,13 +116,13 @@ func (c *Client) messageHandler(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeBlockAnnouncement:
-		err = c.handleBlockAnnouncement(msg)
+		c.handleBlockAnnouncement(msg)
 	case MessageTypeBlockOffer:
-		err = c.handleBlockOffer(msg)
+		c.handleBlockOffer(msg)
 	case MessageTypeBlockTxsOffer:
-		err = c.handleBlockTxsOffer(msg)
+		c.handleBlockTxsOffer(msg)
 	case MessageTypeVotesOffer:
-		err = c.handleVotesOffer(msg)
+		c.handleVotesOffer(msg)
 	default:
 		err = fmt.Errorf(
 			"%s: received unexpected message type %d",
@@ -133,22 +133,18 @@ func (c *Client) messageHandler(msg protocol.Message) error {
 	return err
 }
 
-func (c *Client) handleBlockAnnouncement(msg protocol.Message) error {
+func (c *Client) handleBlockAnnouncement(msg protocol.Message) {
 	c.requestNextChan <- msg
-	return nil
 }
 
-func (c *Client) handleBlockOffer(msg protocol.Message) error {
+func (c *Client) handleBlockOffer(msg protocol.Message) {
 	c.requestNextChan <- msg
-	return nil
 }
 
-func (c *Client) handleBlockTxsOffer(msg protocol.Message) error {
+func (c *Client) handleBlockTxsOffer(msg protocol.Message) {
 	c.requestNextChan <- msg
-	return nil
 }
 
-func (c *Client) handleVotesOffer(msg protocol.Message) error {
+func (c *Client) handleVotesOffer(msg protocol.Message) {
 	c.requestNextChan <- msg
-	return nil
 }

--- a/protocol/leiosnotify/server.go
+++ b/protocol/leiosnotify/server.go
@@ -65,7 +65,7 @@ func (s *Server) messageHandler(msg protocol.Message) error {
 	case MessageTypeNotificationRequestNext:
 		err = s.handleRequestNext()
 	case MessageTypeDone:
-		err = s.handleDone()
+		s.handleDone()
 	default:
 		err = fmt.Errorf(
 			"%s: received unexpected message type %d",
@@ -106,7 +106,7 @@ func (s *Server) handleRequestNext() error {
 	return nil
 }
 
-func (s *Server) handleDone() error {
+func (s *Server) handleDone() {
 	s.Protocol.Logger().
 		Debug("client done",
 			"component", "network",
@@ -118,5 +118,4 @@ func (s *Server) handleDone() error {
 	s.Stop()
 	s.initProtocol()
 	s.Start()
-	return nil
 }

--- a/protocol/localstatequery/server.go
+++ b/protocol/localstatequery/server.go
@@ -82,7 +82,7 @@ func (s *Server) messageHandler(msg protocol.Message) error {
 	case MessageTypeReacquireVolatileTip:
 		err = s.handleReAcquire(msg)
 	case MessageTypeDone:
-		err = s.handleDone()
+		s.handleDone()
 	default:
 		err = fmt.Errorf(
 			"%s: received unexpected message type %d",
@@ -233,7 +233,7 @@ func (s *Server) handleReAcquire(msg protocol.Message) error {
 	return nil
 }
 
-func (s *Server) handleDone() error {
+func (s *Server) handleDone() {
 	s.Protocol.Logger().
 		Debug("done",
 			"component", "network",
@@ -241,5 +241,4 @@ func (s *Server) handleDone() error {
 			"role", "server",
 			"connection_id", s.callbackContext.ConnectionId.String(),
 		)
-	return nil
 }

--- a/protocol/localtxmonitor/client.go
+++ b/protocol/localtxmonitor/client.go
@@ -235,13 +235,13 @@ func (c *Client) messageHandler(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeAcquired:
-		err = c.handleAcquired(msg)
+		c.handleAcquired(msg)
 	case MessageTypeReplyHasTx:
-		err = c.handleReplyHasTx(msg)
+		c.handleReplyHasTx(msg)
 	case MessageTypeReplyNextTx:
-		err = c.handleReplyNextTx(msg)
+		c.handleReplyNextTx(msg)
 	case MessageTypeReplyGetSizes:
-		err = c.handleReplyGetSizes(msg)
+		c.handleReplyGetSizes(msg)
 	default:
 		err = fmt.Errorf(
 			"%s: received unexpected message type %d",
@@ -252,7 +252,7 @@ func (c *Client) messageHandler(msg protocol.Message) error {
 	return err
 }
 
-func (c *Client) handleAcquired(msg protocol.Message) error {
+func (c *Client) handleAcquired(msg protocol.Message) {
 	c.Protocol.Logger().
 		Debug("acquired",
 			"component", "network",
@@ -264,10 +264,9 @@ func (c *Client) handleAcquired(msg protocol.Message) error {
 	c.acquired = true
 	c.acquiredSlot = msgAcquired.SlotNo
 	c.acquireResultChan <- true
-	return nil
 }
 
-func (c *Client) handleReplyHasTx(msg protocol.Message) error {
+func (c *Client) handleReplyHasTx(msg protocol.Message) {
 	c.Protocol.Logger().
 		Debug("reply has tx",
 			"component", "network",
@@ -277,10 +276,9 @@ func (c *Client) handleReplyHasTx(msg protocol.Message) error {
 		)
 	msgReplyHasTx := msg.(*MsgReplyHasTx)
 	c.hasTxResultChan <- msgReplyHasTx.Result
-	return nil
 }
 
-func (c *Client) handleReplyNextTx(msg protocol.Message) error {
+func (c *Client) handleReplyNextTx(msg protocol.Message) {
 	c.Protocol.Logger().
 		Debug("reply next tx",
 			"component", "network",
@@ -290,10 +288,9 @@ func (c *Client) handleReplyNextTx(msg protocol.Message) error {
 		)
 	msgReplyNextTx := msg.(*MsgReplyNextTx)
 	c.nextTxResultChan <- msgReplyNextTx.Transaction.Tx
-	return nil
 }
 
-func (c *Client) handleReplyGetSizes(msg protocol.Message) error {
+func (c *Client) handleReplyGetSizes(msg protocol.Message) {
 	c.Protocol.Logger().
 		Debug("reply get sizes",
 			"component", "network",
@@ -303,7 +300,6 @@ func (c *Client) handleReplyGetSizes(msg protocol.Message) error {
 		)
 	msgReplyGetSizes := msg.(*MsgReplyGetSizes)
 	c.getSizesResultChan <- msgReplyGetSizes.Result
-	return nil
 }
 
 func (c *Client) acquire() error {

--- a/protocol/localtxmonitor/server.go
+++ b/protocol/localtxmonitor/server.go
@@ -66,9 +66,9 @@ func (s *Server) messageHandler(msg protocol.Message) error {
 	case MessageTypeAcquire:
 		err = s.handleAcquire()
 	case MessageTypeDone:
-		err = s.handleDone()
+		s.handleDone()
 	case MessageTypeRelease:
-		err = s.handleRelease()
+		s.handleRelease()
 	case MessageTypeHasTx:
 		err = s.handleHasTx(msg)
 	case MessageTypeNextTx:
@@ -131,7 +131,7 @@ func (s *Server) handleAcquire() error {
 	return nil
 }
 
-func (s *Server) handleDone() error {
+func (s *Server) handleDone() {
 	s.Protocol.Logger().
 		Debug("done",
 			"component", "network",
@@ -139,10 +139,9 @@ func (s *Server) handleDone() error {
 			"role", "server",
 			"connection_id", s.callbackContext.ConnectionId.String(),
 		)
-	return nil
 }
 
-func (s *Server) handleRelease() error {
+func (s *Server) handleRelease() {
 	s.Protocol.Logger().
 		Debug("release",
 			"component", "network",
@@ -152,7 +151,6 @@ func (s *Server) handleRelease() error {
 		)
 	s.mempoolCapacity = 0
 	s.mempoolTxs = nil
-	return nil
 }
 
 func (s *Server) handleHasTx(msg protocol.Message) error {

--- a/protocol/localtxsubmission/server.go
+++ b/protocol/localtxsubmission/server.go
@@ -61,7 +61,7 @@ func (s *Server) messageHandler(msg protocol.Message) error {
 	case MessageTypeSubmitTx:
 		err = s.handleSubmitTx(msg)
 	case MessageTypeDone:
-		err = s.handleDone()
+		s.handleDone()
 	default:
 		err = fmt.Errorf(
 			"%s: received unexpected message type %d",
@@ -106,7 +106,7 @@ func (s *Server) handleSubmitTx(msg protocol.Message) error {
 	return nil
 }
 
-func (s *Server) handleDone() error {
+func (s *Server) handleDone() {
 	s.Protocol.Logger().
 		Debug("done",
 			"component", "network",
@@ -114,5 +114,4 @@ func (s *Server) handleDone() error {
 			"role", "server",
 			"connection_id", s.callbackContext.ConnectionId.String(),
 		)
-	return nil
 }

--- a/protocol/peersharing/client.go
+++ b/protocol/peersharing/client.go
@@ -89,7 +89,7 @@ func (c *Client) messageHandler(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeSharePeers:
-		err = c.handleSharePeers(msg)
+		c.handleSharePeers(msg)
 	default:
 		err = fmt.Errorf(
 			"%s: received unexpected message type %d",
@@ -100,7 +100,7 @@ func (c *Client) messageHandler(msg protocol.Message) error {
 	return err
 }
 
-func (c *Client) handleSharePeers(msg protocol.Message) error {
+func (c *Client) handleSharePeers(msg protocol.Message) {
 	c.Protocol.Logger().
 		Debug("share peers",
 			"component", "network",
@@ -110,5 +110,4 @@ func (c *Client) handleSharePeers(msg protocol.Message) error {
 		)
 	msgSharePeers := msg.(*MsgSharePeers)
 	c.sharePeersChan <- msgSharePeers.PeerAddresses
-	return nil
 }

--- a/protocol/peersharing/server.go
+++ b/protocol/peersharing/server.go
@@ -67,7 +67,7 @@ func (s *Server) handleMessage(msg protocol.Message) error {
 	case MessageTypeShareRequest:
 		err = s.handleShareRequest(msg)
 	case MessageTypeDone:
-		err = s.handleDone(msg)
+		s.handleDone()
 	default:
 		err = fmt.Errorf(
 			"%s: received unexpected message type %d",
@@ -106,7 +106,7 @@ func (s *Server) handleShareRequest(msg protocol.Message) error {
 	return nil
 }
 
-func (s *Server) handleDone(msg protocol.Message) error {
+func (s *Server) handleDone() {
 	s.Protocol.Logger().
 		Debug("done",
 			"component", "network",
@@ -118,5 +118,4 @@ func (s *Server) handleDone(msg protocol.Message) error {
 	s.Stop()
 	s.initProtocol()
 	s.Start()
-	return nil
 }

--- a/protocol/txsubmission/server.go
+++ b/protocol/txsubmission/server.go
@@ -185,9 +185,9 @@ func (s *Server) messageHandler(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeReplyTxIds:
-		err = s.handleReplyTxIds(msg)
+		s.handleReplyTxIds(msg)
 	case MessageTypeReplyTxs:
-		err = s.handleReplyTxs(msg)
+		s.handleReplyTxs(msg)
 	case MessageTypeDone:
 		err = s.handleDone()
 	case MessageTypeInit:
@@ -202,7 +202,7 @@ func (s *Server) messageHandler(msg protocol.Message) error {
 	return err
 }
 
-func (s *Server) handleReplyTxIds(msg protocol.Message) error {
+func (s *Server) handleReplyTxIds(msg protocol.Message) {
 	s.Protocol.Logger().
 		Debug("reply tx ids",
 			"component", "network",
@@ -214,10 +214,9 @@ func (s *Server) handleReplyTxIds(msg protocol.Message) error {
 	s.requestTxIdsResultChan <- requestTxIdsResult{
 		txIds: msgReplyTxIds.TxIds,
 	}
-	return nil
 }
 
-func (s *Server) handleReplyTxs(msg protocol.Message) error {
+func (s *Server) handleReplyTxs(msg protocol.Message) {
 	s.Protocol.Logger().
 		Debug("reply txs",
 			"component", "network",
@@ -227,7 +226,6 @@ func (s *Server) handleReplyTxs(msg protocol.Message) error {
 		)
 	msgReplyTxs := msg.(*MsgReplyTxs)
 	s.requestTxsResultChan <- msgReplyTxs.Txs
-	return nil
 }
 
 func (s *Server) handleDone() error {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Simplified protocol handlers and reward distribution by removing no-op error returns and unused parameters. This cleans up signatures, reduces boilerplate, and resolves linter warnings without changing behavior.

- **Refactors**
  - Converted handler methods in blockfetch, chainsync, leiosfetch/notify, localstatequery, localtxmonitor/submission, peersharing, and txsubmission to not return errors when they never did; updated switch cases accordingly.
  - Removed the unused msg parameter from peersharing server handleDone.
  - distributePoolRewards now returns only *PoolRewards; CalculateRewards no longer handles a non-existent error.
  - Disabled the unparam linter in .golangci.yml to avoid noisy checks on unused parameters.

<sup>Written for commit 5b2ae40b9198089d7b8afbb21c3399b940c22c16. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified error handling in protocol message handlers across multiple subsystems, removing unnecessary error propagation paths while maintaining functionality.
  * Streamlined reward distribution logic by eliminating error returns from internal operations.

* **Chores**
  * Enabled additional code quality linting checks to improve code standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->