### PR TITLE
fix(ledger): use v1/v2 script contexts

### DIFF
--- a/ledger/common/script/wrappers.go
+++ b/ledger/common/script/wrappers.go
@@ -301,9 +301,11 @@ func (w WithWrappedStakeCredential) ToPlutusData() data.PlutusData {
 		}
 		return data.NewMap(tmpPairs)
 	case Pairs[*lcommon.Address, *big.Int]:
+		// V1 withdrawals: List of tuples, each tuple is Constr(0, StakingCredential, Integer)
 		tmpItems := make([]data.PlutusData, len(v))
 		for i := range v {
-			tmpItems[i] = data.NewList(
+			tmpItems[i] = data.NewConstr(
+				0,
 				data.NewConstr(
 					0,
 					v[i].T1.ToPlutusData(),
@@ -313,9 +315,11 @@ func (w WithWrappedStakeCredential) ToPlutusData() data.PlutusData {
 		}
 		return data.NewList(tmpItems...)
 	case Pairs[*lcommon.Address, uint64]:
+		// V1 withdrawals: List of tuples, each tuple is Constr(0, StakingCredential, Integer)
 		tmpItems := make([]data.PlutusData, len(v))
 		for i := range v {
-			tmpItems[i] = data.NewList(
+			tmpItems[i] = data.NewConstr(
+				0,
 				data.NewConstr(
 					0,
 					v[i].T1.ToPlutusData(),
@@ -325,6 +329,14 @@ func (w WithWrappedStakeCredential) ToPlutusData() data.PlutusData {
 		}
 		return data.NewList(tmpItems...)
 	case lcommon.Credential:
+		return data.NewConstr(
+			0,
+			v.ToPlutusData(),
+		)
+	case *lcommon.Credential:
+		if v == nil {
+			return nil
+		}
 		return data.NewConstr(
 			0,
 			v.ToPlutusData(),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Plutus script validation to use V1/V2 contexts for those versions (and V3 for V3), fixing incorrect evaluations and reducing work with lazy TxInfo builds.

- **Bug Fixes**
  - Use ScriptContextV1V2 for Plutus V1/V2 and ScriptContextV3 for V3.
  - Handle scripts as both pointers and values when checking cost models and references.
  - Encode V1 withdrawals as Constr tuples and sort by address bytes for deterministic ordering.

- **Performance**
  - Build TxInfo V1/V2/V3 only when needed.
  - Use pointers for scripts and datums to avoid unnecessary copies.

<sup>Written for commit cabb9bc965da0387d6a016bffc24fc1b8854e981. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and nil-check handling across protocol parameter and script witness processing.
  * Fixed withdrawal and address handling to avoid errors when encountering malformed data; preserved fallback ordering.
  * Added guards for credential inputs to prevent nil-related panics.

* **Performance**
  * Optimized script evaluation by building transaction contexts and datum data on-demand per protocol version.
  * Reduced unnecessary copying and streamlined datum/asset collection for faster processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->