### PR TITLE
fix(ledger): support nil for network to omit

### DIFF
--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -467,7 +467,7 @@ type ConwayTransactionBody struct {
 	TxScriptDataHash        *common.Blake2b256                            `cbor:"11,keyasint,omitempty"`
 	TxCollateral            cbor.SetType[shelley.ShelleyTransactionInput] `cbor:"13,keyasint,omitempty,omitzero"`
 	TxRequiredSigners       cbor.SetType[common.Blake2b224]               `cbor:"14,keyasint,omitempty,omitzero"`
-	TxNetworkId             uint8                                         `cbor:"15,keyasint,omitempty"`
+	TxNetworkId             *uint8                                        `cbor:"15,keyasint,omitempty"`
 	TxCollateralReturn      *babbage.BabbageTransactionOutput             `cbor:"16,keyasint,omitempty"`
 	TxTotalCollateral       uint64                                        `cbor:"17,keyasint,omitempty"`
 	TxReferenceInputs       cbor.SetType[shelley.ShelleyTransactionInput] `cbor:"18,keyasint,omitempty,omitzero"`
@@ -600,15 +600,9 @@ func (b *ConwayTransactionBody) ProposalProcedures() []common.ProposalProcedure 
 
 func (b *ConwayTransactionBody) NetworkId() *uint8 {
 	// TxNetworkId field is optional (omitempty in CBOR)
-	// Return nil if not set, pointer to value if set
-	// Note: Since the field is uint8 (not *uint8), we can't perfectly distinguish
-	// between "not present" and "present with value 0". However, we return the
-	// value if it's non-zero, as that indicates explicit presence.
-	// For value 0 (testnet), we treat it as "not present" since we can't tell.
-	if b.TxNetworkId != 0 {
-		return &b.TxNetworkId
-	}
-	return nil
+	// Since it's a pointer, nil means not present, non-nil means present
+	// This correctly handles testnet (network ID 0) as well as mainnet (ID 1)
+	return b.TxNetworkId
 }
 
 func (b *ConwayTransactionBody) CurrentTreasuryValue() int64 {

--- a/ledger/conway/errors.go
+++ b/ledger/conway/errors.go
@@ -15,6 +15,7 @@
 package conway
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/blinklabs-io/gouroboros/ledger/common"
@@ -59,5 +60,5 @@ type WrongTransactionNetworkIdError struct {
 }
 
 func (e WrongTransactionNetworkIdError) Error() string {
-	return "wrong transaction network ID"
+	return fmt.Sprintf("wrong transaction network ID: transaction has %d, ledger expects %d", e.TxNetworkId, e.LedgerNetworkId)
 }

--- a/ledger/shelley/rules.go
+++ b/ledger/shelley/rules.go
@@ -416,7 +416,7 @@ func validateMetadatumContent(md common.TransactionMetadatum, depth int) error {
 	case common.MetaBytes:
 		// Cardano spec: metadata byte strings must not exceed 64 bytes
 		if len(m.Value) > 64 {
-			return fmt.Errorf("metadata bytes exceeds 64 byte limit: %d bytes", len(m.Value))
+			return fmt.Errorf("metadata byte string exceeds 64 byte limit: %d bytes", len(m.Value))
 		}
 	case common.MetaInt:
 		if m.Value == nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make TxNetworkId optional by switching to a pointer so nil omits the field and network ID 0 (testnet) is preserved. Also improves error messages for network ID mismatches and metadata length.

- **Bug Fixes**
  - Conway: TxNetworkId is now *uint8; NetworkId() returns nil when omitted and correctly handles 0 (testnet) and 1 (mainnet).
  - Errors: WrongTransactionNetworkIdError now shows actual and expected IDs.
  - Shelley: clearer metadata error message for byte string length > 64.

<sup>Written for commit e8b443b8a13c29d096cb9297acfd5a72e31fd743. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

