### PR TITLE
fix(ledger): store metadata bytes

### DIFF
--- a/ledger/common/metadata.go
+++ b/ledger/common/metadata.go
@@ -704,6 +704,7 @@ func DecodeAuxiliaryData(raw []byte) (AuxiliaryData, error) {
 		if _, err := cbor.Decode(raw, auxData); err != nil {
 			return nil, err
 		}
+		auxData.SetCbor(raw)
 		return auxData, nil
 
 	case cborTypeArray:
@@ -712,6 +713,7 @@ func DecodeAuxiliaryData(raw []byte) (AuxiliaryData, error) {
 		if _, err := cbor.Decode(raw, auxData); err != nil {
 			return nil, err
 		}
+		auxData.SetCbor(raw)
 		return auxData, nil
 
 	case cborTypeTag:
@@ -720,6 +722,7 @@ func DecodeAuxiliaryData(raw []byte) (AuxiliaryData, error) {
 		if _, err := cbor.Decode(raw, auxData); err != nil {
 			return nil, err
 		}
+		auxData.SetCbor(raw)
 		return auxData, nil
 
 	default:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Store raw CBOR bytes in AuxiliaryData when decoding metadata. This preserves exact metadata bytes for maps, arrays, and tags and prevents loss during persistence or re-encoding.

<sup>Written for commit c32a0013af7ae4c4b924b2ae66a7a7800ea2f710. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced data preservation to ensure original encoding formats are retained during decoding operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->