### PR TITLE
fix: panic on unsupported PlutusData type conversions

### DIFF
--- a/ledger/common/address.go
+++ b/ledger/common/address.go
@@ -395,7 +395,7 @@ func (a *Address) ToPlutusData() data.PlutusData {
 				),
 			)
 		default:
-			return nil
+			panic(fmt.Sprintf("unsupported staking payload type: %T", p))
 		}
 	}
 	return data.NewConstr(

--- a/ledger/common/certs.go
+++ b/ledger/common/certs.go
@@ -214,8 +214,9 @@ func (d *Drep) ToPlutusData() data.PlutusData {
 		return data.NewConstr(1)
 	case DrepTypeNoConfidence:
 		return data.NewConstr(2)
+	default:
+		panic(fmt.Sprintf("unsupported drep type: %d", d.Type))
 	}
-	return nil
 }
 
 // String returns a CIP-0129 bech32-encoded representation of the DRep.

--- a/ledger/common/credentials.go
+++ b/ledger/common/credentials.go
@@ -91,6 +91,7 @@ func (c *Credential) ToPlutusData() data.PlutusData {
 			1,
 			data.NewByteString(c.Credential.Bytes()),
 		)
+	default:
+		panic(fmt.Sprintf("unsupported credential type: %d", c.CredType))
 	}
-	return nil
 }

--- a/ledger/common/gov.go
+++ b/ledger/common/gov.go
@@ -174,7 +174,7 @@ func (v Voter) ToPlutusData() data.PlutusData {
 	case VoterTypeStakingPoolKeyHash:
 		return data.NewConstr(2, data.NewByteString(v.Hash[:]))
 	default:
-		return nil
+		panic(fmt.Sprintf("unsupported voter type: %d", v.Type))
 	}
 }
 
@@ -195,7 +195,7 @@ func (v Vote) ToPlutusData() data.PlutusData {
 	case Vote(GovVoteAbstain):
 		return data.NewConstr(2)
 	default:
-		return nil
+		panic(fmt.Sprintf("unsupported vote type: %d", v))
 	}
 }
 

--- a/ledger/common/gov_test.go
+++ b/ledger/common/gov_test.go
@@ -88,9 +88,10 @@ func TestVoterToPlutusData(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name         string
-		voter        Voter
-		expectedData data.PlutusData
+		name          string
+		voter         Voter
+		expectedData  data.PlutusData
+		expectedPanic string
 	}{
 		{
 			name: "ConstitutionalCommitteeHotScriptHash",
@@ -150,20 +151,38 @@ func TestVoterToPlutusData(t *testing.T) {
 				Type: 255, // Unknown type
 				Hash: [28]byte{},
 			},
-			expectedData: nil,
+			expectedData:  nil,
+			expectedPanic: "unsupported voter type: 255",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := tc.voter.ToPlutusData()
-			if !reflect.DeepEqual(result, tc.expectedData) {
-				t.Errorf(
-					"ToPlutusData() = %#v, want %#v",
-					result,
-					tc.expectedData,
-				)
-			}
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						if tc.expectedPanic == "" {
+							t.Fatalf("unexpected panic: %v", r)
+						} else {
+							if r != tc.expectedPanic {
+								t.Errorf("did not get expected panic: got %v, wanted %s", r, tc.expectedPanic)
+							}
+						}
+					}
+				}()
+				result := tc.voter.ToPlutusData()
+				if tc.expectedPanic != "" {
+					t.Errorf("did not panic as expected")
+					return
+				}
+				if !reflect.DeepEqual(result, tc.expectedData) {
+					t.Errorf(
+						"ToPlutusData() = %#v, want %#v",
+						result,
+						tc.expectedData,
+					)
+				}
+			}()
 		})
 	}
 }
