### PR TITLE
test(ledger): validate compliance with CIPs

### DIFF
--- a/ledger/babbage/errors_test.go
+++ b/ledger/babbage/errors_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/cbor"
 	test_ledger "github.com/blinklabs-io/gouroboros/internal/test/ledger"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 )
 
@@ -74,5 +75,76 @@ func TestCostModelsPresent_UnresolvedReferenceInputUnwraps(t *testing.T) {
 	}
 	if refErr.Err == nil || refErr.Err.Error() != "utxo not found" {
 		t.Fatalf("expected inner error 'utxo not found', got %v", refErr.Err)
+	}
+}
+
+func TestCostModelsPresent_ResolvedReferenceInputChecksCostModels(
+	t *testing.T,
+) {
+	// Create a BabbageTransaction with a single reference input so the lookup is attempted
+	var slot uint64 = 0
+
+	// construct an output that contains a script reference (PlutusV1)
+	addr := common.Address{}
+	amount := mary.MaryTransactionOutputValue{Amount: 1000}
+
+	// create a PlutusV1 script (PlutusV1Script is []byte)
+	plutus := common.PlutusV1Script{0x01, 0x02}
+	scriptRef := &common.ScriptRef{
+		Type:   common.ScriptRefTypePlutusV1,
+		Script: plutus,
+	}
+
+	output := BabbageTransactionOutput{
+		OutputAddress:  addr,
+		OutputAmount:   amount,
+		TxOutScriptRef: scriptRef,
+	}
+
+	// craft the UTxO that will be returned by the mock ledger state
+	input := shelley.NewShelleyTransactionInput(
+		"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		0,
+	)
+	utxo := common.Utxo{
+		Id:     input,
+		Output: output,
+	}
+
+	ls := test_ledger.NewMockLedgerStateWithUtxos([]common.Utxo{utxo})
+
+	var pp common.ProtocolParameters = &BabbageProtocolParameters{}
+
+	tmpTx := &BabbageTransaction{}
+	tmpTx.Body.TxReferenceInputs = cbor.NewSetType(
+		[]shelley.ShelleyTransactionInput{input},
+		false,
+	)
+	var tx common.Transaction = tmpTx
+
+	// First: missing cost models should return a MissingCostModelError
+	err := UtxoValidateCostModelsPresent(tx, slot, ls, pp)
+	if err == nil {
+		t.Fatal("expected error due to missing cost model, got nil")
+	}
+	var mErr common.MissingCostModelError
+	if !errors.As(err, &mErr) {
+		t.Fatalf("expected MissingCostModelError, got %T", err)
+	}
+
+	// Now provide the cost model for PlutusV1 and expect success
+	if bp, ok := pp.(*BabbageProtocolParameters); ok {
+		if bp.CostModels == nil {
+			bp.CostModels = make(map[uint][]int64)
+		}
+		// populate a dummy non-empty cost model for Plutus V1 (version 0)
+		bp.CostModels[0] = []int64{1}
+	} else {
+		t.Fatalf("protocol parameters not BabbageProtocolParameters: %T", pp)
+	}
+
+	err = UtxoValidateCostModelsPresent(tx, slot, ls, pp)
+	if err != nil {
+		t.Fatalf("expected no error after providing cost model, got %v", err)
 	}
 }

--- a/ledger/babbage/pparams_test.go
+++ b/ledger/babbage/pparams_test.go
@@ -437,6 +437,36 @@ func TestBabbageProtocolParamsUpdate(t *testing.T) {
 	}
 }
 
