### PR TITLE
fix(handshake): improve refusal message handling with specific error types

### DIFF
--- a/protocol/handshake/messages.go
+++ b/protocol/handshake/messages.go
@@ -36,6 +36,56 @@ const (
 	RefuseReasonRefused         uint64 = 2
 )
 
+// RefusalError represents a handshake refusal error
+type RefusalError interface {
+	error
+	ReasonCode() uint64
+}
+
+// VersionMismatchError represents a version mismatch refusal
+// Format: [0, [*anyVersionNumber]]
+type VersionMismatchError struct {
+	SupportedVersions []uint16
+}
+
+func (e *VersionMismatchError) Error() string {
+	return fmt.Sprintf("%s: version mismatch (supported versions: %v)", ProtocolName, e.SupportedVersions)
+}
+
+func (e *VersionMismatchError) ReasonCode() uint64 {
+	return RefuseReasonVersionMismatch
+}
+
+// DecodeError represents a handshake decode error refusal
+// Format: [1, anyVersionNumber, tstr]
+type DecodeError struct {
+	Version uint16
+	Message string
+}
+
+func (e *DecodeError) Error() string {
+	return fmt.Sprintf("%s: decode error (version %d): %s", ProtocolName, e.Version, e.Message)
+}
+
+func (e *DecodeError) ReasonCode() uint64 {
+	return RefuseReasonDecodeError
+}
+
+// RefusedError represents a general refusal
+// Format: [2, anyVersionNumber, tstr]
+type RefusedError struct {
+	Version uint16
+	Message string
+}
+
+func (e *RefusedError) Error() string {
+	return fmt.Sprintf("%s: refused (version %d): %s", ProtocolName, e.Version, e.Message)
+}
+
+func (e *RefusedError) ReasonCode() uint64 {
+	return RefuseReasonRefused
+}
+
 // NewMsgFromCbor parses a Handshake message from CBOR
 func NewMsgFromCbor(msgType uint, data []byte) (protocol.Message, error) {
 	var ret protocol.Message


### PR DESCRIPTION
Closes #562

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds typed refusal errors to the handshake and tightens validation of refusal payloads. This provides clearer, actionable errors and avoids crashes on malformed messages.

- New Features
  - Introduced RefusalError interface with VersionMismatchError, DecodeError, and RefusedError.
  - Errors carry structured details (supported versions, version, message) and expose ReasonCode().
  - Improved error strings for better diagnostics.

- Bug Fixes
  - Added checked type assertions for MsgRefuse and MsgQueryReply to prevent panics.
  - Validates refusal payload shape and numeric ranges; parses version arrays from CBOR-decoded []any into []uint16.
  - Returns precise errors for malformed messages and unknown reason codes.

<sup>Written for commit 991ea9c72e384067ebdb7f890f17ebedf8aa6f4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced protocol handshake error handling to provide more specific, detailed error messages.
  * Improved validation of handshake messages to detect and report malformed data.
  * Added structured error reporting that clearly distinguishes between version mismatches, decode errors, and refusals.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->