@@ -235,9 +254,10 @@ func TestVoterString(t *testing.T) {
 // Tests the ToPlutusData method for Vote types
 func TestVoteToPlutusData(t *testing.T) {
 	testCases := []struct {
-		name         string
-		vote         Vote
-		expectedData data.PlutusData
+		name          string
+		vote          Vote
+		expectedData  data.PlutusData
+		expectedPanic string
 	}{
 		{
 			name:         "No",
@@ -255,22 +275,40 @@ func TestVoteToPlutusData(t *testing.T) {
 			expectedData: data.NewConstr(2),
 		},
 		{
-			name:         "Unknown",
-			vote:         Vote(255), // Unknown vote
-			expectedData: nil,
+			name:          "Unknown",
+			vote:          Vote(255), // Unknown vote
+			expectedData:  nil,
+			expectedPanic: "unsupported vote type: 255",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := tc.vote.ToPlutusData()
-			if !reflect.DeepEqual(result, tc.expectedData) {
-				t.Errorf(
-					"ToPlutusData() = %#v, want %#v",
-					result,
-					tc.expectedData,
-				)
-			}
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						if tc.expectedPanic == "" {
+							t.Fatalf("unexpected panic: %v", r)
+						} else {
+							if r != tc.expectedPanic {
+								t.Errorf("did not get expected panic: got %v, wanted %s", r, tc.expectedPanic)
+							}
+						}
+					}
+				}()
+				result := tc.vote.ToPlutusData()
+				if tc.expectedPanic != "" {
+					t.Errorf("did not panic as expected")
+					return
+				}
+				if !reflect.DeepEqual(result, tc.expectedData) {
+					t.Errorf(
+						"ToPlutusData() = %#v, want %#v",
+						result,
+						tc.expectedData,
+					)
+				}
+			}()
 		})
 	}
 }
@@ -278,9 +316,10 @@ func TestVoteToPlutusData(t *testing.T) {
 // Tests the ToPlutusData method for VotingProcedure types
 func TestVotingProcedureToPlutusData(t *testing.T) {
 	testCases := []struct {
-		name         string
-		procedure    VotingProcedure
-		expectedData data.PlutusData
+		name          string
+		procedure     VotingProcedure
+		expectedData  data.PlutusData
+		expectedPanic string
 	}{
 		{
 			name: "NoVote",
@@ -308,20 +347,38 @@ func TestVotingProcedureToPlutusData(t *testing.T) {
 			procedure: VotingProcedure{
 				Vote: 255, // Unknown vote
 			},
-			expectedData: nil,
+			expectedData:  nil,
+			expectedPanic: "unsupported vote type: 255",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result := tc.procedure.ToPlutusData()
-			if !reflect.DeepEqual(result, tc.expectedData) {
-				t.Errorf(
-					"ToPlutusData() = %#v, want %#v",
-					result,
-					tc.expectedData,
-				)
-			}
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						if tc.expectedPanic == "" {
+							t.Fatalf("unexpected panic: %v", r)
+						} else {
+							if r != tc.expectedPanic {
+								t.Errorf("did not get expected panic: got %v, wanted %s", r, tc.expectedPanic)
+							}
+						}
+					}
+				}()
+				result := tc.procedure.ToPlutusData()
+				if tc.expectedPanic != "" {
+					t.Errorf("did not panic as expected")
+					return
+				}
+				if !reflect.DeepEqual(result, tc.expectedData) {
+					t.Errorf(
+						"ToPlutusData() = %#v, want %#v",
+						result,
+						tc.expectedData,
+					)
+				}
+			}()
 		})
 	}
 }

--- a/ledger/common/script/context.go
+++ b/ledger/common/script/context.go
@@ -16,6 +16,7 @@ package script
 
 import (
 	"bytes"
+	"fmt"
 	"math/big"
 	"slices"
 
@@ -903,6 +904,12 @@ func certificateToPlutusData(
 			10,
 			c.ColdCredential.ToPlutusData(),
 		)
+	default:
+		panic(
+			fmt.Sprintf(
+				"unsupported certificate type: %T",
+				c,
+			),
+		)
 	}
-	return nil
 }

