### PR TITLE
fix: race condition around protocol start when acting as server

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -414,6 +414,20 @@ func (c *Connection) setupConnection() error {
 		}
 		c.leiosNotify = leiosnotify.New(protoOptions, c.leiosNotifyConfig)
 		c.leiosFetch = leiosfetch.New(protoOptions, c.leiosFetchConfig)
+		// Register server protocols early to avoid race conditions where messages arrive
+		if (c.fullDuplex && handshakeFullDuplex) || c.server {
+			c.blockFetch.Server.EnsureRegistered()
+			c.chainSync.Server.EnsureRegistered()
+			c.txSubmission.Server.EnsureRegistered()
+			if c.keepAlive != nil {
+				c.keepAlive.Server.EnsureRegistered()
+			}
+			if c.peerSharing != nil {
+				c.peerSharing.Server.EnsureRegistered()
+			}
+			c.leiosNotify.Server.EnsureRegistered()
+			c.leiosFetch.Server.EnsureRegistered()
+		}
 		// Start protocols
 		if !c.delayProtocolStart {
 			if (c.fullDuplex && handshakeFullDuplex) || !c.server {
@@ -453,6 +467,17 @@ func (c *Connection) setupConnection() error {
 		}
 		if versionNtC.EnableLocalTxMonitorProtocol {
 			c.localTxMonitor = localtxmonitor.New(protoOptions, c.localTxMonitorConfig)
+		}
+		// Register server protocols early to avoid race conditions where messages arrive
+		if (c.fullDuplex && handshakeFullDuplex) || c.server {
+			c.chainSync.Server.EnsureRegistered()
+			c.localTxSubmission.Server.EnsureRegistered()
+			if c.localStateQuery != nil {
+				c.localStateQuery.Server.EnsureRegistered()
+			}
+			if c.localTxMonitor != nil {
+				c.localTxMonitor.Server.EnsureRegistered()
+			}
 		}
 		// Start protocols
 		if !c.delayProtocolStart {


### PR DESCRIPTION
Closes #104 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers server-side mini-protocols with the muxer before any messages can arrive, fixing a race condition during protocol startup. This improves stability when acting as a server or in full-duplex handshakes.

- **Bug Fixes**
  - Added Protocol.EnsureRegistered (sync.Once) and call it from Start.
  - Register server protocols early in Connection.setupConnection for NtN and NtC (e.g., BlockFetch, ChainSync, TxSubmission, KeepAlive, PeerSharing, LeiosNotify/Fetch, LocalTxSubmission, LocalStateQuery, LocalTxMonitor) when server or full duplex.

<sup>Written for commit 0e2785eb6a332f5ce6ed7e0c507ee1b2c3caf93c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server stability by optimizing the timing of protocol handler initialization to prevent race conditions during startup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->