### PR TITLE
refactor(ledger): use *big.Int for monetary amounts

### DIFF
--- a/cbor/tags.go
+++ b/cbor/tags.go
@@ -52,7 +52,7 @@ func init() {
 	// Wrapped CBOR
 	if err := customTagSet.Add(
 		tagOpts,
-		reflect.TypeOf(WrappedCbor{}),
+		reflect.TypeFor[WrappedCbor](),
 		CborTagCbor,
 	); err != nil {
 		panic(err)
@@ -60,7 +60,7 @@ func init() {
 	// Rational numbers
 	if err := customTagSet.Add(
 		tagOpts,
-		reflect.TypeOf(Rat{}),
+		reflect.TypeFor[Rat](),
 		CborTagRational,
 	); err != nil {
 		panic(err)
@@ -68,7 +68,7 @@ func init() {
 	// Sets
 	if err := customTagSet.Add(
 		tagOpts,
-		reflect.TypeOf(Set{}),
+		reflect.TypeFor[Set](),
 		CborTagSet,
 	); err != nil {
 		panic(err)
@@ -76,7 +76,7 @@ func init() {
 	// Maps
 	if err := customTagSet.Add(
 		tagOpts,
-		reflect.TypeOf(Map{}),
+		reflect.TypeFor[Map](),
 		CborTagMap,
 	); err != nil {
 		panic(err)

--- a/ledger/allegra/allegra.go
+++ b/ledger/allegra/allegra.go
@@ -17,6 +17,7 @@ package allegra
 import (
 	"errors"
 	"fmt"
+	"math/big"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
@@ -218,8 +219,8 @@ func (b *AllegraTransactionBody) Outputs() []common.TransactionOutput {
 	return ret
 }
 
-func (b *AllegraTransactionBody) Fee() uint64 {
-	return b.TxFee
+func (b *AllegraTransactionBody) Fee() *big.Int {
+	return new(big.Int).SetUint64(b.TxFee)
 }
 
 func (b *AllegraTransactionBody) TTL() uint64 {
@@ -249,8 +250,15 @@ func (b *AllegraTransactionBody) Certificates() []common.Certificate {
 	return ret
 }
 
-func (b *AllegraTransactionBody) Withdrawals() map[*common.Address]uint64 {
-	return b.TxWithdrawals
+func (b *AllegraTransactionBody) Withdrawals() map[*common.Address]*big.Int {
+	if b.TxWithdrawals == nil {
+		return nil
+	}
+	ret := make(map[*common.Address]*big.Int)
+	for addr, amount := range b.TxWithdrawals {
+		ret[addr] = new(big.Int).SetUint64(amount)
+	}
+	return ret
 }
 
 func (b *AllegraTransactionBody) AuxDataHash() *common.Blake2b256 {
@@ -346,7 +354,7 @@ func (t AllegraTransaction) Outputs() []common.TransactionOutput {
 	return t.Body.Outputs()
 }
 
-func (t AllegraTransaction) Fee() uint64 {
+func (t AllegraTransaction) Fee() *big.Int {
 	return t.Body.Fee()
 }
 
@@ -370,7 +378,7 @@ func (t AllegraTransaction) CollateralReturn() common.TransactionOutput {
 	return t.Body.CollateralReturn()
 }
 
-func (t AllegraTransaction) TotalCollateral() uint64 {
+func (t AllegraTransaction) TotalCollateral() *big.Int {
 	return t.Body.TotalCollateral()
 }
 
@@ -378,7 +386,7 @@ func (t AllegraTransaction) Certificates() []common.Certificate {
 	return t.Body.Certificates()
 }
 
-func (t AllegraTransaction) Withdrawals() map[*common.Address]uint64 {
+func (t AllegraTransaction) Withdrawals() map[*common.Address]*big.Int {
 	return t.Body.Withdrawals()
 }
 
@@ -406,11 +414,11 @@ func (t AllegraTransaction) ProposalProcedures() []common.ProposalProcedure {
 	return t.Body.ProposalProcedures()
 }
 
-func (t AllegraTransaction) CurrentTreasuryValue() int64 {
+func (t AllegraTransaction) CurrentTreasuryValue() *big.Int {
 	return t.Body.CurrentTreasuryValue()
 }
 
-func (t AllegraTransaction) Donation() uint64 {
+func (t AllegraTransaction) Donation() *big.Int {
 	return t.Body.Donation()
 }
 

--- a/ledger/allegra/pparams_test.go
+++ b/ledger/allegra/pparams_test.go
@@ -171,11 +171,11 @@ func TestAllegraTransactionBody_Utxorpc(t *testing.T) {
 	}
 
 	// Check that the fee matches
-	if actual.Fee.GetInt() != int64(txBody.Fee()) {
+	if actual.Fee.GetInt() != txBody.Fee().Int64() {
 		t.Errorf(
 			"AllegraTransactionBody.Utxorpc() fee mismatch\nGot: %d\nWant: %d",
 			actual.Fee.GetInt(),
-			txBody.Fee(),
+			txBody.Fee().Int64(),
 		)
 	}
 	// Check number of inputs
@@ -233,11 +233,11 @@ func TestAllegraTransaction_Utxorpc(t *testing.T) {
 		t.Fatalf("Could not convert transaction to utxorpc format: %v", err)
 	}
 	// Assertion checks
-	if actual.Fee.GetInt() != int64(tx.Fee()) {
+	if actual.Fee.GetInt() != tx.Fee().Int64() {
 		t.Errorf(
 			"AllegraTransaction.Utxorpc() fee mismatch\nGot: %d\nWant: %d",
 			actual.Fee.GetInt(),
-			tx.Fee(),
+			tx.Fee().Int64(),
 		)
 	}
 

--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -277,8 +277,8 @@ func (b *AlonzoTransactionBody) Outputs() []common.TransactionOutput {
 	return ret
 }
 
-func (b *AlonzoTransactionBody) Fee() uint64 {
-	return b.TxFee
+func (b *AlonzoTransactionBody) Fee() *big.Int {
+	return new(big.Int).SetUint64(b.TxFee)
 }
 
 func (b *AlonzoTransactionBody) TTL() uint64 {
@@ -308,8 +308,15 @@ func (b *AlonzoTransactionBody) Certificates() []common.Certificate {
 	return ret
 }
 
-func (b *AlonzoTransactionBody) Withdrawals() map[*common.Address]uint64 {
-	return b.TxWithdrawals
+func (b *AlonzoTransactionBody) Withdrawals() map[*common.Address]*big.Int {
+	if b.TxWithdrawals == nil {
+		return nil
+	}
+	ret := make(map[*common.Address]*big.Int, len(b.TxWithdrawals))
+	for k, v := range b.TxWithdrawals {
+		ret[k] = new(big.Int).SetUint64(v)
+	}
+	return ret
 }
 
 func (b *AlonzoTransactionBody) AuxDataHash() *common.Blake2b256 {
@@ -457,8 +464,8 @@ func (o AlonzoTransactionOutput) ScriptRef() common.Script {
 	return nil
 }
 
-func (o AlonzoTransactionOutput) Amount() uint64 {
-	return o.OutputAmount.Amount
+func (o AlonzoTransactionOutput) Amount() *big.Int {
+	return new(big.Int).SetUint64(o.OutputAmount.Amount)
 }
 
 func (o AlonzoTransactionOutput) Assets() *common.MultiAsset[common.MultiAssetTypeOutput] {
@@ -508,7 +515,7 @@ func (o AlonzoTransactionOutput) Utxorpc() (*utxorpc.TxOutput, error) {
 
 	return &utxorpc.TxOutput{
 			Address: addressBytes,
-			Coin:    common.ToUtxorpcBigInt(o.Amount()),
+			Coin:    common.BigIntToUtxorpcBigInt(o.Amount()),
 			Assets:  assets,
 			Datum: &utxorpc.Datum{
 				Hash: datumHash,
@@ -758,7 +765,7 @@ func (t AlonzoTransaction) Outputs() []common.TransactionOutput {
 	return t.Body.Outputs()
 }
 
-func (t AlonzoTransaction) Fee() uint64 {
+func (t AlonzoTransaction) Fee() *big.Int {
 	return t.Body.Fee()
 }
 
@@ -786,7 +793,7 @@ func (t AlonzoTransaction) CollateralReturn() common.TransactionOutput {
 	return t.Body.CollateralReturn()
 }
 
-func (t AlonzoTransaction) TotalCollateral() uint64 {
+func (t AlonzoTransaction) TotalCollateral() *big.Int {
 	return t.Body.TotalCollateral()
 }
 
@@ -794,7 +801,7 @@ func (t AlonzoTransaction) Certificates() []common.Certificate {
 	return t.Body.Certificates()
 }
 
-func (t AlonzoTransaction) Withdrawals() map[*common.Address]uint64 {
+func (t AlonzoTransaction) Withdrawals() map[*common.Address]*big.Int {
 	return t.Body.Withdrawals()
 }
 
@@ -822,11 +829,11 @@ func (t AlonzoTransaction) ProposalProcedures() []common.ProposalProcedure {
 	return t.Body.ProposalProcedures()
 }
 
-func (t AlonzoTransaction) CurrentTreasuryValue() int64 {
+func (t AlonzoTransaction) CurrentTreasuryValue() *big.Int {
 	return t.Body.CurrentTreasuryValue()
 }
 
-func (t AlonzoTransaction) Donation() uint64 {
+func (t AlonzoTransaction) Donation() *big.Int {
 	return t.Body.Donation()
 }
 

--- a/ledger/alonzo/pparams.go
+++ b/ledger/alonzo/pparams.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"maps"
 	"math"
+	"math/big"
 	"slices"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -69,6 +70,31 @@ type AlonzoProtocolParameters struct {
 	MaxValueSize         uint
 	CollateralPercentage uint
 	MaxCollateralInputs  uint
+}
+
+// KeyDepositAmount returns the key deposit as a *big.Int
+func (p *AlonzoProtocolParameters) KeyDepositAmount() *big.Int {
+	return new(big.Int).SetUint64(uint64(p.KeyDeposit))
+}
+
+// PoolDepositAmount returns the pool deposit as a *big.Int
+func (p *AlonzoProtocolParameters) PoolDepositAmount() *big.Int {
+	return new(big.Int).SetUint64(uint64(p.PoolDeposit))
+}
+
+// MinUtxoValueAmount returns the minimum UTxO value as a *big.Int
+func (p *AlonzoProtocolParameters) MinUtxoValueAmount() *big.Int {
+	return new(big.Int).SetUint64(uint64(p.MinUtxoValue))
+}
+
+// MinPoolCostAmount returns the minimum pool cost as a *big.Int
+func (p *AlonzoProtocolParameters) MinPoolCostAmount() *big.Int {
+	return new(big.Int).SetUint64(p.MinPoolCost)
+}
+
+// AdaPerUtxoByteAmount returns the ADA per UTxO byte as a *big.Int
+func (p *AlonzoProtocolParameters) AdaPerUtxoByteAmount() *big.Int {
+	return new(big.Int).SetUint64(p.AdaPerUtxoByte)
 }
 
 func (p *AlonzoProtocolParameters) Update(

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -395,8 +395,8 @@ func (b *BabbageTransactionBody) Outputs() []common.TransactionOutput {
 	return ret
 }
 
-func (b *BabbageTransactionBody) Fee() uint64 {
-	return b.TxFee
+func (b *BabbageTransactionBody) Fee() *big.Int {
+	return new(big.Int).SetUint64(b.TxFee)
 }
 
 func (b *BabbageTransactionBody) TTL() uint64 {
@@ -426,8 +426,15 @@ func (b *BabbageTransactionBody) Certificates() []common.Certificate {
 	return ret
 }
 
-func (b *BabbageTransactionBody) Withdrawals() map[*common.Address]uint64 {
-	return b.TxWithdrawals
+func (b *BabbageTransactionBody) Withdrawals() map[*common.Address]*big.Int {
+	if b.TxWithdrawals == nil {
+		return nil
+	}
+	ret := make(map[*common.Address]*big.Int)
+	for k, v := range b.TxWithdrawals {
+		ret[k] = new(big.Int).SetUint64(v)
+	}
+	return ret
 }
 
 func (b *BabbageTransactionBody) AuxDataHash() *common.Blake2b256 {
@@ -474,8 +481,8 @@ func (b *BabbageTransactionBody) CollateralReturn() common.TransactionOutput {
 	return b.TxCollateralReturn
 }
 
-func (b *BabbageTransactionBody) TotalCollateral() uint64 {
-	return b.TxTotalCollateral
+func (b *BabbageTransactionBody) TotalCollateral() *big.Int {
+	return new(big.Int).SetUint64(b.TxTotalCollateral)
 }
 
 func (b *BabbageTransactionBody) Utxorpc() (*utxorpc.Tx, error) {
@@ -698,8 +705,8 @@ func (o BabbageTransactionOutput) ScriptRef() common.Script {
 	return o.TxOutScriptRef.Script
 }
 
-func (o BabbageTransactionOutput) Amount() uint64 {
-	return o.OutputAmount.Amount
+func (o BabbageTransactionOutput) Amount() *big.Int {
+	return new(big.Int).SetUint64(o.OutputAmount.Amount)
 }
 
 func (o BabbageTransactionOutput) Assets() *common.MultiAsset[common.MultiAssetTypeOutput] {
@@ -774,7 +781,7 @@ func (o BabbageTransactionOutput) Utxorpc() (*utxorpc.TxOutput, error) {
 
 	return &utxorpc.TxOutput{
 			Address: address,
-			Coin:    common.ToUtxorpcBigInt(o.Amount()),
+			Coin:    common.BigIntToUtxorpcBigInt(o.Amount()),
 			Assets:  assets,
 			Datum: &utxorpc.Datum{
 				Hash: datumHash,
@@ -1000,7 +1007,7 @@ func (t BabbageTransaction) Outputs() []common.TransactionOutput {
 	return t.Body.Outputs()
 }
 
-func (t BabbageTransaction) Fee() uint64 {
+func (t BabbageTransaction) Fee() *big.Int {
 	return t.Body.Fee()
 }
 
@@ -1028,7 +1035,7 @@ func (t BabbageTransaction) CollateralReturn() common.TransactionOutput {
 	return t.Body.CollateralReturn()
 }
 
-func (t BabbageTransaction) TotalCollateral() uint64 {
+func (t BabbageTransaction) TotalCollateral() *big.Int {
 	return t.Body.TotalCollateral()
 }
 
@@ -1036,7 +1043,7 @@ func (t BabbageTransaction) Certificates() []common.Certificate {
 	return t.Body.Certificates()
 }
 
-func (t BabbageTransaction) Withdrawals() map[*common.Address]uint64 {
+func (t BabbageTransaction) Withdrawals() map[*common.Address]*big.Int {
 	return t.Body.Withdrawals()
 }
 
@@ -1064,11 +1071,11 @@ func (t BabbageTransaction) ProposalProcedures() []common.ProposalProcedure {
 	return t.Body.ProposalProcedures()
 }
 
-func (t BabbageTransaction) CurrentTreasuryValue() int64 {
+func (t BabbageTransaction) CurrentTreasuryValue() *big.Int {
 	return t.Body.CurrentTreasuryValue()
 }
 
-func (t BabbageTransaction) Donation() uint64 {
+func (t BabbageTransaction) Donation() *big.Int {
 	return t.Body.Donation()
 }
 

--- a/ledger/babbage/pparams.go
+++ b/ledger/babbage/pparams.go
@@ -17,6 +17,7 @@ package babbage
 import (
 	"errors"
 	"math"
+	"math/big"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
@@ -50,6 +51,26 @@ type BabbageProtocolParameters struct {
 	MaxValueSize         uint
 	CollateralPercentage uint
 	MaxCollateralInputs  uint
+}
+
+// KeyDepositAmount returns the key deposit as a *big.Int
+func (p *BabbageProtocolParameters) KeyDepositAmount() *big.Int {
+	return new(big.Int).SetUint64(uint64(p.KeyDeposit))
+}
+
+// PoolDepositAmount returns the pool deposit as a *big.Int
+func (p *BabbageProtocolParameters) PoolDepositAmount() *big.Int {
+	return new(big.Int).SetUint64(uint64(p.PoolDeposit))
+}
+
+// MinPoolCostAmount returns the minimum pool cost as a *big.Int
+func (p *BabbageProtocolParameters) MinPoolCostAmount() *big.Int {
+	return new(big.Int).SetUint64(p.MinPoolCost)
+}
+
+// AdaPerUtxoByteAmount returns the ADA per UTxO byte as a *big.Int
+func (p *BabbageProtocolParameters) AdaPerUtxoByteAmount() *big.Int {
+	return new(big.Int).SetUint64(p.AdaPerUtxoByte)
 }
 
 func (p *BabbageProtocolParameters) Update(

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -16,7 +16,6 @@ package babbage
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -307,12 +306,17 @@ func UtxoValidateFeeTooSmallUtxo(
 	if err != nil {
 		return err
 	}
-	if tx.Fee() >= minFee {
+	minFeeBig := new(big.Int).SetUint64(minFee)
+	fee := tx.Fee()
+	if fee == nil {
+		fee = new(big.Int)
+	}
+	if fee.Cmp(minFeeBig) >= 0 {
 		return nil
 	}
 	return shelley.FeeTooSmallUtxoError{
-		Provided: tx.Fee(),
-		Min:      minFee,
+		Provided: fee,
+		Min:      minFeeBig,
 	}
 }
 
@@ -334,21 +338,37 @@ func UtxoValidateInsufficientCollateral(
 	if len(tmpTx.WitnessSet.WsRedeemers) == 0 {
 		return nil
 	}
-	var totalCollateral uint64
+	totalCollateral := new(big.Int)
 	for _, collateralInput := range tx.Collateral() {
 		utxo, err := ls.UtxoById(collateralInput)
 		if err != nil {
 			return err
 		}
-		totalCollateral += utxo.Output.Amount()
+		if amount := utxo.Output.Amount(); amount != nil {
+			totalCollateral.Add(totalCollateral, amount)
+		}
 	}
-	minCollateral := tmpTx.Fee() * uint64(tmpPparams.CollateralPercentage) / 100
-	if totalCollateral >= minCollateral {
+	// minCollateral = fee * collateralPercentage / 100
+	fee := tmpTx.Fee()
+	if fee == nil {
+		fee = new(big.Int)
+	}
+	minCollateral := new(big.Int).Mul(fee, new(big.Int).SetUint64(uint64(tmpPparams.CollateralPercentage)))
+	minCollateral.Div(minCollateral, big.NewInt(100))
+	if totalCollateral.Cmp(minCollateral) >= 0 {
 		return nil
 	}
+	// Convert to uint64 for error struct (best effort)
+	var providedU, requiredU uint64
+	if totalCollateral.IsUint64() {
+		providedU = totalCollateral.Uint64()
+	}
+	if minCollateral.IsUint64() {
+		requiredU = minCollateral.Uint64()
+	}
 	return alonzo.InsufficientCollateralError{
-		Provided: totalCollateral,
-		Required: minCollateral,
+		Provided: providedU,
+		Required: requiredU,
 	}
 }
 
@@ -367,14 +387,16 @@ func UtxoValidateCollateralContainsNonAda(
 		return nil
 	}
 	badOutputs := []common.TransactionOutput{}
-	var totalCollateral uint64
+	totalCollateral := new(big.Int)
 	totalAssets := common.NewMultiAsset[common.MultiAssetTypeOutput](nil)
 	for _, collateralInput := range tx.Collateral() {
 		utxo, err := ls.UtxoById(collateralInput)
 		if err != nil {
 			return err
 		}
-		totalCollateral += utxo.Output.Amount()
+		if amount := utxo.Output.Amount(); amount != nil {
+			totalCollateral.Add(totalCollateral, amount)
+		}
 		totalAssets.Add(utxo.Output.Assets())
 		if utxo.Output.Assets() == nil ||
 			len(utxo.Output.Assets().Policies()) == 0 {
@@ -393,8 +415,12 @@ func UtxoValidateCollateralContainsNonAda(
 			return nil
 		}
 	}
+	var providedU uint64
+	if totalCollateral.IsUint64() {
+		providedU = totalCollateral.Uint64()
+	}
 	return alonzo.CollateralContainsNonAdaError{
-		Provided: totalCollateral,
+		Provided: providedU,
 	}
 }
 
@@ -406,37 +432,48 @@ func UtxoValidateCollateralEqBalance(
 	pp common.ProtocolParameters,
 ) error {
 	totalCollateral := tx.TotalCollateral()
-	if totalCollateral == 0 {
+	if totalCollateral == nil || totalCollateral.Sign() == 0 {
 		return nil
 	}
 	// Collect collateral input amounts
-	var collBalance uint64
+	collBalance := new(big.Int)
 	for _, collInput := range tx.Collateral() {
 		utxo, err := ls.UtxoById(collInput)
 		if err != nil {
 			continue
 		}
-		collBalance += utxo.Output.Amount()
+		if amount := utxo.Output.Amount(); amount != nil {
+			collBalance.Add(collBalance, amount)
+		}
 	}
 
 	// Skip validation if no valid collateral UTxOs were found
 	// This avoids subtracting from zero and prevents uint underflow
-	if collBalance == 0 {
+	if collBalance.Sign() == 0 {
 		return nil
 	}
 
 	// Subtract collateral return amount with underflow protection
 	collReturn := tx.CollateralReturn()
-	if collReturn != nil && collBalance >= collReturn.Amount() {
-		collBalance -= collReturn.Amount()
+	if collReturn != nil {
+		if returnAmount := collReturn.Amount(); returnAmount != nil && collBalance.Cmp(returnAmount) >= 0 {
+			collBalance.Sub(collBalance, returnAmount)
+		}
 	}
 
-	if totalCollateral == collBalance {
+	if totalCollateral.Cmp(collBalance) == 0 {
 		return nil
 	}
+	var providedU, totalCollU uint64
+	if collBalance.IsUint64() {
+		providedU = collBalance.Uint64()
+	}
+	if totalCollateral.IsUint64() {
+		totalCollU = totalCollateral.Uint64()
+	}
 	return IncorrectTotalCollateralFieldError{
-		Provided:        collBalance,
-		TotalCollateral: totalCollateral,
+		Provided:        providedU,
+		TotalCollateral: totalCollU,
 	}
 }
 
@@ -491,31 +528,39 @@ func UtxoValidateValueNotConservedUtxo(
 	}
 	// Calculate consumed value
 	// consumed = value from input(s) + withdrawals + refunds
-	var consumedValue uint64
+	consumedValue := new(big.Int)
 	for _, tmpInput := range tx.Inputs() {
 		tmpUtxo, err := ls.UtxoById(tmpInput)
 		// Ignore errors fetching the UTxO and exclude it from calculations
 		if err != nil {
 			continue
 		}
-		consumedValue += tmpUtxo.Output.Amount()
+		if amount := tmpUtxo.Output.Amount(); amount != nil {
+			consumedValue.Add(consumedValue, amount)
+		}
 	}
 	for _, tmpWithdrawalAmount := range tx.Withdrawals() {
-		consumedValue += tmpWithdrawalAmount
+		if tmpWithdrawalAmount != nil {
+			consumedValue.Add(consumedValue, tmpWithdrawalAmount)
+		}
 	}
 	for _, cert := range tx.Certificates() {
 		switch cert.(type) {
 		case *common.StakeDeregistrationCertificate:
-			consumedValue += uint64(tmpPparams.KeyDeposit)
+			consumedValue.Add(consumedValue, new(big.Int).SetUint64(uint64(tmpPparams.KeyDeposit)))
 		}
 	}
 	// Calculate produced value
 	// produced = value from output(s) + fee + deposits
-	var producedValue uint64
+	producedValue := new(big.Int)
 	for _, tmpOutput := range tx.Outputs() {
-		producedValue += tmpOutput.Amount()
+		if amount := tmpOutput.Amount(); amount != nil {
+			producedValue.Add(producedValue, amount)
+		}
 	}
-	producedValue += tx.Fee()
+	if fee := tx.Fee(); fee != nil {
+		producedValue.Add(producedValue, fee)
+	}
 	for _, cert := range tx.Certificates() {
 		switch tmpCert := cert.(type) {
 		case *common.PoolRegistrationCertificate:
@@ -524,13 +569,13 @@ func UtxoValidateValueNotConservedUtxo(
 				return err
 			}
 			if reg == nil {
-				producedValue += uint64(tmpPparams.PoolDeposit)
+				producedValue.Add(producedValue, new(big.Int).SetUint64(uint64(tmpPparams.PoolDeposit)))
 			}
 		case *common.StakeRegistrationCertificate:
-			producedValue += uint64(tmpPparams.KeyDeposit)
+			producedValue.Add(producedValue, new(big.Int).SetUint64(uint64(tmpPparams.KeyDeposit)))
 		}
 	}
-	if consumedValue != producedValue {
+	if consumedValue.Cmp(producedValue) != 0 {
 		return shelley.ValueNotConservedUtxoError{
 			Consumed: consumedValue,
 			Produced: producedValue,
@@ -629,28 +674,10 @@ func UtxoValidateValueNotConservedUtxo(
 			produced = new(big.Int)
 		}
 		if consumed.Cmp(produced) != 0 {
-			// For error reporting, convert to uint64 if possible
-			var consumedU, producedU uint64
-			if consumed.IsUint64() {
-				consumedU = consumed.Uint64()
+			return shelley.ValueNotConservedUtxoError{
+				Consumed: consumed,
+				Produced: produced,
 			}
-			if produced.IsUint64() {
-				producedU = produced.Uint64()
-			}
-			// Wrap with context if values don't fit in uint64
-			baseErr := shelley.ValueNotConservedUtxoError{
-				Consumed: consumedU,
-				Produced: producedU,
-			}
-			if !consumed.IsUint64() || !produced.IsUint64() {
-				return fmt.Errorf(
-					"multi-asset value not conserved: consumed %s, produced %s: %w",
-					consumed.String(),
-					produced.String(),
-					baseErr,
-				)
-			}
-			return baseErr
 		}
 	}
 
@@ -669,7 +696,12 @@ func UtxoValidateOutputTooSmallUtxo(
 		if err != nil {
 			return err
 		}
-		if tmpOutput.Amount() < minCoin {
+		minCoinBig := new(big.Int).SetUint64(minCoin)
+		amount := tmpOutput.Amount()
+		if amount == nil {
+			amount = new(big.Int)
+		}
+		if amount.Cmp(minCoinBig) < 0 {
 			badOutputs = append(badOutputs, tmpOutput)
 		}
 	}

--- a/ledger/byron/byron.go
+++ b/ledger/byron/byron.go
@@ -193,11 +193,11 @@ func (t *ByronTransactionBody) Outputs() []common.TransactionOutput {
 	return ret
 }
 
-func (t *ByronTransactionBody) Fee() uint64 {
+func (t *ByronTransactionBody) Fee() *big.Int {
 	// The fee is implicit in Byron, and we don't have enough information here to calculate it.
 	// You need to know the Lovelace in the inputs to determine the fee, and that information is
 	// not provided directly in the TX
-	return 0
+	return big.NewInt(0)
 }
 
 func (t *ByronTransactionBody) TTL() uint64 {
@@ -225,9 +225,9 @@ func (t *ByronTransactionBody) CollateralReturn() common.TransactionOutput {
 	return nil
 }
 
-func (t *ByronTransactionBody) TotalCollateral() uint64 {
+func (t *ByronTransactionBody) TotalCollateral() *big.Int {
 	// No collateral in Byron
-	return 0
+	return nil
 }
 
 func (t *ByronTransactionBody) Certificates() []common.Certificate {
@@ -235,7 +235,7 @@ func (t *ByronTransactionBody) Certificates() []common.Certificate {
 	return nil
 }
 
-func (t *ByronTransactionBody) Withdrawals() map[*common.Address]uint64 {
+func (t *ByronTransactionBody) Withdrawals() map[*common.Address]*big.Int {
 	// No withdrawals in Byron
 	return nil
 }
@@ -270,14 +270,14 @@ func (t *ByronTransactionBody) ProposalProcedures() []common.ProposalProcedure {
 	return nil
 }
 
-func (t *ByronTransactionBody) CurrentTreasuryValue() int64 {
+func (t *ByronTransactionBody) CurrentTreasuryValue() *big.Int {
 	// No current treasury value in Byron
-	return 0
+	return nil
 }
 
-func (t *ByronTransactionBody) Donation() uint64 {
+func (t *ByronTransactionBody) Donation() *big.Int {
 	// No donation in Byron
-	return 0
+	return nil
 }
 
 func (t *ByronTransactionBody) Utxorpc() (*utxorpc.Tx, error) {
@@ -383,7 +383,7 @@ func (t *ByronTransaction) Outputs() []common.TransactionOutput {
 	return t.Body.Outputs()
 }
 
-func (t *ByronTransaction) Fee() uint64 {
+func (t *ByronTransaction) Fee() *big.Int {
 	return t.Body.Fee()
 }
 
@@ -407,7 +407,7 @@ func (t *ByronTransaction) CollateralReturn() common.TransactionOutput {
 	return t.Body.CollateralReturn()
 }
 
-func (t *ByronTransaction) TotalCollateral() uint64 {
+func (t *ByronTransaction) TotalCollateral() *big.Int {
 	return t.Body.TotalCollateral()
 }
 
@@ -415,7 +415,7 @@ func (t *ByronTransaction) Certificates() []common.Certificate {
 	return t.Body.Certificates()
 }
 
-func (t *ByronTransaction) Withdrawals() map[*common.Address]uint64 {
+func (t *ByronTransaction) Withdrawals() map[*common.Address]*big.Int {
 	return t.Body.Withdrawals()
 }
 
@@ -443,11 +443,11 @@ func (t *ByronTransaction) ProposalProcedures() []common.ProposalProcedure {
 	return t.Body.ProposalProcedures()
 }
 
-func (t *ByronTransaction) CurrentTreasuryValue() int64 {
+func (t *ByronTransaction) CurrentTreasuryValue() *big.Int {
 	return t.Body.CurrentTreasuryValue()
 }
 
-func (t *ByronTransaction) Donation() uint64 {
+func (t *ByronTransaction) Donation() *big.Int {
 	return t.Body.Donation()
 }
 
@@ -826,8 +826,8 @@ func (o ByronTransactionOutput) ScriptRef() common.Script {
 	return nil
 }
 
-func (o ByronTransactionOutput) Amount() uint64 {
-	return o.OutputAmount
+func (o ByronTransactionOutput) Amount() *big.Int {
+	return new(big.Int).SetUint64(o.OutputAmount)
 }
 
 func (o ByronTransactionOutput) Assets() *common.MultiAsset[common.MultiAssetTypeOutput] {
@@ -849,7 +849,7 @@ func (o ByronTransactionOutput) Utxorpc() (*utxorpc.TxOutput, error) {
 	}
 	return &utxorpc.TxOutput{
 			Address: addressBytes,
-			Coin:    common.ToUtxorpcBigInt(o.Amount()),
+			Coin:    common.BigIntToUtxorpcBigInt(o.Amount()),
 		},
 		nil
 }

--- a/ledger/byron/genesis_test.go
+++ b/ledger/byron/genesis_test.go
@@ -298,10 +298,10 @@ func TestGenesisNonAvvmUtxos(t *testing.T) {
 			testAddr,
 		)
 	}
-	if tmpUtxo.Output.Amount() != testAmount {
+	if tmpUtxo.Output.Amount().Uint64() != testAmount {
 		t.Fatalf(
-			"did not get expected amount: got %d, wanted %d",
-			tmpUtxo.Output.Amount(),
+			"did not get expected amount: got %s, wanted %d",
+			tmpUtxo.Output.Amount().String(),
 			testAmount,
 		)
 	}
@@ -351,10 +351,10 @@ func TestGenesisAvvmUtxos(t *testing.T) {
 			expectedAddr,
 		)
 	}
-	if tmpUtxo.Output.Amount() != testAmount {
+	if tmpUtxo.Output.Amount().Uint64() != testAmount {
 		t.Fatalf(
-			"did not get expected amount: got %d, wanted %d",
-			tmpUtxo.Output.Amount(),
+			"did not get expected amount: got %s, wanted %d",
+			tmpUtxo.Output.Amount().String(),
 			testAmount,
 		)
 	}

--- a/ledger/common/certs.go
+++ b/ledger/common/certs.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"net"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -632,6 +633,16 @@ func (c *PoolRegistrationCertificate) Type() uint {
 	return c.CertType
 }
 
+// PledgeAmount returns the pool pledge as a *big.Int
+func (c *PoolRegistrationCertificate) PledgeAmount() *big.Int {
+	return new(big.Int).SetUint64(c.Pledge)
+}
+
+// CostAmount returns the pool cost as a *big.Int
+func (c *PoolRegistrationCertificate) CostAmount() *big.Int {
+	return new(big.Int).SetUint64(c.Cost)
+}
+
 type PoolRetirementCertificate struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
@@ -802,6 +813,23 @@ func (c *MoveInstantaneousRewardsCertificate) Type() uint {
 	return c.CertType
 }
 
+// RewardsAmount returns the rewards map with amounts as *big.Int
+func (r *MoveInstantaneousRewardsCertificateReward) RewardsAmount() map[*Credential]*big.Int {
+	if r.Rewards == nil {
+		return nil
+	}
+	result := make(map[*Credential]*big.Int)
+	for cred, amount := range r.Rewards {
+		result[cred] = new(big.Int).SetUint64(amount)
+	}
+	return result
+}
+
+// OtherPotAmount returns the other pot amount as a *big.Int
+func (r *MoveInstantaneousRewardsCertificateReward) OtherPotAmount() *big.Int {
+	return new(big.Int).SetUint64(r.OtherPot)
+}
+
 type RegistrationCertificate struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
@@ -843,6 +871,11 @@ func (c *RegistrationCertificate) Type() uint {
 	return c.CertType
 }
 
+// DepositAmount returns the deposit amount as a *big.Int
+func (c *RegistrationCertificate) DepositAmount() *big.Int {
+	return new(big.Int).SetInt64(c.Amount)
+}
+
 type DeregistrationCertificate struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
@@ -882,6 +915,11 @@ func (c *DeregistrationCertificate) Utxorpc() (*utxorpc.Certificate, error) {
 
 func (c *DeregistrationCertificate) Type() uint {
 	return c.CertType
+}
+
+// DepositAmount returns the deposit amount as a *big.Int
+func (c *DeregistrationCertificate) DepositAmount() *big.Int {
+	return new(big.Int).SetInt64(c.Amount)
 }
 
 type VoteDelegationCertificate struct {
@@ -1022,6 +1060,11 @@ func (c *StakeRegistrationDelegationCertificate) Type() uint {
 	return c.CertType
 }
 
+// DepositAmount returns the deposit amount as a *big.Int
+func (c *StakeRegistrationDelegationCertificate) DepositAmount() *big.Int {
+	return new(big.Int).SetInt64(c.Amount)
+}
+
 type VoteRegistrationDelegationCertificate struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
@@ -1068,6 +1111,11 @@ func (c *VoteRegistrationDelegationCertificate) Utxorpc() (*utxorpc.Certificate,
 
 func (c *VoteRegistrationDelegationCertificate) Type() uint {
 	return c.CertType
+}
+
+// DepositAmount returns the deposit amount as a *big.Int
+func (c *VoteRegistrationDelegationCertificate) DepositAmount() *big.Int {
+	return new(big.Int).SetInt64(c.Amount)
 }
 
 type StakeVoteRegistrationDelegationCertificate struct {
@@ -1129,6 +1177,11 @@ func (c *StakeVoteRegistrationDelegationCertificate) Utxorpc() (*utxorpc.Certifi
 
 func (c *StakeVoteRegistrationDelegationCertificate) Type() uint {
 	return c.CertType
+}
+
+// DepositAmount returns the deposit amount as a *big.Int
+func (c *StakeVoteRegistrationDelegationCertificate) DepositAmount() *big.Int {
+	return new(big.Int).SetInt64(c.Amount)
 }
 
 type AuthCommitteeHotCertificate struct {
@@ -1277,6 +1330,11 @@ func (c *RegistrationDrepCertificate) Type() uint {
 	return c.CertType
 }
 
+// DepositAmount returns the deposit amount as a *big.Int
+func (c *RegistrationDrepCertificate) DepositAmount() *big.Int {
+	return new(big.Int).SetInt64(c.Amount)
+}
+
 type DeregistrationDrepCertificate struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
@@ -1316,6 +1374,11 @@ func (c *DeregistrationDrepCertificate) Utxorpc() (*utxorpc.Certificate, error) 
 
 func (c *DeregistrationDrepCertificate) Type() uint {
 	return c.CertType
+}
+
+// DepositAmount returns the deposit amount as a *big.Int
+func (c *DeregistrationDrepCertificate) DepositAmount() *big.Int {
+	return new(big.Int).SetInt64(c.Amount)
 }
 
 type UpdateDrepCertificate struct {

--- a/ledger/common/common_test.go
+++ b/ledger/common/common_test.go
@@ -385,12 +385,6 @@ func TestOriginalIssue_ZeroHashNotNull(t *testing.T) {
 	)
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
 func TestAssetFingerprint(t *testing.T) {
 	testDefs := []struct {
 		policyIdHex         string
@@ -1147,7 +1141,7 @@ func TestCertificateTypeMethods(t *testing.T) {
 // TestCertificateTypeCoverage ensures all CertificateType constants are tested
 func TestCertificateTypeCoverage(t *testing.T) {
 	// Get all CertificateType constants via reflection
-	certTypeType := reflect.TypeOf(CertificateTypeStakeRegistration)
+	certTypeType := reflect.TypeFor[CertificateType]()
 	if certTypeType.Kind() != reflect.Uint {
 		t.Fatalf("CertificateType is not uint, got %s", certTypeType.Kind())
 	}

--- a/ledger/common/script/purpose.go
+++ b/ledger/common/script/purpose.go
@@ -263,7 +263,7 @@ func scriptPurposeBuilder(
 	inputs []lcommon.TransactionInput,
 	mint lcommon.MultiAsset[lcommon.MultiAssetTypeMint],
 	certificates []lcommon.Certificate,
-	withdrawals KeyValuePairs[*lcommon.Address, uint64],
+	withdrawals KeyValuePairs[*lcommon.Address, *big.Int],
 	votes KeyValuePairs[*lcommon.Voter, KeyValuePairs[*lcommon.GovActionId, lcommon.VotingProcedure]],
 	proposalProcedures []lcommon.ProposalProcedure,
 ) toScriptPurposeFunc {
@@ -349,7 +349,7 @@ func BuildScriptPurpose(
 	inputs []lcommon.TransactionInput,
 	mint lcommon.MultiAsset[lcommon.MultiAssetTypeMint],
 	certificates []lcommon.Certificate,
-	withdrawals map[*lcommon.Address]uint64,
+	withdrawals map[*lcommon.Address]*big.Int,
 	votes lcommon.VotingProcedures,
 	proposalProcedures []lcommon.ProposalProcedure,
 ) ScriptPurpose {

--- a/ledger/common/tx.go
+++ b/ledger/common/tx.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	"iter"
+	"math/big"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/plutigo/data"
@@ -38,7 +39,7 @@ type Transaction interface {
 
 type TransactionBody interface {
 	Cbor() []byte
-	Fee() uint64
+	Fee() *big.Int
 	Id() Blake2b256
 	Inputs() []TransactionInput
 	Outputs() []TransactionOutput
@@ -48,17 +49,17 @@ type TransactionBody interface {
 	ReferenceInputs() []TransactionInput
 	Collateral() []TransactionInput
 	CollateralReturn() TransactionOutput
-	TotalCollateral() uint64
+	TotalCollateral() *big.Int
 	Certificates() []Certificate
-	Withdrawals() map[*Address]uint64
+	Withdrawals() map[*Address]*big.Int
 	AuxDataHash() *Blake2b256
 	RequiredSigners() []Blake2b224
 	AssetMint() *MultiAsset[MultiAssetTypeMint]
 	ScriptDataHash() *Blake2b256
 	VotingProcedures() VotingProcedures
 	ProposalProcedures() []ProposalProcedure
-	CurrentTreasuryValue() int64
-	Donation() uint64
+	CurrentTreasuryValue() *big.Int
+	Donation() *big.Int
 	Utxorpc() (*utxorpc.Tx, error)
 }
 
@@ -72,7 +73,7 @@ type TransactionInput interface {
 
 type TransactionOutput interface {
 	Address() Address
-	Amount() uint64
+	Amount() *big.Int
 	Assets() *MultiAsset[MultiAssetTypeOutput]
 	Datum() *Datum
 	DatumHash() *Blake2b256
@@ -130,8 +131,8 @@ func (b *TransactionBodyBase) Outputs() []TransactionOutput {
 	return nil
 }
 
-func (b *TransactionBodyBase) Fee() uint64 {
-	return 0
+func (b *TransactionBodyBase) Fee() *big.Int {
+	return nil
 }
 
 func (b *TransactionBodyBase) TTL() uint64 {
@@ -154,15 +155,15 @@ func (b *TransactionBodyBase) CollateralReturn() TransactionOutput {
 	return nil
 }
 
-func (b *TransactionBodyBase) TotalCollateral() uint64 {
-	return 0
+func (b *TransactionBodyBase) TotalCollateral() *big.Int {
+	return nil
 }
 
 func (b *TransactionBodyBase) Certificates() []Certificate {
 	return nil
 }
 
-func (b *TransactionBodyBase) Withdrawals() map[*Address]uint64 {
+func (b *TransactionBodyBase) Withdrawals() map[*Address]*big.Int {
 	return nil
 }
 
@@ -190,12 +191,12 @@ func (b *TransactionBodyBase) ProposalProcedures() []ProposalProcedure {
 	return nil
 }
 
-func (b *TransactionBodyBase) CurrentTreasuryValue() int64 {
-	return 0
+func (b *TransactionBodyBase) CurrentTreasuryValue() *big.Int {
+	return nil
 }
 
-func (b *TransactionBodyBase) Donation() uint64 {
-	return 0
+func (b *TransactionBodyBase) Donation() *big.Int {
+	return nil
 }
 
 func (b *TransactionBodyBase) Utxorpc() (*utxorpc.Tx, error) {
@@ -229,7 +230,7 @@ func TransactionBodyToUtxorpc(tx TransactionBody) (*utxorpc.Tx, error) {
 		// ReferenceInputs: tx.ReferenceInputs(),
 		// Witnesses:       tx.Witnesses(),
 		// Collateral:      tx.Collateral(),
-		Fee: ToUtxorpcBigInt(tx.Fee()),
+		Fee: BigIntToUtxorpcBigInt(tx.Fee()),
 		// Validity:        tx.Validity(),
 		// Successful:      tx.Successful(),
 		// Auxiliary:       tx.AuxData(),

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"iter"
 	"maps"
+	"math/big"
 	"slices"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -505,8 +506,8 @@ func (b *ConwayTransactionBody) Outputs() []common.TransactionOutput {
 	return ret
 }
 
-func (b *ConwayTransactionBody) Fee() uint64 {
-	return b.TxFee
+func (b *ConwayTransactionBody) Fee() *big.Int {
+	return new(big.Int).SetUint64(b.TxFee)
 }
 
 func (b *ConwayTransactionBody) TTL() uint64 {
@@ -536,8 +537,15 @@ func (b *ConwayTransactionBody) Certificates() []common.Certificate {
 	return ret
 }
 
-func (b *ConwayTransactionBody) Withdrawals() map[*common.Address]uint64 {
-	return b.TxWithdrawals
+func (b *ConwayTransactionBody) Withdrawals() map[*common.Address]*big.Int {
+	if b.TxWithdrawals == nil {
+		return nil
+	}
+	ret := make(map[*common.Address]*big.Int, len(b.TxWithdrawals))
+	for addr, amount := range b.TxWithdrawals {
+		ret[addr] = new(big.Int).SetUint64(amount)
+	}
+	return ret
 }
 
 func (b *ConwayTransactionBody) AuxDataHash() *common.Blake2b256 {
@@ -584,8 +592,8 @@ func (b *ConwayTransactionBody) CollateralReturn() common.TransactionOutput {
 	return b.TxCollateralReturn
 }
 
-func (b *ConwayTransactionBody) TotalCollateral() uint64 {
-	return b.TxTotalCollateral
+func (b *ConwayTransactionBody) TotalCollateral() *big.Int {
+	return new(big.Int).SetUint64(b.TxTotalCollateral)
 }
 
 func (b *ConwayTransactionBody) VotingProcedures() common.VotingProcedures {
@@ -607,12 +615,12 @@ func (b *ConwayTransactionBody) NetworkId() *uint8 {
 	return b.TxNetworkId
 }
 
-func (b *ConwayTransactionBody) CurrentTreasuryValue() int64 {
-	return b.TxCurrentTreasuryValue
+func (b *ConwayTransactionBody) CurrentTreasuryValue() *big.Int {
+	return big.NewInt(b.TxCurrentTreasuryValue)
 }
 
-func (b *ConwayTransactionBody) Donation() uint64 {
-	return b.TxDonation
+func (b *ConwayTransactionBody) Donation() *big.Int {
+	return new(big.Int).SetUint64(b.TxDonation)
 }
 
 func (b *ConwayTransactionBody) Utxorpc() (*utxorpc.Tx, error) {
@@ -721,7 +729,7 @@ func (t ConwayTransaction) Outputs() []common.TransactionOutput {
 	return t.Body.Outputs()
 }
 
-func (t ConwayTransaction) Fee() uint64 {
+func (t ConwayTransaction) Fee() *big.Int {
 	return t.Body.Fee()
 }
 
@@ -749,7 +757,7 @@ func (t ConwayTransaction) CollateralReturn() common.TransactionOutput {
 	return t.Body.CollateralReturn()
 }
 
-func (t ConwayTransaction) TotalCollateral() uint64 {
+func (t ConwayTransaction) TotalCollateral() *big.Int {
 	return t.Body.TotalCollateral()
 }
 
@@ -757,7 +765,7 @@ func (t ConwayTransaction) Certificates() []common.Certificate {
 	return t.Body.Certificates()
 }
 
-func (t ConwayTransaction) Withdrawals() map[*common.Address]uint64 {
+func (t ConwayTransaction) Withdrawals() map[*common.Address]*big.Int {
 	return t.Body.Withdrawals()
 }
 
@@ -785,11 +793,11 @@ func (t ConwayTransaction) ProposalProcedures() []common.ProposalProcedure {
 	return t.Body.ProposalProcedures()
 }
 
-func (t ConwayTransaction) CurrentTreasuryValue() int64 {
+func (t ConwayTransaction) CurrentTreasuryValue() *big.Int {
 	return t.Body.CurrentTreasuryValue()
 }
 
-func (t ConwayTransaction) Donation() uint64 {
+func (t ConwayTransaction) Donation() *big.Int {
 	return t.Body.Donation()
 }
 

--- a/ledger/conway/pparams.go
+++ b/ledger/conway/pparams.go
@@ -61,6 +61,36 @@ type ConwayProtocolParameters struct {
 	MinFeeRefScriptCostPerByte *cbor.Rat
 }
 
+// KeyDepositAmount returns the key deposit as a *big.Int
+func (p *ConwayProtocolParameters) KeyDepositAmount() *big.Int {
+	return new(big.Int).SetUint64(uint64(p.KeyDeposit))
+}
+
+// PoolDepositAmount returns the pool deposit as a *big.Int
+func (p *ConwayProtocolParameters) PoolDepositAmount() *big.Int {
+	return new(big.Int).SetUint64(uint64(p.PoolDeposit))
+}
+
+// MinPoolCostAmount returns the minimum pool cost as a *big.Int
+func (p *ConwayProtocolParameters) MinPoolCostAmount() *big.Int {
+	return new(big.Int).SetUint64(p.MinPoolCost)
+}
+
+// AdaPerUtxoByteAmount returns the ada per utxo byte as a *big.Int
+func (p *ConwayProtocolParameters) AdaPerUtxoByteAmount() *big.Int {
+	return new(big.Int).SetUint64(p.AdaPerUtxoByte)
+}
+
+// GovActionDepositAmount returns the governance action deposit as a *big.Int
+func (p *ConwayProtocolParameters) GovActionDepositAmount() *big.Int {
+	return new(big.Int).SetUint64(p.GovActionDeposit)
+}
+
+// DRepDepositAmount returns the DRep deposit as a *big.Int
+func (p *ConwayProtocolParameters) DRepDepositAmount() *big.Int {
+	return new(big.Int).SetUint64(p.DRepDeposit)
+}
+
 func (p *ConwayProtocolParameters) Utxorpc() (*utxorpc.PParams, error) {
 	// sanity check
 	if p.A0 == nil ||

--- a/ledger/error_test.go
+++ b/ledger/error_test.go
@@ -3,6 +3,7 @@ package ledger
 import (
 	"bytes"
 	"fmt"
+	"math/big"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
@@ -97,12 +98,13 @@ func TestScriptsNotPaidUtxo_MarshalUnmarshalCBOR(t *testing.T) {
 				originalOutput := originalUtxo.Output.(*shelley.ShelleyTransactionOutput)
 
 				// Check the amount using the interface method
-				if decodedUtxo.Output.Amount() != originalOutput.OutputAmount {
+				originalAmount := new(big.Int).SetUint64(originalOutput.OutputAmount)
+				if decodedUtxo.Output.Amount().Cmp(originalAmount) != 0 {
 					t.Errorf(
-						"UTxO %d: Amount mismatch - expected %d, got %d",
+						"UTxO %d: Amount mismatch - expected %s, got %s",
 						i,
-						originalOutput.OutputAmount,
-						decodedUtxo.Output.Amount(),
+						originalAmount.String(),
+						decodedUtxo.Output.Amount().String(),
 					)
 				}
 

--- a/ledger/leios/pparams.go
+++ b/ledger/leios/pparams.go
@@ -16,6 +16,7 @@ package leios
 
 import (
 	"errors"
+	"math/big"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
@@ -261,4 +262,34 @@ func (u *LeiosProtocolParameterUpdate) UnmarshalCBOR(cborData []byte) error {
 
 func (p *LeiosProtocolParameters) Utxorpc() (any, error) {
 	return nil, errors.New("not implemented")
+}
+
+// KeyDepositAmount returns the key deposit as a *big.Int
+func (p *LeiosProtocolParameters) KeyDepositAmount() *big.Int {
+	return new(big.Int).SetUint64(uint64(p.KeyDeposit))
+}
+
+// PoolDepositAmount returns the pool deposit as a *big.Int
+func (p *LeiosProtocolParameters) PoolDepositAmount() *big.Int {
+	return new(big.Int).SetUint64(uint64(p.PoolDeposit))
+}
+
+// MinPoolCostAmount returns the minimum pool cost as a *big.Int
+func (p *LeiosProtocolParameters) MinPoolCostAmount() *big.Int {
+	return new(big.Int).SetUint64(p.MinPoolCost)
+}
+
+// AdaPerUtxoByteAmount returns the ada per UTxO byte as a *big.Int
+func (p *LeiosProtocolParameters) AdaPerUtxoByteAmount() *big.Int {
+	return new(big.Int).SetUint64(p.AdaPerUtxoByte)
+}
+
+// GovActionDepositAmount returns the governance action deposit as a *big.Int
+func (p *LeiosProtocolParameters) GovActionDepositAmount() *big.Int {
+	return new(big.Int).SetUint64(p.GovActionDeposit)
+}
+
+// DRepDepositAmount returns the DRep deposit as a *big.Int
+func (p *LeiosProtocolParameters) DRepDepositAmount() *big.Int {
+	return new(big.Int).SetUint64(p.DRepDeposit)
 }

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -240,8 +240,8 @@ func (b *MaryTransactionBody) Outputs() []common.TransactionOutput {
 	return ret
 }
 
-func (b *MaryTransactionBody) Fee() uint64 {
-	return b.TxFee
+func (b *MaryTransactionBody) Fee() *big.Int {
+	return new(big.Int).SetUint64(b.TxFee)
 }
 
 func (b *MaryTransactionBody) TTL() uint64 {
@@ -274,8 +274,15 @@ func (b *MaryTransactionBody) Certificates() []common.Certificate {
 	return ret
 }
 
-func (b *MaryTransactionBody) Withdrawals() map[*common.Address]uint64 {
-	return b.TxWithdrawals
+func (b *MaryTransactionBody) Withdrawals() map[*common.Address]*big.Int {
+	if b.TxWithdrawals == nil {
+		return nil
+	}
+	ret := make(map[*common.Address]*big.Int)
+	for k, v := range b.TxWithdrawals {
+		ret[k] = new(big.Int).SetUint64(v)
+	}
+	return ret
 }
 
 func (b *MaryTransactionBody) AuxDataHash() *common.Blake2b256 {
@@ -389,7 +396,7 @@ func (t MaryTransaction) Outputs() []common.TransactionOutput {
 	return t.Body.Outputs()
 }
 
-func (t MaryTransaction) Fee() uint64 {
+func (t MaryTransaction) Fee() *big.Int {
 	return t.Body.Fee()
 }
 
@@ -417,7 +424,7 @@ func (t MaryTransaction) CollateralReturn() common.TransactionOutput {
 	return t.Body.CollateralReturn()
 }
 
-func (t MaryTransaction) TotalCollateral() uint64 {
+func (t MaryTransaction) TotalCollateral() *big.Int {
 	return t.Body.TotalCollateral()
 }
 
@@ -425,7 +432,7 @@ func (t MaryTransaction) Certificates() []common.Certificate {
 	return t.Body.Certificates()
 }
 
-func (t MaryTransaction) Withdrawals() map[*common.Address]uint64 {
+func (t MaryTransaction) Withdrawals() map[*common.Address]*big.Int {
 	return t.Body.Withdrawals()
 }
 
@@ -453,11 +460,11 @@ func (t MaryTransaction) ProposalProcedures() []common.ProposalProcedure {
 	return t.Body.ProposalProcedures()
 }
 
-func (t MaryTransaction) CurrentTreasuryValue() int64 {
+func (t MaryTransaction) CurrentTreasuryValue() *big.Int {
 	return t.Body.CurrentTreasuryValue()
 }
 
-func (t MaryTransaction) Donation() uint64 {
+func (t MaryTransaction) Donation() *big.Int {
 	return t.Body.Donation()
 }
 
@@ -618,8 +625,8 @@ func (txo MaryTransactionOutput) ScriptRef() common.Script {
 	return nil
 }
 
-func (o MaryTransactionOutput) Amount() uint64 {
-	return o.OutputAmount.Amount
+func (o MaryTransactionOutput) Amount() *big.Int {
+	return new(big.Int).SetUint64(o.OutputAmount.Amount)
 }
 
 func (o MaryTransactionOutput) Assets() *common.MultiAsset[common.MultiAssetTypeOutput] {
@@ -641,7 +648,7 @@ func (o MaryTransactionOutput) Utxorpc() (*utxorpc.TxOutput, error) {
 	}
 	return &utxorpc.TxOutput{
 			Address: addressBytes,
-			Coin:    common.ToUtxorpcBigInt(o.Amount()),
+			Coin:    common.BigIntToUtxorpcBigInt(o.Amount()),
 			// Assets: o.Assets,
 		},
 		err

--- a/ledger/mary/pparams.go
+++ b/ledger/mary/pparams.go
@@ -47,6 +47,26 @@ type MaryProtocolParameters struct {
 	MinPoolCost        uint64
 }
 
+// KeyDepositAmount returns the key deposit as a *big.Int
+func (p *MaryProtocolParameters) KeyDepositAmount() *big.Int {
+	return new(big.Int).SetUint64(uint64(p.KeyDeposit))
+}
+
+// PoolDepositAmount returns the pool deposit as a *big.Int
+func (p *MaryProtocolParameters) PoolDepositAmount() *big.Int {
+	return new(big.Int).SetUint64(uint64(p.PoolDeposit))
+}
+
+// MinUtxoValueAmount returns the minimum UTxO value as a *big.Int
+func (p *MaryProtocolParameters) MinUtxoValueAmount() *big.Int {
+	return new(big.Int).SetUint64(uint64(p.MinUtxoValue))
+}
+
+// MinPoolCostAmount returns the minimum pool cost as a *big.Int
+func (p *MaryProtocolParameters) MinPoolCostAmount() *big.Int {
+	return new(big.Int).SetUint64(p.MinPoolCost)
+}
+
 func (p *MaryProtocolParameters) Update(
 	paramUpdate *MaryProtocolParameterUpdate,
 ) {

--- a/ledger/shelley/errors.go
+++ b/ledger/shelley/errors.go
@@ -16,6 +16,7 @@ package shelley
 
 import (
 	"fmt"
+	"math/big"
 	"strings"
 
 	"github.com/blinklabs-io/gouroboros/ledger/common"
@@ -41,16 +42,20 @@ func (InputSetEmptyUtxoError) Error() string {
 }
 
 type FeeTooSmallUtxoError struct {
-	Provided uint64
-	Min      uint64
+	Provided *big.Int
+	Min      *big.Int
 }
 
 func (e FeeTooSmallUtxoError) Error() string {
-	return fmt.Sprintf(
-		"fee too small: provided %d, minimum %d",
-		e.Provided,
-		e.Min,
-	)
+	provided := "<nil>"
+	min := "<nil>"
+	if e.Provided != nil {
+		provided = e.Provided.String()
+	}
+	if e.Min != nil {
+		min = e.Min.String()
+	}
+	return fmt.Sprintf("fee too small: provided %s, minimum %s", provided, min)
 }
 
 type BadInputsUtxoError struct {
@@ -92,16 +97,20 @@ func (e WrongNetworkWithdrawalError) Error() string {
 }
 
 type ValueNotConservedUtxoError struct {
-	Consumed uint64
-	Produced uint64
+	Consumed *big.Int
+	Produced *big.Int
 }
 
 func (e ValueNotConservedUtxoError) Error() string {
-	return fmt.Sprintf(
-		"value not conserved: consumed %d, produced %d",
-		e.Consumed,
-		e.Produced,
-	)
+	consumed := "<nil>"
+	produced := "<nil>"
+	if e.Consumed != nil {
+		consumed = e.Consumed.String()
+	}
+	if e.Produced != nil {
+		produced = e.Produced.String()
+	}
+	return fmt.Sprintf("value not conserved: consumed %s, produced %s", consumed, produced)
 }
 
 type OutputTooSmallUtxoError struct {

--- a/ledger/shelley/genesis_test.go
+++ b/ledger/shelley/genesis_test.go
@@ -243,10 +243,11 @@ func TestGenesisUtxos(t *testing.T) {
 			expectedAddr,
 		)
 	}
-	if tmpUtxo.Output.Amount() != testAmount {
+	expectedAmount := new(big.Int).SetUint64(testAmount)
+	if tmpUtxo.Output.Amount().Cmp(expectedAmount) != 0 {
 		t.Fatalf(
-			"did not get expected amount: got %d, wanted %d",
-			tmpUtxo.Output.Amount(),
+			"did not get expected amount: got %s, wanted %d",
+			tmpUtxo.Output.Amount().String(),
 			testAmount,
 		)
 	}

--- a/ledger/shelley/pparams.go
+++ b/ledger/shelley/pparams.go
@@ -45,6 +45,21 @@ type ShelleyProtocolParameters struct {
 	MinUtxoValue       uint
 }
 
+// KeyDepositAmount returns the key deposit as a *big.Int
+func (p *ShelleyProtocolParameters) KeyDepositAmount() *big.Int {
+	return new(big.Int).SetUint64(uint64(p.KeyDeposit))
+}
+
+// PoolDepositAmount returns the pool deposit as a *big.Int
+func (p *ShelleyProtocolParameters) PoolDepositAmount() *big.Int {
+	return new(big.Int).SetUint64(uint64(p.PoolDeposit))
+}
+
+// MinUtxoValueAmount returns the minimum UTxO value as a *big.Int
+func (p *ShelleyProtocolParameters) MinUtxoValueAmount() *big.Int {
+	return new(big.Int).SetUint64(uint64(p.MinUtxoValue))
+}
+
 func (p *ShelleyProtocolParameters) Update(
 	paramUpdate *ShelleyProtocolParameterUpdate,
 ) {

--- a/ledger/shelley/pparams_test.go
+++ b/ledger/shelley/pparams_test.go
@@ -278,11 +278,11 @@ func TestShelleyTransactionBody_Utxorpc(t *testing.T) {
 	}
 
 	// Check that the fee matches
-	if actual.Fee.GetInt() != int64(txBody.Fee()) {
+	if actual.Fee.GetInt() != txBody.Fee().Int64() {
 		t.Errorf(
 			"TxBody.Utxorpc() fee mismatch\nGot: %d\nWant: %d",
 			actual.Fee.GetInt(),
-			txBody.Fee(),
+			txBody.Fee().Int64(),
 		)
 	}
 
@@ -346,11 +346,11 @@ func TestShelleyTransaction_Utxorpc(t *testing.T) {
 	}
 
 	// Verify the fee
-	if got.Fee.GetInt() != int64(tx.Body.Fee()) {
+	if got.Fee.GetInt() != tx.Body.Fee().Int64() {
 		t.Errorf(
 			"ShelleyTransaction.Utxorpc() fee mismatch\nGot: %d\nWant: %d",
 			got.Fee.GetInt(),
-			tx.Body.Fee(),
+			tx.Body.Fee().Int64(),
 		)
 	}
 

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -292,8 +292,8 @@ func (b *ShelleyTransactionBody) Outputs() []common.TransactionOutput {
 	return ret
 }
 
-func (b *ShelleyTransactionBody) Fee() uint64 {
-	return b.TxFee
+func (b *ShelleyTransactionBody) Fee() *big.Int {
+	return new(big.Int).SetUint64(b.TxFee)
 }
 
 func (b *ShelleyTransactionBody) TTL() uint64 {
@@ -319,8 +319,15 @@ func (b *ShelleyTransactionBody) Certificates() []common.Certificate {
 	return ret
 }
 
-func (b *ShelleyTransactionBody) Withdrawals() map[*common.Address]uint64 {
-	return b.TxWithdrawals
+func (b *ShelleyTransactionBody) Withdrawals() map[*common.Address]*big.Int {
+	if b.TxWithdrawals == nil {
+		return nil
+	}
+	ret := make(map[*common.Address]*big.Int)
+	for addr, amount := range b.TxWithdrawals {
+		ret[addr] = new(big.Int).SetUint64(amount)
+	}
+	return ret
 }
 
 func (b *ShelleyTransactionBody) AuxDataHash() *common.Blake2b256 {
@@ -481,8 +488,8 @@ func (o ShelleyTransactionOutput) ScriptRef() common.Script {
 	return nil
 }
 
-func (o ShelleyTransactionOutput) Amount() uint64 {
-	return o.OutputAmount
+func (o ShelleyTransactionOutput) Amount() *big.Int {
+	return new(big.Int).SetUint64(o.OutputAmount)
 }
 
 func (o ShelleyTransactionOutput) Assets() *common.MultiAsset[common.MultiAssetTypeOutput] {
@@ -505,7 +512,7 @@ func (o ShelleyTransactionOutput) Utxorpc() (*utxorpc.TxOutput, error) {
 
 	return &utxorpc.TxOutput{
 		Address: addressBytes,
-		Coin:    common.ToUtxorpcBigInt(o.Amount()),
+		Coin:    common.BigIntToUtxorpcBigInt(o.Amount()),
 	}, nil
 }
 
@@ -670,7 +677,7 @@ func (t ShelleyTransaction) Outputs() []common.TransactionOutput {
 	return t.Body.Outputs()
 }
 
-func (t ShelleyTransaction) Fee() uint64 {
+func (t ShelleyTransaction) Fee() *big.Int {
 	return t.Body.Fee()
 }
 
@@ -694,7 +701,7 @@ func (t ShelleyTransaction) CollateralReturn() common.TransactionOutput {
 	return t.Body.CollateralReturn()
 }
 
-func (t ShelleyTransaction) TotalCollateral() uint64 {
+func (t ShelleyTransaction) TotalCollateral() *big.Int {
 	return t.Body.TotalCollateral()
 }
 
@@ -702,7 +709,7 @@ func (t ShelleyTransaction) Certificates() []common.Certificate {
 	return t.Body.Certificates()
 }
 
-func (t ShelleyTransaction) Withdrawals() map[*common.Address]uint64 {
+func (t ShelleyTransaction) Withdrawals() map[*common.Address]*big.Int {
 	return t.Body.Withdrawals()
 }
 
@@ -730,11 +737,11 @@ func (t ShelleyTransaction) ProposalProcedures() []common.ProposalProcedure {
 	return t.Body.ProposalProcedures()
 }
 
-func (t ShelleyTransaction) CurrentTreasuryValue() int64 {
+func (t ShelleyTransaction) CurrentTreasuryValue() *big.Int {
 	return t.Body.CurrentTreasuryValue()
 }
 
-func (t ShelleyTransaction) Donation() uint64 {
+func (t ShelleyTransaction) Donation() *big.Int {
 	return t.Body.Donation()
 }
 

--- a/ledger/verify_block_body.go
+++ b/ledger/verify_block_body.go
@@ -320,9 +320,13 @@ func GetBlockOutput(
 func ExtractTokens(output TransactionOutput) ([]UTXOOutputToken, error) {
 	var outputTokens []UTXOOutputToken
 	// append lovelace first
+	tokenValue := "0"
+	if output.Amount() != nil {
+		tokenValue = output.Amount().String()
+	}
 	outputTokens = append(outputTokens, UTXOOutputToken{
 		TokenAssetName: LOVELACE_TOKEN,
-		TokenValue:     strconv.FormatUint(output.Amount(), 10),
+		TokenValue:     tokenValue,
 	})
 	if output.Assets() != nil {
 		tmpAssets := output.Assets()


### PR DESCRIPTION
Closes #1354 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the ledger to use big.Int for all monetary amounts (fees, outputs, withdrawals, collateral, treasury) to prevent overflow and standardize arithmetic across eras. This updates public APIs, validation rules, serialization, and tests.

- **Refactors**
  - TransactionBody and TransactionOutput now return big.Int for Fee(), Amount(), TotalCollateral(), CurrentTreasuryValue(), and Donation().
  - Withdrawals maps use big.Int values; Byron era returns nil where amounts are not applicable and sets fee to 0.
  - Protocol parameters add big.Int helpers (e.g., KeyDepositAmount, PoolDepositAmount, MinUtxoValueAmount, MinPoolCostAmount, AdaPerUtxoByteAmount, GovActionDepositAmount, DRepDepositAmount).
  - Certificates add big.Int helpers for pledge, cost, MIR rewards/other pot, and CIP-94 deposit amounts.
  - UTXO and rule checks use big.Int (fee minimums, collateral math, min-coin, value conservation); FeeTooSmallUtxoError and ValueNotConservedUtxoError carry big.Int.
  - Plutus script wrappers/TxInfo accept big.Int (CoinBigInt, withdrawals) and serialize integers accordingly.
  - UTXORPC conversions use BigIntToUtxorpcBigInt; outputs updated to pass big.Int amounts.
  - Minor CBOR tag registration updated to reflect.TypeFor.

- **Migration**
  - Replace uint64 with *big.Int in callers of Fee(), Amount(), Withdrawals(), TotalCollateral(), CurrentTreasuryValue(), Donation(); use Cmp for comparisons.
  - Handle nil amounts where applicable (e.g., Byron treasury/donation, missing totals); Byron fee returns 0.
  - Switch ToUtxorpcBigInt(...) to BigIntToUtxorpcBigInt(...).
  - Use new protocol parameter Amount() helpers instead of raw numeric fields when big.Int is needed.
  - In Plutus code, set Value.CoinBigInt and pass withdrawals as big.Int; avoid uint64-based serialization.

<sup>Written for commit 53c40af42feeadc76d77d979cad2ad28a7d76eaa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System-wide support for arbitrary-precision integers for monetary values across all ledger eras.

* **Improvements**
  * Fee, collateral, withdrawal, output and protocol-parameter accessors now use big integers to prevent overflow and preserve precision.
  * Validation and error reporting use high-precision values and nil-safe checks for more robust multi-asset handling.

* **Bug Fixes**
  * Nil-safe amount handling to avoid panics and incorrect token/value extraction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->