### PR TITLE
refactor(ledger): use cbor from aux data directly

### DIFF
--- a/ledger/allegra/allegra.go
+++ b/ledger/allegra/allegra.go
@@ -259,7 +259,6 @@ type AllegraTransaction struct {
 	Body       AllegraTransactionBody
 	WitnessSet shelley.ShelleyTransactionWitnessSet
 	TxMetadata common.TransactionMetadatum
-	RawAuxData []byte // Raw auxiliary data bytes (includes scripts)
 	auxData    common.AuxiliaryData
 }
 
@@ -286,8 +285,8 @@ func (t *AllegraTransaction) UnmarshalCBOR(cborData []byte) error {
 	// Handle metadata (component 3, index 2) - always present, but may be CBOR nil
 	// Store raw auxiliary data bytes (including any scripts)
 	if len(txArray) > 2 && len(txArray[2]) > 0 &&
-		txArray[2][0] != 0xF6 { // 0xF6 is CBOR null
-		t.RawAuxData = []byte(txArray[2])
+		txArray[2][0] != 0xF6 {
+		// 0xF6 is CBOR null
 
 		// Decode auxiliary data
 		auxData, err := common.DecodeAuxiliaryData(txArray[2])
@@ -408,10 +407,6 @@ func (t AllegraTransaction) Donation() uint64 {
 
 func (t *AllegraTransaction) Metadata() common.TransactionMetadatum {
 	return t.TxMetadata
-}
-
-func (t *AllegraTransaction) RawAuxiliaryData() []byte {
-	return t.RawAuxData
 }
 
 func (t *AllegraTransaction) AuxiliaryData() common.AuxiliaryData {

--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -655,7 +655,6 @@ type AlonzoTransaction struct {
 	WitnessSet AlonzoTransactionWitnessSet
 	TxIsValid  bool
 	TxMetadata common.TransactionMetadatum
-	rawAuxData []byte
 	auxData    common.AuxiliaryData
 }
 
@@ -688,10 +687,9 @@ func (t *AlonzoTransaction) UnmarshalCBOR(cborData []byte) error {
 	if _, err := cbor.Decode([]byte(txArray[2]), &t.TxIsValid); err != nil {
 		return fmt.Errorf("failed to decode TxIsValid: %w", err)
 	}
-
 	// Handle metadata (component 4, always present - either data or CBOR nil)
-	if len(txArray[3]) > 0 && txArray[3][0] != 0xF6 { // 0xF6 is CBOR null
-		t.rawAuxData = []byte(txArray[3])
+	if len(txArray[3]) > 0 && txArray[3][0] != 0xF6 {
+		// 0xF6 is CBOR null
 
 		// Decode auxiliary data
 		auxData, err := common.DecodeAuxiliaryData(txArray[3])
@@ -717,10 +715,6 @@ func (t *AlonzoTransaction) UnmarshalCBOR(cborData []byte) error {
 
 func (t *AlonzoTransaction) Metadata() common.TransactionMetadatum {
 	return t.TxMetadata
-}
-
-func (t *AlonzoTransaction) RawAuxiliaryData() []byte {
-	return t.rawAuxData
 }
 
 func (t *AlonzoTransaction) AuxiliaryData() common.AuxiliaryData {

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -886,7 +886,6 @@ type BabbageTransaction struct {
 	WitnessSet BabbageTransactionWitnessSet
 	TxIsValid  bool
 	TxMetadata common.TransactionMetadatum
-	rawAuxData []byte
 	auxData    common.AuxiliaryData
 }
 
@@ -919,10 +918,9 @@ func (t *BabbageTransaction) UnmarshalCBOR(cborData []byte) error {
 	if _, err := cbor.Decode([]byte(txArray[2]), &t.TxIsValid); err != nil {
 		return fmt.Errorf("failed to decode TxIsValid: %w", err)
 	}
-
 	// Handle metadata (component 4, always present - either data or CBOR nil)
-	if len(txArray[3]) > 0 && txArray[3][0] != 0xF6 { // 0xF6 is CBOR null
-		t.rawAuxData = []byte(txArray[3])
+	if len(txArray[3]) > 0 && txArray[3][0] != 0xF6 {
+		// 0xF6 is CBOR null
 
 		// Decode auxiliary data
 		auxData, err := common.DecodeAuxiliaryData(txArray[3])
@@ -948,10 +946,6 @@ func (t *BabbageTransaction) UnmarshalCBOR(cborData []byte) error {
 
 func (t *BabbageTransaction) Metadata() common.TransactionMetadatum {
 	return t.TxMetadata
-}
-
-func (t *BabbageTransaction) RawAuxiliaryData() []byte {
-	return t.rawAuxData
 }
 
 func (t *BabbageTransaction) AuxiliaryData() common.AuxiliaryData {

--- a/ledger/byron/byron.go
+++ b/ledger/byron/byron.go
@@ -316,7 +316,10 @@ func (t *ByronTransaction) UnmarshalCBOR(cborData []byte) error {
 	}
 	// Decode witnesses (Twit)
 	if _, err := cbor.Decode([]byte(txArray[1]), &t.Twit); err != nil {
-		return fmt.Errorf("failed to decode byron transaction witnesses: %w", err)
+		return fmt.Errorf(
+			"failed to decode byron transaction witnesses: %w",
+			err,
+		)
 	}
 	t.SetCbor(cborData)
 	return nil
@@ -452,10 +455,6 @@ func (t *ByronTransaction) Metadata() common.TransactionMetadatum {
 	return nil
 }
 
-func (t *ByronTransaction) RawAuxiliaryData() []byte {
-	return nil
-}
-
 func (t *ByronTransaction) AuxiliaryData() common.AuxiliaryData {
 	return nil
 }
@@ -502,7 +501,9 @@ type ByronTransactionWitnessSet struct {
 	bootstrap []common.BootstrapWitness
 }
 
-func NewByronTransactionWitnessSet(twit []cbor.Value) *ByronTransactionWitnessSet {
+func NewByronTransactionWitnessSet(
+	twit []cbor.Value,
+) *ByronTransactionWitnessSet {
 	ws := &ByronTransactionWitnessSet{}
 	for i := range twit {
 		if vw, bw, ok := decodeByronWitness(twit[i]); ok {

--- a/ledger/common/auxiliary_data_e2e_test.go
+++ b/ledger/common/auxiliary_data_e2e_test.go
@@ -492,9 +492,5 @@ func TestE2ETransactionWithoutAuxiliaryData(t *testing.T) {
 		t.Fatal("expected nil metadata")
 	}
 
-	if tx.RawAuxiliaryData() != nil {
-		t.Fatal("expected nil raw auxiliary data")
-	}
-
 	t.Logf("✓ E2E: Successfully handled transaction without auxiliary data")
 }

--- a/ledger/common/rules_test.go
+++ b/ledger/common/rules_test.go
@@ -39,7 +39,6 @@ func (m *mockTxEmpty) Hash() common.Blake2b256 { return common.Blake2b256{} }
 
 func (m *mockTxEmpty) LeiosHash() common.Blake2b256            { return common.Blake2b256{} }
 func (m *mockTxEmpty) Metadata() common.TransactionMetadatum   { return nil }
-func (m *mockTxEmpty) RawAuxiliaryData() []byte                { return nil }
 func (m *mockTxEmpty) AuxiliaryData() common.AuxiliaryData     { return nil }
 func (m *mockTxEmpty) IsValid() bool                           { return true }
 func (m *mockTxEmpty) Consumed() []common.TransactionInput     { return nil }

--- a/ledger/common/tx.go
+++ b/ledger/common/tx.go
@@ -29,7 +29,6 @@ type Transaction interface {
 	Hash() Blake2b256
 	LeiosHash() Blake2b256
 	Metadata() TransactionMetadatum
-	RawAuxiliaryData() []byte
 	AuxiliaryData() AuxiliaryData
 	IsValid() bool
 	Consumed() []TransactionInput

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -610,7 +610,6 @@ type ConwayTransaction struct {
 	WitnessSet ConwayTransactionWitnessSet
 	TxIsValid  bool
 	TxMetadata common.TransactionMetadatum
-	rawAuxData []byte
 	auxData    common.AuxiliaryData
 }
 
@@ -643,10 +642,9 @@ func (t *ConwayTransaction) UnmarshalCBOR(cborData []byte) error {
 	if _, err := cbor.Decode([]byte(txArray[2]), &t.TxIsValid); err != nil {
 		return fmt.Errorf("failed to decode TxIsValid: %w", err)
 	}
-
 	// Handle metadata (component 4, always present - either data or CBOR nil)
-	if len(txArray[3]) > 0 && txArray[3][0] != 0xF6 { // 0xF6 is CBOR null
-		t.rawAuxData = []byte(txArray[3])
+	if len(txArray[3]) > 0 && txArray[3][0] != 0xF6 {
+		// 0xF6 is CBOR null
 
 		// Decode auxiliary data
 		auxData, err := common.DecodeAuxiliaryData(txArray[3])
@@ -672,10 +670,6 @@ func (t *ConwayTransaction) UnmarshalCBOR(cborData []byte) error {
 
 func (t *ConwayTransaction) Metadata() common.TransactionMetadatum {
 	return t.TxMetadata
-}
-
-func (t *ConwayTransaction) RawAuxiliaryData() []byte {
-	return t.rawAuxData
 }
 
 func (t *ConwayTransaction) AuxiliaryData() common.AuxiliaryData {

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -288,7 +288,6 @@ type MaryTransaction struct {
 	Body       MaryTransactionBody
 	WitnessSet shelley.ShelleyTransactionWitnessSet
 	TxMetadata common.TransactionMetadatum
-	RawAuxData []byte // Raw auxiliary data bytes (includes scripts)
 	auxData    common.AuxiliaryData
 }
 
@@ -318,9 +317,10 @@ func (t *MaryTransaction) UnmarshalCBOR(cborData []byte) error {
 	}
 
 	// Handle metadata (component 3, index 2) - always present, but may be CBOR nil
+	// Handle metadata (component 3, index 2) - always present, but may be CBOR nil
 	if len(txArray) > 2 && len(txArray[2]) > 0 &&
-		txArray[2][0] != 0xF6 { // 0xF6 is CBOR null
-		t.RawAuxData = []byte(txArray[2])
+		txArray[2][0] != 0xF6 {
+		// 0xF6 is CBOR null
 
 		// Decode auxiliary data
 		auxData, err := common.DecodeAuxiliaryData(txArray[2])
@@ -346,10 +346,6 @@ func (t *MaryTransaction) UnmarshalCBOR(cborData []byte) error {
 
 func (t *MaryTransaction) Metadata() common.TransactionMetadatum {
 	return t.TxMetadata
-}
-
-func (t *MaryTransaction) RawAuxiliaryData() []byte {
-	return t.RawAuxData
 }
 
 func (t *MaryTransaction) AuxiliaryData() common.AuxiliaryData {

--- a/ledger/shelley/rules.go
+++ b/ledger/shelley/rules.go
@@ -387,10 +387,10 @@ func UtxoValidateMetadata(
 ) error {
 	bodyAuxDataHash := tx.AuxDataHash()
 	txAuxData := tx.Metadata()
-	rawAuxData := tx.RawAuxiliaryData()
-	// If metadata is present but raw auxiliary data bytes are missing,
-	// fall back to encoding the metadata so validation still runs.
-	if len(rawAuxData) == 0 && txAuxData != nil {
+	var rawAuxData []byte
+	if aux := tx.AuxiliaryData(); aux != nil {
+		rawAuxData = aux.Cbor()
+	} else if txAuxData != nil {
 		rawAuxData = txAuxData.Cbor()
 	}
 

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -569,7 +569,6 @@ type ShelleyTransaction struct {
 	Body       ShelleyTransactionBody
 	WitnessSet ShelleyTransactionWitnessSet
 	TxMetadata common.TransactionMetadatum
-	rawAuxData []byte
 	auxData    common.AuxiliaryData
 }
 
@@ -600,8 +599,8 @@ func (t *ShelleyTransaction) UnmarshalCBOR(cborData []byte) error {
 
 	// Handle metadata (component 3, index 2) - always present, but may be CBOR nil
 	if len(txArray) > 2 && len(txArray[2]) > 0 &&
-		txArray[2][0] != 0xF6 { // 0xF6 is CBOR null
-		t.rawAuxData = []byte(txArray[2])
+		txArray[2][0] != 0xF6 {
+		// 0xF6 is CBOR null
 
 		// Decode auxiliary data
 		auxData, err := common.DecodeAuxiliaryData(txArray[2])
@@ -627,10 +626,6 @@ func (t *ShelleyTransaction) UnmarshalCBOR(cborData []byte) error {
 
 func (t *ShelleyTransaction) Metadata() common.TransactionMetadatum {
 	return t.TxMetadata
-}
-
-func (t *ShelleyTransaction) RawAuxiliaryData() []byte {
-	return t.rawAuxData
 }
 
 func (t *ShelleyTransaction) AuxiliaryData() common.AuxiliaryData {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored auxiliary data handling to read CBOR directly from AuxiliaryData, removing RawAuxiliaryData across all eras. This simplifies metadata validation and reduces duplicated state.

- **Refactors**
  - Removed RawAuxiliaryData from transaction structs and the Transaction interface.
  - UnmarshalCBOR now decodes auxiliary data without storing raw bytes.
  - Updated UtxoValidateMetadata to use tx.AuxiliaryData().Cbor(), with metadata.Cbor() as a fallback.
  - Adjusted tests and minor Byron witness code formatting. 

- **Migration**
  - Replace tx.RawAuxiliaryData() with tx.AuxiliaryData().Cbor(), or tx.Metadata().Cbor() if aux data is nil.

<sup>Written for commit cc9d4ab216c2086761963503e355451e928150ca. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the `RawAuxiliaryData()` accessor method from all transaction types to streamline the public API.
  * Enhanced auxiliary data handling through internal refactoring with improved fallback mechanisms for metadata extraction, ensuring consistent behavior across all transaction types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->