### PR TITLE
feat(ledger): CIP-0005 strings for everything

### DIFF
--- a/ledger/common/certs.go
+++ b/ledger/common/certs.go
@@ -217,6 +217,24 @@ func (d *Drep) ToPlutusData() data.PlutusData {
 	return nil
 }
 
+// String returns a CIP-0129 bech32-encoded representation of the DRep.
+// Returns "drep_abstain" for abstain, "drep_no_confidence" for no confidence,
+// and a CIP-0129 encoded bech32 string with "drep" prefix for key/script hashes.
+func (d *Drep) String() string {
+	switch d.Type {
+	case DrepTypeAddrKeyHash:
+		return encodeCip129Credential("drep", CredentialTypeAddrKeyHash, d.Credential)
+	case DrepTypeScriptHash:
+		return encodeCip129Credential("drep", CredentialTypeScriptHash, d.Credential)
+	case DrepTypeAbstain:
+		return "drep_abstain"
+	case DrepTypeNoConfidence:
+		return "drep_no_confidence"
+	default:
+		return fmt.Sprintf("drep_unknown_%d", d.Type)
+	}
+}
+
 type StakeRegistrationCertificate struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor

--- a/ledger/common/certs_test.go
+++ b/ledger/common/certs_test.go
@@ -1,0 +1,113 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestDrepString tests CIP-0129 bech32 encoding for DRep identifiers.
+func TestDrepString(t *testing.T) {
+	var zeroHash = make([]byte, 28)
+	var sequentialHash = make([]byte, 28)
+	for i := range sequentialHash {
+		sequentialHash[i] = byte(i)
+	}
+
+	testCases := []struct {
+		name string
+		drep Drep
+		want string
+	}{
+		{
+			name: "CIP0129KeyHashZero",
+			drep: Drep{
+				Type:       DrepTypeAddrKeyHash,
+				Credential: zeroHash,
+			},
+			want: "drep1ygqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq7vlc9n",
+		},
+		{
+			name: "CIP0129ScriptHashZero",
+			drep: Drep{
+				Type:       DrepTypeScriptHash,
+				Credential: zeroHash,
+			},
+			want: "drep1yvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq770f95",
+		},
+		{
+			name: "CIP0129KeyHashSequential",
+			drep: Drep{
+				Type:       DrepTypeAddrKeyHash,
+				Credential: sequentialHash,
+			},
+			// Uses CIP-0129 header byte encoding (0x22 for key hash)
+			want: "drep1ygqqzqsrqszsvpcgpy9qkrqdpc83qygjzv2p29shrqv35xc6zv3a4",
+		},
+		{
+			name: "CIP0129Abstain",
+			drep: Drep{
+				Type: DrepTypeAbstain,
+			},
+			want: "drep_abstain",
+		},
+		{
+			name: "CIP0129NoConfidence",
+			drep: Drep{
+				Type: DrepTypeNoConfidence,
+			},
+			want: "drep_no_confidence",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.drep.String()
+			assert.Equal(t, tc.want, result)
+		})
+	}
+
+	// Test unknown type returns descriptive string (doesn't panic)
+	t.Run("UnknownType", func(t *testing.T) {
+		drep := Drep{Type: 99}
+		result := drep.String()
+		assert.Equal(t, "drep_unknown_99", result)
+	})
+
+	// Test with wrong credential length (should still encode but produces non-standard output)
+	// CIP-0129 expects 28-byte credentials for key/script hashes
+	t.Run("ShortCredential", func(t *testing.T) {
+		drep := Drep{
+			Type:       DrepTypeAddrKeyHash,
+			Credential: []byte{0x01, 0x02, 0x03}, // Only 3 bytes
+		}
+		// Should not panic, but produces non-standard bech32
+		result := drep.String()
+		assert.True(t, len(result) > 0)
+		assert.True(t, strings.HasPrefix(result, "drep1"))
+	})
+
+	// Test nil credential for abstain/no-confidence (should work fine)
+	t.Run("NilCredentialAbstain", func(t *testing.T) {
+		drep := Drep{
+			Type:       DrepTypeAbstain,
+			Credential: nil,
+		}
+		assert.Equal(t, "drep_abstain", drep.String())
+	})
+}

