### PR TITLE
fix: prealloc linter errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
     - nilerr
     - nilnesserr
     - perfsprint
+    - prealloc
     - protogetter
     - reassign
     - rowserrcheck
@@ -40,7 +41,6 @@ linters:
     - depguard
     - noctx
     - recvcheck
-    - prealloc
   exclusions:
     generated: lax
     presets:

--- a/ledger/allegra/allegra.go
+++ b/ledger/allegra/allegra.go
@@ -136,8 +136,9 @@ func (b *AllegraBlock) Transactions() []common.Transaction {
 }
 
 func (b *AllegraBlock) Utxorpc() (*utxorpc.Block, error) {
-	txs := []*utxorpc.Tx{}
-	for _, t := range b.Transactions() {
+	tmpTxs := b.Transactions()
+	txs := make([]*utxorpc.Tx, 0, len(tmpTxs))
+	for _, t := range tmpTxs {
 		tx, err := t.Utxorpc()
 		if err != nil {
 			return nil, err
@@ -202,7 +203,7 @@ func (b *AllegraTransactionBody) UnmarshalCBOR(cborData []byte) error {
 }
 
 func (b *AllegraTransactionBody) Inputs() []common.TransactionInput {
-	ret := []common.TransactionInput{}
+	ret := make([]common.TransactionInput, 0, len(b.TxInputs.Items()))
 	for _, input := range b.TxInputs.Items() {
 		ret = append(ret, input)
 	}
@@ -430,8 +431,9 @@ func (t AllegraTransaction) Consumed() []common.TransactionInput {
 }
 
 func (t AllegraTransaction) Produced() []common.Utxo {
-	ret := []common.Utxo{}
-	for idx, output := range t.Outputs() {
+	outputs := t.Outputs()
+	ret := make([]common.Utxo, 0, len(outputs))
+	for idx, output := range outputs {
 		ret = append(
 			ret,
 			common.Utxo{

--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -189,8 +189,9 @@ func (b *AlonzoBlock) Transactions() []common.Transaction {
 }
 
 func (b *AlonzoBlock) Utxorpc() (*utxorpc.Block, error) {
-	txs := []*utxorpc.Tx{}
-	for _, t := range b.Transactions() {
+	tmpTxs := b.Transactions()
+	txs := make([]*utxorpc.Tx, 0, len(tmpTxs))
+	for _, t := range tmpTxs {
 		tx, err := t.Utxorpc()
 		if err != nil {
 			return nil, err
@@ -843,8 +844,9 @@ func (t AlonzoTransaction) Consumed() []common.TransactionInput {
 
 func (t AlonzoTransaction) Produced() []common.Utxo {
 	if t.IsValid() {
-		var ret []common.Utxo
-		for idx, output := range t.Outputs() {
+		outputs := t.Outputs()
+		ret := make([]common.Utxo, 0, len(outputs))
+		for idx, output := range outputs {
 			ret = append(
 				ret,
 				common.Utxo{

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -220,8 +220,9 @@ func (b *BabbageBlock) Transactions() []common.Transaction {
 }
 
 func (b *BabbageBlock) Utxorpc() (*utxorpc.Block, error) {
-	txs := []*utxorpc.Tx{}
-	for _, t := range b.Transactions() {
+	tmpTxs := b.Transactions()
+	txs := make([]*utxorpc.Tx, 0, len(tmpTxs))
+	for _, t := range tmpTxs {
 		tx, err := t.Utxorpc()
 		if err != nil {
 			return nil, err
@@ -1085,8 +1086,9 @@ func (t BabbageTransaction) Consumed() []common.TransactionInput {
 
 func (t BabbageTransaction) Produced() []common.Utxo {
 	if t.IsValid() {
-		var ret []common.Utxo
-		for idx, output := range t.Outputs() {
+		outputs := t.Outputs()
+		ret := make([]common.Utxo, 0, len(outputs))
+		for idx, output := range outputs {
 			ret = append(
 				ret,
 				common.Utxo{

--- a/ledger/byron/byron.go
+++ b/ledger/byron/byron.go
@@ -178,7 +178,7 @@ func (t *ByronTransactionBody) Id() common.Blake2b256 {
 }
 
 func (t *ByronTransactionBody) Inputs() []common.TransactionInput {
-	ret := []common.TransactionInput{}
+	ret := make([]common.TransactionInput, 0, len(t.TxInputs))
 	for _, input := range t.TxInputs {
 		ret = append(ret, input)
 	}
@@ -476,8 +476,9 @@ func (t *ByronTransaction) Consumed() []common.TransactionInput {
 }
 
 func (t *ByronTransaction) Produced() []common.Utxo {
-	ret := []common.Utxo{}
-	for idx, output := range t.Outputs() {
+	outputs := t.Outputs()
+	ret := make([]common.Utxo, 0, len(outputs))
+	for idx, output := range outputs {
 		ret = append(
 			ret,
 			common.Utxo{

--- a/ledger/common/common.go
+++ b/ledger/common/common.go
@@ -253,7 +253,7 @@ func (m *MultiAsset[T]) MarshalCBOR() ([]byte, error) {
 }
 
 func (m MultiAsset[T]) MarshalJSON() ([]byte, error) {
-	tmpAssets := []multiAssetJson[T]{}
+	tmpAssets := make([]multiAssetJson[T], 0, len(m.data))
 	for policyId, policyData := range m.data {
 		for assetName, amount := range policyData {
 			tmpObj := multiAssetJson[T]{
@@ -342,7 +342,7 @@ func (m *MultiAsset[T]) ToPlutusData() data.PlutusData {
 }
 
 func (m *MultiAsset[T]) Policies() []Blake2b224 {
-	ret := []Blake2b224{}
+	ret := make([]Blake2b224, 0, len(m.data))
 	for policyId := range m.data {
 		ret = append(ret, policyId)
 	}
@@ -354,7 +354,7 @@ func (m *MultiAsset[T]) Assets(policyId Blake2b224) [][]byte {
 	if !ok {
 		return nil
 	}
-	ret := [][]byte{}
+	ret := make([][]byte, 0, len(assets))
 	for assetName := range assets {
 		ret = append(ret, assetName.Bytes())
 	}

--- a/ledger/common/verify.go
+++ b/ledger/common/verify.go
@@ -80,7 +80,7 @@ func computeByronAddressRoot(
 	// Build the CBOR structure: [0, [0, bytes(pubkey || chainCode)], attributes]
 	// Byron addresses always use addrType = 0 for public key addresses
 	// CBOR prefix: 0x83 (array of 3) 0x00 (int 0) 0x82 (array of 2) 0x00 (int 0) 0x5840 (bytes of 64)
-	var buf []byte
+	var buf []byte                // nolint:prealloc
 	buf = append(buf, 0x83)       // CBOR array of 3 elements
 	buf = append(buf, 0x00)       // First element: addrType = 0
 	buf = append(buf, 0x82)       // Second element: array of 2

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -220,8 +220,9 @@ func (b *ConwayBlock) Transactions() []common.Transaction {
 }
 
 func (b *ConwayBlock) Utxorpc() (*utxorpc.Block, error) {
-	txs := []*utxorpc.Tx{}
-	for _, t := range b.Transactions() {
+	tmpTxs := b.Transactions()
+	txs := make([]*utxorpc.Tx, 0, len(tmpTxs))
+	for _, t := range tmpTxs {
 		tx, err := t.Utxorpc()
 		if err != nil {
 			return nil, err
@@ -489,7 +490,7 @@ func (b *ConwayTransactionBody) UnmarshalCBOR(cborData []byte) error {
 }
 
 func (b *ConwayTransactionBody) Inputs() []common.TransactionInput {
-	ret := []common.TransactionInput{}
+	ret := make([]common.TransactionInput, 0, len(b.TxInputs.Items()))
 	for _, input := range b.TxInputs.Items() {
 		ret = append(ret, input)
 	}
@@ -548,8 +549,9 @@ func (b *ConwayTransactionBody) AssetMint() *common.MultiAsset[common.MultiAsset
 }
 
 func (b *ConwayTransactionBody) Collateral() []common.TransactionInput {
-	ret := []common.TransactionInput{}
-	for _, collateral := range b.TxCollateral.Items() {
+	items := b.TxCollateral.Items()
+	ret := make([]common.TransactionInput, 0, len(items))
+	for _, collateral := range items {
 		ret = append(ret, collateral)
 	}
 	return ret
@@ -808,8 +810,9 @@ func (t ConwayTransaction) Consumed() []common.TransactionInput {
 
 func (t ConwayTransaction) Produced() []common.Utxo {
 	if t.IsValid() {
-		var ret []common.Utxo
-		for idx, output := range t.Outputs() {
+		outputs := t.Outputs()
+		ret := make([]common.Utxo, 0, len(outputs))
+		for idx, output := range outputs {
 			ret = append(
 				ret,
 				common.Utxo{

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -150,8 +150,9 @@ func (b *MaryBlock) Transactions() []common.Transaction {
 }
 
 func (b *MaryBlock) Utxorpc() (*utxorpc.Block, error) {
-	txs := []*utxorpc.Tx{}
-	for _, t := range b.Transactions() {
+	tmpTxs := b.Transactions()
+	txs := make([]*utxorpc.Tx, 0, len(tmpTxs))
+	for _, t := range tmpTxs {
 		tx, err := t.Utxorpc()
 		if err != nil {
 			return nil, err
@@ -224,7 +225,7 @@ func (b *MaryTransactionBody) MarshalCBOR() ([]byte, error) {
 }
 
 func (b *MaryTransactionBody) Inputs() []common.TransactionInput {
-	ret := []common.TransactionInput{}
+	ret := make([]common.TransactionInput, 0, len(b.TxInputs.Items()))
 	for _, input := range b.TxInputs.Items() {
 		ret = append(ret, input)
 	}
@@ -469,8 +470,9 @@ func (t MaryTransaction) Consumed() []common.TransactionInput {
 }
 
 func (t MaryTransaction) Produced() []common.Utxo {
-	ret := []common.Utxo{}
-	for idx, output := range t.Outputs() {
+	outputs := t.Outputs()
+	ret := make([]common.Utxo, 0, len(outputs))
+	for idx, output := range outputs {
 		ret = append(
 			ret,
 			common.Utxo{

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -145,8 +145,9 @@ func (b *ShelleyBlock) Transactions() []common.Transaction {
 }
 
 func (b *ShelleyBlock) Utxorpc() (*utxorpc.Block, error) {
-	txs := []*utxorpc.Tx{}
-	for _, t := range b.Transactions() {
+	tmpTxs := b.Transactions()
+	txs := make([]*utxorpc.Tx, 0, len(tmpTxs))
+	for _, t := range tmpTxs {
 		tx, err := t.Utxorpc()
 		if err != nil {
 			return nil, err
@@ -746,8 +747,9 @@ func (t ShelleyTransaction) Consumed() []common.TransactionInput {
 }
 
 func (t ShelleyTransaction) Produced() []common.Utxo {
-	ret := []common.Utxo{}
-	for idx, output := range t.Outputs() {
+	outputs := t.Outputs()
+	ret := make([]common.Utxo, 0, len(outputs))
+	for idx, output := range outputs {
 		ret = append(
 			ret,
 			common.Utxo{

--- a/ledger/verify_block_body.go
+++ b/ledger/verify_block_body.go
@@ -229,7 +229,7 @@ func CalculateBlockBodyHash(txsRaw [][]string) ([]byte, error) {
 	txSeqIsValidSum32Bytes := blake2b.Sum256(txSeqNonValidBytes)
 	txSeqIsValidSumBytes := txSeqIsValidSum32Bytes[:]
 
-	var serializeBytes []byte
+	serializeBytes := make([]byte, 0, len(txSeqBodySumBytes)+len(txSeqWitsSumBytes)+len(txSeqMetadataSumBytes)+len(txSeqIsValidSumBytes))
 	// Ref: https://github.com/IntersectMBO/cardano-ledger/blob/9cc766a31ad6fb31f88e25a770c902d24fa32499/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxSeq.hs#L183
 	serializeBytes = append(serializeBytes, txSeqBodySumBytes...)
 	serializeBytes = append(serializeBytes, txSeqWitsSumBytes...)
@@ -240,7 +240,7 @@ func CalculateBlockBodyHash(txsRaw [][]string) ([]byte, error) {
 }
 
 func GetTxBodies(txsRaw [][]string) ([]BabbageTransactionBody, error) {
-	bodies := []BabbageTransactionBody{}
+	bodies := make([]BabbageTransactionBody, 0, len(txsRaw))
 	for index, tx := range txsRaw {
 		var tmp BabbageTransactionBody
 		bodyTmpHex := tx[0]

--- a/protocol/localstatequery/client.go
+++ b/protocol/localstatequery/client.go
@@ -839,11 +839,12 @@ func (c *Client) GetPoolDistr(poolIds []any) (*PoolDistrResult, error) {
 	// GetPoolDistr always requires a pool set parameter according to the Haskell implementation
 	// The query expects (len=2, tag=21) format: [21, Set(poolIds)]
 	// If no pool IDs specified, use an empty set to query all pools
-	var params []any
 	if poolIds == nil {
 		poolIds = []any{}
 	}
-	params = append(params, poolIds)
+	params := []any{
+		poolIds,
+	}
 	query := buildShelleyQuery(
 		currentEra,
 		QueryTypeShelleyPoolDistr,

--- a/protocol/txsubmission/messages.go
+++ b/protocol/txsubmission/messages.go
@@ -87,7 +87,7 @@ type MsgReplyTxIds struct {
 }
 
 func (m *MsgReplyTxIds) MarshalCBOR() ([]byte, error) {
-	items := []any{}
+	items := make([]any, 0, len(m.TxIds))
 	for _, txId := range m.TxIds {
 		items = append(items, txId)
 	}
@@ -114,7 +114,7 @@ type MsgRequestTxs struct {
 }
 
 func (m *MsgRequestTxs) MarshalCBOR() ([]byte, error) {
-	items := []any{}
+	items := make([]any, 0, len(m.TxIds))
 	for _, txId := range m.TxIds {
 		items = append(items, txId)
 	}
@@ -141,7 +141,7 @@ type MsgReplyTxs struct {
 }
 
 func (m *MsgReplyTxs) MarshalCBOR() ([]byte, error) {
-	items := []any{}
+	items := make([]any, 0, len(m.Txs))
 	for _, tx := range m.Txs {
 		items = append(items, tx)
 	}


### PR DESCRIPTION
Fixes #1403 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the prealloc linter and refactor slice initializations to preallocate capacity across ledger and protocol code paths. This reduces allocations in transaction/UTxO conversions, CBOR/JSON marshaling, and block serialization.

- **Refactors**
  - Enabled prealloc in golangci-lint.
  - Preallocated slices in Utxorpc(), Inputs(), Collateral(), and Produced() for Byron, Shelley, Mary, Allegra, Alonzo, Babbage, and Conway.
  - Preallocated in MultiAsset JSON marshal, Policies(), Assets(), txsubmission message marshaling, block body hash serialization, and GetTxBodies().
  - Replaced append to empty slices with literals (e.g., query params).
  - Added nolint:prealloc where sequential byte appends are required (Byron address root).

<sup>Written for commit 6bf9d5740e0a14ce4daf7a6a8be3ac2d6c30913a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized internal slice allocation across ledger and protocol components to reduce memory reallocations and improve runtime consistency.
  * Enabled the prealloc linter to enforce efficient slice preallocation practices across the codebase.
  * Applied minor allocation and serialization adjustments to stabilize performance characteristics without changing external behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->