### PR TITLE
fix(ledger): update plutus conway rules

### DIFF
--- a/ledger/common/script.go
+++ b/ledger/common/script.go
@@ -137,6 +137,63 @@ func (s PlutusV1Script) RawScriptBytes() []byte {
 	return []byte(s)
 }
 
+// Evaluate executes a PlutusV1 script with datum, redeemer, and script context
+// V1 scripts take 3 arguments applied in order: datum, redeemer, context
+func (s PlutusV1Script) Evaluate(
+	datum data.PlutusData,
+	redeemer data.PlutusData,
+	scriptContext data.PlutusData,
+	budget ExUnits,
+) (ExUnits, error) {
+	var usedExUnits ExUnits
+	var err error
+	var program *syn.Program[syn.DeBruijn]
+	// Set budget
+	machineBudget := cek.DefaultExBudget
+	if budget.Steps > 0 || budget.Memory > 0 {
+		machineBudget = cek.ExBudget{
+			Cpu: budget.Steps,
+			Mem: budget.Memory,
+		}
+	}
+	// Decode raw script as bytestring to get actual script bytes
+	var innerScript []byte
+	if _, err = cbor.Decode([]byte(s), &innerScript); err != nil {
+		return usedExUnits, fmt.Errorf("decode cbor: %w", err)
+	}
+	// Decode program
+	program, err = syn.Decode[syn.DeBruijn]([]byte(innerScript))
+	if err != nil {
+		return usedExUnits, fmt.Errorf("decode script: %w", err)
+	}
+	// Apply arguments to program: datum, redeemer, context
+	datumTerm := &syn.Constant{Con: &syn.Data{Inner: datum}}
+	redeemerTerm := &syn.Constant{Con: &syn.Data{Inner: redeemer}}
+	contextTerm := &syn.Constant{Con: &syn.Data{Inner: scriptContext}}
+
+	wrappedProgram := &syn.Apply[syn.DeBruijn]{
+		Function: &syn.Apply[syn.DeBruijn]{
+			Function: &syn.Apply[syn.DeBruijn]{
+				Function: program.Term,
+				Argument: datumTerm,
+			},
+			Argument: redeemerTerm,
+		},
+		Argument: contextTerm,
+	}
+	// Execute wrapped program (1.0.0 is Plutus V1)
+	machine := cek.NewMachine[syn.DeBruijn]([3]uint32{1, 0, 0}, 200)
+	machine.ExBudget = machineBudget
+	_, err = machine.Run(wrappedProgram)
+	if err != nil {
+		return usedExUnits, fmt.Errorf("execute script: %w", err)
+	}
+	consumedBudget := machineBudget.Sub(&machine.ExBudget)
+	usedExUnits.Memory = consumedBudget.Mem
+	usedExUnits.Steps = consumedBudget.Cpu
+	return usedExUnits, nil
+}
+
 type PlutusV2Script []byte
 
 func (PlutusV2Script) isScript() {}
