### PR TITLE
fix(ledger): script data hash without redeemers

### DIFF
--- a/ledger/common/rules.go
+++ b/ledger/common/rules.go
@@ -357,7 +357,18 @@ func ValidateRedeemerAndScriptWitnesses(tx Transaction, ls LedgerState) error {
 		}
 	}
 
-	if tx.ScriptDataHash() != nil && redeemerCount == 0 {
+	// Check witness PlutusData (datums)
+	hasWitnessPlutusData := false
+	if wits != nil {
+		if len(wits.PlutusData()) > 0 {
+			hasWitnessPlutusData = true
+		}
+	}
+
+	// ScriptDataHash covers redeemers, datums, and language views.
+	// It's valid to have ScriptDataHash with no redeemers if there are witness datums.
+	if tx.ScriptDataHash() != nil && redeemerCount == 0 &&
+		!hasWitnessPlutusData {
 		return MissingRedeemersForScriptDataHashError{}
 	}
 	if redeemerCount > 0 && !hasPlutus && !hasPlutusReference {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow transactions with a ScriptDataHash and witness datums to pass validation even when there are no redeemers. This prevents incorrect MissingRedeemersForScriptDataHashError.

- **Bug Fixes**
  - Updated ValidateRedeemerAndScriptWitnesses to detect witness datums (PlutusData) and only error when ScriptDataHash is set with neither redeemers nor datums.

<sup>Written for commit 636d5160b84af1b1ec85ef48ac1170f51a9ccb44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved script data validation to correctly handle cases where witness datums are present without redeemers, enabling valid transaction configurations that were previously rejected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->