### PR TITLE
test(ledger): more CIP tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ This is not an exhaustive list of existing and planned features, but it covers t
         - [ ] SPO stake distribution
         - [ ] Committee state
         - [ ] Treasury
+    - [X] LeiosFetch
+      - [X] Client support
+      - [X] Server support
+    - [X] LeiosNotify
+      - [X] Client support
+      - [X] Server support
 - [ ] Ledger
   - [ ] Eras
     - [X] Byron
@@ -122,7 +128,7 @@ This is not an exhaustive list of existing and planned features, but it covers t
       - [X] Transactions
       - [X] TX inputs
       - [X] TX outputs
-      - [ ] Parameter updates
+      - [X] Parameter updates
   - [X] Transaction attributes
     - [X] Inputs
     - [X] Outputs
@@ -149,9 +155,9 @@ This is not an exhaustive list of existing and planned features, but it covers t
   - [X] Test framework for mocking Ouroboros conversations
   - [ ] CBOR deserialization and serialization
     - [X] Protocol messages
-    - [ ] Ledger
-      - [ ] Block parsing
-      - [ ] Transaction parsing
+    - [X] Ledger
+      - [X] Block parsing
+      - [X] Transaction parsing
 - [ ] Misc
   - [X] Address handling
     - [X] Decode from bech32

--- a/ledger/tx_test.go
+++ b/ledger/tx_test.go
@@ -88,6 +88,9 @@ func TestMaryTransactionCborRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to deserialize Mary transaction: %s", err)
 	}
+	if tx == nil {
+		t.Fatal("tx is nil")
+	}
 
 	// Serialize
 	serializedCbor := tx.Cbor()
@@ -212,6 +215,9 @@ func BenchmarkTransactionSerialization_Shelley(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
+	if tx == nil {
+		b.Fatal("tx is nil")
+	}
 	b.ResetTimer()
 	for b.Loop() {
 		_ = tx.Cbor()
@@ -234,6 +240,9 @@ func BenchmarkTransactionSerialization_Allegra(b *testing.B) {
 	tx, err := ledger.NewAllegraTransactionFromCbor(txCbor)
 	if err != nil {
 		b.Fatal(err)
+	}
+	if tx == nil {
+		b.Fatal("tx is nil")
 	}
 	b.ResetTimer()
 	for b.Loop() {
@@ -258,6 +267,9 @@ func BenchmarkTransactionSerialization_Mary(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
+	if tx == nil {
+		b.Fatal("tx is nil")
+	}
 	b.ResetTimer()
 	for b.Loop() {
 		_ = tx.Cbor()
@@ -281,6 +293,9 @@ func BenchmarkTransactionSerialization_Alonzo(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
+	if tx == nil {
+		b.Fatal("tx is nil")
+	}
 	b.ResetTimer()
 	for b.Loop() {
 		_ = tx.Cbor()
@@ -303,6 +318,9 @@ func BenchmarkTransactionSerialization_Babbage(b *testing.B) {
 	tx, err := ledger.NewBabbageTransactionFromCbor(txCbor)
 	if err != nil {
 		b.Fatal(err)
+	}
+	if tx == nil {
+		b.Fatal("tx is nil")
 	}
 	b.ResetTimer()
 	for b.Loop() {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CIP compliance tests that validate CBOR/Bech32 round-trips and Conway-era features. Covers addresses (CIP-19, CIP-5), pool metadata (CIP-6), reference inputs (CIP-31), reference scripts (CIP-33), governance actions (CIP-1694), and protocol parameters (CIP-9).

<sup>Written for commit d73400ecadce0369b97a12ec1312f85b143ce0fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive CBOR round-trip tests covering addresses, pool metadata, Conway governance, protocol parameters, and Conway transaction reference inputs/scripts.
  * Added runtime nil checks in transaction tests/benchmarks to fail early on deserialization errors.
  * Strengthened assertions across tests for more reliable encoding/decoding validation.

* **Documentation**
  * Updated README feature checklist: enabled Ledger block/transaction parsing, marked Parameter updates done, and listed LeiosFetch/LeiosNotify client/server support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->