+func TestBabbageProtocolParameters_UpdateCopiesFields(t *testing.T) {
+	base := &babbage.BabbageProtocolParameters{}
+	upd := &babbage.BabbageProtocolParameterUpdate{}
+	a := uint(42)
+	mtx := uint(12345)
+	ada := uint64(9999)
+	upd.MinFeeA = &a
+	upd.MaxTxSize = &mtx
+	upd.AdaPerUtxoByte = &ada
+	upd.CostModels = map[uint][]int64{0: {1, 2}, 1: {3}}
+	// call Update
+	base.Update(upd)
+	if base.MinFeeA != 42 {
+		t.Fatalf("MinFeeA not updated: got %d", base.MinFeeA)
+	}
+	if base.MaxTxSize != 12345 {
+		t.Fatalf("MaxTxSize not updated: got %d", base.MaxTxSize)
+	}
+	if base.AdaPerUtxoByte != 9999 {
+		t.Fatalf("AdaPerUtxoByte not updated: got %d", base.AdaPerUtxoByte)
+	}
+	if !reflect.DeepEqual(base.CostModels, upd.CostModels) {
+		t.Fatalf(
+			"CostModels not updated: got %+v want %+v",
+			base.CostModels,
+			upd.CostModels,
+		)
+	}
+}
+
 func TestBabbageUtxorpc(t *testing.T) {
 	testDefs := []struct {
 		startParams     babbage.BabbageProtocolParameters

--- a/ledger/common/address_test.go
+++ b/ledger/common/address_test.go
@@ -386,6 +386,37 @@ func TestAddressToPlutusData(t *testing.T) {
 	}
 }
 
+func TestBech32Roundtrip_MainnetExamples(t *testing.T) {
+	examples := []string{
+		"addr1z8snz7c4974vzdpxu65ruphl3zjdvtxw8strf2c2tmqnxz2j2c79gy9l76sdg0xwhd7r0c0kna0tycz4y5s6mlenh8pq0xmsha",
+		"addr1qyln2c2cx5jc4hw768pwz60n5245462dvp4auqcw09rl2xz07huw84puu6cea3qe0ce3apks7hjckqkh5ad4uax0l9ws0q9xty",
+		"addr1wysmmrpwphe0h6fpxlmcmw46frmzxz89yvpsf8cdv29kcnqsw3vw6",
+	}
+
+	for _, s := range examples {
+		a, err := NewAddress(s)
+		assert.Nil(t, err, "should decode example address: %s", s)
+		// Roundtrip
+		r := a.String()
+		assert.Equal(t, s, r, "roundtrip should preserve bech32 string")
+	}
+}
+
+func TestBech32Roundtrip_TestnetExample(t *testing.T) {
+	s := "addr_test1gqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqypnz75xxcrsxvt6scmqvvrw720"
+	a, err := NewAddress(s)
+	assert.Nil(t, err)
+	assert.Equal(t, s, a.String())
+}
+
+func TestBech32MalformedInputs(t *testing.T) {
+	bad := []string{"", "not-bech32", "addr1xxxxzzzz..."}
+	for _, s := range bad {
+		_, err := NewAddress(s)
+		assert.Error(t, err, "expected error for malformed input: %s", s)
+	}
+}
+
 func BenchmarkAddressFromBytes(b *testing.B) {
 	addrBytes, err := hex.DecodeString(
 		"11e1317b152faac13426e6a83e06ff88a4d62cce3c1634ab0a5ec1330952563c5410bff6a0d43ccebb7c37e1f69f5eb260552521adff33b9c2",

--- a/ledger/common/pparams_test.go
+++ b/ledger/common/pparams_test.go
@@ -1,0 +1,62 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
+)
+
+func TestConvertToUtxorpcCardanoCostModels_Mapping(t *testing.T) {
+	models := map[uint][]int64{
+		1:  {10, 20},
+		2:  {30},
+		3:  {40, 50, 60},
+		99: {999}, // unsupported, should be ignored
+	}
+
+	cm := ConvertToUtxorpcCardanoCostModels(models)
+	if cm == nil {
+		t.Fatal("expected non-nil CostModels")
+	}
+	if cm.PlutusV1 == nil ||
+		!reflect.DeepEqual(cm.PlutusV1.Values, []int64{10, 20}) {
+		t.Fatalf("PlutusV1 not mapped correctly: %+v", cm.PlutusV1)
+	}
+	if cm.PlutusV2 == nil ||
+		!reflect.DeepEqual(cm.PlutusV2.Values, []int64{30}) {
+		t.Fatalf("PlutusV2 not mapped correctly: %+v", cm.PlutusV2)
+	}
+	if cm.PlutusV3 == nil ||
+		!reflect.DeepEqual(cm.PlutusV3.Values, []int64{40, 50, 60}) {
+		t.Fatalf("PlutusV3 not mapped correctly: %+v", cm.PlutusV3)
+	}
+}
+
+func TestConvertToUtxorpcCardanoCostModels_Empty(t *testing.T) {
+	cm := ConvertToUtxorpcCardanoCostModels(map[uint][]int64{})
+	if cm == nil {
+		t.Fatal("expected non-nil CostModels")
+	}
+	if cm.PlutusV1 != nil || cm.PlutusV2 != nil || cm.PlutusV3 != nil {
+		t.Fatalf("expected all nil cost model fields for empty input: %+v", cm)
+	}
+	// ensure it is a *cardano.CostModels
+	if _, ok := any(cm).(*cardano.CostModels); !ok {
+		t.Fatalf("expected *cardano.CostModels, got %T", cm)
+	}
+}

--- a/ledger/conway/errors_test.go
+++ b/ledger/conway/errors_test.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	test_ledger "github.com/blinklabs-io/gouroboros/internal/test/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 )
 
@@ -76,5 +78,189 @@ func TestConway_CostModelsPresent_UnresolvedReferenceInputUnwraps(
 	}
 	if refErr.Err == nil || refErr.Err.Error() != "utxo not found" {
 		t.Fatalf("expected inner error 'utxo not found', got %v", refErr.Err)
+	}
+}
+
+func TestConway_CostModelsPresent_ResolvedReferenceInputChecksCostModels(
+	t *testing.T,
+) {
+	var slot uint64 = 0
+
+	// construct an output that contains a script reference (PlutusV2)
+	addr := common.Address{}
+	amount := uint64(1000)
+
+	// PlutusV2Script is []byte
+	plutus := common.PlutusV2Script{0x01, 0x02}
+	scriptRef := &common.ScriptRef{
+		Type:   common.ScriptRefTypePlutusV2,
+		Script: plutus,
+	}
+
+	output := babbage.BabbageTransactionOutput{
+		OutputAddress:  addr,
+		OutputAmount:   mary.MaryTransactionOutputValue{Amount: amount},
+		TxOutScriptRef: scriptRef,
+	}
+
+	input := shelley.NewShelleyTransactionInput(
+		"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		0,
+	)
+	utxo := common.Utxo{
+		Id:     input,
+		Output: output,
+	}
+
+	ls := test_ledger.NewMockLedgerStateWithUtxos([]common.Utxo{utxo})
+
+	var pp common.ProtocolParameters = &ConwayProtocolParameters{}
+
+	tmpTx := &ConwayTransaction{}
+	tmpTx.Body.TxReferenceInputs = cbor.NewSetType(
+		[]shelley.ShelleyTransactionInput{input},
+		false,
+	)
+	var tx common.Transaction = tmpTx
+
+	// First: missing cost models should return a MissingCostModelError
+	err := UtxoValidateCostModelsPresent(tx, slot, ls, pp)
+	if err == nil {
+		t.Fatal("expected error due to missing cost model, got nil")
+	}
+	var mErr common.MissingCostModelError
+	if !errors.As(err, &mErr) {
+		t.Fatalf("expected MissingCostModelError, got %T", err)
+	}
+
+	// Now provide a dummy cost model for PlutusV2 (version 1)
+	if cp, ok := pp.(*ConwayProtocolParameters); ok {
+		if cp.CostModels == nil {
+			cp.CostModels = make(map[uint][]int64)
+		}
+		cp.CostModels[1] = []int64{1}
+	} else {
+		t.Fatalf("protocol parameters not ConwayProtocolParameters: %T", pp)
+	}
+
+	err = UtxoValidateCostModelsPresent(tx, slot, ls, pp)
+	if err != nil {
+		t.Fatalf("expected no error after providing cost model, got %v", err)
+	}
+}
+
+func TestConway_CostModelsPresent_ResolvedReferenceInput_PlutusV1(
+	t *testing.T,
+) {
+	var slot uint64 = 0
+
+	addr := common.Address{}
+	amount := uint64(500)
+	plutus := common.PlutusV1Script{0x0A}
+	scriptRef := &common.ScriptRef{
+		Type:   common.ScriptRefTypePlutusV1,
+		Script: plutus,
+	}
+
+	output := babbage.BabbageTransactionOutput{
+		OutputAddress:  addr,
+		OutputAmount:   mary.MaryTransactionOutputValue{Amount: amount},
+		TxOutScriptRef: scriptRef,
+	}
+
+	input := shelley.NewShelleyTransactionInput(
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		0,
+	)
+	utxo := common.Utxo{Id: input, Output: output}
+	ls := test_ledger.NewMockLedgerStateWithUtxos([]common.Utxo{utxo})
+	var pp common.ProtocolParameters = &ConwayProtocolParameters{}
+
+	tmpTx := &ConwayTransaction{}
+	tmpTx.Body.TxReferenceInputs = cbor.NewSetType(
+		[]shelley.ShelleyTransactionInput{input},
+		false,
+	)
+	var tx common.Transaction = tmpTx
+
+	err := UtxoValidateCostModelsPresent(tx, slot, ls, pp)
+	if err == nil {
+		t.Fatal("expected error due to missing cost model, got nil")
+	}
+	var mErr common.MissingCostModelError
+	if !errors.As(err, &mErr) {
+		t.Fatalf("expected MissingCostModelError, got %T", err)
+	}
+
+	if cp, ok := pp.(*ConwayProtocolParameters); ok {
+		if cp.CostModels == nil {
+			cp.CostModels = make(map[uint][]int64)
+		}
+		cp.CostModels[0] = []int64{1}
+	} else {
+		t.Fatalf("protocol parameters not ConwayProtocolParameters: %T", pp)
+	}
+
+	err = UtxoValidateCostModelsPresent(tx, slot, ls, pp)
+	if err != nil {
+		t.Fatalf("expected no error after providing cost model, got %v", err)
+	}
+}
+
+func TestConway_CostModelsPresent_ResolvedReferenceInput_PlutusV3(
+	t *testing.T,
+) {
+	var slot uint64 = 0
+
+	addr := common.Address{}
+	amount := uint64(750)
+	plutus := common.PlutusV3Script{0x0B}
+	scriptRef := &common.ScriptRef{
+		Type:   common.ScriptRefTypePlutusV3,
+		Script: plutus,
+	}
+
+	output := babbage.BabbageTransactionOutput{
+		OutputAddress:  addr,
+		OutputAmount:   mary.MaryTransactionOutputValue{Amount: amount},
+		TxOutScriptRef: scriptRef,
+	}
+
+	input := shelley.NewShelleyTransactionInput(
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		0,
+	)
+	utxo := common.Utxo{Id: input, Output: output}
+	ls := test_ledger.NewMockLedgerStateWithUtxos([]common.Utxo{utxo})
+	var pp common.ProtocolParameters = &ConwayProtocolParameters{}
+
+	tmpTx := &ConwayTransaction{}
+	tmpTx.Body.TxReferenceInputs = cbor.NewSetType(
+		[]shelley.ShelleyTransactionInput{input},
+		false,
+	)
+	var tx common.Transaction = tmpTx
+
+	err := UtxoValidateCostModelsPresent(tx, slot, ls, pp)
+	if err == nil {
+		t.Fatal("expected error due to missing cost model, got nil")
+	}
+	var mErr common.MissingCostModelError
+	if !errors.As(err, &mErr) {
+		t.Fatalf("expected MissingCostModelError, got %T", err)
+	}
+
+	if cp, ok := pp.(*ConwayProtocolParameters); ok {
+		if cp.CostModels == nil {
+			cp.CostModels = make(map[uint][]int64)
+		}
+		cp.CostModels[2] = []int64{1}
+	} else {
+		t.Fatalf("protocol parameters not ConwayProtocolParameters: %T", pp)
+	}
+
+	err = UtxoValidateCostModelsPresent(tx, slot, ls, pp)
+	if err != nil {
+		t.Fatalf("expected no error after providing cost model, got %v", err)
 	}
 }

--- a/ledger/conway/pparams_test.go
+++ b/ledger/conway/pparams_test.go
@@ -442,6 +442,36 @@ func TestConwayProtocolParamsUpdate(t *testing.T) {
 	}
 }
 
