### PR TITLE
fix(ledger): babbage cost model rules like conway

### DIFF
--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -154,9 +154,9 @@ func UtxoValidateCostModelsPresent(
 			continue
 		}
 		switch script.(type) {
-		case *common.PlutusV1Script:
+		case common.PlutusV1Script:
 			required[0] = struct{}{}
-		case *common.PlutusV2Script:
+		case common.PlutusV2Script:
 			required[1] = struct{}{}
 		}
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Align Babbage cost model validation with Conway by switching Plutus script type checks from pointers to values. This fixes missed cost model requirements when scripts are provided as values, ensuring V1/V2 cost models are correctly detected.

<sup>Written for commit 7050c6e23f716dc3364e1ec135221443a30b36e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal validation logic for Plutus script handling to enhance code reliability and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->