### PR TITLE
fix(ledger): ensure big int errors don't overflow

### DIFF
--- a/ledger/alonzo/rules.go
+++ b/ledger/alonzo/rules.go
@@ -16,6 +16,7 @@ package alonzo
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -516,10 +517,20 @@ func UtxoValidateValueNotConservedUtxo(
 			if produced.IsUint64() {
 				producedU = produced.Uint64()
 			}
-			return shelley.ValueNotConservedUtxoError{
+			// Wrap with context if values don't fit in uint64
+			baseErr := shelley.ValueNotConservedUtxoError{
 				Consumed: consumedU,
 				Produced: producedU,
 			}
+			if !consumed.IsUint64() || !produced.IsUint64() {
+				return fmt.Errorf(
+					"multi-asset value not conserved: consumed %s, produced %s: %w",
+					consumed.String(),
+					produced.String(),
+					baseErr,
+				)
+			}
+			return baseErr
 		}
 	}
 

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -16,6 +16,7 @@ package babbage
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -636,10 +637,20 @@ func UtxoValidateValueNotConservedUtxo(
 			if produced.IsUint64() {
 				producedU = produced.Uint64()
 			}
-			return shelley.ValueNotConservedUtxoError{
+			// Wrap with context if values don't fit in uint64
+			baseErr := shelley.ValueNotConservedUtxoError{
 				Consumed: consumedU,
 				Produced: producedU,
 			}
+			if !consumed.IsUint64() || !produced.IsUint64() {
+				return fmt.Errorf(
+					"multi-asset value not conserved: consumed %s, produced %s: %w",
+					consumed.String(),
+					produced.String(),
+					baseErr,
+				)
+			}
+			return baseErr
 		}
 	}
 

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -16,6 +16,7 @@ package conway
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -796,10 +797,20 @@ func UtxoValidateValueNotConservedUtxo(
 			if produced.IsUint64() {
 				producedU = produced.Uint64()
 			}
-			return shelley.ValueNotConservedUtxoError{
+			// Wrap with context if values don't fit in uint64
+			baseErr := shelley.ValueNotConservedUtxoError{
 				Consumed: consumedU,
 				Produced: producedU,
 			}
+			if !consumed.IsUint64() || !produced.IsUint64() {
+				return fmt.Errorf(
+					"multi-asset value not conserved: consumed %s, produced %s: %w",
+					consumed.String(),
+					produced.String(),
+					baseErr,
+				)
+			}
+			return baseErr
 		}
 	}
 

--- a/ledger/mary/rules.go
+++ b/ledger/mary/rules.go
@@ -16,6 +16,7 @@ package mary
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -305,10 +306,20 @@ func UtxoValidateValueNotConservedUtxo(
 			if produced.IsUint64() {
 				producedU = produced.Uint64()
 			}
-			return shelley.ValueNotConservedUtxoError{
+			// Wrap with context if values don't fit in uint64
+			baseErr := shelley.ValueNotConservedUtxoError{
 				Consumed: consumedU,
 				Produced: producedU,
 			}
+			if !consumed.IsUint64() || !produced.IsUint64() {
+				return fmt.Errorf(
+					"multi-asset value not conserved: consumed %s, produced %s: %w",
+					consumed.String(),
+					produced.String(),
+					baseErr,
+				)
+			}
+			return baseErr
 		}
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent overflow in UTxO value conservation errors by wrapping big-int amounts when they exceed uint64 in Mary, Alonzo, Babbage, and Conway rule checks. This keeps error values accurate and easier to debug.

- **Bug Fixes**
  - In UtxoValidateValueNotConservedUtxo, convert big.Int to uint64 only if safe; otherwise return a contextual error with consumed/produced as big-int strings.
  - Preserve the ValueNotConservedUtxoError type when values fit; wrap it with %w when they don’t so callers can still detect the original error.

<sup>Written for commit a73b1cf5065b57297d73d446a9495db8f61b401b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting for multi-asset value conservation validation to provide detailed context when processing large transaction values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->