### PR TITLE
feat: support for building PlutusV2 script context

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,7 +26,6 @@ linters:
     - nilerr
     - nilnesserr
     - perfsprint
-    - prealloc
     - protogetter
     - reassign
     - rowserrcheck
@@ -41,6 +40,7 @@ linters:
     - depguard
     - noctx
     - recvcheck
+    - prealloc
   exclusions:
     generated: lax
     presets:


### PR DESCRIPTION
Closes #1165 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for building Plutus V2 script contexts with correct CBOR serialization from transactions and resolved inputs. This enables V2 scripts to receive the expected TxInfo format and improves compatibility with on-chain contracts.

- **New Features**
  - Implemented TxInfoV2 and ToPlutusData, plus NewTxInfoV2FromTransaction to construct V2 context from slot state, transaction, and resolved inputs.
  - Extended wrappers to encode V2 structures:
    - WithZeroAdaAsset now serializes TransactionOutput and ResolvedInput(s).
    - WithWrappedTransactionId handles KeyValuePairs[ScriptPurpose, Redeemer].
    - WithWrappedStakeCredential encodes withdrawals as a map for V2.
  - Added Pairs type and conversion from KeyValuePairs; updated TxInfoV1 withdrawals to use Pairs for V1 encoding.
  - Added tests for V2 ScriptContext (SimpleSend, Mint) with deterministic CBOR outputs.

<sup>Written for commit 53683aa4c3cea847586475c54ef7c795fd0f2b9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer Babbage (V2) transaction/script context: more complete transaction info (inputs, outputs, withdrawals, redeemers, validity range, IDs) and improved Plutus data encoding for compatibility.
  * New generic pairing abstractions to support consistent key/value and pair encodings.

* **Tests**
  * Added comprehensive V2 script-context tests validating generation and CBOR encoding.

* **Chores**
  * Disabled the prealloc linter in CI configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->