### PR TITLE
feat(ledger): use *big.Int for multi-asset outputs

### DIFF
--- a/cbor/encode.go
+++ b/cbor/encode.go
@@ -29,7 +29,8 @@ func Encode(data any) ([]byte, error) {
 	buf := bytes.NewBuffer(nil)
 	opts := _cbor.EncOptions{
 		// Make sure that maps have ordered keys
-		Sort: _cbor.SortCoreDeterministic,
+		Sort:          _cbor.SortCoreDeterministic,
+		BigIntConvert: _cbor.BigIntConvertShortest,
 	}
 	em, err := opts.EncModeWithTags(customTagSet)
 	if err != nil {

--- a/cbor/value.go
+++ b/cbor/value.go
@@ -191,6 +191,13 @@ func generateAstJson(obj any) ([]byte, error) {
 			v.String(),
 		)
 		return []byte(tmpJson), nil
+	case *big.Int:
+		if v == nil {
+			tmpJson := `{"int":0}`
+			return []byte(tmpJson), nil
+		}
+		tmpJson := fmt.Sprintf(`{"int":%s}`, v.String())
+		return []byte(tmpJson), nil
 	case Rat:
 		return generateAstJson(
 			[]any{

--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -485,7 +485,7 @@ func (o AlonzoTransactionOutput) Utxorpc() (*utxorpc.TxOutput, error) {
 				asset := &utxorpc.Asset{
 					Name: assetName,
 					Quantity: &utxorpc.Asset_OutputCoin{
-						OutputCoin: common.ToUtxorpcBigInt(amount),
+						OutputCoin: common.BigIntToUtxorpcBigInt(amount),
 					},
 				}
 				ma.Assets = append(ma.Assets, asset)

--- a/ledger/alonzo/alonzo_test.go
+++ b/ledger/alonzo/alonzo_test.go
@@ -90,10 +90,10 @@ func TestAlonzoTransactionOutputToPlutusDataCoinAssets(t *testing.T) {
 	testAssets := common.NewMultiAsset(
 		map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{
 			common.NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-				cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): 123456,
+				cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(123456),
 			},
 			common.NewBlake2b224(test.DecodeHexString("eaf8042c1d8203b1c585822f54ec32c4c1bb4d3914603e2cca20bbd5")): {
-				cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e63657074733638")): 234567,
+				cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e63657074733638")): big.NewInt(234567),
 			},
 		},
 	)
@@ -282,11 +282,9 @@ func TestAlonzoRedeemersIter(t *testing.T) {
 func TestAlonzoTransactionOutputString(t *testing.T) {
 	addrStr := "addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd"
 	addr, _ := common.NewAddress(addrStr)
-	ma := common.NewMultiAsset(
-		map[common.Blake2b224]map[cbor.ByteString]uint64{
-			common.NewBlake2b224(make([]byte, 28)): {
-				cbor.NewByteString([]byte("t")): 2,
-			},
+	ma := common.NewMultiAsset[common.MultiAssetTypeOutput](
+		map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{
+			common.NewBlake2b224(make([]byte, 28)): {cbor.NewByteString([]byte("t")): big.NewInt(2)},
 		},
 	)
 	out := AlonzoTransactionOutput{

--- a/ledger/alonzo/rules.go
+++ b/ledger/alonzo/rules.go
@@ -16,8 +16,7 @@ package alonzo
 
 import (
 	"errors"
-	"fmt"
-	"math"
+	"math/big"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/allegra"
@@ -424,8 +423,8 @@ func UtxoValidateValueNotConservedUtxo(
 		asset  string
 	}
 
-	consumedAssets := make(map[assetKey]int64)
-	producedAssets := make(map[assetKey]int64)
+	consumedAssets := make(map[assetKey]*big.Int)
+	producedAssets := make(map[assetKey]*big.Int)
 
 	// Collect consumed multi-assets from inputs
 	for _, tmpInput := range tx.Inputs() {
@@ -437,24 +436,14 @@ func UtxoValidateValueNotConservedUtxo(
 			for _, policy := range assets.Policies() {
 				for _, assetName := range assets.Assets(policy) {
 					amount := assets.Asset(policy, assetName)
+					if amount == nil {
+						continue
+					}
 					key := assetKey{policy: policy, asset: string(assetName)}
-					if amount > uint64(math.MaxInt64) {
-						return fmt.Errorf(
-							"consumed multi-asset amount for asset %s (policy %x) exceeds MaxInt64: %d",
-							string(assetName),
-							policy,
-							amount,
-						)
+					if consumedAssets[key] == nil {
+						consumedAssets[key] = new(big.Int)
 					}
-					// Check for overflow when accumulating
-					if consumedAssets[key] > math.MaxInt64-int64(amount) { //nolint:gosec // G115: overflow checked above
-						return fmt.Errorf(
-							"consumed multi-asset accumulation overflow for asset %s (policy %x)",
-							string(assetName),
-							policy,
-						)
-					}
-					consumedAssets[key] += int64(amount) //nolint:gosec // G115: overflow checked above
+					consumedAssets[key].Add(consumedAssets[key], amount)
 				}
 			}
 		}
@@ -469,26 +458,14 @@ func UtxoValidateValueNotConservedUtxo(
 			}
 			for _, assetName := range mint.Assets(policy) {
 				amount := mint.Asset(policy, assetName)
-				key := assetKey{policy: policy, asset: string(assetName)}
-				// Check for overflow when adding mint amount (can be negative for burns)
-				if amount > 0 {
-					if consumedAssets[key] > math.MaxInt64-amount {
-						return fmt.Errorf(
-							"consumed multi-asset accumulation overflow for minted asset %s (policy %x)",
-							string(assetName),
-							policy,
-						)
-					}
-				} else if amount < 0 {
-					if consumedAssets[key] < math.MinInt64-amount {
-						return fmt.Errorf(
-							"consumed multi-asset accumulation underflow for burned asset %s (policy %x)",
-							string(assetName),
-							policy,
-						)
-					}
+				if amount == nil {
+					continue
 				}
-				consumedAssets[key] += amount // Already int64
+				key := assetKey{policy: policy, asset: string(assetName)}
+				if consumedAssets[key] == nil {
+					consumedAssets[key] = new(big.Int)
+				}
+				consumedAssets[key].Add(consumedAssets[key], amount)
 			}
 		}
 	}
@@ -499,24 +476,14 @@ func UtxoValidateValueNotConservedUtxo(
 			for _, policy := range assets.Policies() {
 				for _, assetName := range assets.Assets(policy) {
 					amount := assets.Asset(policy, assetName)
+					if amount == nil {
+						continue
+					}
 					key := assetKey{policy: policy, asset: string(assetName)}
-					if amount > uint64(math.MaxInt64) {
-						return fmt.Errorf(
-							"produced multi-asset amount for asset %s (policy %x) exceeds MaxInt64: %d",
-							string(assetName),
-							policy,
-							amount,
-						)
+					if producedAssets[key] == nil {
+						producedAssets[key] = new(big.Int)
 					}
-					// Check for overflow when accumulating
-					if producedAssets[key] > math.MaxInt64-int64(amount) { //nolint:gosec // G115: overflow checked above
-						return fmt.Errorf(
-							"produced multi-asset accumulation overflow for asset %s (policy %x)",
-							string(assetName),
-							policy,
-						)
-					}
-					producedAssets[key] += int64(amount) //nolint:gosec // G115: overflow checked above
+					producedAssets[key].Add(producedAssets[key], amount)
 				}
 			}
 		}
@@ -534,27 +501,20 @@ func UtxoValidateValueNotConservedUtxo(
 	for key := range allKeys {
 		consumed := consumedAssets[key]
 		produced := producedAssets[key]
-		if consumed != produced {
+		if consumed == nil {
+			consumed = new(big.Int)
+		}
+		if produced == nil {
+			produced = new(big.Int)
+		}
+		if consumed.Cmp(produced) != 0 {
+			// For error reporting, convert to uint64 if possible
 			var consumedU, producedU uint64
-			if consumed < 0 {
-				if consumed == math.MinInt64 {
-					// Special case: MinInt64 cannot be negated in int64
-					consumedU = uint64(math.MaxInt64) + 1
-				} else {
-					consumedU = uint64(-consumed) //nolint:gosec // G115: safe for values > MinInt64
-				}
-			} else {
-				consumedU = uint64(consumed)
+			if consumed.IsUint64() {
+				consumedU = consumed.Uint64()
 			}
-			if produced < 0 {
-				if produced == math.MinInt64 {
-					// Special case: MinInt64 cannot be negated in int64
-					producedU = uint64(math.MaxInt64) + 1
-				} else {
-					producedU = uint64(-produced) //nolint:gosec // G115: safe for values > MinInt64
-				}
-			} else {
-				producedU = uint64(produced)
+			if produced.IsUint64() {
+				producedU = produced.Uint64()
 			}
 			return shelley.ValueNotConservedUtxoError{
 				Consumed: consumedU,

--- a/ledger/alonzo/rules_test.go
+++ b/ledger/alonzo/rules_test.go
@@ -17,6 +17,7 @@ package alonzo_test
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"math/big"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -735,7 +736,7 @@ func TestUtxoValidateOutputTooBigUtxo(t *testing.T) {
 	var testOutputValueGood = mary.MaryTransactionOutputValue{
 		Amount: 1234567,
 	}
-	var tmpBadAssets = map[common.Blake2b224]map[cbor.ByteString]uint64{}
+	var tmpBadAssets = map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{}
 	// Build too-large asset set
 	// We create 45 random policy IDs and asset names in order to exceed the max value size (4000 bytes)
 	for range 45 {
@@ -747,8 +748,8 @@ func TestUtxoValidateOutputTooBigUtxo(t *testing.T) {
 		if _, err := rand.Read(tmpAssetName); err != nil {
 			t.Fatalf("could not read random bytes")
 		}
-		tmpBadAssets[common.NewBlake2b224(tmpPolicyId)] = map[cbor.ByteString]uint64{
-			cbor.NewByteString(tmpAssetName): 1,
+		tmpBadAssets[common.NewBlake2b224(tmpPolicyId)] = map[cbor.ByteString]common.MultiAssetTypeOutput{
+			cbor.NewByteString(tmpAssetName): big.NewInt(1),
 		}
 	}
 	tmpBadMultiAsset := common.NewMultiAsset(
@@ -1063,8 +1064,8 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 			},
 		},
 	}
-	tmpMultiAsset := common.NewMultiAsset(
-		map[common.Blake2b224]map[cbor.ByteString]uint64{},
+	tmpMultiAsset := common.NewMultiAsset[common.MultiAssetTypeOutput](
+		map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{},
 	)
 	utxos := []common.Utxo{
 		{

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -750,7 +750,7 @@ func (o BabbageTransactionOutput) Utxorpc() (*utxorpc.TxOutput, error) {
 				asset := &utxorpc.Asset{
 					Name: assetName,
 					Quantity: &utxorpc.Asset_OutputCoin{
-						OutputCoin: common.ToUtxorpcBigInt(amount),
+						OutputCoin: common.BigIntToUtxorpcBigInt(amount),
 					},
 				}
 				ma.Assets = append(ma.Assets, asset)

--- a/ledger/babbage/babbage_test.go
+++ b/ledger/babbage/babbage_test.go
@@ -2919,10 +2919,10 @@ func TestBabbageTransactionOutputToPlutusDataCoinAssets(t *testing.T) {
 	testAssets := common.NewMultiAsset(
 		map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{
 			common.NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-				cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): 123456,
+				cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(123456),
 			},
 			common.NewBlake2b224(test.DecodeHexString("eaf8042c1d8203b1c585822f54ec32c4c1bb4d3914603e2cca20bbd5")): {
-				cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e63657074733638")): 234567,
+				cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e63657074733638")): big.NewInt(234567),
 			},
 		},
 	)
@@ -3022,11 +3022,9 @@ func TestBabbageTransactionOutputToPlutusDataCoinAssets(t *testing.T) {
 func TestBabbageTransactionOutputString(t *testing.T) {
 	addrStr := "addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd"
 	addr, _ := common.NewAddress(addrStr)
-	ma := common.NewMultiAsset(
-		map[common.Blake2b224]map[cbor.ByteString]uint64{
-			common.NewBlake2b224(make([]byte, 28)): {
-				cbor.NewByteString([]byte("x")): 2,
-			},
+	ma := common.NewMultiAsset[common.MultiAssetTypeOutput](
+		map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{
+			common.NewBlake2b224(make([]byte, 28)): {cbor.NewByteString([]byte("x")): big.NewInt(2)},
 		},
 	)
 	out := BabbageTransactionOutput{

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -16,8 +16,7 @@ package babbage
 
 import (
 	"errors"
-	"fmt"
-	"math"
+	"math/big"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/allegra"
@@ -544,8 +543,8 @@ func UtxoValidateValueNotConservedUtxo(
 		asset  string
 	}
 
-	consumedAssets := make(map[assetKey]int64)
-	producedAssets := make(map[assetKey]int64)
+	consumedAssets := make(map[assetKey]*big.Int)
+	producedAssets := make(map[assetKey]*big.Int)
 
 	// Collect consumed multi-assets from inputs
 	for _, tmpInput := range tx.Inputs() {
@@ -557,24 +556,14 @@ func UtxoValidateValueNotConservedUtxo(
 			for _, policy := range assets.Policies() {
 				for _, assetName := range assets.Assets(policy) {
 					amount := assets.Asset(policy, assetName)
+					if amount == nil {
+						continue
+					}
 					key := assetKey{policy: policy, asset: string(assetName)}
-					if amount > uint64(math.MaxInt64) {
-						return fmt.Errorf(
-							"consumed multi-asset amount for asset %s (policy %x) exceeds MaxInt64: %d",
-							string(assetName),
-							policy,
-							amount,
-						)
+					if consumedAssets[key] == nil {
+						consumedAssets[key] = new(big.Int)
 					}
-					// Check for overflow when accumulating
-					if consumedAssets[key] > math.MaxInt64-int64(amount) { //nolint:gosec // G115: overflow checked above
-						return fmt.Errorf(
-							"consumed multi-asset accumulation overflow for asset %s (policy %x)",
-							string(assetName),
-							policy,
-						)
-					}
-					consumedAssets[key] += int64(amount) //nolint:gosec // G115: overflow checked above
+					consumedAssets[key].Add(consumedAssets[key], amount)
 				}
 			}
 		}
@@ -589,26 +578,14 @@ func UtxoValidateValueNotConservedUtxo(
 			}
 			for _, assetName := range mint.Assets(policy) {
 				amount := mint.Asset(policy, assetName)
-				key := assetKey{policy: policy, asset: string(assetName)}
-				// Check for overflow when adding mint amount (can be negative for burns)
-				if amount > 0 {
-					if consumedAssets[key] > math.MaxInt64-amount {
-						return fmt.Errorf(
-							"consumed multi-asset accumulation overflow for minted asset %s (policy %x)",
-							string(assetName),
-							policy,
-						)
-					}
-				} else if amount < 0 {
-					if consumedAssets[key] < math.MinInt64-amount {
-						return fmt.Errorf(
-							"consumed multi-asset accumulation underflow for burned asset %s (policy %x)",
-							string(assetName),
-							policy,
-						)
-					}
+				if amount == nil {
+					continue
 				}
-				consumedAssets[key] += amount // Already int64
+				key := assetKey{policy: policy, asset: string(assetName)}
+				if consumedAssets[key] == nil {
+					consumedAssets[key] = new(big.Int)
+				}
+				consumedAssets[key].Add(consumedAssets[key], amount)
 			}
 		}
 	}
@@ -619,24 +596,14 @@ func UtxoValidateValueNotConservedUtxo(
 			for _, policy := range assets.Policies() {
 				for _, assetName := range assets.Assets(policy) {
 					amount := assets.Asset(policy, assetName)
+					if amount == nil {
+						continue
+					}
 					key := assetKey{policy: policy, asset: string(assetName)}
-					if amount > uint64(math.MaxInt64) {
-						return fmt.Errorf(
-							"produced multi-asset amount for asset %s (policy %x) exceeds MaxInt64: %d",
-							string(assetName),
-							policy,
-							amount,
-						)
+					if producedAssets[key] == nil {
+						producedAssets[key] = new(big.Int)
 					}
-					// Check for overflow when accumulating
-					if producedAssets[key] > math.MaxInt64-int64(amount) { //nolint:gosec // G115: overflow checked above
-						return fmt.Errorf(
-							"produced multi-asset accumulation overflow for asset %s (policy %x)",
-							string(assetName),
-							policy,
-						)
-					}
-					producedAssets[key] += int64(amount) //nolint:gosec // G115: overflow checked above
+					producedAssets[key].Add(producedAssets[key], amount)
 				}
 			}
 		}
@@ -654,27 +621,20 @@ func UtxoValidateValueNotConservedUtxo(
 	for key := range allKeys {
 		consumed := consumedAssets[key]
 		produced := producedAssets[key]
-		if consumed != produced {
+		if consumed == nil {
+			consumed = new(big.Int)
+		}
+		if produced == nil {
+			produced = new(big.Int)
+		}
+		if consumed.Cmp(produced) != 0 {
+			// For error reporting, convert to uint64 if possible
 			var consumedU, producedU uint64
-			if consumed < 0 {
-				if consumed == math.MinInt64 {
-					// Special case: MinInt64 cannot be negated in int64
-					consumedU = uint64(math.MaxInt64) + 1
-				} else {
-					consumedU = uint64(-consumed) //nolint:gosec // G115: safe for values > MinInt64
-				}
-			} else {
-				consumedU = uint64(consumed)
+			if consumed.IsUint64() {
+				consumedU = consumed.Uint64()
 			}
-			if produced < 0 {
-				if produced == math.MinInt64 {
-					// Special case: MinInt64 cannot be negated in int64
-					producedU = uint64(math.MaxInt64) + 1
-				} else {
-					producedU = uint64(-produced) //nolint:gosec // G115: safe for values > MinInt64
-				}
-			} else {
-				producedU = uint64(produced)
+			if produced.IsUint64() {
+				producedU = produced.Uint64()
 			}
 			return shelley.ValueNotConservedUtxoError{
 				Consumed: consumedU,

--- a/ledger/babbage/rules_test.go
+++ b/ledger/babbage/rules_test.go
@@ -18,6 +18,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"math/big"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -737,7 +738,7 @@ func TestUtxoValidateOutputTooBigUtxo(t *testing.T) {
 	var testOutputValueGood = mary.MaryTransactionOutputValue{
 		Amount: 1234567,
 	}
-	var tmpBadAssets = map[common.Blake2b224]map[cbor.ByteString]uint64{}
+	var tmpBadAssets = map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{}
 	// Build too-large asset set
 	// We create 45 random policy IDs and asset names in order to exceed the max value size (4000 bytes)
 	for range 45 {
@@ -749,8 +750,8 @@ func TestUtxoValidateOutputTooBigUtxo(t *testing.T) {
 		if _, err := rand.Read(tmpAssetName); err != nil {
 			t.Fatalf("could not read random bytes")
 		}
-		tmpBadAssets[common.NewBlake2b224(tmpPolicyId)] = map[cbor.ByteString]uint64{
-			cbor.NewByteString(tmpAssetName): 1,
+		tmpBadAssets[common.NewBlake2b224(tmpPolicyId)] = map[cbor.ByteString]common.MultiAssetTypeOutput{
+			cbor.NewByteString(tmpAssetName): big.NewInt(1),
 		}
 	}
 	tmpBadMultiAsset := common.NewMultiAsset(
@@ -1068,17 +1069,17 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 			},
 		},
 	}
-	tmpMultiAsset := common.NewMultiAsset(
-		map[common.Blake2b224]map[cbor.ByteString]uint64{
+	tmpMultiAsset := common.NewMultiAsset[common.MultiAssetTypeOutput](
+		map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{
 			common.Blake2b224Hash([]byte("abcd")): {
-				cbor.NewByteString([]byte("efgh")): 123,
+				cbor.NewByteString([]byte("efgh")): big.NewInt(123),
 			},
 		},
 	)
-	tmpZeroMultiAsset := common.NewMultiAsset(
-		map[common.Blake2b224]map[cbor.ByteString]uint64{
+	tmpZeroMultiAsset := common.NewMultiAsset[common.MultiAssetTypeOutput](
+		map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{
 			common.Blake2b224Hash([]byte("abcd")): {
-				cbor.NewByteString([]byte("efgh")): 0,
+				cbor.NewByteString([]byte("efgh")): big.NewInt(0),
 			},
 		},
 	)

--- a/ledger/common/common_test.go
+++ b/ledger/common/common_test.go
@@ -484,40 +484,42 @@ func TestMultiAssetJson(t *testing.T) {
 			multiAssetObj: MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): 123456,
+						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(123456),
 					},
 				},
 			},
-			expectedJson: `[{"name":"furnisha29hn","nameHex":"6675726e697368613239686e","policyId":"29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61","fingerprint":"asset1jdu2xcrwlqsjqqjger6kj2szddz8dcpvcg4ksz","amount":123456}]`,
+			expectedJson: `[{"name":"furnisha29hn","nameHex":"6675726e697368613239686e","policyId":"29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61","fingerprint":"asset1jdu2xcrwlqsjqqjger6kj2szddz8dcpvcg4ksz","amount":"123456"}]`,
 		},
 		{
 			multiAssetObj: MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224(test.DecodeHexString("eaf8042c1d8203b1c585822f54ec32c4c1bb4d3914603e2cca20bbd5")): {
-						cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e63657074733638")): 234567,
+						cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e63657074733638")): big.NewInt(234567),
 					},
 				},
 			},
-			expectedJson: `[{"name":"BowduraConcepts68","nameHex":"426f7764757261436f6e63657074733638","policyId":"eaf8042c1d8203b1c585822f54ec32c4c1bb4d3914603e2cca20bbd5","fingerprint":"asset1kp7hdhqc7chmyqvtqrsljfdrdt6jz8mg5culpe","amount":234567}]`,
+			expectedJson: `[{"name":"BowduraConcepts68","nameHex":"426f7764757261436f6e63657074733638","policyId":"eaf8042c1d8203b1c585822f54ec32c4c1bb4d3914603e2cca20bbd5","fingerprint":"asset1kp7hdhqc7chmyqvtqrsljfdrdt6jz8mg5culpe","amount":"234567"}]`,
 		},
 		{
 			multiAssetObj: MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224(test.DecodeHexString("cf78aeb9736e8aa94ce8fab44da86b522fa9b1c56336b92a28420525")): {
-						cbor.NewByteString(test.DecodeHexString("363438346330393264363164373033656236333233346461")): 12345678,
+						cbor.NewByteString(test.DecodeHexString("363438346330393264363164373033656236333233346461")): big.NewInt(12345678),
 					},
 				},
 			},
-			expectedJson: `[{"name":"6484c092d61d703eb63234da","nameHex":"363438346330393264363164373033656236333233346461","policyId":"cf78aeb9736e8aa94ce8fab44da86b522fa9b1c56336b92a28420525","fingerprint":"asset1rx3cnlsvh3udka56wyqyed3u695zd5q2jck2yd","amount":12345678}]`,
+			expectedJson: `[{"name":"6484c092d61d703eb63234da","nameHex":"363438346330393264363164373033656236333233346461","policyId":"cf78aeb9736e8aa94ce8fab44da86b522fa9b1c56336b92a28420525","fingerprint":"asset1rx3cnlsvh3udka56wyqyed3u695zd5q2jck2yd","amount":"12345678"}]`,
 		},
 	}
 	for _, test := range testDefs {
 		var err error
 		var jsonData []byte
 		switch v := test.multiAssetObj.(type) {
-		case MultiAsset[MultiAssetTypeOutput]:
+		case MultiAsset[int64]:
 			jsonData, err = json.Marshal(&v)
-		case MultiAsset[MultiAssetTypeMint]:
+		case MultiAsset[uint64]:
+			jsonData, err = json.Marshal(&v)
+		case MultiAsset[*big.Int]:
 			jsonData, err = json.Marshal(&v)
 		default:
 			t.Fatalf("unexpected test object type: %T", test.multiAssetObj)
@@ -544,7 +546,7 @@ func TestMultiAssetToPlutusData(t *testing.T) {
 			multiAssetObj: MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): 123456,
+						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(123456),
 					},
 				},
 			},
@@ -576,10 +578,10 @@ func TestMultiAssetToPlutusData(t *testing.T) {
 			multiAssetObj: MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): 123456,
+						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(123456),
 					},
 					NewBlake2b224(test.DecodeHexString("eaf8042c1d8203b1c585822f54ec32c4c1bb4d3914603e2cca20bbd5")): {
-						cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e63657074733638")): 234567,
+						cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e63657074733638")): big.NewInt(234567),
 					},
 				},
 			},
@@ -630,9 +632,11 @@ func TestMultiAssetToPlutusData(t *testing.T) {
 	for _, testDef := range testDefs {
 		var tmpData data.PlutusData
 		switch v := testDef.multiAssetObj.(type) {
-		case MultiAsset[MultiAssetTypeOutput]:
+		case MultiAsset[int64]:
 			tmpData = v.ToPlutusData()
-		case MultiAsset[MultiAssetTypeMint]:
+		case MultiAsset[uint64]:
+			tmpData = v.ToPlutusData()
+		case MultiAsset[*big.Int]:
 			tmpData = v.ToPlutusData()
 		default:
 			t.Fatalf("test def multi-asset object was not expected type: %T", v)
@@ -657,14 +661,14 @@ func TestMultiAssetCompare(t *testing.T) {
 			asset1: &MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224([]byte("abcd")): {
-						cbor.NewByteString([]byte("cdef")): 123,
+						cbor.NewByteString([]byte("cdef")): big.NewInt(123),
 					},
 				},
 			},
 			asset2: &MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224([]byte("abcd")): {
-						cbor.NewByteString([]byte("cdef")): 123,
+						cbor.NewByteString([]byte("cdef")): big.NewInt(123),
 					},
 				},
 			},
@@ -674,14 +678,14 @@ func TestMultiAssetCompare(t *testing.T) {
 			asset1: &MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224([]byte("abcd")): {
-						cbor.NewByteString([]byte("cdef")): 123,
+						cbor.NewByteString([]byte("cdef")): big.NewInt(123),
 					},
 				},
 			},
 			asset2: &MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224([]byte("abcd")): {
-						cbor.NewByteString([]byte("cdef")): 124,
+						cbor.NewByteString([]byte("cdef")): big.NewInt(124),
 					},
 				},
 			},
@@ -691,7 +695,7 @@ func TestMultiAssetCompare(t *testing.T) {
 			asset1: &MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224([]byte("abcd")): {
-						cbor.NewByteString([]byte("cdef")): 0,
+						cbor.NewByteString([]byte("cdef")): big.NewInt(0),
 					},
 				},
 			},
@@ -702,15 +706,15 @@ func TestMultiAssetCompare(t *testing.T) {
 			asset1: &MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224([]byte("abcd")): {
-						cbor.NewByteString([]byte("cdef")): 123,
+						cbor.NewByteString([]byte("cdef")): big.NewInt(123),
 					},
 				},
 			},
 			asset2: &MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224([]byte("abcd")): {
-						cbor.NewByteString([]byte("cdef")): 123,
-						cbor.NewByteString([]byte("efgh")): 123,
+						cbor.NewByteString([]byte("cdef")): big.NewInt(123),
+						cbor.NewByteString([]byte("efgh")): big.NewInt(123),
 					},
 				},
 			},
@@ -740,7 +744,7 @@ func TestMultiAssetCborRoundTrip(t *testing.T) {
 			multiAsset: MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): 123456,
+						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(123456),
 					},
 				},
 			},
@@ -750,8 +754,8 @@ func TestMultiAssetCborRoundTrip(t *testing.T) {
 			multiAsset: MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): 123456,
-						cbor.NewByteString(test.DecodeHexString("746f6b656e32")):             789,
+						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(123456),
+						cbor.NewByteString(test.DecodeHexString("746f6b656e32")):             big.NewInt(789),
 					},
 				},
 			},
@@ -761,10 +765,10 @@ func TestMultiAssetCborRoundTrip(t *testing.T) {
 			multiAsset: MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): 123456,
+						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(123456),
 					},
 					NewBlake2b224(test.DecodeHexString("eaf8042c1d8203b1c585822f54ec32c4c1bb4d3914603e2cca20bbd5")): {
-						cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e636574737638")): 234567,
+						cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e636574737638")): big.NewInt(234567),
 					},
 				},
 			},
@@ -837,7 +841,7 @@ func TestMultiAssetCborRoundTripMint(t *testing.T) {
 			multiAsset: MultiAsset[MultiAssetTypeMint]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeMint{
 					NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): -50000,
+						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(-50000),
 					},
 				},
 			},
@@ -847,8 +851,8 @@ func TestMultiAssetCborRoundTripMint(t *testing.T) {
 			multiAsset: MultiAsset[MultiAssetTypeMint]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeMint{
 					NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): 100000,
-						cbor.NewByteString(test.DecodeHexString("746f6b656e32")):             -25000,
+						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(100000),
+						cbor.NewByteString(test.DecodeHexString("746f6b656e32")):             big.NewInt(-25000),
 					},
 				},
 			},
@@ -858,10 +862,10 @@ func TestMultiAssetCborRoundTripMint(t *testing.T) {
 			multiAsset: MultiAsset[MultiAssetTypeMint]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeMint{
 					NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): -75000,
+						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(-75000),
 					},
 					NewBlake2b224(test.DecodeHexString("eaf8042c1d8203b1c585822f54ec32c4c1bb4d3914603e2cca20bbd5")): {
-						cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e636574737638")): -100000,
+						cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e636574737638")): big.NewInt(-100000),
 					},
 				},
 			},
@@ -1195,11 +1199,11 @@ func TestMultiAssetDeterministicEncoding(t *testing.T) {
 	multiAsset := MultiAsset[MultiAssetTypeOutput]{
 		data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 			NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-				cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): 123456,
-				cbor.NewByteString(test.DecodeHexString("746f6b656e32")):             789,
+				cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(123456),
+				cbor.NewByteString(test.DecodeHexString("746f6b656e32")):             big.NewInt(789),
 			},
 			NewBlake2b224(test.DecodeHexString("eaf8042c1d8203b1c585822f54ec32c4c1bb4d3914603e2cca20bbd5")): {
-				cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e636574737638")): 234567,
+				cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e636574737638")): big.NewInt(234567),
 			},
 		},
 	}

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -19,6 +19,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"math/big"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -1070,8 +1071,8 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 	t.Run(
 		"minting",
 		func(t *testing.T) {
-			mintData := map[common.Blake2b224]map[cbor.ByteString]int64{
-				{}: {cbor.ByteString{}: 7000000},
+			mintData := map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeMint{
+				{}: {cbor.ByteString{}: big.NewInt(7000000)},
 			}
 			mint := common.NewMultiAsset[common.MultiAssetTypeMint](mintData)
 			mintTx := &conway.ConwayTransaction{
@@ -1175,7 +1176,7 @@ func TestUtxoValidateOutputTooBigUtxo(t *testing.T) {
 	var testOutputValueGood = mary.MaryTransactionOutputValue{
 		Amount: 1234567,
 	}
-	var tmpBadAssets = map[common.Blake2b224]map[cbor.ByteString]uint64{}
+	var tmpBadAssets = map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{}
 	// Build too-large asset set
 	// We create 45 random policy IDs and asset names in order to exceed the max value size (4000 bytes)
 	for range 45 {
@@ -1187,8 +1188,8 @@ func TestUtxoValidateOutputTooBigUtxo(t *testing.T) {
 		if _, err := rand.Read(tmpAssetName); err != nil {
 			t.Fatalf("could not read random bytes")
 		}
-		tmpBadAssets[common.NewBlake2b224(tmpPolicyId)] = map[cbor.ByteString]uint64{
-			cbor.NewByteString(tmpAssetName): 1,
+		tmpBadAssets[common.NewBlake2b224(tmpPolicyId)] = map[cbor.ByteString]common.MultiAssetTypeOutput{
+			cbor.NewByteString(tmpAssetName): big.NewInt(1),
 		}
 	}
 	tmpBadMultiAsset := common.NewMultiAsset(
@@ -1510,17 +1511,17 @@ func TestUtxoValidateCollateralContainsNonAda(t *testing.T) {
 			},
 		},
 	}
-	tmpMultiAsset := common.NewMultiAsset(
-		map[common.Blake2b224]map[cbor.ByteString]uint64{
+	tmpMultiAsset := common.NewMultiAsset[common.MultiAssetTypeOutput](
+		map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{
 			common.Blake2b224Hash([]byte("abcd")): {
-				cbor.NewByteString([]byte("efgh")): 123,
+				cbor.NewByteString([]byte("efgh")): big.NewInt(123),
 			},
 		},
 	)
-	tmpZeroMultiAsset := common.NewMultiAsset(
-		map[common.Blake2b224]map[cbor.ByteString]uint64{
+	tmpZeroMultiAsset := common.NewMultiAsset[common.MultiAssetTypeOutput](
+		map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{
 			common.Blake2b224Hash([]byte("abcd")): {
-				cbor.NewByteString([]byte("efgh")): 0,
+				cbor.NewByteString([]byte("efgh")): big.NewInt(0),
 			},
 		},
 	)

--- a/ledger/mary/mary_test.go
+++ b/ledger/mary/mary_test.go
@@ -17,6 +17,7 @@ package mary
 import (
 	"encoding/hex"
 	"fmt"
+	"math/big"
 	"reflect"
 	"testing"
 
@@ -28,13 +29,13 @@ import (
 func createMaryTransactionOutputValueAssets(
 	policyId []byte,
 	assetName []byte,
-	amount uint64,
+	amount *big.Int,
 ) *common.MultiAsset[common.MultiAssetTypeOutput] {
-	data := map[common.Blake2b224]map[cbor.ByteString]uint64{}
+	data := map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{}
 	policyIdKey := common.Blake2b224{}
 	copy(policyIdKey[:], policyId)
 	assetKey := cbor.NewByteString(assetName)
-	data[policyIdKey] = map[cbor.ByteString]uint64{
+	data[policyIdKey] = map[cbor.ByteString]common.MultiAssetTypeOutput{
 		assetKey: amount,
 	}
 	ret := common.NewMultiAsset(data)
@@ -64,7 +65,7 @@ func TestMaryTransactionOutputValueEncodeDecode(t *testing.T) {
 						"00000002DF633853F6A47465C9496721D2D5B1291B8398016C0E87AE",
 					),
 					test.DecodeHexString("6E7574636F696E"),
-					1,
+					big.NewInt(1),
 				),
 			},
 		},
@@ -78,7 +79,7 @@ func TestMaryTransactionOutputValueEncodeDecode(t *testing.T) {
 						"3A9241CD79895E3A8D65261B40077D4437CE71E9D7C8C6C00E3F658E",
 					),
 					test.DecodeHexString("4669727374636F696E"),
-					1,
+					big.NewInt(1),
 				),
 			},
 		},
@@ -120,10 +121,10 @@ func TestMaryTransactionOutputValueEncodeDecode(t *testing.T) {
 func TestMaryTransactionOutputString(t *testing.T) {
 	addrStr := "addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd"
 	addr, _ := common.NewAddress(addrStr)
-	ma := common.NewMultiAsset(
-		map[common.Blake2b224]map[cbor.ByteString]uint64{
+	ma := common.NewMultiAsset[common.MultiAssetTypeOutput](
+		map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{
 			common.NewBlake2b224(make([]byte, 28)): {
-				cbor.NewByteString([]byte("token")): 2,
+				cbor.NewByteString([]byte("token")): big.NewInt(2),
 			},
 		},
 	)

--- a/ledger/mary/rules.go
+++ b/ledger/mary/rules.go
@@ -16,8 +16,7 @@ package mary
 
 import (
 	"errors"
-	"fmt"
-	"math"
+	"math/big"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/allegra"
@@ -213,8 +212,8 @@ func UtxoValidateValueNotConservedUtxo(
 		asset  string
 	}
 
-	consumedAssets := make(map[assetKey]int64)
-	producedAssets := make(map[assetKey]int64)
+	consumedAssets := make(map[assetKey]*big.Int)
+	producedAssets := make(map[assetKey]*big.Int)
 
 	// Collect consumed multi-assets from inputs
 	for _, tmpInput := range tx.Inputs() {
@@ -226,24 +225,14 @@ func UtxoValidateValueNotConservedUtxo(
 			for _, policy := range assets.Policies() {
 				for _, assetName := range assets.Assets(policy) {
 					amount := assets.Asset(policy, assetName)
+					if amount == nil {
+						continue
+					}
 					key := assetKey{policy: policy, asset: string(assetName)}
-					if amount > uint64(math.MaxInt64) {
-						return fmt.Errorf(
-							"consumed multi-asset amount for asset %s (policy %x) exceeds MaxInt64: %d",
-							string(assetName),
-							policy,
-							amount,
-						)
+					if consumedAssets[key] == nil {
+						consumedAssets[key] = new(big.Int)
 					}
-					// Check for overflow when accumulating
-					if consumedAssets[key] > math.MaxInt64-int64(amount) { //nolint:gosec // G115: overflow checked above
-						return fmt.Errorf(
-							"consumed multi-asset accumulation overflow for asset %s (policy %x)",
-							string(assetName),
-							policy,
-						)
-					}
-					consumedAssets[key] += int64(amount) //nolint:gosec // G115: overflow checked above
+					consumedAssets[key].Add(consumedAssets[key], amount)
 				}
 			}
 		}
@@ -258,26 +247,14 @@ func UtxoValidateValueNotConservedUtxo(
 			}
 			for _, assetName := range mint.Assets(policy) {
 				amount := mint.Asset(policy, assetName)
-				key := assetKey{policy: policy, asset: string(assetName)}
-				// Check for overflow when adding mint amount (can be negative for burns)
-				if amount > 0 {
-					if consumedAssets[key] > math.MaxInt64-amount {
-						return fmt.Errorf(
-							"consumed multi-asset accumulation overflow for minted asset %s (policy %x)",
-							string(assetName),
-							policy,
-						)
-					}
-				} else if amount < 0 {
-					if consumedAssets[key] < math.MinInt64-amount {
-						return fmt.Errorf(
-							"consumed multi-asset accumulation underflow for burned asset %s (policy %x)",
-							string(assetName),
-							policy,
-						)
-					}
+				if amount == nil {
+					continue
 				}
-				consumedAssets[key] += amount // Already int64
+				key := assetKey{policy: policy, asset: string(assetName)}
+				if consumedAssets[key] == nil {
+					consumedAssets[key] = new(big.Int)
+				}
+				consumedAssets[key].Add(consumedAssets[key], amount)
 			}
 		}
 	}
@@ -288,24 +265,14 @@ func UtxoValidateValueNotConservedUtxo(
 			for _, policy := range assets.Policies() {
 				for _, assetName := range assets.Assets(policy) {
 					amount := assets.Asset(policy, assetName)
+					if amount == nil {
+						continue
+					}
 					key := assetKey{policy: policy, asset: string(assetName)}
-					if amount > uint64(math.MaxInt64) {
-						return fmt.Errorf(
-							"produced multi-asset amount for asset %s (policy %x) exceeds MaxInt64: %d",
-							string(assetName),
-							policy,
-							amount,
-						)
+					if producedAssets[key] == nil {
+						producedAssets[key] = new(big.Int)
 					}
-					// Check for overflow when accumulating
-					if producedAssets[key] > math.MaxInt64-int64(amount) { //nolint:gosec // G115: overflow checked above
-						return fmt.Errorf(
-							"produced multi-asset accumulation overflow for asset %s (policy %x)",
-							string(assetName),
-							policy,
-						)
-					}
-					producedAssets[key] += int64(amount) //nolint:gosec // G115: overflow checked above
+					producedAssets[key].Add(producedAssets[key], amount)
 				}
 			}
 		}
@@ -323,27 +290,20 @@ func UtxoValidateValueNotConservedUtxo(
 	for key := range allKeys {
 		consumed := consumedAssets[key]
 		produced := producedAssets[key]
-		if consumed != produced {
+		if consumed == nil {
+			consumed = new(big.Int)
+		}
+		if produced == nil {
+			produced = new(big.Int)
+		}
+		if consumed.Cmp(produced) != 0 {
+			// For error reporting, convert to uint64 if possible
 			var consumedU, producedU uint64
-			if consumed < 0 {
-				if consumed == math.MinInt64 {
-					// Special case: MinInt64 cannot be negated in int64
-					consumedU = uint64(math.MaxInt64) + 1
-				} else {
-					consumedU = uint64(-consumed) //nolint:gosec // G115: safe for values > MinInt64
-				}
-			} else {
-				consumedU = uint64(consumed)
+			if consumed.IsUint64() {
+				consumedU = consumed.Uint64()
 			}
-			if produced < 0 {
-				if produced == math.MinInt64 {
-					// Special case: MinInt64 cannot be negated in int64
-					producedU = uint64(math.MaxInt64) + 1
-				} else {
-					producedU = uint64(-produced) //nolint:gosec // G115: safe for values > MinInt64
-				}
-			} else {
-				producedU = uint64(produced)
+			if produced.IsUint64() {
+				producedU = produced.Uint64()
 			}
 			return shelley.ValueNotConservedUtxoError{
 				Consumed: consumedU,

--- a/ledger/mary/rules_test.go
+++ b/ledger/mary/rules_test.go
@@ -17,6 +17,7 @@ package mary_test
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"math/big"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -733,7 +734,7 @@ func TestUtxoValidateOutputTooBigUtxo(t *testing.T) {
 	var testOutputValueGood = mary.MaryTransactionOutputValue{
 		Amount: 1234567,
 	}
-	var tmpBadAssets = map[common.Blake2b224]map[cbor.ByteString]uint64{}
+	var tmpBadAssets = map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{}
 	// Build too-large asset set
 	// We create 45 random policy IDs and asset names in order to exceed the max value size (4000 bytes)
 	for range 45 {
@@ -745,8 +746,8 @@ func TestUtxoValidateOutputTooBigUtxo(t *testing.T) {
 		if _, err := rand.Read(tmpAssetName); err != nil {
 			t.Fatalf("could not read random bytes")
 		}
-		tmpBadAssets[common.NewBlake2b224(tmpPolicyId)] = map[cbor.ByteString]uint64{
-			cbor.NewByteString(tmpAssetName): 1,
+		tmpBadAssets[common.NewBlake2b224(tmpPolicyId)] = map[cbor.ByteString]common.MultiAssetTypeOutput{
+			cbor.NewByteString(tmpAssetName): big.NewInt(1),
 		}
 	}
 	tmpBadMultiAsset := common.NewMultiAsset(

--- a/ledger/tx.go
+++ b/ledger/tx.go
@@ -147,5 +147,6 @@ func DetermineTransactionType(data []byte) (uint, error) {
 	if _, err := NewLeiosTransactionFromCbor(data); err == nil {
 		return TxTypeLeios, nil
 	}
+
 	return 0, errors.New("unknown transaction type")
 }

--- a/ledger/verify_block_body.go
+++ b/ledger/verify_block_body.go
@@ -329,11 +329,15 @@ func ExtractTokens(output TransactionOutput) ([]UTXOOutputToken, error) {
 		for _, policyId := range tmpAssets.Policies() {
 			for _, assetName := range tmpAssets.Assets(policyId) {
 				amount := tmpAssets.Asset(policyId, assetName)
+				tokenValue := "0"
+				if amount != nil {
+					tokenValue = amount.String()
+				}
 				outputTokens = append(outputTokens, UTXOOutputToken{
 					TokenAssetName: policyId.String() + hex.EncodeToString(
 						assetName,
 					),
-					TokenValue: strconv.FormatUint(amount, 10),
+					TokenValue: tokenValue,
 				})
 			}
 		}


### PR DESCRIPTION
This changes MultiAssetTypeOutput from uint64 to *big.Int to properly handle large token amounts that exceed uint64 range.

Changes include:
- MultiAssetTypeOutput type alias changed from uint64 to *big.Int
- MultiAssetTypeMint for minted amounts also uses *big.Int
- Added helper functions for generic amount handling (addAmounts, amountsEqual, amountIsZero, amountToString, amountToBigInt, parseAmount)
- Updated JSON marshaling/unmarshaling to handle big.Int as strings
- Updated all test files to use *big.Int for amount values
- Removed unnecessary CBOR decode overrides

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch multi-asset amounts to big.Int for outputs and minting to safely handle very large token quantities and burns. This removes overflow risk and aligns JSON/CBOR/utxorpc handling with big integers.

- **Refactors**
  - MultiAssetTypeOutput and MultiAssetTypeMint now use *big.Int; all ledger rules updated to add/compare with big.Int.
  - JSON for MultiAsset amounts now uses strings; added UnmarshalJSON and helpers (addAmounts, amountsEqual, amountIsZero, amountToString/BigInt, parseAmount).
  - CBOR encoder uses BigIntConvertShortest; AST JSON supports *big.Int.
  - Added BigIntToUtxorpcBigInt and updated uses; ExtractTokens now emits big.Int amounts as strings.

- **Migration**
  - Construct MultiAsset values with big.NewInt(...), including minting/burning.
  - Expect JSON amounts as strings in APIs and tests.
  - Use BigIntToUtxorpcBigInt when building utxorpc assets.

<sup>Written for commit 5a21c3d54ba4d58f8d35e52936a08a3e3d47899a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Asset amounts moved from fixed-size integers to arbitrary-precision integers for robust large-value handling.
  * Multi-asset validation and conservation logic updated to use big-integer arithmetic and nil-safe accumulation.
  * Serialization updated: asset amounts now round-trip as strings in JSON and use big-int-aware conversions.

* **Tests**
  * Test suite updated across ledger components to validate big-integer asset representations and updated multi-asset construction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->