### PR TITLE
fix: don't wrap V1/V2 script evaluations in null datum

### DIFF
--- a/ledger/common/script.go
+++ b/ledger/common/script.go
@@ -171,17 +171,19 @@ func (s PlutusV1Script) Evaluate(
 	if err != nil {
 		return usedExUnits, fmt.Errorf("decode script: %w", err)
 	}
-	// Apply arguments to program: datum, redeemer, context
-	datumTerm := &syn.Constant{Con: &syn.Data{Inner: datum}}
+	// Apply arguments to program: datum (optional), redeemer, context
 	redeemerTerm := &syn.Constant{Con: &syn.Data{Inner: redeemer}}
 	contextTerm := &syn.Constant{Con: &syn.Data{Inner: scriptContext}}
-
-	wrappedProgram := &syn.Apply[syn.DeBruijn]{
+	wrappedProgram := program.Term
+	if datum != nil {
+		wrappedProgram = &syn.Apply[syn.DeBruijn]{
+			Function: wrappedProgram,
+			Argument: &syn.Constant{Con: &syn.Data{Inner: datum}},
+		}
+	}
+	wrappedProgram = &syn.Apply[syn.DeBruijn]{
 		Function: &syn.Apply[syn.DeBruijn]{
-			Function: &syn.Apply[syn.DeBruijn]{
-				Function: program.Term,
-				Argument: datumTerm,
-			},
+			Function: wrappedProgram,
 			Argument: redeemerTerm,
 		},
 		Argument: contextTerm,
@@ -245,17 +247,19 @@ func (s PlutusV2Script) Evaluate(
 	if err != nil {
 		return usedExUnits, fmt.Errorf("decode script: %w", err)
 	}
-	// Apply arguments to program: datum, redeemer, context
-	datumTerm := &syn.Constant{Con: &syn.Data{Inner: datum}}
+	// Apply arguments to program: datum (optional), redeemer, context
 	redeemerTerm := &syn.Constant{Con: &syn.Data{Inner: redeemer}}
 	contextTerm := &syn.Constant{Con: &syn.Data{Inner: scriptContext}}
-
-	wrappedProgram := &syn.Apply[syn.DeBruijn]{
+	wrappedProgram := program.Term
+	if datum != nil {
+		wrappedProgram = &syn.Apply[syn.DeBruijn]{
+			Function: wrappedProgram,
+			Argument: &syn.Constant{Con: &syn.Data{Inner: datum}},
+		}
+	}
+	wrappedProgram = &syn.Apply[syn.DeBruijn]{
 		Function: &syn.Apply[syn.DeBruijn]{
-			Function: &syn.Apply[syn.DeBruijn]{
-				Function: program.Term,
-				Argument: datumTerm,
-			},
+			Function: wrappedProgram,
 			Argument: redeemerTerm,
 		},
 		Argument: contextTerm,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Plutus V1/V2 script evaluation by not passing a null datum when none is provided. Datum is now optional; we only apply redeemer and context if datum is absent, preventing validation errors and incorrect execution units.

<sup>Written for commit 9bfdd2a37543259d11f375ca8cf0ce54e2f6c9c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Plutus V1 and V2 script evaluation logic to conditionally apply parameters based on availability, enhancing script execution reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->