### PR TITLE
test: CIP-0031 tests

### DIFF
--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -1741,6 +1741,7 @@ func TestUtxoValidateExUnitsTooBigUtxo(t *testing.T) {
 }
 
 func TestUtxoValidateDisjointRefInputs(t *testing.T) {
+	// Test validation for reference inputs (CIP-0031)
 	testInputTxId := "d228b482a1aae768e4a796380f49e021d9c21f70d3c12cb186b188dedfc0ee22"
 	testTx := &conway.ConwayTransaction{
 		Body: conway.ConwayTransactionBody{},


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified the disjoint reference inputs test by marking it as CIP-0031 reference inputs validation. Improves test readability and aligns the suite with upcoming CIP-0031 coverage.

<sup>Written for commit 13cc8a8cb1a89a6dead82ab3ff35a8e4abda4aac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

