### PR TITLE
test: add message encoding/decoding tests

### DIFF
--- a/protocol/blockfetch/messages_test.go
+++ b/protocol/blockfetch/messages_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 type testDefinition struct {
@@ -29,8 +30,39 @@ type testDefinition struct {
 	MessageType uint
 }
 
-// TODO: implement tests for more messages (#871)
 var tests = []testDefinition{
+	{
+		CborHex:     "830082187b480102030405060708821901c848090a0b0c0d0e0f10",
+		Message:     NewMsgRequestRange(pcommon.NewPoint(123, []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}), pcommon.NewPoint(456, []byte{0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10})),
+		MessageType: MessageTypeRequestRange,
+	},
+	{
+		CborHex:     "8101",
+		Message:     NewMsgClientDone(),
+		MessageType: MessageTypeClientDone,
+	},
+	{
+		CborHex:     "8102",
+		Message:     NewMsgStartBatch(),
+		MessageType: MessageTypeStartBatch,
+	},
+	{
+		CborHex:     "8103",
+		Message:     NewMsgNoBlocks(),
+		MessageType: MessageTypeNoBlocks,
+	},
+	{
+		CborHex: "8204d818458206820102",
+		Message: func() *MsgBlock {
+			wrappedBlock := WrappedBlock{
+				Type:     6,
+				RawBlock: cbor.RawMessage([]byte{0x82, 0x01, 0x02}),
+			}
+			wrappedBlockCbor, _ := cbor.Encode(&wrappedBlock)
+			return NewMsgBlock(wrappedBlockCbor)
+		}(),
+		MessageType: MessageTypeBlock,
+	},
 	{
 		CborHex:     "8105",
 		Message:     NewMsgBatchDone(),


### PR DESCRIPTION
Closes #871 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add encoding/decoding tests for blockfetch protocol messages to verify CBOR compatibility and prevent regressions. Covers RequestRange, ClientDone, StartBatch, NoBlocks, Block (including WrappedBlock), and BatchDone.

<sup>Written for commit 98febd1bfccd707ad3f862fd22520eb0d0a0dff7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for blockfetch protocol message types, including RequestRange, ClientDone, StartBatch, NoBlocks, and Block message scenarios with CBOR encoding validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->