--- a/ledger/common/script/wrappers.go
+++ b/ledger/common/script/wrappers.go
@@ -15,6 +15,7 @@
 package script
 
 import (
+	"fmt"
 	"math/big"
 	"reflect"
 	"slices"
@@ -128,9 +129,10 @@ func toPlutusData(val any) data.PlutusData {
 				}
 			}
 			return data.NewMap(tmpPairs)
+		default:
+			panic(fmt.Sprintf("unsupported type: %T", v))
 		}
 	}
-	return nil
 }
 
 type Coin int64
@@ -265,9 +267,12 @@ func (w WithWrappedTransactionId) ToPlutusData() data.PlutusData {
 					p.Certificate,
 				}.ToPlutusData(),
 			)
+		default:
+			panic(fmt.Sprintf("unsupported type: %T", p))
 		}
+	default:
+		panic(fmt.Sprintf("unsupported type: %T", v))
 	}
-	return nil
 }
 
 type WithWrappedStakeCredential struct {
@@ -341,8 +346,9 @@ func (w WithWrappedStakeCredential) ToPlutusData() data.PlutusData {
 			0,
 			v.ToPlutusData(),
 		)
+	default:
+		panic(fmt.Sprintf("unsupported type: %T", v))
 	}
-	return nil
 }
 
 type WithOptionDatum struct {
@@ -397,10 +403,15 @@ func (w WithOptionDatum) ToPlutusData() data.PlutusData {
 					WithWrappedTransactionId{v3.Id}.ToPlutusData(),
 					WithOptionDatum{WithZeroAdaAsset{v3.Output}}.ToPlutusData(),
 				)
+			default:
+				panic(fmt.Sprintf("unsupported type: %T", v3))
 			}
+		default:
+			panic(fmt.Sprintf("unsupported type: %T", v2))
 		}
+	default:
+		panic(fmt.Sprintf("unsupported type: %T", v))
 	}
-	return nil
 }
 
 type WithZeroAdaAsset struct {
@@ -499,9 +510,12 @@ func (w WithZeroAdaAsset) ToPlutusData() data.PlutusData {
 					v2.Output,
 				}.ToPlutusData(),
 			)
+		default:
+			panic(fmt.Sprintf("unsupported type: %T", v2))
 		}
+	default:
+		panic(fmt.Sprintf("unsupported type: %T", v))
 	}
-	return nil
 }
 
 type WithPartialCertificates struct {
@@ -558,9 +572,12 @@ func (w WithPartialCertificates) ToPlutusData() data.PlutusData {
 				toPlutusData(c.PoolKeyHash),
 				data.NewInteger(new(big.Int).SetUint64(c.Epoch)),
 			)
+		default:
+			panic(fmt.Sprintf("unsupported type: %T", c))
 		}
+	default:
+		panic(fmt.Sprintf("unsupported type: %T", v))
 	}
-	return nil
 }
 
 func coinToPlutusDataMapPair(val uint64) [2]data.PlutusData {


### PR DESCRIPTION
This exposes problems with unsupported types rather than silently causing errors downstream with a nil value

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail fast on unsupported PlutusData conversions and script-purpose building by panicking instead of returning nil. This surfaces invalid inputs early and prevents silent downstream errors.

- **Bug Fixes**
  - Replaced nil returns with panics in ToPlutusData for Address staking payloads, DRep, Credential, Voter, Vote, certificateToPlutusData, and generic/wrapper conversions.
  - Script purpose builders now panic on unsupported redeemer tags, out-of-range indices (spend, mint, cert, reward, voting, proposing), and missing UTxOs in resolved inputs.
  - Updated gov tests to assert expected panics for unknown voter/vote and voting procedure.

<sup>Written for commit 7050ef6cfe801fbe959c9b088f581e0a53169fe5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling across data type conversions to provide explicit failure messages for unsupported types, replacing silent failures that could mask data integrity issues.

* **Tests**
  * Updated test cases to verify proper error handling and assertion of expected failures for edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->