### PR TITLE
fix(ledger): validate metadata size

### DIFF
--- a/ledger/shelley/rules.go
+++ b/ledger/shelley/rules.go
@@ -16,6 +16,7 @@ package shelley
 
 import (
 	"errors"
+	"fmt"
 	"unicode/utf8"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -408,8 +409,15 @@ func validateMetadatumContent(md common.TransactionMetadatum, depth int) error {
 		if !utf8.ValidString(m.Value) {
 			return errors.New("metadata contains invalid UTF-8 text")
 		}
+		// Cardano spec: metadata text strings must not exceed 64 bytes
+		if len(m.Value) > 64 {
+			return fmt.Errorf("metadata text exceeds 64 byte limit: %d bytes", len(m.Value))
+		}
 	case common.MetaBytes:
-		// Consider: validate against empty or excessively large byte arrays
+		// Cardano spec: metadata byte strings must not exceed 64 bytes
+		if len(m.Value) > 64 {
+			return fmt.Errorf("metadata bytes exceeds 64 byte limit: %d bytes", len(m.Value))
+		}
 	case common.MetaInt:
 		if m.Value == nil {
 			return errors.New("metadata contains nil integer value")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enforces the Cardano spec by validating that transaction metadata text and byte strings do not exceed 64 bytes. Adds clear errors in validateMetadatumContent to block oversized metadata during ledger validation.

<sup>Written for commit 66e52031bcc2153878b23d6369e9af4c50c5e305. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

