### PR TITLE
refactor: use cbor.StructAsArray

### DIFF
--- a/ledger/verify_block_body.go
+++ b/ledger/verify_block_body.go
@@ -344,14 +344,14 @@ func ExtractTokens(output TransactionOutput) ([]UTXOOutputToken, error) {
 // These are copied from types.go
 
 type UTXOOutputToken struct {
-	_              struct{} `cbor:",toarray"`
+	cbor.StructAsArray
 	Flag           int
 	TokenAssetName string
 	TokenValue     string
 }
 
 type UTXOOutput struct {
-	_           struct{} `cbor:",toarray"`
+	cbor.StructAsArray
 	Flag        int
 	TxHash      string
 	OutputIndex string

--- a/protocol/chainsync/wrappers.go
+++ b/protocol/chainsync/wrappers.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2025 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,8 +24,7 @@ import (
 
 // WrappedBlock represents a block returned via a NtC RollForward message
 type WrappedBlock struct {
-	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
-	_         struct{} `cbor:",toarray"`
+	cbor.StructAsArray
 	BlockType uint
 	BlockCbor cbor.RawMessage
 }
@@ -40,8 +39,7 @@ func NewWrappedBlock(blockType uint, blockCbor []byte) *WrappedBlock {
 
 // WrappedHeader represents a block header returned via NtN RollForward message
 type WrappedHeader struct {
-	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
-	_          struct{} `cbor:",toarray"`
+	cbor.StructAsArray
 	Era        uint
 	RawMessage cbor.RawMessage
 	byronType  uint
@@ -82,8 +80,7 @@ func NewWrappedHeader(
 
 func (w *WrappedHeader) UnmarshalCBOR(data []byte) error {
 	var tmpHeader struct {
-		// Tells the CBOR decoder to convert to/from a struct and a CBOR array
-		_         struct{} `cbor:",toarray"`
+		cbor.StructAsArray
 		Era       uint
 		HeaderRaw cbor.RawMessage
 	}
@@ -152,11 +149,9 @@ func (w *WrappedHeader) ByronType() uint {
 }
 
 type wrappedHeaderByron struct {
-	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
-	_        struct{} `cbor:",toarray"`
+	cbor.StructAsArray
 	Metadata struct {
-		// Tells the CBOR decoder to convert to/from a struct and a CBOR array
-		_    struct{} `cbor:",toarray"`
+		cbor.StructAsArray
 		Type uint
 		Size uint
 	}

--- a/protocol/common/types.go
+++ b/protocol/common/types.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2025 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,8 +23,7 @@ import (
 
 // The Point type represents a point on the blockchain. It consists of a slot number and block hash
 type Point struct {
-	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
-	_    struct{} `cbor:",toarray"`
+	cbor.StructAsArray
 	Slot uint64
 	Hash []byte
 }

--- a/protocol/localstatequery/queries.go
+++ b/protocol/localstatequery/queries.go
@@ -417,8 +417,7 @@ type SystemStartQuery struct {
 }
 
 type SystemStartResult struct {
-	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
-	_           struct{} `cbor:",toarray"`
+	cbor.StructAsArray
 	Year        big.Int
 	Day         int
 	Picoseconds big.Int
@@ -477,29 +476,25 @@ type HardForkEraHistoryQuery struct {
 }
 
 type EraHistoryResult struct {
-	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
-	_      struct{} `cbor:",toarray"`
+	cbor.StructAsArray
 	Begin  eraHistoryResultBeginEnd
 	End    eraHistoryResultBeginEnd
 	Params eraHistoryResultParams
 }
 
 type eraHistoryResultBeginEnd struct {
-	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
-	_        struct{} `cbor:",toarray"`
+	cbor.StructAsArray
 	Timespan any
 	SlotNo   int
 	EpochNo  int
 }
 
 type eraHistoryResultParams struct {
-	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
-	_                 struct{} `cbor:",toarray"`
+	cbor.StructAsArray
 	EpochLength       int
 	SlotLength        int
 	SlotsPerKESPeriod struct {
-		// Tells the CBOR decoder to convert to/from a struct and a CBOR array
-		_      struct{} `cbor:",toarray"`
+		cbor.StructAsArray
 		Dummy1 int
 		Value  int
 		Dummy2 []int
@@ -612,8 +607,7 @@ It seems to be a requirement to sort the reward addresses on the query. Scriptha
 type FilteredDelegationsAndRewardAccountsResult any
 
 type GenesisConfigResult struct {
-	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
-	_                 struct{} `cbor:",toarray"`
+	cbor.StructAsArray
 	Start             SystemStartResult
 	NetworkMagic      int
 	NetworkId         uint8
@@ -633,7 +627,7 @@ type GenesisConfigResult struct {
 }
 
 type GenesisConfigResultProtocolParameters struct {
-	_                     struct{} `cbor:",toarray"`
+	cbor.StructAsArray
 	MinFeeA               int
 	MinFeeB               int
 	MaxBlockBodySize      int

--- a/protocol/localtxmonitor/messages.go
+++ b/protocol/localtxmonitor/messages.go
@@ -145,8 +145,7 @@ type MsgReplyNextTx struct {
 }
 
 type MsgReplyNextTxTransaction struct {
-	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
-	_     struct{} `cbor:",toarray"`
+	cbor.StructAsArray
 	EraId uint8
 	Tx    []byte
 }
@@ -221,8 +220,7 @@ func (m *MsgReplyNextTx) MarshalCBOR() ([]byte, error) {
 	tmp := []any{m.MessageType}
 	if m.Transaction.Tx != nil {
 		type tmpTxObj struct {
-			// Tells the CBOR decoder to convert to/from a struct and a CBOR array
-			_     struct{} `cbor:",toarray"`
+			cbor.StructAsArray
 			EraId uint8
 			Tx    cbor.Tag
 		}
@@ -292,8 +290,7 @@ type MsgReplyGetSizes struct {
 }
 
 type MsgReplyGetSizesResult struct {
-	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
-	_           struct{} `cbor:",toarray"`
+	cbor.StructAsArray
 	Capacity    uint32
 	Size        uint32
 	NumberOfTxs uint32

--- a/protocol/localtxsubmission/messages.go
+++ b/protocol/localtxsubmission/messages.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2025 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -58,8 +58,7 @@ type MsgSubmitTx struct {
 }
 
 type MsgSubmitTxTransaction struct {
-	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
-	_     struct{} `cbor:",toarray"`
+	cbor.StructAsArray
 	EraId uint16
 	Raw   cbor.Tag
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced cbor:",toarray" placeholders with cbor.StructAsArray across protocol types to standardize CBOR array encoding/decoding. No behavior changes; this simplifies structs and improves readability.

- **Refactors**
  - Switched to cbor.StructAsArray in ledger, chainsync, common, localstatequery, localtxmonitor, and localtxsubmission structs (including nested/temp structs).
  - Updated file headers to 2025 where touched.

<sup>Written for commit ff08e1fdd20b9971bb8ee4252fdfd7864865083d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal data serialization across multiple components for improved code consistency and maintainability. These structural improvements maintain full compatibility while enhancing the codebase's technical foundation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->