### PR TITLE
fix(ledger): lenient conway witness switch

### DIFF
--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -176,7 +176,7 @@ func UtxoValidateRedeemerAndScriptWitnesses(
 			continue
 		}
 		switch script.(type) {
-		case common.PlutusV1Script, common.PlutusV2Script, common.PlutusV3Script:
+		case *common.PlutusV1Script, common.PlutusV1Script, *common.PlutusV2Script, common.PlutusV2Script, *common.PlutusV3Script, common.PlutusV3Script:
 			hasPlutusReference = true
 		}
 		if hasPlutusReference {
@@ -258,11 +258,11 @@ func UtxoValidateCostModelsPresent(
 			continue
 		}
 		switch script.(type) {
-		case common.PlutusV1Script:
+		case *common.PlutusV1Script, common.PlutusV1Script:
 			required[0] = struct{}{}
-		case common.PlutusV2Script:
+		case *common.PlutusV2Script, common.PlutusV2Script:
 			required[1] = struct{}{}
-		case common.PlutusV3Script:
+		case *common.PlutusV3Script, common.PlutusV3Script:
 			required[2] = struct{}{}
 		}
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make Conway witness and cost model checks accept both pointer and value Plutus scripts (V1–V3) to avoid validation failures when scripts are passed by pointer. This fixes false negatives during UTxO validation.

- **Bug Fixes**
  - Updated type switches in UtxoValidateRedeemerAndScriptWitnesses and UtxoValidateCostModelsPresent to handle pointer and value forms of Plutus V1/V2/V3.
  - Ensures hasPlutusReference and required cost models are set correctly when scripts are pointers.

<sup>Written for commit 6b21281737e4b569859128387ef061aed04c1c79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved validation of Plutus script references to ensure all script types are properly recognized during transaction processing, enhancing transaction safety and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->