### PR TITLE
fix(ledger): pass witness datums to script purpose

### DIFF
--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -1270,6 +1270,14 @@ func UtxoValidatePlutusScripts(
 	proposalProcedures := tx.ProposalProcedures()
 	certificates := tx.Certificates()
 
+	// Build witness datums map for datum hash lookups
+	// This allows resolving datums from witness set when UTxOs have datum hashes
+	witnessDatums := make(map[common.Blake2b256]*common.Datum)
+	for _, datum := range witnesses.PlutusData() {
+		datumCopy := datum
+		witnessDatums[datum.Hash()] = &datumCopy
+	}
+
 	// Execute each redeemer's script
 	for redeemerKey, redeemerValue := range redeemers.Iter() {
 		// Build script purpose for this redeemer
@@ -1282,6 +1290,7 @@ func UtxoValidatePlutusScripts(
 			withdrawals,
 			votes,
 			proposalProcedures,
+			witnessDatums,
 		)
 		if purpose == nil {
 			continue


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix datum resolution in Plutus script validation by passing witness datums into script purpose building. Spending redeemers can now resolve datums by hash when UTxOs lack inline datums, preventing validation failures.

- **Bug Fixes**
  - Build a witnessDatums map from witnesses.PlutusData() and pass it to BuildScriptPurpose in UtxoValidatePlutusScripts.
  - In BuildScriptPurpose, when an output has a datum hash but no inline datum, look up the datum in witnessDatums and use it.

<sup>Written for commit 0403029f7e3f1fdfb61933f4dcffdfa33055f9b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Plutus script validation with witness datum resolution support
  * Deterministic ordering for voting and reward withdrawal processing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->