### PR TITLE
refactor: use cbor helpers in protocol/message.go

### DIFF
--- a/protocol/keepalive/client_test.go
+++ b/protocol/keepalive/client_test.go
@@ -136,8 +136,8 @@ func TestServerKeepaliveHandlingWithWrongResponse(t *testing.T) {
 
 	// Expected cookie is 0x3e8 instead of 0x3e7 based on the mock connection
 	expectedErr := "input error: parsed message does not match expected value: " +
-		"got &keepalive.MsgKeepAlive{MessageBase:protocol.MessageBase{_:struct {}{}, rawCbor:[]uint8(nil), MessageType:0x0}, Cookie:0x3e7}, " +
-		"expected &keepalive.MsgKeepAlive{MessageBase:protocol.MessageBase{_:struct {}{}, rawCbor:[]uint8(nil), MessageType:0x0}, Cookie:0x3e8}"
+		"got &keepalive.MsgKeepAlive{MessageBase:protocol.MessageBase{StructAsArray:cbor.StructAsArray{_:struct {}{}}, DecodeStoreCbor:cbor.DecodeStoreCbor{cborData:[]uint8(nil)}, MessageType:0x0}, Cookie:0x3e7}, " +
+		"expected &keepalive.MsgKeepAlive{MessageBase:protocol.MessageBase{StructAsArray:cbor.StructAsArray{_:struct {}{}}, DecodeStoreCbor:cbor.DecodeStoreCbor{cborData:[]uint8(nil)}, MessageType:0x0}, Cookie:0x3e8}"
 	// Async mock connection error handler
 	asyncErrChan := make(chan error, 1)
 	go func() {

--- a/protocol/message.go
+++ b/protocol/message.go
@@ -14,6 +14,10 @@
 
 package protocol
 
+import (
+	"github.com/blinklabs-io/gouroboros/cbor"
+)
+
 // Message provides a common interface for message utility functions
 type Message interface {
 	SetCbor([]byte)
@@ -23,25 +27,9 @@ type Message interface {
 
 // MessageBase is the minimum implementation for a mini-protocol message
 type MessageBase struct {
-	// Tells the CBOR decoder to convert to/from a struct and a CBOR array
-	_           struct{} `cbor:",toarray"`
-	rawCbor     []byte
+	cbor.StructAsArray
+	cbor.DecodeStoreCbor
 	MessageType uint8
-}
-
-// SetCbor stores the original CBOR that was parsed
-func (m *MessageBase) SetCbor(data []byte) {
-	if data == nil {
-		m.rawCbor = nil
-		return
-	}
-	m.rawCbor = make([]byte, len(data))
-	copy(m.rawCbor, data)
-}
-
-// Cbor returns the original CBOR that was parsed
-func (m *MessageBase) Cbor() []byte {
-	return m.rawCbor
 }
 
 // Type returns the message type


### PR DESCRIPTION
Closes #1352

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored MessageBase to use shared CBOR helpers (StructAsArray and DecodeStoreCbor) for consistent encoding/decoding and CBOR storage. Updated the keepalive test to match the new struct representation in error messages.

- **Refactors**
  - Embedded cbor.StructAsArray and cbor.DecodeStoreCbor in MessageBase; removed custom struct tag and rawCbor handling.
  - Preserved Message interface via promoted methods from the helper types.
  - Updated keepalive client test expected error string to reflect new field names.

<sup>Written for commit cdb28d052e8602a76e699fcff8708a5a8f897863. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal CBOR message representation and handling mechanisms to improve data processing.

* **Tests**
  * Adjusted test expectations to align with updated message formatting and validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->