### PR TITLE
fix(ledger): metadata store and validate

### DIFF
--- a/ledger/allegra/allegra.go
+++ b/ledger/allegra/allegra.go
@@ -119,8 +119,16 @@ func (b *AllegraBlock) Transactions() []common.Transaction {
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],
 		}
+		// Populate metadata and preserve original auxiliary CBOR when present
 		if metadata, ok := b.TransactionMetadataSet.GetMetadata(uint(idx)); ok {
 			tx.TxMetadata = metadata
+		}
+		if raw, ok := b.TransactionMetadataSet.GetRawMetadata(uint(idx)); ok &&
+			len(raw) > 0 {
+			if aux, err := common.DecodeAuxiliaryData(raw); err == nil &&
+				aux != nil {
+				tx.auxData = aux
+			}
 		}
 		ret[idx] = tx
 	}

--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -172,8 +172,16 @@ func (b *AlonzoBlock) Transactions() []common.Transaction {
 			WitnessSet: b.TransactionWitnessSets[idx],
 			TxIsValid:  !invalidTxMap[uint(idx)],
 		}
+		// Populate metadata and preserve original auxiliary CBOR when present
 		if metadata, ok := b.TransactionMetadataSet.GetMetadata(uint(idx)); ok {
 			tx.TxMetadata = metadata
+		}
+		if raw, ok := b.TransactionMetadataSet.GetRawMetadata(uint(idx)); ok &&
+			len(raw) > 0 {
+			if aux, err := common.DecodeAuxiliaryData(raw); err == nil &&
+				aux != nil {
+				tx.auxData = aux
+			}
 		}
 		ret[idx] = tx
 	}

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -203,8 +203,16 @@ func (b *BabbageBlock) Transactions() []common.Transaction {
 			WitnessSet: b.TransactionWitnessSets[idx],
 			TxIsValid:  !invalidTxMap[uint(idx)],
 		}
+		// Populate metadata and preserve original auxiliary CBOR when present
 		if metadata, ok := b.TransactionMetadataSet.GetMetadata(uint(idx)); ok {
 			tx.TxMetadata = metadata
+		}
+		if raw, ok := b.TransactionMetadataSet.GetRawMetadata(uint(idx)); ok &&
+			len(raw) > 0 {
+			if aux, err := common.DecodeAuxiliaryData(raw); err == nil &&
+				aux != nil {
+				tx.auxData = aux
+			}
 		}
 		ret[idx] = tx
 	}

--- a/ledger/babbage/babbage_test.go
+++ b/ledger/babbage/babbage_test.go
@@ -2850,7 +2850,7 @@ func TestBabbageTransactionOutput_Utxorpc_InlineDatum(t *testing.T) {
 	txOutput, err := output.Utxorpc()
 	assert.NoError(t, err)
 	assert.NotNil(t, txOutput)
-	
+
 	// Should return the computed hash of the inline datum
 	expectedHash := output.DatumHash()
 	assert.Equal(t, expectedHash.Bytes(), txOutput.Datum.Hash)
@@ -3209,7 +3209,11 @@ func TestBabbageInlineDatumRoundTrip(t *testing.T) {
 
 	// Verify all fields match
 	assert.Equal(t, originalOutput.OutputAddress, decodedOutput.OutputAddress)
-	assert.Equal(t, originalOutput.OutputAmount.Amount, decodedOutput.OutputAmount.Amount)
+	assert.Equal(
+		t,
+		originalOutput.OutputAmount.Amount,
+		decodedOutput.OutputAmount.Amount,
+	)
 	assert.NotNil(t, decodedOutput.DatumOption)
 	assert.NotNil(t, decodedOutput.DatumOption.data)
 

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -203,8 +203,16 @@ func (b *ConwayBlock) Transactions() []common.Transaction {
 			WitnessSet: b.TransactionWitnessSets[idx],
 			TxIsValid:  !invalidTxMap[uint(idx)],
 		}
+		// Populate metadata and preserve original auxiliary CBOR when present
 		if metadata, ok := b.TransactionMetadataSet.GetMetadata(uint(idx)); ok {
 			tx.TxMetadata = metadata
+		}
+		if raw, ok := b.TransactionMetadataSet.GetRawMetadata(uint(idx)); ok &&
+			len(raw) > 0 {
+			if aux, err := common.DecodeAuxiliaryData(raw); err == nil &&
+				aux != nil {
+				tx.auxData = aux
+			}
 		}
 		ret[idx] = tx
 	}

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -133,8 +133,16 @@ func (b *MaryBlock) Transactions() []common.Transaction {
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],
 		}
+		// Populate metadata and preserve original auxiliary CBOR when present
 		if metadata, ok := b.TransactionMetadataSet.GetMetadata(uint(idx)); ok {
 			tx.TxMetadata = metadata
+		}
+		if raw, ok := b.TransactionMetadataSet.GetRawMetadata(uint(idx)); ok &&
+			len(raw) > 0 {
+			if aux, err := common.DecodeAuxiliaryData(raw); err == nil &&
+				aux != nil {
+				tx.auxData = aux
+			}
 		}
 		ret[idx] = tx
 	}

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -127,8 +127,17 @@ func (b *ShelleyBlock) Transactions() []common.Transaction {
 			Body:       b.TransactionBodies[idx],
 			WitnessSet: b.TransactionWitnessSets[idx],
 		}
+		// Populate metadata and preserve original auxiliary CBOR when present
 		if metadata, ok := b.TransactionMetadataSet.GetMetadata(uint(idx)); ok {
 			tx.TxMetadata = metadata
+		}
+		if raw, ok := b.TransactionMetadataSet.GetRawMetadata(uint(idx)); ok &&
+			len(raw) > 0 {
+			// Decode auxiliary data from raw CBOR and set auxData for hashing
+			if aux, err := common.DecodeAuxiliaryData(raw); err == nil &&
+				aux != nil {
+				tx.auxData = aux
+			}
 		}
 		ret[idx] = tx
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix metadata storage and validation across all ledger eras to preserve raw auxiliary CBOR and avoid placeholder values, making metadata hashing consistent and preventing false hash conflicts.

- **Bug Fixes**
  - Populate TxMetadata from TransactionMetadataSet and set tx.auxData by decoding its raw CBOR (Allegra, Mary, Shelley, Alonzo, Babbage, Conway).
  - Treat single-byte CBOR simple values (null 0xf6, true 0xf5, false 0xf4) as placeholders and fall back to block-level metadata.
  - Hash using raw auxiliary CBOR (includes scripts) and validate metadata content when present.

<sup>Written for commit 6c0bd654467cda59ef2f6c6ac929fa36d282cb22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auxiliary transaction data is now decoded when present and preserved on transactions across all ledger eras.

* **Bug Fixes**
  * Validation now ignores single-byte CBOR placeholders in auxiliary data and falls back to appropriate metadata, improving correctness.

* **Tests**
  * Minor test formatting updates for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->