### PR TITLE
fix(ledger): conway proposal rules for empty treasury withdrawal and invalid network

### DIFF
--- a/ledger/conway/errors.go
+++ b/ledger/conway/errors.go
@@ -127,3 +127,24 @@ type ProtocolParameterUpdateFieldZeroError struct {
 func (e ProtocolParameterUpdateFieldZeroError) Error() string {
 	return fmt.Sprintf("protocol parameter update field %s cannot be 0, got %d", e.FieldName, e.Value)
 }
+
+// EmptyTreasuryWithdrawalsError indicates that a TreasuryWithdrawalGovAction has an empty withdrawals map
+type EmptyTreasuryWithdrawalsError struct{}
+
+func (e EmptyTreasuryWithdrawalsError) Error() string {
+	return "treasury withdrawal governance action has empty withdrawals map"
+}
+
+// WrongNetworkProposalAddressError indicates that a proposal address has wrong network ID
+type WrongNetworkProposalAddressError struct {
+	NetId uint
+	Addrs []common.Address
+}
+
+func (e WrongNetworkProposalAddressError) Error() string {
+	tmpAddrs := make([]string, len(e.Addrs))
+	for idx, addr := range e.Addrs {
+		tmpAddrs[idx] = addr.String()
+	}
+	return fmt.Sprintf("wrong network ID in proposal address(es): expected %d, got %s", e.NetId, strings.Join(tmpAddrs, ", "))
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add validations to Conway proposal procedures to reject empty treasury withdrawals and wrong-network addresses. This prevents invalid governance actions and mismatched reward account or withdrawal addresses.

- **Bug Fixes**
  - Validate TreasuryWithdrawalGovAction has non-empty withdrawals.
  - Ensure reward accounts and treasury withdrawal addresses match the ledger’s network ID.
  - Add specific errors (EmptyTreasuryWithdrawalsError, WrongNetworkProposalAddressError) and wire both checks into UtxoValidationRules.

<sup>Written for commit 6cc2f85328576c0e00db44087e471154eb10ae98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced proposal transaction validation to ensure all addresses match the current network.
  * Added validation preventing treasury withdrawal proposals with empty fund allocations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->