### PR TITLE
fix(ledger): multi-asset conservation

### DIFF
--- a/ledger/alonzo/rules.go
+++ b/ledger/alonzo/rules.go
@@ -16,6 +16,8 @@ package alonzo
 
 import (
 	"errors"
+	"fmt"
+	"math"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/allegra"
@@ -408,13 +410,160 @@ func UtxoValidateValueNotConservedUtxo(
 			producedValue += uint64(tmpPparams.KeyDeposit)
 		}
 	}
-	if consumedValue == producedValue {
-		return nil
+	if consumedValue != producedValue {
+		return shelley.ValueNotConservedUtxoError{
+			Consumed: consumedValue,
+			Produced: producedValue,
+		}
 	}
-	return shelley.ValueNotConservedUtxoError{
-		Consumed: consumedValue,
-		Produced: producedValue,
+
+	// Multi-asset value conservation check
+	// For each policy and asset: consumed + minted == produced
+	type assetKey struct {
+		policy common.Blake2b224
+		asset  string
 	}
+
+	consumedAssets := make(map[assetKey]int64)
+	producedAssets := make(map[assetKey]int64)
+
+	// Collect consumed multi-assets from inputs
+	for _, tmpInput := range tx.Inputs() {
+		tmpUtxo, err := ls.UtxoById(tmpInput)
+		if err != nil {
+			continue
+		}
+		if assets := tmpUtxo.Output.Assets(); assets != nil {
+			for _, policy := range assets.Policies() {
+				for _, assetName := range assets.Assets(policy) {
+					amount := assets.Asset(policy, assetName)
+					key := assetKey{policy: policy, asset: string(assetName)}
+					if amount > uint64(math.MaxInt64) {
+						return fmt.Errorf(
+							"consumed multi-asset amount for asset %s (policy %x) exceeds MaxInt64: %d",
+							string(assetName),
+							policy,
+							amount,
+						)
+					}
+					// Check for overflow when accumulating
+					if consumedAssets[key] > math.MaxInt64-int64(amount) { //nolint:gosec // G115: overflow checked above
+						return fmt.Errorf(
+							"consumed multi-asset accumulation overflow for asset %s (policy %x)",
+							string(assetName),
+							policy,
+						)
+					}
+					consumedAssets[key] += int64(amount) //nolint:gosec // G115: overflow checked above
+				}
+			}
+		}
+	}
+
+	// Add minted/burned assets to consumed (positive for mint, negative for burn)
+	if mint := tx.AssetMint(); mint != nil {
+		for _, policy := range mint.Policies() {
+			// Skip ADA (empty policy ID) as it's tracked separately in consumed/produced value
+			if policy == (common.Blake2b224{}) {
+				continue
+			}
+			for _, assetName := range mint.Assets(policy) {
+				amount := mint.Asset(policy, assetName)
+				key := assetKey{policy: policy, asset: string(assetName)}
+				// Check for overflow when adding mint amount (can be negative for burns)
+				if amount > 0 {
+					if consumedAssets[key] > math.MaxInt64-amount {
+						return fmt.Errorf(
+							"consumed multi-asset accumulation overflow for minted asset %s (policy %x)",
+							string(assetName),
+							policy,
+						)
+					}
+				} else if amount < 0 {
+					if consumedAssets[key] < math.MinInt64-amount {
+						return fmt.Errorf(
+							"consumed multi-asset accumulation underflow for burned asset %s (policy %x)",
+							string(assetName),
+							policy,
+						)
+					}
+				}
+				consumedAssets[key] += amount // Already int64
+			}
+		}
+	}
+
+	// Collect produced multi-assets from outputs
+	for _, tmpOutput := range tx.Outputs() {
+		if assets := tmpOutput.Assets(); assets != nil {
+			for _, policy := range assets.Policies() {
+				for _, assetName := range assets.Assets(policy) {
+					amount := assets.Asset(policy, assetName)
+					key := assetKey{policy: policy, asset: string(assetName)}
+					if amount > uint64(math.MaxInt64) {
+						return fmt.Errorf(
+							"produced multi-asset amount for asset %s (policy %x) exceeds MaxInt64: %d",
+							string(assetName),
+							policy,
+							amount,
+						)
+					}
+					// Check for overflow when accumulating
+					if producedAssets[key] > math.MaxInt64-int64(amount) { //nolint:gosec // G115: overflow checked above
+						return fmt.Errorf(
+							"produced multi-asset accumulation overflow for asset %s (policy %x)",
+							string(assetName),
+							policy,
+						)
+					}
+					producedAssets[key] += int64(amount) //nolint:gosec // G115: overflow checked above
+				}
+			}
+		}
+	}
+
+	// Check that all consumed assets match produced assets
+	allKeys := make(map[assetKey]bool)
+	for k := range consumedAssets {
+		allKeys[k] = true
+	}
+	for k := range producedAssets {
+		allKeys[k] = true
+	}
+
+	for key := range allKeys {
+		consumed := consumedAssets[key]
+		produced := producedAssets[key]
+		if consumed != produced {
+			var consumedU, producedU uint64
+			if consumed < 0 {
+				if consumed == math.MinInt64 {
+					// Special case: MinInt64 cannot be negated in int64
+					consumedU = uint64(math.MaxInt64) + 1
+				} else {
+					consumedU = uint64(-consumed) //nolint:gosec // G115: safe for values > MinInt64
+				}
+			} else {
+				consumedU = uint64(consumed)
+			}
+			if produced < 0 {
+				if produced == math.MinInt64 {
+					// Special case: MinInt64 cannot be negated in int64
+					producedU = uint64(math.MaxInt64) + 1
+				} else {
+					producedU = uint64(-produced) //nolint:gosec // G115: safe for values > MinInt64
+				}
+			} else {
+				producedU = uint64(produced)
+			}
+			return shelley.ValueNotConservedUtxoError{
+				Consumed: consumedU,
+				Produced: producedU,
+			}
+		}
+	}
+
+	return nil
 }
 
 func UtxoValidateOutputTooSmallUtxo(

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -16,6 +16,8 @@ package conway
 
 import (
 	"errors"
+	"fmt"
+	"math"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/allegra"
@@ -673,13 +675,162 @@ func UtxoValidateValueNotConservedUtxo(
 		// Only apply donation if not using PlutusV1/V2 scripts
 		producedValue += donation
 	}
-	if consumedValue == producedValue {
-		return nil
+	if consumedValue != producedValue {
+		return shelley.ValueNotConservedUtxoError{
+			Consumed: consumedValue,
+			Produced: producedValue,
+		}
 	}
-	return shelley.ValueNotConservedUtxoError{
-		Consumed: consumedValue,
-		Produced: producedValue,
+
+	// Multi-asset value conservation check
+	// For each policy and asset: consumed + minted == produced
+	type assetKey struct {
+		policy common.Blake2b224
+		asset  string
 	}
+
+	consumedAssets := make(map[assetKey]int64)
+	producedAssets := make(map[assetKey]int64)
+
+	// Collect consumed multi-assets from inputs
+	for _, tmpInput := range tx.Inputs() {
+		tmpUtxo, err := ls.UtxoById(tmpInput)
+		if err != nil {
+			continue
+		}
+		if assets := tmpUtxo.Output.Assets(); assets != nil {
+			for _, policy := range assets.Policies() {
+				for _, assetName := range assets.Assets(policy) {
+					amount := assets.Asset(policy, assetName)
+					key := assetKey{policy: policy, asset: string(assetName)}
+					if amount > uint64(math.MaxInt64) {
+						return fmt.Errorf(
+							"consumed multi-asset amount for asset %s (policy %x) exceeds MaxInt64: %d",
+							string(assetName),
+							policy,
+							amount,
+						)
+					}
+					// Check for overflow when accumulating
+					if consumedAssets[key] > math.MaxInt64-int64(amount) { //nolint:gosec // G115: overflow checked above
+						return fmt.Errorf(
+							"consumed multi-asset accumulation overflow for asset %s (policy %x)",
+							string(assetName),
+							policy,
+						)
+					}
+					consumedAssets[key] += int64(amount) //nolint:gosec // G115: overflow checked above
+				}
+			}
+		}
+	}
+
+	// Add minted/burned assets to consumed (positive for mint, negative for burn)
+	if mint := tx.AssetMint(); mint != nil {
+		for _, policy := range mint.Policies() {
+			// Skip ADA (empty policy ID) as it's tracked separately in consumed/produced value
+			if policy == (common.Blake2b224{}) {
+				continue
+			}
+			for _, assetName := range mint.Assets(policy) {
+				amount := mint.Asset(policy, assetName)
+				key := assetKey{policy: policy, asset: string(assetName)}
+				// Check for overflow when adding mint amount (can be negative for burns)
+				if amount > 0 {
+					if consumedAssets[key] > math.MaxInt64-amount {
+						return fmt.Errorf(
+							"consumed multi-asset accumulation overflow for minted asset %s (policy %x)",
+							string(assetName),
+							policy,
+						)
+					}
+				} else if amount < 0 {
+					if consumedAssets[key] < math.MinInt64-amount {
+						return fmt.Errorf(
+							"consumed multi-asset accumulation underflow for burned asset %s (policy %x)",
+							string(assetName),
+							policy,
+						)
+					}
+				}
+				consumedAssets[key] += amount // Already int64
+			}
+		}
+	}
+
+	// Collect produced multi-assets from outputs
+	for _, tmpOutput := range tx.Outputs() {
+		if assets := tmpOutput.Assets(); assets != nil {
+			for _, policy := range assets.Policies() {
+				for _, assetName := range assets.Assets(policy) {
+					amount := assets.Asset(policy, assetName)
+					key := assetKey{policy: policy, asset: string(assetName)}
+					if amount > uint64(math.MaxInt64) {
+						return fmt.Errorf(
+							"produced multi-asset amount for asset %s (policy %x) exceeds MaxInt64: %d",
+							string(assetName),
+							policy,
+							amount,
+						)
+					}
+					// Check for overflow when accumulating
+					if producedAssets[key] > math.MaxInt64-int64(amount) { //nolint:gosec // G115: overflow checked above
+						return fmt.Errorf(
+							"produced multi-asset accumulation overflow for asset %s (policy %x)",
+							string(assetName),
+							policy,
+						)
+					}
+					producedAssets[key] += int64(amount) //nolint:gosec // G115: overflow checked above
+				}
+			}
+		}
+	}
+
+	// Check that all consumed assets match produced assets
+	allKeys := make(map[assetKey]bool)
+	for k := range consumedAssets {
+		allKeys[k] = true
+	}
+	for k := range producedAssets {
+		allKeys[k] = true
+	}
+
+	for key := range allKeys {
+		consumed := consumedAssets[key]
+		produced := producedAssets[key]
+		if consumed != produced {
+			// Multi-asset value not conserved - return error
+			// Use the same error type for consistency
+			var consumedU, producedU uint64
+			if consumed < 0 {
+				if consumed == math.MinInt64 {
+					// Special case: MinInt64 cannot be negated in int64
+					consumedU = uint64(math.MaxInt64) + 1
+				} else {
+					consumedU = uint64(-consumed) //nolint:gosec // G115: safe for values > MinInt64
+				}
+			} else {
+				consumedU = uint64(consumed)
+			}
+			if produced < 0 {
+				if produced == math.MinInt64 {
+					// Special case: MinInt64 cannot be negated in int64
+					producedU = uint64(math.MaxInt64) + 1
+				} else {
+					producedU = uint64(-produced) //nolint:gosec // G115: safe for values > MinInt64
+				}
+			} else {
+				producedU = uint64(produced)
+			}
+			return shelley.ValueNotConservedUtxoError{
+				Consumed: consumedU,
+				Produced: producedU,
+			}
+		}
+	}
+
+	return nil
 }
 
 func UtxoValidateOutputTooSmallUtxo(

--- a/ledger/mary/rules.go
+++ b/ledger/mary/rules.go
@@ -16,6 +16,8 @@ package mary
 
 import (
 	"errors"
+	"fmt"
+	"math"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/allegra"
@@ -197,13 +199,160 @@ func UtxoValidateValueNotConservedUtxo(
 			producedValue += uint64(tmpPparams.KeyDeposit)
 		}
 	}
-	if consumedValue == producedValue {
-		return nil
+	if consumedValue != producedValue {
+		return shelley.ValueNotConservedUtxoError{
+			Consumed: consumedValue,
+			Produced: producedValue,
+		}
 	}
-	return shelley.ValueNotConservedUtxoError{
-		Consumed: consumedValue,
-		Produced: producedValue,
+
+	// Multi-asset value conservation check
+	// For each policy and asset: consumed + minted == produced
+	type assetKey struct {
+		policy common.Blake2b224
+		asset  string
 	}
+
+	consumedAssets := make(map[assetKey]int64)
+	producedAssets := make(map[assetKey]int64)
+
+	// Collect consumed multi-assets from inputs
+	for _, tmpInput := range tx.Inputs() {
+		tmpUtxo, err := ls.UtxoById(tmpInput)
+		if err != nil {
+			continue
+		}
+		if assets := tmpUtxo.Output.Assets(); assets != nil {
+			for _, policy := range assets.Policies() {
+				for _, assetName := range assets.Assets(policy) {
+					amount := assets.Asset(policy, assetName)
+					key := assetKey{policy: policy, asset: string(assetName)}
+					if amount > uint64(math.MaxInt64) {
+						return fmt.Errorf(
+							"consumed multi-asset amount for asset %s (policy %x) exceeds MaxInt64: %d",
+							string(assetName),
+							policy,
+							amount,
+						)
+					}
+					// Check for overflow when accumulating
+					if consumedAssets[key] > math.MaxInt64-int64(amount) { //nolint:gosec // G115: overflow checked above
+						return fmt.Errorf(
+							"consumed multi-asset accumulation overflow for asset %s (policy %x)",
+							string(assetName),
+							policy,
+						)
+					}
+					consumedAssets[key] += int64(amount) //nolint:gosec // G115: overflow checked above
+				}
+			}
+		}
+	}
+
+	// Add minted/burned assets to consumed (positive for mint, negative for burn)
+	if mint := tx.AssetMint(); mint != nil {
+		for _, policy := range mint.Policies() {
+			// Skip ADA (empty policy ID) as it's tracked separately in consumed/produced value
+			if policy == (common.Blake2b224{}) {
+				continue
+			}
+			for _, assetName := range mint.Assets(policy) {
+				amount := mint.Asset(policy, assetName)
+				key := assetKey{policy: policy, asset: string(assetName)}
+				// Check for overflow when adding mint amount (can be negative for burns)
+				if amount > 0 {
+					if consumedAssets[key] > math.MaxInt64-amount {
+						return fmt.Errorf(
+							"consumed multi-asset accumulation overflow for minted asset %s (policy %x)",
+							string(assetName),
+							policy,
+						)
+					}
+				} else if amount < 0 {
+					if consumedAssets[key] < math.MinInt64-amount {
+						return fmt.Errorf(
+							"consumed multi-asset accumulation underflow for burned asset %s (policy %x)",
+							string(assetName),
+							policy,
+						)
+					}
+				}
+				consumedAssets[key] += amount // Already int64
+			}
+		}
+	}
+
+	// Collect produced multi-assets from outputs
+	for _, tmpOutput := range tx.Outputs() {
+		if assets := tmpOutput.Assets(); assets != nil {
+			for _, policy := range assets.Policies() {
+				for _, assetName := range assets.Assets(policy) {
+					amount := assets.Asset(policy, assetName)
+					key := assetKey{policy: policy, asset: string(assetName)}
+					if amount > uint64(math.MaxInt64) {
+						return fmt.Errorf(
+							"produced multi-asset amount for asset %s (policy %x) exceeds MaxInt64: %d",
+							string(assetName),
+							policy,
+							amount,
+						)
+					}
+					// Check for overflow when accumulating
+					if producedAssets[key] > math.MaxInt64-int64(amount) { //nolint:gosec // G115: overflow checked above
+						return fmt.Errorf(
+							"produced multi-asset accumulation overflow for asset %s (policy %x)",
+							string(assetName),
+							policy,
+						)
+					}
+					producedAssets[key] += int64(amount) //nolint:gosec // G115: overflow checked above
+				}
+			}
+		}
+	}
+
+	// Check that all consumed assets match produced assets
+	allKeys := make(map[assetKey]bool)
+	for k := range consumedAssets {
+		allKeys[k] = true
+	}
+	for k := range producedAssets {
+		allKeys[k] = true
+	}
+
+	for key := range allKeys {
+		consumed := consumedAssets[key]
+		produced := producedAssets[key]
+		if consumed != produced {
+			var consumedU, producedU uint64
+			if consumed < 0 {
+				if consumed == math.MinInt64 {
+					// Special case: MinInt64 cannot be negated in int64
+					consumedU = uint64(math.MaxInt64) + 1
+				} else {
+					consumedU = uint64(-consumed) //nolint:gosec // G115: safe for values > MinInt64
+				}
+			} else {
+				consumedU = uint64(consumed)
+			}
+			if produced < 0 {
+				if produced == math.MinInt64 {
+					// Special case: MinInt64 cannot be negated in int64
+					producedU = uint64(math.MaxInt64) + 1
+				} else {
+					producedU = uint64(-produced) //nolint:gosec // G115: safe for values > MinInt64
+				}
+			} else {
+				producedU = uint64(produced)
+			}
+			return shelley.ValueNotConservedUtxoError{
+				Consumed: consumedU,
+				Produced: producedU,
+			}
+		}
+	}
+
+	return nil
 }
 
 func UtxoValidateOutputTooSmallUtxo(

--- a/ledger/shelley/rules.go
+++ b/ledger/shelley/rules.go
@@ -461,7 +461,8 @@ func UtxoValidateMetadata(
 		// placeholder as well. If the auxiliary-data is exactly one
 		// simple-value byte, ignore it here.
 		if len(ac) > 0 {
-			if len(ac) != 1 || (ac[0] != 0xF6 && ac[0] != 0xF5 && ac[0] != 0xF4) {
+			if len(ac) != 1 ||
+				(ac[0] != 0xF6 && ac[0] != 0xF5 && ac[0] != 0xF4) {
 				rawAuxData = ac
 			}
 		}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces multi-asset value conservation in UTXO validation for Mary, Alonzo, Babbage, and Conway. Transactions now fail if per policy+asset balances aren’t conserved, including mint/burn.

- **Bug Fixes**
  - Check per policy+asset: inputs + mint/burn == outputs; return ValueNotConservedUtxoError on mismatch.
  - Implemented across era rules; counts assets from inputs/outputs and includes positive mint and negative burn using int64.

<sup>Written for commit 6fe95166e496312d21c727d40567748aa2437fdb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced value conservation validation across all ledger eras to properly enforce that consumed and produced assets match exactly, including minted assets.
  * Improved validation logic to detect asset imbalances with precise reporting of consumed versus produced amounts for better transaction accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->