+func TestConwayProtocolParameters_UpdateCopiesFields(t *testing.T) {
+	base := &conway.ConwayProtocolParameters{}
+	upd := &conway.ConwayProtocolParameterUpdate{}
+	a := uint(11)
+	mt := uint(2222)
+	ada := uint64(7777)
+	upd.MinFeeA = &a
+	upd.MaxTxSize = &mt
+	upd.AdaPerUtxoByte = &ada
+	upd.CostModels = map[uint][]int64{0: {9}, 2: {8, 7}}
+
+	base.Update(upd)
+	if base.MinFeeA != 11 {
+		t.Fatalf("MinFeeA not updated: got %d", base.MinFeeA)
+	}
+	if base.MaxTxSize != 2222 {
+		t.Fatalf("MaxTxSize not updated: got %d", base.MaxTxSize)
+	}
+	if base.AdaPerUtxoByte != 7777 {
+		t.Fatalf("AdaPerUtxoByte not updated: got %d", base.AdaPerUtxoByte)
+	}
+	if !reflect.DeepEqual(base.CostModels, upd.CostModels) {
+		t.Fatalf(
+			"CostModels not updated: got %+v want %+v",
+			base.CostModels,
+			upd.CostModels,
+		)
+	}
+}
+
 func TestConwayProtocolParamsUpdateFromGenesis(t *testing.T) {
 	testDefs := []struct {
 		startParams    conway.ConwayProtocolParameters


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add tests to verify CIP compliance and protocol behavior across Babbage, Conway, and Leios. Covered areas: cost model checks for reference scripts (Plutus V1/V2/V3), protocol parameter updates, bech32 address roundtrips, datum CBOR roundtrip and hash, CIP-25 NFT metadata decoding, UTxO-RPC cost model mapping, and Leios CIP-0164 header/block formats.

<sup>Written for commit 640014df0478f0f9666aa62075b14ee4f51d87a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for protocol parameter updates and cost model validation across ledger versions.
  * Added tests for address encoding/decoding round-trips, metadata processing, and block format validation.
  * Improved test infrastructure for ledger functionality verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->