@@ -152,6 +209,63 @@ func (s PlutusV2Script) Hash() ScriptHash {
 
 func (s PlutusV2Script) RawScriptBytes() []byte {
 	return []byte(s)
+}
+
+// Evaluate executes a PlutusV2 script with datum, redeemer, and script context
+// V2 scripts take 3 arguments applied in order: datum, redeemer, context
+func (s PlutusV2Script) Evaluate(
+	datum data.PlutusData,
+	redeemer data.PlutusData,
+	scriptContext data.PlutusData,
+	budget ExUnits,
+) (ExUnits, error) {
+	var usedExUnits ExUnits
+	var err error
+	var program *syn.Program[syn.DeBruijn]
+	// Set budget
+	machineBudget := cek.DefaultExBudget
+	if budget.Steps > 0 || budget.Memory > 0 {
+		machineBudget = cek.ExBudget{
+			Cpu: budget.Steps,
+			Mem: budget.Memory,
+		}
+	}
+	// Decode raw script as bytestring to get actual script bytes
+	var innerScript []byte
+	if _, err = cbor.Decode([]byte(s), &innerScript); err != nil {
+		return usedExUnits, fmt.Errorf("decode cbor: %w", err)
+	}
+	// Decode program
+	program, err = syn.Decode[syn.DeBruijn]([]byte(innerScript))
+	if err != nil {
+		return usedExUnits, fmt.Errorf("decode script: %w", err)
+	}
+	// Apply arguments to program: datum, redeemer, context
+	datumTerm := &syn.Constant{Con: &syn.Data{Inner: datum}}
+	redeemerTerm := &syn.Constant{Con: &syn.Data{Inner: redeemer}}
+	contextTerm := &syn.Constant{Con: &syn.Data{Inner: scriptContext}}
+
+	wrappedProgram := &syn.Apply[syn.DeBruijn]{
+		Function: &syn.Apply[syn.DeBruijn]{
+			Function: &syn.Apply[syn.DeBruijn]{
+				Function: program.Term,
+				Argument: datumTerm,
+			},
+			Argument: redeemerTerm,
+		},
+		Argument: contextTerm,
+	}
+	// Execute wrapped program (1.1.0 is Plutus V2)
+	machine := cek.NewMachine[syn.DeBruijn]([3]uint32{1, 1, 0}, 200)
+	machine.ExBudget = machineBudget
+	_, err = machine.Run(wrappedProgram)
+	if err != nil {
+		return usedExUnits, fmt.Errorf("execute script: %w", err)
+	}
+	consumedBudget := machineBudget.Sub(&machine.ExBudget)
+	usedExUnits.Memory = consumedBudget.Mem
+	usedExUnits.Steps = consumedBudget.Cpu
+	return usedExUnits, nil
 }
 
 type PlutusV3Script []byte
@@ -177,7 +291,7 @@ func (s PlutusV3Script) Evaluate(
 ) (ExUnits, error) {
 	var usedExUnits ExUnits
 	var err error
-	program := &syn.Program[syn.DeBruijn]{}
+	var program *syn.Program[syn.DeBruijn]
 	// Set budget
 	machineBudget := cek.DefaultExBudget
 	if budget.Steps > 0 || budget.Memory > 0 {
@@ -189,7 +303,7 @@ func (s PlutusV3Script) Evaluate(
 	// Decode raw script as bytestring to get actual script bytes
 	var innerScript []byte
 	if _, err = cbor.Decode([]byte(s), &innerScript); err != nil {
-		return usedExUnits, err
+		return usedExUnits, fmt.Errorf("decode cbor: %w", err)
 	}
 	// Decode program
 	program, err = syn.Decode[syn.DeBruijn]([]byte(innerScript))

--- a/ledger/common/script/context.go
+++ b/ledger/common/script/context.go
@@ -499,6 +499,9 @@ func dataInfo(
 	witnessSet lcommon.TransactionWitnessSet,
 ) KeyValuePairs[lcommon.DatumHash, data.PlutusData] {
 	var ret KeyValuePairs[lcommon.DatumHash, data.PlutusData]
+	if witnessSet == nil {
+		return ret
+	}
 	for _, datum := range witnessSet.PlutusData() {
 		ret = append(
 			ret,
@@ -522,6 +525,9 @@ func redeemersInfo(
 	witnessSet lcommon.TransactionWitnessSet,
 	toScriptPurpose toScriptPurposeFunc,
 ) KeyValuePairs[ScriptPurpose, Redeemer] {
+	if witnessSet == nil {
+		return KeyValuePairs[ScriptPurpose, Redeemer]{}
+	}
 	redeemers := witnessSet.Redeemers()
 	if redeemers == nil {
 		return KeyValuePairs[ScriptPurpose, Redeemer]{}

--- a/ledger/common/script/context_test.go
+++ b/ledger/common/script/context_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package script
+package script_test
 
 import (
 	"encoding/hex"
@@ -26,6 +26,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/common/script"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/blinklabs-io/plutigo/data"
@@ -36,7 +37,7 @@ func buildTxInfoV1(
 	txHex string,
 	inputsHex string,
 	inputOutputsHex string,
-) (TxInfo, error) {
+) (script.TxInfo, error) {
 	// Transaction
 	txBytes, err := hex.DecodeString(txHex)
 	if err != nil {
@@ -79,7 +80,7 @@ func buildTxInfoV1(
 		)
 	}
 	// Build TxInfo
-	txInfo, err := NewTxInfoV1FromTransaction(slotState, tx, resolvedInputs)
+	txInfo, err := script.NewTxInfoV1FromTransaction(slotState, tx, resolvedInputs)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +92,7 @@ func buildTxInfoV3(
 	txHex string,
 	inputsHex string,
 	inputOutputsHex string,
-) (TxInfo, error) {
+) (script.TxInfo, error) {
 	// Transaction
 	txBytes, err := hex.DecodeString(txHex)
 	if err != nil {
@@ -134,7 +135,7 @@ func buildTxInfoV3(
 		)
 	}
 	// Build TxInfo
-	txInfo, err := NewTxInfoV3FromTransaction(slotState, tx, resolvedInputs)
+	txInfo, err := script.NewTxInfoV3FromTransaction(slotState, tx, resolvedInputs)
 	if err != nil {
 		return nil, err
 	}
@@ -204,8 +205,8 @@ func TestScriptContextV1(t *testing.T) {
 				}
 
 				// Extract purpose and redeemer from TxInfo
-				var purpose ScriptPurpose
-				for _, redeemerPair := range txInfo.(TxInfoV1).Redeemers {
+				var purpose script.ScriptPurpose
+				for _, redeemerPair := range txInfo.(script.TxInfoV1).Redeemers {
 					if redeemerPair.Value.Tag == testDef.redeemerTag &&
 						redeemerPair.Value.Index == testDef.redeemerIndex {
 						purpose = redeemerPair.Key
@@ -213,7 +214,7 @@ func TestScriptContextV1(t *testing.T) {
 					}
 				}
 				// Build script context
-				sc := NewScriptContextV1V2(txInfo, purpose)
+				sc := script.NewScriptContextV1V2(txInfo, purpose)
 				scCbor, err := data.Encode(sc.ToPlutusData())
 				if err != nil {
 					t.Fatalf("unexpected error: %s", err)
@@ -374,9 +375,9 @@ func TestScriptContextV3(t *testing.T) {
 				}
 
 				// Extract purpose and redeemer from TxInfo
-				var purpose ScriptPurpose
-				var redeemer Redeemer
-				for _, redeemerPair := range txInfo.(TxInfoV3).Redeemers {
+				var purpose script.ScriptPurpose
+				var redeemer script.Redeemer
+				for _, redeemerPair := range txInfo.(script.TxInfoV3).Redeemers {
 					if redeemerPair.Value.Tag == testDef.redeemerTag &&
 						redeemerPair.Value.Index == testDef.redeemerIndex {
 						purpose = redeemerPair.Key
@@ -385,7 +386,7 @@ func TestScriptContextV3(t *testing.T) {
 					}
 				}
 				// Build script context
-				sc := NewScriptContextV3(txInfo, redeemer, purpose)
+				sc := script.NewScriptContextV3(txInfo, redeemer, purpose)
 				scCbor, err := data.Encode(sc.ToPlutusData())
 				if err != nil {
 					t.Fatalf("unexpected error: %s", err)

--- a/ledger/conway/errors.go
+++ b/ledger/conway/errors.go
@@ -71,3 +71,42 @@ type TreasuryDonationWithPlutusV1V2Error struct {
 func (e TreasuryDonationWithPlutusV1V2Error) Error() string {
 	return fmt.Sprintf("treasury donation (%d lovelace) cannot be used with %s scripts - treasury donation is a Conway feature only available for PlutusV3", e.Donation, e.PlutusVersion)
 }
+
+// PlutusScriptFailedError indicates that a Plutus script execution failed
+type PlutusScriptFailedError struct {
+	ScriptHash common.ScriptHash
+	Tag        common.RedeemerTag
+	Index      uint32
+	Err        error
+}
+
+func (e PlutusScriptFailedError) Error() string {
+	return fmt.Sprintf("plutus script failed (hash=%x, tag=%d, index=%d): %v", e.ScriptHash[:], e.Tag, e.Index, e.Err)
+}
+
+func (e PlutusScriptFailedError) Unwrap() error {
+	return e.Err
+}
+
+// ScriptContextConstructionError indicates that the script context could not be built
+type ScriptContextConstructionError struct {
+	Err error
+}
+
+func (e ScriptContextConstructionError) Error() string {
+	return fmt.Sprintf("failed to construct script context: %v", e.Err)
+}
+
+func (e ScriptContextConstructionError) Unwrap() error {
+	return e.Err
+}
+
+// MissingDatumForSpendingScriptError indicates that a spending script requires a datum but none was provided
+type MissingDatumForSpendingScriptError struct {
+	ScriptHash common.ScriptHash
+	Input      common.TransactionInput
+}
+
+func (e MissingDatumForSpendingScriptError) Error() string {
+	return fmt.Sprintf("missing datum for spending script (hash=%x, input=%s)", e.ScriptHash[:], e.Input.String())
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds phase-2 Plutus validation in Conway by executing V1/V2/V3 scripts during UTxO validation. Also adds V1/V2 evaluation helpers and fixes script purpose mapping and redeemer index checks.

- **New Features**
  - Execute all Plutus scripts in UtxoValidatePlutusScripts, using witness and reference scripts with a TxInfoV3-based context.
  - Add Evaluate for PlutusV1Script and PlutusV2Script to run with datum, redeemer, and context, respecting ExUnits and returning used budget.

- **Bug Fixes**
  - Use GovActionWithPolicy to compute proposing script hashes without importing Conway types.
  - Add bounds checks for redeemer indices across spend/mint/cert/reward/voting/proposing to avoid invalid indexing.
  - Return PlutusScriptFailedError with script hash, tag, and index when a script execution fails.
  - Return MissingDatumForSpendingScriptError when V1/V2 spending scripts lack a datum, and guard datum/redeemer collection against nil witness sets.

<sup>Written for commit fe3c3b38cd7ae4d81fd7f2e5e40ae1161fbb3257. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Plutus V1 and V2 script execution with resource consumption tracking.
  * Integrated Plutus script validation into transaction processing (phase-2).

* **Bug Fixes**
  * Improved error reporting for script failures with richer diagnostic details.
  * Added defensive bounds and nil-checks to prevent runtime panics during script handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->