### PR TITLE
fix(txsubmission) add DoneChan to CallbackContext

### DIFF
--- a/protocol/txsubmission/client.go
+++ b/protocol/txsubmission/client.go
@@ -64,6 +64,7 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 		InitialState:        stateInit,
 	}
 	c.Protocol = protocol.New(protoConfig)
+	c.callbackContext.DoneChan = c.DoneChan()
 	return c
 }
 

--- a/protocol/txsubmission/server.go
+++ b/protocol/txsubmission/server.go
@@ -70,6 +70,7 @@ func (s *Server) initProtocol() {
 		InitialState:        stateInit,
 	}
 	s.Protocol = protocol.New(protoConfig)
+	s.callbackContext.DoneChan = s.DoneChan()
 }
 
 func (s *Server) Start() {

--- a/protocol/txsubmission/txsubmission.go
+++ b/protocol/txsubmission/txsubmission.go
@@ -159,6 +159,7 @@ type CallbackContext struct {
 	ConnectionId connection.ConnectionId
 	Client       *Client
 	Server       *Server
+	DoneChan     <-chan struct{}
 }
 
 // Callback function types


### PR DESCRIPTION
Closes #486 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose DoneChan in TxSubmission CallbackContext to propagate shutdown signals to callbacks, preventing blocked handlers during client/server shutdown. Client and Server now set callbackContext.DoneChan from their DoneChan() so callbacks can stop work promptly.

- **Bug Fixes**
  - Added DoneChan to CallbackContext.
  - Wired DoneChan in client and server initialization.

<sup>Written for commit 24958e81daa7cb1cc371fa4a42733d648027daa9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved transaction submission protocol shutdown handling to ensure proper termination signaling for client and server operations, enhancing system stability during graceful closure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->