### PR TITLE
fix(ledger): refuse inline datums in plutus v1

### DIFF
--- a/ledger/common/errors.go
+++ b/ledger/common/errors.go
@@ -59,3 +59,15 @@ var ErrReferenceInputResolution = errors.New(
 func (ReferenceInputResolutionError) Is(target error) bool {
 	return target == ErrReferenceInputResolution
 }
+
+// InlineDatumsNotSupportedError indicates inline datums used with PlutusV1 scripts
+type InlineDatumsNotSupportedError struct {
+	PlutusVersion string
+}
+
+func (e InlineDatumsNotSupportedError) Error() string {
+	return fmt.Sprintf(
+		"inline datums are not supported with %s scripts - inline datums are a Babbage feature only available for PlutusV2+",
+		e.PlutusVersion,
+	)
+}

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -34,6 +34,7 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateRedeemerAndScriptWitnesses,
 	UtxoValidateSignatures,
 	UtxoValidateCostModelsPresent,
+	UtxoValidateInlineDatumsWithPlutusV1,
 	UtxoValidateDisjointRefInputs,
 	UtxoValidateOutsideValidityIntervalUtxo,
 	UtxoValidateInputSetEmptyUtxo,
@@ -695,6 +696,15 @@ func UtxoValidateOutputBootAddrAttrsTooBig(
 	pp common.ProtocolParameters,
 ) error {
 	return shelley.UtxoValidateOutputBootAddrAttrsTooBig(tx, slot, ls, pp)
+}
+
+func UtxoValidateInlineDatumsWithPlutusV1(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return babbage.UtxoValidateInlineDatumsWithPlutusV1(tx, slot, ls, pp)
 }
 
 func UtxoValidateWrongNetwork(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reject inline datums when Plutus V1 scripts are used, preventing invalid Babbage-era transactions and returning a clear error. This adds a UTXO validation rule for Babbage and Conway to enforce the spec.

- **Bug Fixes**
  - Added UtxoValidateInlineDatumsWithPlutusV1 to block txs that spend inline datums with Plutus V1 scripts (in witnesses or reference scripts).
  - Introduced InlineDatumsNotSupportedError with a direct, helpful message.
  - Wired the rule into Babbage and Conway UTXO validation pipelines.

<sup>Written for commit dcffaa1dbd2b59a8f5d25e2bf8679d9dfc04f869. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject transactions attempting to use inline datums with PlutusV1 scripts, which are not supported. Transactions containing this combination will now be rejected during validation with a descriptive error message, preventing invalid transactions from being submitted to the network.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->