### PR TITLE
ci(lint): enable unparam in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,7 @@ linters:
     - spancheck
     - sqlclosecheck
     - testifylint
+    - unparam
     - usestdlibvars
     - whitespace
     - zerologlint


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable the unparam linter in golangci-lint to catch unused function parameters and return values. This tightens CI to block dead code and encourage cleaner APIs.

<sup>Written for commit e3959b4c52f6e5fdd2c336a3d859cbc4a6b35213. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

