### PR TITLE
fix(ledger): rules and errors for pparam proposals

### DIFF
--- a/ledger/conway/errors.go
+++ b/ledger/conway/errors.go
@@ -110,3 +110,20 @@ type MissingDatumForSpendingScriptError struct {
 func (e MissingDatumForSpendingScriptError) Error() string {
 	return fmt.Sprintf("missing datum for spending script (hash=%x, input=%s)", e.ScriptHash[:], e.Input.String())
 }
+
+// ProtocolParameterUpdateEmptyError indicates that a PPU has no fields set
+type ProtocolParameterUpdateEmptyError struct{}
+
+func (e ProtocolParameterUpdateEmptyError) Error() string {
+	return "protocol parameter update is empty (at least one field must be set)"
+}
+
+// ProtocolParameterUpdateFieldZeroError indicates that a PPU field cannot be zero
+type ProtocolParameterUpdateFieldZeroError struct {
+	FieldName string
+	Value     uint
+}
+
+func (e ProtocolParameterUpdateFieldZeroError) Error() string {
+	return fmt.Sprintf("protocol parameter update field %s cannot be 0, got %d", e.FieldName, e.Value)
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds validation for protocol parameter update proposals in Conway governance. Rejects empty updates and zero-value fields with clear errors to prevent malformed proposals.

- **Bug Fixes**
  - Added UtxoValidateProposalProcedures to UtxoValidationRules.
  - Validates Conway ParameterChangeGovAction ParamUpdate.
  - Introduced ProtocolParameterUpdateEmptyError and ProtocolParameterUpdateFieldZeroError.
  - Blocks zero values for maxBHSize, maxTxSize, maxValSize, and maxBlockBodySize.

<sup>Written for commit 83ef05a316f0cbbbaba88293b5b6d03528146430. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced governance proposal validation to reject empty protocol-parameter updates and enforce non-zero values for key size fields.
  * Added clear, user-facing error messages distinguishing completely empty updates from specific fields set to zero, improving diagnostics for invalid proposals.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->