### PR TITLE
fix(ledger): validate conway network

### DIFF
--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -467,7 +467,7 @@ type ConwayTransactionBody struct {
 	TxScriptDataHash        *common.Blake2b256                            `cbor:"11,keyasint,omitempty"`
 	TxCollateral            cbor.SetType[shelley.ShelleyTransactionInput] `cbor:"13,keyasint,omitempty,omitzero"`
 	TxRequiredSigners       cbor.SetType[common.Blake2b224]               `cbor:"14,keyasint,omitempty,omitzero"`
-	NetworkId               uint8                                         `cbor:"15,keyasint,omitempty"`
+	TxNetworkId             uint8                                         `cbor:"15,keyasint,omitempty"`
 	TxCollateralReturn      *babbage.BabbageTransactionOutput             `cbor:"16,keyasint,omitempty"`
 	TxTotalCollateral       uint64                                        `cbor:"17,keyasint,omitempty"`
 	TxReferenceInputs       cbor.SetType[shelley.ShelleyTransactionInput] `cbor:"18,keyasint,omitempty,omitzero"`
@@ -596,6 +596,19 @@ func (b *ConwayTransactionBody) ProposalProcedures() []common.ProposalProcedure 
 		ret[i] = item
 	}
 	return ret
+}
+
+func (b *ConwayTransactionBody) NetworkId() *uint8 {
+	// TxNetworkId field is optional (omitempty in CBOR)
+	// Return nil if not set, pointer to value if set
+	// Note: Since the field is uint8 (not *uint8), we can't perfectly distinguish
+	// between "not present" and "present with value 0". However, we return the
+	// value if it's non-zero, as that indicates explicit presence.
+	// For value 0 (testnet), we treat it as "not present" since we can't tell.
+	if b.TxNetworkId != 0 {
+		return &b.TxNetworkId
+	}
+	return nil
 }
 
 func (b *ConwayTransactionBody) CurrentTreasuryValue() int64 {
@@ -782,6 +795,10 @@ func (t ConwayTransaction) CurrentTreasuryValue() int64 {
 
 func (t ConwayTransaction) Donation() uint64 {
 	return t.Body.Donation()
+}
+
+func (t ConwayTransaction) NetworkId() *uint8 {
+	return t.Body.NetworkId()
 }
 
 func (t ConwayTransaction) IsValid() bool {

--- a/ledger/conway/errors.go
+++ b/ledger/conway/errors.go
@@ -52,3 +52,12 @@ type (
 	MissingCostModelError                    = common.MissingCostModelError
 	InvalidIsValidFlagError                  = common.InvalidIsValidFlagError
 )
+
+type WrongTransactionNetworkIdError struct {
+	TxNetworkId     uint8
+	LedgerNetworkId uint
+}
+
+func (e WrongTransactionNetworkIdError) Error() string {
+	return "wrong transaction network ID"
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Validate Conway transaction NetworkId against the ledger network to prevent cross-network submissions. Adds a targeted UTxO rule and error, plus a safe accessor for the optional field.

- **Bug Fixes**
  - Added UtxoValidateTransactionNetworkId: if a Conway tx sets NetworkId, it must match ls.NetworkId(), else returns WrongTransactionNetworkIdError.
  - Renamed ConwayTransactionBody.NetworkId to TxNetworkId and added NetworkId() accessors on body/transaction to read the optional field.
  - Rule is skipped for non-Conway transactions or when NetworkId is not set.

<sup>Written for commit fecb9748652a6ef60d0d5086e475e5551cf5568b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added transaction network ID validation for Conway transactions to verify compatibility with the ledger network state.

* **Error Handling**
  * Enhanced error diagnostics for network ID validation failures, providing clearer feedback when transaction network IDs don't match the ledger state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->