### PR TITLE
feat: update local state query result types with proper field mappings

### DIFF
--- a/protocol/localstatequery/queries.go
+++ b/protocol/localstatequery/queries.go
@@ -597,8 +597,7 @@ func (u *UtxoId) MarshalCBOR() ([]byte, error) {
 	return cbor.Encode(tmpData)
 }
 
-// TODO (#863)
-type DebugEpochStateResult any
+type DebugEpochStateResult cbor.RawMessage
 
 // TODO (#858)
 /*
@@ -654,34 +653,29 @@ type GenesisConfigResultProtocolParameters struct {
 	MinPoolCost           int
 }
 
-// TODO (#864)
-type DebugNewEpochStateResult any
+type DebugNewEpochStateResult cbor.RawMessage
 
-// TODO (#865)
-type DebugChainDepStateResult any
+type DebugChainDepStateResult cbor.RawMessage
 
-// TODO (#866)
-/*
-result	[ *Element ]	Expanded in order on the next rows.
-Element	CDDL	Comment
-epochLength
-poolMints	{ *poolid => block-count }
-maxLovelaceSupply
-NA
-NA
-NA
-?circulatingsupply?
-total-blocks
-?decentralization?	[num den]
-?available block entries
-success-rate	[num den]
-NA
-NA		??treasuryCut
-activeStakeGo
-nil
-nil
-*/
-type RewardProvenanceResult any
+type RewardProvenanceResult struct {
+	_                     struct{} `cbor:",toarray"`
+	EpochLength           int
+	PoolMints             map[ledger.PoolId]int
+	MaxLovelaceSupply     int64
+	DeltaR1               int64
+	DeltaR2               int64
+	R                     int64
+	TotalStake            int64
+	TotalBlocks           int
+	Decentralization      any
+	AvailableBlockEntries int
+	SuccessRate           any
+	RewardPot             int64
+	DeltaT1               int64
+	ActiveStake           int64
+	Pools                 any
+	Desirabilities        any
+}
 
 type UTxOByTxInResult struct {
 	cbor.StructAsArray
@@ -713,8 +707,18 @@ type StakePoolParamsResult struct {
 	}
 }
 
-// TODO (#867)
-type RewardInfoPoolsResult any
+type RewardInfoPoolsResult struct {
+	cbor.StructAsArray
+	Results map[ledger.PoolId]struct {
+		cbor.StructAsArray
+		Stake               uint
+		OwnerPledge         uint
+		OwnerStake          uint
+		Cost                uint
+		Margin              *cbor.Rat
+		PerformanceEstimate float64
+	}
+}
 
 // TODO (#868)
 type PoolStateResult any


### PR DESCRIPTION
- RewardProvenanceResult
- RewardInfoPoolsResult
- DebugEpochStateResult
- DebugNewEpochStateResult
- DebugChainDepStateResult

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set concrete types for several Local State Query results to improve CBOR decoding and type safety. Adds field mappings for reward provenance and pool info; debug state results now use raw CBOR.

- **Refactors**
  - RewardProvenanceResult -> struct with mapped fields (e.g., EpochLength, PoolMints, MaxLovelaceSupply, TotalStake, TotalBlocks, RewardPot, ActiveStake, etc.).
  - RewardInfoPoolsResult -> struct mapping per-pool metrics: Stake, OwnerPledge, OwnerStake, Cost, Margin, PerformanceEstimate.
  - DebugEpochStateResult, DebugNewEpochStateResult, DebugChainDepStateResult -> cbor.RawMessage to defer decoding.

<sup>Written for commit cd48e77c2374e64924c5c61e8d45a47da4e6f793. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated query result types to use explicit, strongly-typed structures instead of generic types, improving type safety and field-based handling for state query responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->