### PR TITLE
fix(ledger): use slices.Clone vs append to nil slice

### DIFF
--- a/ledger/common/metadata.go
+++ b/ledger/common/metadata.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 )
@@ -251,7 +252,7 @@ func decodeMapBytes(b []byte) (TransactionMetadatum, bool, error) {
 
 		bs := k.Bytes()
 		pairs = append(pairs, MetaPair{
-			Key:   MetaBytes{Value: append([]byte(nil), bs...)},
+			Key:   MetaBytes{Value: slices.Clone(bs)},
 			Value: val,
 		})
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use slices.Clone to copy metadata key bytes during CBOR map decoding. This makes the copy explicit, avoids accidental aliasing, and aligns with Go 1.21 idioms.

<sup>Written for commit 94d72cde48c3f7f95bb43e79dd884a1b84a529b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code efficiency through standard utility optimization. No user-facing changes or functional modifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->