--- a/ledger/common/common.go
+++ b/ledger/common/common.go
@@ -69,6 +69,21 @@ func (b Blake2b256) MarshalCBOR() ([]byte, error) {
 	return cbor.Encode(hashBytes)
 }
 
+func (b Blake2b256) Bech32(prefix string) string {
+	// Convert data to base32 and encode as bech32
+	convData, err := bech32.ConvertBits(b[:], 8, 5, true)
+	if err != nil {
+		panic(
+			fmt.Sprintf("unexpected error converting data to base32: %s", err),
+		)
+	}
+	encoded, err := bech32.Encode(prefix, convData)
+	if err != nil {
+		panic(fmt.Sprintf("unexpected error encoding data as bech32: %s", err))
+	}
+	return encoded
+}
+
 // Blake2b256Hash generates a Blake2b-256 hash from the provided data
 func Blake2b256Hash(data []byte) Blake2b256 {
 	tmpHash, err := blake2b.New(Blake2b256Size, nil)
@@ -483,18 +498,7 @@ func NewPoolIdFromBech32(poolId string) (PoolId, error) {
 }
 
 func (p PoolId) String() string {
-	// Convert data to base32 and encode as bech32
-	convData, err := bech32.ConvertBits(p[:], 8, 5, true)
-	if err != nil {
-		panic(
-			fmt.Sprintf("unexpected error converting data to base32: %s", err),
-		)
-	}
-	encoded, err := bech32.Encode("pool", convData)
-	if err != nil {
-		panic(fmt.Sprintf("unexpected error encoding data as bech32: %s", err))
-	}
-	return encoded
+	return Blake2b224(p).Bech32("pool")
 }
 
 // IssuerVkey represents the verification key for the stake pool that minted a block

--- a/ledger/common/data.go
+++ b/ledger/common/data.go
@@ -21,6 +21,11 @@ import (
 
 type DatumHash = Blake2b256
 
+// DatumHashToBech32 encodes a DatumHash as a CIP-0005 bech32 string with "datum" prefix.
+func DatumHashToBech32(d DatumHash) string {
+	return d.Bech32("datum")
+}
+
 // Datum represents a Plutus datum
 type Datum struct {
 	cbor.DecodeStoreCbor

--- a/ledger/common/script.go
+++ b/ledger/common/script.go
@@ -58,6 +58,11 @@ func NewScriptHashFromBech32(scriptHash string) (ScriptHash, error) {
 	return s, nil
 }
 
+// ScriptHashToBech32 encodes a ScriptHash as a CIP-0005 bech32 string with "script" prefix.
+func ScriptHashToBech32(s ScriptHash) string {
+	return s.Bech32("script")
+}
+
 type ScriptRef struct {
 	Type   uint
 	Script Script


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CIP-0005 and CIP-0129 string encoders across ledger types to provide bech32 identifiers for datums, scripts, DReps, governance actions, and pool IDs. Improves readability and consistency with tests for prefixes and round trips.

- **New Features**
  - Drep.String returns CIP-0129 bech32 (prefix "drep"), with "drep_abstain" and "drep_no_confidence" for special cases.
  - DatumHashToBech32 encodes 32-byte datum hashes with "datum" prefix; ScriptHashToBech32 uses "script" with a round-trip test.
  - GovActionId.String outputs "gov_action" bech32 using tx_id + single-byte index.
  - PoolId.String encodes to bech32 with "pool" prefix; includes round-trip and negative tests.
  - Added encodeCip129Credential helper for credential bech32 encoding.

<sup>Written for commit 25d77a331f110e52819d6c46442164bce58c5a8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bech32 encoding capabilities for datum hashes, script hashes, governance action IDs, and delegation representative credentials, enabling standardized representation across the system following CIP standards.

* **Tests**
  * Added comprehensive test coverage validating bech32 encoding functionality, including round-trip conversion verification and prefix validation for encoded hashes and identifiers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->