### PR TITLE
feat(localstatequery): implement ShelleyStakePoolParamsQuery structure

### DIFF
--- a/protocol/localstatequery/queries.go
+++ b/protocol/localstatequery/queries.go
@@ -318,8 +318,9 @@ type ShelleyStakePoolsQuery struct {
 }
 
 type ShelleyStakePoolParamsQuery struct {
-	simpleQueryBase
-	// TODO: add params (#859)
+	cbor.StructAsArray
+	Type    int
+	PoolIds cbor.SetType[ledger.PoolId]
 }
 
 type ShelleyRewardInfoPoolsQuery struct {


### PR DESCRIPTION
Closes #859 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Implemented ShelleyStakePoolParamsQuery with proper CBOR array encoding and fields for type and pool IDs. This enables querying stake pool parameters via Local State Query.

- **New Features**
  - Added cbor.StructAsArray for CBOR array encoding.
  - Added Type (int) and PoolIds (cbor.SetType[ledger.PoolId]) fields.

<sup>Written for commit c6402aeb76dbfb11a3dce01adc8773e4f7f971b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for filtering stake pool parameter queries by specific pool identifiers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->