### PR TITLE
fix(ledger): subtract treasury donations

### DIFF
--- a/ledger/conway/errors.go
+++ b/ledger/conway/errors.go
@@ -62,3 +62,12 @@ type WrongTransactionNetworkIdError struct {
 func (e WrongTransactionNetworkIdError) Error() string {
 	return fmt.Sprintf("wrong transaction network ID: transaction has %d, ledger expects %d", e.TxNetworkId, e.LedgerNetworkId)
 }
+
+type TreasuryDonationWithPlutusV1V2Error struct {
+	Donation      uint64
+	PlutusVersion string
+}
+
+func (e TreasuryDonationWithPlutusV1V2Error) Error() string {
+	return fmt.Sprintf("treasury donation (%d lovelace) cannot be used with %s scripts - treasury donation is a Conway feature only available for PlutusV3", e.Donation, e.PlutusVersion)
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes UTXO value conservation by accounting for Conway treasury donations. Donation is applied only when the transaction uses no PlutusV1/V2 scripts; otherwise a clear error is returned.

- **Bug Fixes**
  - Include tx.Donation() in producedValue for Conway transactions.
  - Detect PlutusV1/V2 scripts via witnesses and reference inputs.

<sup>Written for commit 6712a25d4b6c7558f12251b1b4fa6c6c3ca8fe3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved value-conservation checks for Conway treasury donations to correctly handle transactions that include different Plutus script versions.
  * Transactions that include donations now return a clear error when incompatible (older) Plutus scripts are detected or when reference-input resolution fails.

* **Chores**
  * Added explicit, user-facing error messaging for misuse of treasury donations with unsupported Plutus versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->