### PR TITLE
fix(ledger): governance script witnesses

### DIFF
--- a/ledger/common/gov.go
+++ b/ledger/common/gov.go
@@ -232,6 +232,11 @@ type GovAction interface {
 	ToPlutusData() data.PlutusData
 }
 
+// GovActionWithPolicy is an optional interface for governance actions that have a policy script
+type GovActionWithPolicy interface {
+	GetPolicyHash() []byte
+}
+
 type GovActionBase struct{}
 
 //nolint:unused
@@ -298,6 +303,11 @@ func (a *TreasuryWithdrawalGovAction) ToPlutusData() data.PlutusData {
 }
 
 func (a TreasuryWithdrawalGovAction) isGovAction() {}
+
+// GetPolicyHash returns the policy script hash for this governance action
+func (a *TreasuryWithdrawalGovAction) GetPolicyHash() []byte {
+	return a.PolicyHash
+}
 
 type NoConfidenceGovAction struct {
 	cbor.StructAsArray

--- a/ledger/conway/gov.go
+++ b/ledger/conway/gov.go
@@ -131,3 +131,8 @@ func (a *ConwayParameterChangeGovAction) ToPlutusData() data.PlutusData {
 		policyHash,
 	)
 }
+
+// GetPolicyHash returns the policy script hash for this governance action
+func (a *ConwayParameterChangeGovAction) GetPolicyHash() []byte {
+	return a.PolicyHash
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix governance script witness validation so transactions include required witnesses for script-based voters and governance policy scripts. This prevents missing witness errors in voting and proposal procedures.

- **Bug Fixes**
  - Include CC hot and DRep script voters when collecting required script hashes.
  - Require policy script witnesses for governance actions via a new GovActionWithPolicy interface.
  - Implement GetPolicyHash for TreasuryWithdrawalGovAction and ConwayParameterChangeGovAction.

<sup>Written for commit dc24d330ac2c0185477ad3ba3618501e79f67b69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Governance actions now expose policy hash information for better integration with validation workflows.
  * Enhanced validation logic to properly recognize and track required policy scripts associated with governance proposals and voting procedures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->