### PR TITLE
refactor: return non-pointer for script from script ref

### DIFF
--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -156,9 +156,9 @@ func UtxoValidateCostModelsPresent(
 			continue
 		}
 		switch script.(type) {
-		case *common.PlutusV1Script, common.PlutusV1Script:
+		case common.PlutusV1Script:
 			required[0] = struct{}{}
-		case *common.PlutusV2Script, common.PlutusV2Script:
+		case common.PlutusV2Script:
 			required[1] = struct{}{}
 		}
 	}
@@ -178,9 +178,9 @@ func UtxoValidateCostModelsPresent(
 			continue
 		}
 		switch script.(type) {
-		case *common.PlutusV1Script, common.PlutusV1Script:
+		case common.PlutusV1Script:
 			required[0] = struct{}{}
-		case *common.PlutusV2Script, common.PlutusV2Script:
+		case common.PlutusV2Script:
 			required[1] = struct{}{}
 		}
 	}
@@ -255,7 +255,7 @@ func UtxoValidateInlineDatumsWithPlutusV1(
 			continue
 		}
 		switch script.(type) {
-		case common.PlutusV1Script, *common.PlutusV1Script:
+		case common.PlutusV1Script:
 			return common.InlineDatumsNotSupportedError{
 				PlutusVersion: "PlutusV1",
 			}
@@ -277,7 +277,7 @@ func UtxoValidateInlineDatumsWithPlutusV1(
 			continue
 		}
 		switch script.(type) {
-		case common.PlutusV1Script, *common.PlutusV1Script:
+		case common.PlutusV1Script:
 			return common.InlineDatumsNotSupportedError{
 				PlutusVersion: "PlutusV1",
 			}

--- a/ledger/common/script.go
+++ b/ledger/common/script.go
@@ -87,25 +87,37 @@ func (s *ScriptRef) UnmarshalCBOR(data []byte) error {
 	if _, err := cbor.Decode(innerCbor, &rawScript); err != nil {
 		return err
 	}
-	var tmpScript Script
+	var script Script
 	switch rawScript.Type {
 	case ScriptRefTypeNativeScript:
-		tmpScript = &NativeScript{}
+		tmpScript := &NativeScript{}
+		if _, err := cbor.Decode(rawScript.Raw, tmpScript); err != nil {
+			return err
+		}
+		script = *tmpScript
 	case ScriptRefTypePlutusV1:
-		tmpScript = &PlutusV1Script{}
+		tmpScript := &PlutusV1Script{}
+		if _, err := cbor.Decode(rawScript.Raw, tmpScript); err != nil {
+			return err
+		}
+		script = *tmpScript
 	case ScriptRefTypePlutusV2:
-		tmpScript = &PlutusV2Script{}
+		tmpScript := &PlutusV2Script{}
+		if _, err := cbor.Decode(rawScript.Raw, tmpScript); err != nil {
+			return err
+		}
+		script = *tmpScript
 	case ScriptRefTypePlutusV3:
-		tmpScript = &PlutusV3Script{}
+		tmpScript := &PlutusV3Script{}
+		if _, err := cbor.Decode(rawScript.Raw, tmpScript); err != nil {
+			return err
+		}
+		script = *tmpScript
 	default:
 		return fmt.Errorf("unknown script type %d", rawScript.Type)
 	}
-	// Decode script
-	if _, err := cbor.Decode(rawScript.Raw, tmpScript); err != nil {
-		return err
-	}
 	s.Type = rawScript.Type
-	s.Script = tmpScript
+	s.Script = script
 	return nil
 }
 

--- a/ledger/common/script_test.go
+++ b/ledger/common/script_test.go
@@ -34,11 +34,11 @@ func TestScriptRefDecodeEncode(t *testing.T) {
 	if _, err := cbor.Decode(testCbor, &testScriptRef); err != nil {
 		t.Fatalf("unexpected error decoding script ref CBOR: %s", err)
 	}
-	if !reflect.DeepEqual(testScriptRef.Script, &expectedScript) {
+	if !reflect.DeepEqual(testScriptRef.Script, expectedScript) {
 		t.Fatalf(
 			"did not get expected script\n     got: %#v\n  wanted: %#v",
 			testScriptRef.Script,
-			&expectedScript,
+			expectedScript,
 		)
 	}
 	if !bytes.Equal(testScriptRef.Script.RawScriptBytes(), scriptCbor) {

--- a/ledger/conway/conway_test.go
+++ b/ledger/conway/conway_test.go
@@ -328,9 +328,9 @@ func TestConwayTx_WithReferenceScripts_CborRoundTrip(t *testing.T) {
 	output := decoded.Body.TxOutputs[0]
 	assert.NotNil(t, output.TxOutScriptRef)
 	assert.Equal(t, uint(1), output.TxOutScriptRef.Type)
-	if plutusScript, ok := output.TxOutScriptRef.Script.(*common.PlutusV1Script); ok {
+	if plutusScript, ok := output.TxOutScriptRef.Script.(common.PlutusV1Script); ok {
 		expectedScript := common.PlutusV1Script{0x01, 0x02, 0x03, 0x04}
-		assert.Equal(t, expectedScript, *plutusScript)
+		assert.Equal(t, expectedScript, plutusScript)
 	} else {
 		t.Fatalf("expected PlutusV1Script, got %T", output.TxOutScriptRef.Script)
 	}

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -347,7 +347,7 @@ func UtxoValidateRedeemerAndScriptWitnesses(
 			continue
 		}
 		switch script.(type) {
-		case *common.PlutusV1Script, common.PlutusV1Script, *common.PlutusV2Script, common.PlutusV2Script, *common.PlutusV3Script, common.PlutusV3Script:
+		case common.PlutusV1Script, common.PlutusV2Script, common.PlutusV3Script:
 			hasPlutusReference = true
 		}
 		if hasPlutusReference {
@@ -372,7 +372,7 @@ func UtxoValidateRedeemerAndScriptWitnesses(
 				continue
 			}
 			switch script.(type) {
-			case *common.PlutusV1Script, common.PlutusV1Script, *common.PlutusV2Script, common.PlutusV2Script, *common.PlutusV3Script, common.PlutusV3Script:
+			case common.PlutusV1Script, common.PlutusV2Script, common.PlutusV3Script:
 				hasPlutusReference = true
 			}
 			if hasPlutusReference {
@@ -455,11 +455,11 @@ func UtxoValidateCostModelsPresent(
 			continue
 		}
 		switch script.(type) {
-		case *common.PlutusV1Script, common.PlutusV1Script:
+		case common.PlutusV1Script:
 			required[0] = struct{}{}
-		case *common.PlutusV2Script, common.PlutusV2Script:
+		case common.PlutusV2Script:
 			required[1] = struct{}{}
-		case *common.PlutusV3Script, common.PlutusV3Script:
+		case common.PlutusV3Script:
 			required[2] = struct{}{}
 		}
 	}
@@ -479,11 +479,11 @@ func UtxoValidateCostModelsPresent(
 			continue
 		}
 		switch script.(type) {
-		case *common.PlutusV1Script, common.PlutusV1Script:
+		case common.PlutusV1Script:
 			required[0] = struct{}{}
-		case *common.PlutusV2Script, common.PlutusV2Script:
+		case common.PlutusV2Script:
 			required[1] = struct{}{}
-		case *common.PlutusV3Script, common.PlutusV3Script:
+		case common.PlutusV3Script:
 			required[2] = struct{}{}
 		}
 	}
@@ -853,9 +853,9 @@ func UtxoValidateValueNotConservedUtxo(
 				script := utxo.Output.ScriptRef()
 				if script != nil {
 					switch script.(type) {
-					case *common.PlutusV1Script, common.PlutusV1Script:
+					case common.PlutusV1Script:
 						plutusVersion = "PlutusV1"
-					case *common.PlutusV2Script, common.PlutusV2Script:
+					case common.PlutusV2Script:
 						plutusVersion = "PlutusV2"
 					}
 					if plutusVersion != "" {
@@ -1314,15 +1314,15 @@ func UtxoValidatePlutusScripts(
 	// Add witness scripts
 	for _, s := range witnesses.PlutusV1Scripts() {
 		sCopy := s
-		availableScripts[s.Hash()] = &sCopy
+		availableScripts[s.Hash()] = sCopy
 	}
 	for _, s := range witnesses.PlutusV2Scripts() {
 		sCopy := s
-		availableScripts[s.Hash()] = &sCopy
+		availableScripts[s.Hash()] = sCopy
 	}
 	for _, s := range witnesses.PlutusV3Scripts() {
 		sCopy := s
-		availableScripts[s.Hash()] = &sCopy
+		availableScripts[s.Hash()] = sCopy
 	}
 
 	// Add reference scripts from resolved inputs
@@ -1407,28 +1407,9 @@ func UtxoValidatePlutusScripts(
 		// Execute based on script version
 		var execErr error
 		switch s := plutusScript.(type) {
-		case *common.PlutusV3Script:
-			_, execErr = s.Evaluate(ctxData, redeemerValue.ExUnits)
 		case common.PlutusV3Script:
 			_, execErr = s.Evaluate(ctxData, redeemerValue.ExUnits)
-		case *common.PlutusV2Script:
-			// V1/V2 scripts require a datum for spending purposes
-			if _, isSpend := purpose.(script.ScriptPurposeSpending); isSpend && datum == nil {
-				return MissingDatumForSpendingScriptError{
-					ScriptHash: scriptHash,
-					Input:      spendInput,
-				}
-			}
-			_, execErr = s.Evaluate(datum, redeemerValue.Data.Data, ctxData, redeemerValue.ExUnits)
 		case common.PlutusV2Script:
-			if _, isSpend := purpose.(script.ScriptPurposeSpending); isSpend && datum == nil {
-				return MissingDatumForSpendingScriptError{
-					ScriptHash: scriptHash,
-					Input:      spendInput,
-				}
-			}
-			_, execErr = s.Evaluate(datum, redeemerValue.Data.Data, ctxData, redeemerValue.ExUnits)
-		case *common.PlutusV1Script:
 			if _, isSpend := purpose.(script.ScriptPurposeSpending); isSpend && datum == nil {
 				return MissingDatumForSpendingScriptError{
 					ScriptHash: scriptHash,

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -227,7 +227,7 @@ func TestUtxoValidateWitnessRules_Conway(t *testing.T) {
 			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
 			TxOutScriptRef: &common.ScriptRef{
 				Type:   0,
-				Script: &script,
+				Script: script,
 			},
 		}
 		refUtxo := common.Utxo{
@@ -275,7 +275,7 @@ func TestUtxoValidateWitnessRules_Conway(t *testing.T) {
 				OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
 				TxOutScriptRef: &common.ScriptRef{
 					Type:   0,
-					Script: &script,
+					Script: script,
 				},
 			}
 			refUtxo := common.Utxo{


### PR DESCRIPTION
This makes it consistent with the witness script functions

Fixes #1412

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return script as a value instead of a pointer when decoding ScriptRef. This aligns ScriptRef behavior with witness script functions and simplifies type handling.

- **Refactors**
  - Set ScriptRef.Script to a value for NativeScript/Plutus V1/V2/V3 during CBOR decode.
  - Updated rules in Babbage and Conway to switch on value types and remove pointer checks.
  - Updated tests to compare value equality instead of pointer equality.

<sup>Written for commit d068192940a4d151e9f49fb4dabd0858668dfc7c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal script decoding and type handling for clearer, more maintainable processing while preserving external behavior and validation outcomes.

* **Tests**
  * Adjusted tests to align with the updated script handling, improving reliability of serialization/round-trip and script-related checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->