### PR TITLE
refactor(ledger): rules, errors, and formatting

### DIFF
--- a/ledger/allegra/errors.go
+++ b/ledger/allegra/errors.go
@@ -15,7 +15,10 @@
 package allegra
 
 import (
+	"errors"
 	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
 type OutsideValidityIntervalUtxoError struct {
@@ -29,4 +32,19 @@ func (e OutsideValidityIntervalUtxoError) Error() string {
 		e.ValidityIntervalStart,
 		e.Slot,
 	)
+}
+
+type NativeScriptFailedError struct {
+	ScriptHash common.ScriptHash
+}
+
+func (e NativeScriptFailedError) Error() string {
+	return fmt.Sprintf("native script failed (hash=%x)", e.ScriptHash[:])
+}
+
+// Sentinel error for native script failures so callers can use errors.Is
+var ErrNativeScriptFailed = errors.New("native script failed")
+
+func (NativeScriptFailedError) Is(target error) bool {
+	return target == ErrNativeScriptFailed
 }

--- a/ledger/alonzo/alonzo_test.go
+++ b/ledger/alonzo/alonzo_test.go
@@ -90,10 +90,14 @@ func TestAlonzoTransactionOutputToPlutusDataCoinAssets(t *testing.T) {
 	testAssets := common.NewMultiAsset(
 		map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{
 			common.NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-				cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(123456),
+				cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(
+					123456,
+				),
 			},
 			common.NewBlake2b224(test.DecodeHexString("eaf8042c1d8203b1c585822f54ec32c4c1bb4d3914603e2cca20bbd5")): {
-				cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e63657074733638")): big.NewInt(234567),
+				cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e63657074733638")): big.NewInt(
+					234567,
+				),
 			},
 		},
 	)
@@ -284,7 +288,9 @@ func TestAlonzoTransactionOutputString(t *testing.T) {
 	addr, _ := common.NewAddress(addrStr)
 	ma := common.NewMultiAsset[common.MultiAssetTypeOutput](
 		map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{
-			common.NewBlake2b224(make([]byte, 28)): {cbor.NewByteString([]byte("t")): big.NewInt(2)},
+			common.NewBlake2b224(make([]byte, 28)): {
+				cbor.NewByteString([]byte("t")): big.NewInt(2),
+			},
 		},
 	)
 	out := AlonzoTransactionOutput{

--- a/ledger/alonzo/rules.go
+++ b/ledger/alonzo/rules.go
@@ -40,6 +40,7 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateCollateralContainsNonAda,
 	UtxoValidateNoCollateralInputs,
 	UtxoValidateBadInputsUtxo,
+	UtxoValidateScriptWitnesses,
 	UtxoValidateValueNotConservedUtxo,
 	UtxoValidateOutputTooSmallUtxo,
 	UtxoValidateOutputTooBigUtxo,
@@ -48,6 +49,9 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateWrongNetworkWithdrawal,
 	UtxoValidateMaxTxSizeUtxo,
 	UtxoValidateExUnitsTooBigUtxo,
+	UtxoValidateNativeScripts,
+	UtxoValidateDelegation,
+	UtxoValidateWithdrawals,
 }
 
 // UtxoValidateOutputTooBigUtxo ensures that transaction output values are not too large
@@ -285,6 +289,9 @@ func UtxoValidateInsufficientCollateral(
 		if err != nil {
 			return err
 		}
+		if utxo.Output == nil {
+			continue
+		}
 		if amount := utxo.Output.Amount(); amount != nil {
 			totalCollateral.Add(totalCollateral, amount)
 		}
@@ -334,6 +341,9 @@ func UtxoValidateCollateralContainsNonAda(
 		utxo, err := ls.UtxoById(collateralInput)
 		if err != nil {
 			return err
+		}
+		if utxo.Output == nil {
+			continue
 		}
 		if amount := utxo.Output.Amount(); amount != nil {
 			totalCollateral.Add(totalCollateral, amount)
@@ -685,4 +695,43 @@ func UtxoValidateMetadata(
 	pp common.ProtocolParameters,
 ) error {
 	return shelley.UtxoValidateMetadata(tx, slot, ls, pp)
+}
+
+func UtxoValidateDelegation(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return shelley.UtxoValidateDelegation(tx, slot, ls, pp)
+}
+
+// UtxoValidateScriptWitnesses checks that script witnesses are provided for all script address inputs.
+func UtxoValidateScriptWitnesses(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return common.ValidateScriptWitnesses(tx, ls)
+}
+
+// UtxoValidateNativeScripts evaluates native scripts in the transaction.
+func UtxoValidateNativeScripts(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return mary.UtxoValidateNativeScripts(tx, slot, ls, pp)
+}
+
+// UtxoValidateWithdrawals validates withdrawals against ledger state.
+func UtxoValidateWithdrawals(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return shelley.UtxoValidateWithdrawals(tx, slot, ls, pp)
 }

--- a/ledger/babbage/babbage_test.go
+++ b/ledger/babbage/babbage_test.go
@@ -2919,10 +2919,14 @@ func TestBabbageTransactionOutputToPlutusDataCoinAssets(t *testing.T) {
 	testAssets := common.NewMultiAsset(
 		map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{
 			common.NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-				cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(123456),
+				cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(
+					123456,
+				),
 			},
 			common.NewBlake2b224(test.DecodeHexString("eaf8042c1d8203b1c585822f54ec32c4c1bb4d3914603e2cca20bbd5")): {
-				cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e63657074733638")): big.NewInt(234567),
+				cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e63657074733638")): big.NewInt(
+					234567,
+				),
 			},
 		},
 	)
@@ -3024,7 +3028,9 @@ func TestBabbageTransactionOutputString(t *testing.T) {
 	addr, _ := common.NewAddress(addrStr)
 	ma := common.NewMultiAsset[common.MultiAssetTypeOutput](
 		map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{
-			common.NewBlake2b224(make([]byte, 28)): {cbor.NewByteString([]byte("x")): big.NewInt(2)},
+			common.NewBlake2b224(make([]byte, 28)): {
+				cbor.NewByteString([]byte("x")): big.NewInt(2),
+			},
 		},
 	)
 	out := BabbageTransactionOutput{

--- a/ledger/babbage/errors.go
+++ b/ledger/babbage/errors.go
@@ -66,3 +66,15 @@ type (
 	MissingCostModelError                    = common.MissingCostModelError
 	InvalidIsValidFlagError                  = common.InvalidIsValidFlagError
 )
+
+// NonDisjointRefInputsError indicates reference inputs overlap with regular inputs
+type NonDisjointRefInputsError struct {
+	Inputs []common.TransactionInput
+}
+
+func (e NonDisjointRefInputsError) Error() string {
+	return fmt.Sprintf(
+		"non-disjoint reference inputs: %d common inputs",
+		len(e.Inputs),
+	)
+}

--- a/ledger/common/certs.go
+++ b/ledger/common/certs.go
@@ -225,9 +225,17 @@ func (d *Drep) ToPlutusData() data.PlutusData {
 func (d *Drep) String() string {
 	switch d.Type {
 	case DrepTypeAddrKeyHash:
-		return encodeCip129Credential("drep", CredentialTypeAddrKeyHash, d.Credential)
+		return encodeCip129Credential(
+			"drep",
+			CredentialTypeAddrKeyHash,
+			d.Credential,
+		)
 	case DrepTypeScriptHash:
-		return encodeCip129Credential("drep", CredentialTypeScriptHash, d.Credential)
+		return encodeCip129Credential(
+			"drep",
+			CredentialTypeScriptHash,
+			d.Credential,
+		)
 	case DrepTypeAbstain:
 		return "drep_abstain"
 	case DrepTypeNoConfidence:

--- a/ledger/common/common_test.go
+++ b/ledger/common/common_test.go
@@ -478,7 +478,9 @@ func TestMultiAssetJson(t *testing.T) {
 			multiAssetObj: MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(123456),
+						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(
+							123456,
+						),
 					},
 				},
 			},
@@ -488,7 +490,9 @@ func TestMultiAssetJson(t *testing.T) {
 			multiAssetObj: MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224(test.DecodeHexString("eaf8042c1d8203b1c585822f54ec32c4c1bb4d3914603e2cca20bbd5")): {
-						cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e63657074733638")): big.NewInt(234567),
+						cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e63657074733638")): big.NewInt(
+							234567,
+						),
 					},
 				},
 			},
@@ -498,7 +502,9 @@ func TestMultiAssetJson(t *testing.T) {
 			multiAssetObj: MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224(test.DecodeHexString("cf78aeb9736e8aa94ce8fab44da86b522fa9b1c56336b92a28420525")): {
-						cbor.NewByteString(test.DecodeHexString("363438346330393264363164373033656236333233346461")): big.NewInt(12345678),
+						cbor.NewByteString(test.DecodeHexString("363438346330393264363164373033656236333233346461")): big.NewInt(
+							12345678,
+						),
 					},
 				},
 			},
@@ -540,7 +546,9 @@ func TestMultiAssetToPlutusData(t *testing.T) {
 			multiAssetObj: MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(123456),
+						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(
+							123456,
+						),
 					},
 				},
 			},
@@ -572,10 +580,14 @@ func TestMultiAssetToPlutusData(t *testing.T) {
 			multiAssetObj: MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(123456),
+						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(
+							123456,
+						),
 					},
 					NewBlake2b224(test.DecodeHexString("eaf8042c1d8203b1c585822f54ec32c4c1bb4d3914603e2cca20bbd5")): {
-						cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e63657074733638")): big.NewInt(234567),
+						cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e63657074733638")): big.NewInt(
+							234567,
+						),
 					},
 				},
 			},
@@ -738,7 +750,9 @@ func TestMultiAssetCborRoundTrip(t *testing.T) {
 			multiAsset: MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(123456),
+						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(
+							123456,
+						),
 					},
 				},
 			},
@@ -748,8 +762,12 @@ func TestMultiAssetCborRoundTrip(t *testing.T) {
 			multiAsset: MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(123456),
-						cbor.NewByteString(test.DecodeHexString("746f6b656e32")):             big.NewInt(789),
+						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(
+							123456,
+						),
+						cbor.NewByteString(test.DecodeHexString("746f6b656e32")): big.NewInt(
+							789,
+						),
 					},
 				},
 			},
@@ -759,10 +777,14 @@ func TestMultiAssetCborRoundTrip(t *testing.T) {
 			multiAsset: MultiAsset[MultiAssetTypeOutput]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 					NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(123456),
+						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(
+							123456,
+						),
 					},
 					NewBlake2b224(test.DecodeHexString("eaf8042c1d8203b1c585822f54ec32c4c1bb4d3914603e2cca20bbd5")): {
-						cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e636574737638")): big.NewInt(234567),
+						cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e636574737638")): big.NewInt(
+							234567,
+						),
 					},
 				},
 			},
@@ -835,7 +857,9 @@ func TestMultiAssetCborRoundTripMint(t *testing.T) {
 			multiAsset: MultiAsset[MultiAssetTypeMint]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeMint{
 					NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(-50000),
+						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(
+							-50000,
+						),
 					},
 				},
 			},
@@ -845,8 +869,12 @@ func TestMultiAssetCborRoundTripMint(t *testing.T) {
 			multiAsset: MultiAsset[MultiAssetTypeMint]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeMint{
 					NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(100000),
-						cbor.NewByteString(test.DecodeHexString("746f6b656e32")):             big.NewInt(-25000),
+						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(
+							100000,
+						),
+						cbor.NewByteString(test.DecodeHexString("746f6b656e32")): big.NewInt(
+							-25000,
+						),
 					},
 				},
 			},
@@ -856,10 +884,14 @@ func TestMultiAssetCborRoundTripMint(t *testing.T) {
 			multiAsset: MultiAsset[MultiAssetTypeMint]{
 				data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeMint{
 					NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(-75000),
+						cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(
+							-75000,
+						),
 					},
 					NewBlake2b224(test.DecodeHexString("eaf8042c1d8203b1c585822f54ec32c4c1bb4d3914603e2cca20bbd5")): {
-						cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e636574737638")): big.NewInt(-100000),
+						cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e636574737638")): big.NewInt(
+							-100000,
+						),
 					},
 				},
 			},
@@ -1193,11 +1225,17 @@ func TestMultiAssetDeterministicEncoding(t *testing.T) {
 	multiAsset := MultiAsset[MultiAssetTypeOutput]{
 		data: map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
 			NewBlake2b224(test.DecodeHexString("29a8fb8318718bd756124f0c144f56d4b4579dc5edf2dd42d669ac61")): {
-				cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(123456),
-				cbor.NewByteString(test.DecodeHexString("746f6b656e32")):             big.NewInt(789),
+				cbor.NewByteString(test.DecodeHexString("6675726e697368613239686e")): big.NewInt(
+					123456,
+				),
+				cbor.NewByteString(test.DecodeHexString("746f6b656e32")): big.NewInt(
+					789,
+				),
 			},
 			NewBlake2b224(test.DecodeHexString("eaf8042c1d8203b1c585822f54ec32c4c1bb4d3914603e2cca20bbd5")): {
-				cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e636574737638")): big.NewInt(234567),
+				cbor.NewByteString(test.DecodeHexString("426f7764757261436f6e636574737638")): big.NewInt(
+					234567,
+				),
 			},
 		},
 	}
@@ -1253,7 +1291,10 @@ func TestNewPoolIdFromBech32_Negative(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := NewPoolIdFromBech32(tc.input)
 			if err == nil {
-				t.Errorf("NewPoolIdFromBech32(%q) expected error, got nil", tc.input)
+				t.Errorf(
+					"NewPoolIdFromBech32(%q) expected error, got nil",
+					tc.input,
+				)
 			}
 		})
 	}
@@ -1332,7 +1373,11 @@ func TestPoolIdBech32RoundTrip(t *testing.T) {
 				t.Fatalf("NewPoolIdFromBech32() unexpected error: %v", err)
 			}
 			if decoded != tc.poolId {
-				t.Errorf("Round-trip failed: got %x, want %x", decoded, tc.poolId)
+				t.Errorf(
+					"Round-trip failed: got %x, want %x",
+					decoded,
+					tc.poolId,
+				)
 			}
 		})
 	}

--- a/ledger/common/data_test.go
+++ b/ledger/common/data_test.go
@@ -176,7 +176,11 @@ func TestDatumHashToBech32(t *testing.T) {
 				t.Errorf("result too short: got %s", result)
 			}
 			if result[:len(tc.wantPrefix)] != tc.wantPrefix {
-				t.Errorf("wrong prefix: got %s, want prefix %s", result, tc.wantPrefix)
+				t.Errorf(
+					"wrong prefix: got %s, want prefix %s",
+					result,
+					tc.wantPrefix,
+				)
 			}
 		})
 	}
@@ -185,7 +189,9 @@ func TestDatumHashToBech32(t *testing.T) {
 // TestDatumHashBech32Specific tests specific expected bech32 encoded values.
 func TestDatumHashBech32Specific(t *testing.T) {
 	// Known datum hash from above test
-	hashBytes, _ := hex.DecodeString("4dfec91f63f946d7c91af0041e5d92a45531790a4a104637dd8691f46fdce842")
+	hashBytes, _ := hex.DecodeString(
+		"4dfec91f63f946d7c91af0041e5d92a45531790a4a104637dd8691f46fdce842",
+	)
 	var hash common.DatumHash
 	copy(hash[:], hashBytes)
 

--- a/ledger/common/errors.go
+++ b/ledger/common/errors.go
@@ -71,3 +71,36 @@ func (e InlineDatumsNotSupportedError) Error() string {
 		e.PlutusVersion,
 	)
 }
+
+// MissingScriptDataHashError indicates the transaction is missing a required ScriptDataHash
+type MissingScriptDataHashError struct{}
+
+func (MissingScriptDataHashError) Error() string {
+	return "transaction requires a script data hash but none was provided"
+}
+
+// Sentinel error for missing script data hash so callers can use errors.Is
+var ErrMissingScriptDataHash = errors.New("missing script data hash")
+
+func (MissingScriptDataHashError) Is(target error) bool {
+	return target == ErrMissingScriptDataHash
+}
+
+// ExtraneousScriptDataHashError indicates the transaction has a ScriptDataHash when none is needed
+type ExtraneousScriptDataHashError struct {
+	Provided Blake2b256
+}
+
+func (e ExtraneousScriptDataHashError) Error() string {
+	return fmt.Sprintf(
+		"transaction has script data hash %x but no Plutus scripts require it",
+		e.Provided[:],
+	)
+}
+
+// Sentinel error for extraneous script data hash so callers can use errors.Is
+var ErrExtraneousScriptDataHash = errors.New("extraneous script data hash")
+
+func (ExtraneousScriptDataHashError) Is(target error) bool {
+	return target == ErrExtraneousScriptDataHash
+}

--- a/ledger/common/gov.go
+++ b/ledger/common/gov.go
@@ -78,7 +78,11 @@ func encodeCip129Voter(
 // The header byte uses the credential type (0x22 for key hash, 0x23 for script hash)
 // following CIP-0129 specification where the low nibble encodes 0x2 for key hash
 // and 0x3 for script hash.
-func encodeCip129Credential(prefix string, credentialType uint8, hash []byte) string {
+func encodeCip129Credential(
+	prefix string,
+	credentialType uint8,
+	hash []byte,
+) string {
 	// CIP-0129: low nibble encodes credential type offset by 2
 	// (0x2 for key hash, 0x3 for script hash)
 	header := byte(0x20 | ((credentialType + 2) & 0x0f))
@@ -119,7 +123,7 @@ func (v Voter) String() string {
 	case VoterTypeConstitutionalCommitteeHotScriptHash:
 		return encodeCip129Voter(
 			"cc_hot",
-			VoterTypeConstitutionalCommitteeHotKeyHash,
+			VoterTypeConstitutionalCommitteeHotScriptHash,
 			CredentialTypeScriptHash,
 			v.Hash[:],
 		)
@@ -133,7 +137,7 @@ func (v Voter) String() string {
 	case VoterTypeDRepScriptHash:
 		return encodeCip129Voter(
 			"drep",
-			VoterTypeDRepKeyHash,
+			VoterTypeDRepScriptHash,
 			CredentialTypeScriptHash,
 			v.Hash[:],
 		)
@@ -286,14 +290,17 @@ type ProposalProcedureBase struct{}
 //nolint:unused
 func (ProposalProcedureBase) isProposalProcedure() {}
 
+// GovActionType represents the type of a governance action
+type GovActionType uint
+
 const (
-	GovActionTypeParameterChange    = 0
-	GovActionTypeHardForkInitiation = 1
-	GovActionTypeTreasuryWithdrawal = 2
-	GovActionTypeNoConfidence       = 3
-	GovActionTypeUpdateCommittee    = 4
-	GovActionTypeNewConstitution    = 5
-	GovActionTypeInfo               = 6
+	GovActionTypeParameterChange    GovActionType = 0
+	GovActionTypeHardForkInitiation GovActionType = 1
+	GovActionTypeTreasuryWithdrawal GovActionType = 2
+	GovActionTypeNoConfidence       GovActionType = 3
+	GovActionTypeUpdateCommittee    GovActionType = 4
+	GovActionTypeNewConstitution    GovActionType = 5
+	GovActionTypeInfo               GovActionType = 6
 )
 
 type GovAction interface {

--- a/ledger/common/gov_test.go
+++ b/ledger/common/gov_test.go
@@ -212,7 +212,7 @@ func TestVoterString(t *testing.T) {
 				Type: VoterTypeConstitutionalCommitteeHotScriptHash,
 				Hash: zeroHash,
 			},
-			want: "cc_hot1qvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqv2arke",
+			want: "cc_hot1zvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq9zprpe",
 		},
 		{
 			name: "CIP129DRepKeyHash",
@@ -228,7 +228,7 @@ func TestVoterString(t *testing.T) {
 				Type: VoterTypeDRepScriptHash,
 				Hash: zeroHash,
 			},
-			want: "drep1yvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq770f95",
+			want: "drep1xvqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqhknfj5",
 		},
 		{
 			name: "StakingPoolKeyHash",
@@ -551,10 +551,40 @@ func TestGovActionIdString(t *testing.T) {
 		{
 			name: "MaxValidActionIdx",
 			govActionId: GovActionId{
-				TransactionId: [32]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-					0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-					0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-					0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+				TransactionId: [32]byte{
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+					0xff,
+				},
 				GovActionIdx: 255,
 			},
 			wantPrefix: "gov_action",
@@ -564,8 +594,17 @@ func TestGovActionIdString(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			result := tc.govActionId.String()
-			assert.True(t, len(result) > len(tc.wantPrefix), "result should be longer than prefix")
-			assert.Equal(t, tc.wantPrefix+"1", result[:len(tc.wantPrefix)+1], "should have correct prefix")
+			assert.True(
+				t,
+				len(result) > len(tc.wantPrefix),
+				"result should be longer than prefix",
+			)
+			assert.Equal(
+				t,
+				tc.wantPrefix+"1",
+				result[:len(tc.wantPrefix)+1],
+				"should have correct prefix",
+			)
 		})
 	}
 

--- a/ledger/common/poolmetadata_test.go
+++ b/ledger/common/poolmetadata_test.go
@@ -104,5 +104,10 @@ func TestPoolMetadataCbor(t *testing.T) {
 	// Re-encode and verify byte-identical round-trip
 	reEncodedData, err := cbor.Encode(&decoded)
 	assert.NoError(t, err)
-	assert.Equal(t, cborData, reEncodedData, "CBOR round-trip should be byte-identical")
+	assert.Equal(
+		t,
+		cborData,
+		reEncodedData,
+		"CBOR round-trip should be byte-identical",
+	)
 }

--- a/ledger/common/rules.go
+++ b/ledger/common/rules.go
@@ -346,8 +346,17 @@ func ValidateScriptWitnesses(tx Transaction, ls LedgerState) error {
 		// Check if governance action has a policy script
 		if actionWithPolicy, ok := govAction.(GovActionWithPolicy); ok {
 			policyHash := actionWithPolicy.GetPolicyHash()
-			if len(policyHash) > 0 {
-				requiredScriptHashes[ScriptHash(policyHash)] = true
+			if len(policyHash) == Blake2b224Size {
+				var hash ScriptHash
+				copy(hash[:], policyHash)
+				requiredScriptHashes[hash] = true
+			} else if len(policyHash) != 0 {
+				// Non-empty but invalid length - fail fast to surface upstream bugs
+				return fmt.Errorf(
+					"malformed governance policy hash: got %d bytes, want %d",
+					len(policyHash),
+					Blake2b224Size,
+				)
 			}
 		}
 	}

--- a/ledger/common/script/context_test.go
+++ b/ledger/common/script/context_test.go
@@ -80,7 +80,11 @@ func buildTxInfoV1(
 		)
 	}
 	// Build TxInfo
-	txInfo, err := script.NewTxInfoV1FromTransaction(slotState, tx, resolvedInputs)
+	txInfo, err := script.NewTxInfoV1FromTransaction(
+		slotState,
+		tx,
+		resolvedInputs,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +139,11 @@ func buildTxInfoV2(
 		)
 	}
 	// Build TxInfo
-	txInfo, err := script.NewTxInfoV2FromTransaction(slotState, tx, resolvedInputs)
+	txInfo, err := script.NewTxInfoV2FromTransaction(
+		slotState,
+		tx,
+		resolvedInputs,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +198,11 @@ func buildTxInfoV3(
 		)
 	}
 	// Build TxInfo
-	txInfo, err := script.NewTxInfoV3FromTransaction(slotState, tx, resolvedInputs)
+	txInfo, err := script.NewTxInfoV3FromTransaction(
+		slotState,
+		tx,
+		resolvedInputs,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/ledger/common/script_test.go
+++ b/ledger/common/script_test.go
@@ -108,13 +108,71 @@ func TestScriptHashToBech32(t *testing.T) {
 		wantPrefix string
 	}{
 		{
-			name:       "ZeroHash",
-			hash:       common.ScriptHash{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			name: "ZeroHash",
+			hash: common.ScriptHash{
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+				0,
+			},
 			wantPrefix: "script1",
 		},
 		{
-			name:       "SequentialHash",
-			hash:       common.ScriptHash{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27},
+			name: "SequentialHash",
+			hash: common.ScriptHash{
+				0,
+				1,
+				2,
+				3,
+				4,
+				5,
+				6,
+				7,
+				8,
+				9,
+				10,
+				11,
+				12,
+				13,
+				14,
+				15,
+				16,
+				17,
+				18,
+				19,
+				20,
+				21,
+				22,
+				23,
+				24,
+				25,
+				26,
+				27,
+			},
 			wantPrefix: "script1",
 		},
 	}
@@ -126,7 +184,11 @@ func TestScriptHashToBech32(t *testing.T) {
 				t.Fatalf("result too short: got %s", result)
 			}
 			if result[:len(tc.wantPrefix)] != tc.wantPrefix {
-				t.Errorf("wrong prefix: got %s, want prefix %s", result, tc.wantPrefix)
+				t.Errorf(
+					"wrong prefix: got %s, want prefix %s",
+					result,
+					tc.wantPrefix,
+				)
 			}
 		})
 	}
@@ -153,7 +215,11 @@ func TestScriptHashBech32RoundTrip(t *testing.T) {
 
 	// Verify round-trip
 	if decodedHash != originalHash {
-		t.Errorf("round-trip failed: got %x, want %x", decodedHash, originalHash)
+		t.Errorf(
+			"round-trip failed: got %x, want %x",
+			decodedHash,
+			originalHash,
+		)
 	}
 }
 

--- a/ledger/common/verify.go
+++ b/ledger/common/verify.go
@@ -71,10 +71,16 @@ func computeByronAddressRoot(
 	// Validate input sizes to ensure correct CBOR encoding
 	// Byron addresses require exactly 32 bytes for both pubkey and chain code
 	if len(pubkey) != 32 {
-		return Blake2b224{}, fmt.Errorf("invalid Byron pubkey size: expected 32 bytes, got %d", len(pubkey))
+		return Blake2b224{}, fmt.Errorf(
+			"invalid Byron pubkey size: expected 32 bytes, got %d",
+			len(pubkey),
+		)
 	}
 	if len(chainCode) != 32 {
-		return Blake2b224{}, fmt.Errorf("invalid Byron chain code size: expected 32 bytes, got %d", len(chainCode))
+		return Blake2b224{}, fmt.Errorf(
+			"invalid Byron chain code size: expected 32 bytes, got %d",
+			len(chainCode),
+		)
 	}
 
 	// Build the CBOR structure: [0, [0, bytes(pubkey || chainCode)], attributes]

--- a/ledger/conway/conway_test.go
+++ b/ledger/conway/conway_test.go
@@ -274,7 +274,12 @@ func TestConwayTx_WithReferenceInputs_CborRoundTrip(t *testing.T) {
 	// Verify byte-identical round-trip
 	reEncoded, err := cbor.Encode(&decoded)
 	assert.NoError(t, err)
-	assert.Equal(t, cborData, reEncoded, "CBOR round-trip should be byte-identical")
+	assert.Equal(
+		t,
+		cborData,
+		reEncoded,
+		"CBOR round-trip should be byte-identical",
+	)
 }
 
 func TestConwayTx_WithReferenceScripts_CborRoundTrip(t *testing.T) {
@@ -338,5 +343,10 @@ func TestConwayTx_WithReferenceScripts_CborRoundTrip(t *testing.T) {
 	// Verify byte-identical round-trip
 	reEncoded, err := cbor.Encode(&decoded)
 	assert.NoError(t, err)
-	assert.Equal(t, cborData, reEncoded, "CBOR round-trip should be byte-identical")
+	assert.Equal(
+		t,
+		cborData,
+		reEncoded,
+		"CBOR round-trip should be byte-identical",
+	)
 }

--- a/ledger/conway/errors.go
+++ b/ledger/conway/errors.go
@@ -15,23 +15,18 @@
 package conway
 
 import (
+	"encoding/hex"
 	"fmt"
 	"strings"
 
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 )
 
-type NonDisjointRefInputsError struct {
-	Inputs []common.TransactionInput
-}
-
-func (e NonDisjointRefInputsError) Error() string {
-	tmpInputs := make([]string, len(e.Inputs))
-	for idx, tmpInput := range e.Inputs {
-		tmpInputs[idx] = tmpInput.String()
-	}
-	return "non-disjoint reference inputs: " + strings.Join(tmpInputs, ", ")
-}
+// NonDisjointRefInputsError is an alias to babbage.NonDisjointRefInputsError
+type NonDisjointRefInputsError = babbage.NonDisjointRefInputsError
 
 // Witness validation errors (alias to common types)
 type MissingVKeyWitnessesError = common.MissingVKeyWitnessesError
@@ -60,7 +55,11 @@ type WrongTransactionNetworkIdError struct {
 }
 
 func (e WrongTransactionNetworkIdError) Error() string {
-	return fmt.Sprintf("wrong transaction network ID: transaction has %d, ledger expects %d", e.TxNetworkId, e.LedgerNetworkId)
+	return fmt.Sprintf(
+		"wrong transaction network ID: transaction has %d, ledger expects %d",
+		e.TxNetworkId,
+		e.LedgerNetworkId,
+	)
 }
 
 type TreasuryDonationWithPlutusV1V2Error struct {
@@ -69,7 +68,47 @@ type TreasuryDonationWithPlutusV1V2Error struct {
 }
 
 func (e TreasuryDonationWithPlutusV1V2Error) Error() string {
-	return fmt.Sprintf("treasury donation (%d lovelace) cannot be used with %s scripts - treasury donation is a Conway feature only available for PlutusV3", e.Donation, e.PlutusVersion)
+	return fmt.Sprintf(
+		"treasury donation (%d lovelace) cannot be used with %s scripts - treasury donation is a Conway feature only available for PlutusV3",
+		e.Donation,
+		e.PlutusVersion,
+	)
+}
+
+// CurrentTreasuryValueWithPlutusV1V2Error indicates CurrentTreasuryValue cannot be used with V1/V2 scripts
+type CurrentTreasuryValueWithPlutusV1V2Error struct {
+	PlutusVersion string
+}
+
+func (e CurrentTreasuryValueWithPlutusV1V2Error) Error() string {
+	return fmt.Sprintf(
+		"current treasury value cannot be used with %s scripts - only available for PlutusV3",
+		e.PlutusVersion,
+	)
+}
+
+// ProposalProceduresWithPlutusV1V2Error indicates ProposalProcedures cannot be used with V1/V2 scripts
+type ProposalProceduresWithPlutusV1V2Error struct {
+	PlutusVersion string
+}
+
+func (e ProposalProceduresWithPlutusV1V2Error) Error() string {
+	return fmt.Sprintf(
+		"proposal procedures cannot be used with %s scripts - only available for PlutusV3",
+		e.PlutusVersion,
+	)
+}
+
+// VotingProceduresWithPlutusV1V2Error indicates VotingProcedures cannot be used with V1/V2 scripts
+type VotingProceduresWithPlutusV1V2Error struct {
+	PlutusVersion string
+}
+
+func (e VotingProceduresWithPlutusV1V2Error) Error() string {
+	return fmt.Sprintf(
+		"voting procedures cannot be used with %s scripts - only available for PlutusV3",
+		e.PlutusVersion,
+	)
 }
 
 // PlutusScriptFailedError indicates that a Plutus script execution failed
@@ -81,12 +120,24 @@ type PlutusScriptFailedError struct {
 }
 
 func (e PlutusScriptFailedError) Error() string {
-	return fmt.Sprintf("plutus script failed (hash=%x, tag=%d, index=%d): %v", e.ScriptHash[:], e.Tag, e.Index, e.Err)
+	return fmt.Sprintf(
+		"plutus script failed (hash=%x, tag=%d, index=%d): %v",
+		e.ScriptHash[:],
+		e.Tag,
+		e.Index,
+		e.Err,
+	)
 }
 
 func (e PlutusScriptFailedError) Unwrap() error {
 	return e.Err
 }
+
+// NativeScriptFailedError indicates that a native (timelock) script evaluation failed
+type NativeScriptFailedError = allegra.NativeScriptFailedError
+
+// ErrNativeScriptFailed is the sentinel error for native script failures
+var ErrNativeScriptFailed = allegra.ErrNativeScriptFailed
 
 // ScriptContextConstructionError indicates that the script context could not be built
 type ScriptContextConstructionError struct {
@@ -108,7 +159,53 @@ type MissingDatumForSpendingScriptError struct {
 }
 
 func (e MissingDatumForSpendingScriptError) Error() string {
-	return fmt.Sprintf("missing datum for spending script (hash=%x, input=%s)", e.ScriptHash[:], e.Input.String())
+	return fmt.Sprintf(
+		"missing datum for spending script (hash=%x, input=%s)",
+		e.ScriptHash[:],
+		e.Input.String(),
+	)
+}
+
+// NotAllowedSupplementalDatumsError indicates that datums in the witness set are not required by any script input
+type NotAllowedSupplementalDatumsError struct {
+	DatumHashes []common.Blake2b256
+}
+
+func (e NotAllowedSupplementalDatumsError) Error() string {
+	hashes := make([]string, len(e.DatumHashes))
+	for i, h := range e.DatumHashes {
+		hashes[i] = hex.EncodeToString(h[:])
+	}
+	return "not allowed supplemental datums in witness set: " + strings.Join(
+		hashes,
+		", ",
+	)
+}
+
+// ExtraRedeemerError indicates a redeemer exists that doesn't match any valid script purpose
+// (e.g., redeemer index is out of bounds for the inputs/mints/etc.)
+type ExtraRedeemerError struct {
+	RedeemerKey common.RedeemerKey
+}
+
+func (e ExtraRedeemerError) Error() string {
+	return fmt.Sprintf(
+		"extra redeemer: tag=%d, index=%d doesn't match any valid script purpose",
+		e.RedeemerKey.Tag,
+		e.RedeemerKey.Index,
+	)
+}
+
+// MissingRedeemerForScriptError indicates a script purpose requires a redeemer but none was provided
+type MissingRedeemerForScriptError struct {
+	ScriptHash common.ScriptHash
+	Tag        common.RedeemerTag
+	Index      uint32
+}
+
+func (e MissingRedeemerForScriptError) Error() string {
+	return fmt.Sprintf("missing redeemer for script %x: tag=%d, index=%d",
+		e.ScriptHash[:], e.Tag, e.Index)
 }
 
 // ProtocolParameterUpdateEmptyError indicates that a PPU has no fields set
@@ -125,7 +222,11 @@ type ProtocolParameterUpdateFieldZeroError struct {
 }
 
 func (e ProtocolParameterUpdateFieldZeroError) Error() string {
-	return fmt.Sprintf("protocol parameter update field %s cannot be 0, got %d", e.FieldName, e.Value)
+	return fmt.Sprintf(
+		"protocol parameter update field %s cannot be 0, got %d",
+		e.FieldName,
+		e.Value,
+	)
 }
 
 // EmptyTreasuryWithdrawalsError indicates that a TreasuryWithdrawalGovAction has an empty withdrawals map
@@ -133,6 +234,13 @@ type EmptyTreasuryWithdrawalsError struct{}
 
 func (e EmptyTreasuryWithdrawalsError) Error() string {
 	return "treasury withdrawal governance action has empty withdrawals map"
+}
+
+// ZeroTreasuryWithdrawalAmountError indicates that a TreasuryWithdrawalGovAction has all zero amounts
+type ZeroTreasuryWithdrawalAmountError struct{}
+
+func (e ZeroTreasuryWithdrawalAmountError) Error() string {
+	return "treasury withdrawal governance action has zero withdrawal amount"
 }
 
 // WrongNetworkProposalAddressError indicates that a proposal address has wrong network ID
@@ -146,5 +254,120 @@ func (e WrongNetworkProposalAddressError) Error() string {
 	for idx, addr := range e.Addrs {
 		tmpAddrs[idx] = addr.String()
 	}
-	return fmt.Sprintf("wrong network ID in proposal address(es): expected %d, got %s", e.NetId, strings.Join(tmpAddrs, ", "))
+	return fmt.Sprintf(
+		"wrong network ID in proposal address(es): expected %d, got %s",
+		e.NetId,
+		strings.Join(tmpAddrs, ", "),
+	)
+}
+
+// Delegation errors (alias to shelley types)
+type (
+	DelegateToUnregisteredPoolError          = shelley.DelegateToUnregisteredPoolError
+	DelegateUnregisteredStakeCredentialError = shelley.DelegateUnregisteredStakeCredentialError
+)
+
+// DelegateVoteToUnregisteredDRepError indicates vote delegation to a DRep that is not registered
+type DelegateVoteToUnregisteredDRepError struct {
+	DRepCredential common.Credential
+}
+
+func (e DelegateVoteToUnregisteredDRepError) Error() string {
+	return fmt.Sprintf(
+		"vote delegation to unregistered DRep: %x",
+		e.DRepCredential.Credential[:],
+	)
+}
+
+// WithdrawalFromUnregisteredRewardAccountError indicates withdrawal from an unregistered reward account
+type WithdrawalFromUnregisteredRewardAccountError struct {
+	RewardAddress common.Address
+}
+
+func (e WithdrawalFromUnregisteredRewardAccountError) Error() string {
+	return "withdrawal from unregistered reward account: " + e.RewardAddress.String()
+}
+
+// WithdrawalWrongAmountError indicates withdrawal of wrong amount from reward account
+type WithdrawalWrongAmountError struct {
+	RewardAddress   common.Address
+	RequestedAmount uint64
+	ActualBalance   uint64
+}
+
+func (e WithdrawalWrongAmountError) Error() string {
+	return fmt.Sprintf(
+		"withdrawal wrong amount from %s: requested %d, actual balance %d",
+		e.RewardAddress.String(),
+		e.RequestedAmount,
+		e.ActualBalance,
+	)
+}
+
+// StakeCredentialAlreadyRegisteredError indicates attempting to register an already registered stake credential
+type StakeCredentialAlreadyRegisteredError struct {
+	Credential common.Credential
+}
+
+func (e StakeCredentialAlreadyRegisteredError) Error() string {
+	return fmt.Sprintf(
+		"stake credential already registered: %x",
+		e.Credential.Credential[:],
+	)
+}
+
+// DRepAlreadyRegisteredError indicates attempting to register an already registered DRep
+type DRepAlreadyRegisteredError struct {
+	Credential common.Credential
+}
+
+func (e DRepAlreadyRegisteredError) Error() string {
+	return fmt.Sprintf(
+		"DRep already registered: %x",
+		e.Credential.Credential[:],
+	)
+}
+
+// NotCommitteeMemberError indicates an operation on a credential that is not a CC member
+type NotCommitteeMemberError struct {
+	Credential common.Blake2b224
+	Operation  string
+}
+
+func (e NotCommitteeMemberError) Error() string {
+	return fmt.Sprintf(
+		"not a CC member, cannot %s: %x",
+		e.Operation,
+		e.Credential[:],
+	)
+}
+
+// ResignedCommitteeMemberHotKeyError indicates trying to authorize hot key for resigned CC member
+type ResignedCommitteeMemberHotKeyError struct {
+	ColdKey common.Blake2b224
+}
+
+func (e ResignedCommitteeMemberHotKeyError) Error() string {
+	return fmt.Sprintf(
+		"cannot authorize hot key for resigned CC member: %x",
+		e.ColdKey[:],
+	)
+}
+
+// CommitteeMemberLookupError indicates a failure to look up a committee member
+type CommitteeMemberLookupError struct {
+	Credential common.Blake2b224
+	Err        error
+}
+
+func (e CommitteeMemberLookupError) Error() string {
+	return fmt.Sprintf(
+		"failed to look up CC member %x: %v",
+		e.Credential[:],
+		e.Err,
+	)
+}
+
+func (e CommitteeMemberLookupError) Unwrap() error {
+	return e.Err
 }

--- a/ledger/conway/errors_test.go
+++ b/ledger/conway/errors_test.go
@@ -264,3 +264,99 @@ func TestConway_CostModelsPresent_ResolvedReferenceInput_PlutusV3(
 		t.Fatalf("expected no error after providing cost model, got %v", err)
 	}
 }
+
+func TestConway_ScriptDataHash_MissingScriptDataHashError_Is(t *testing.T) {
+	var slot uint64 = 0
+	ls := test_ledger.NewMockLedgerStateWithUtxos([]common.Utxo{})
+	pp := &ConwayProtocolParameters{}
+
+	// Create a transaction with redeemers but no script data hash
+	tmpTx := &ConwayTransaction{}
+	tmpTx.WitnessSet.WsRedeemers.Redeemers = map[common.RedeemerKey]common.RedeemerValue{
+		{Tag: 0, Index: 0}: {},
+	}
+	var tx common.Transaction = tmpTx
+
+	err := UtxoValidateScriptDataHash(tx, slot, ls, pp)
+	if err == nil {
+		t.Fatal("expected MissingScriptDataHashError, got nil")
+	}
+	if !errors.Is(err, common.ErrMissingScriptDataHash) {
+		t.Fatalf(
+			"expected errors.Is(err, ErrMissingScriptDataHash) to be true, got false: %v",
+			err,
+		)
+	}
+}
+
+func TestConway_ScriptDataHash_MissingScriptDataHashError_As(t *testing.T) {
+	var slot uint64 = 0
+	ls := test_ledger.NewMockLedgerStateWithUtxos([]common.Utxo{})
+	pp := &ConwayProtocolParameters{}
+
+	// Create a transaction with redeemers but no script data hash
+	tmpTx := &ConwayTransaction{}
+	tmpTx.WitnessSet.WsRedeemers.Redeemers = map[common.RedeemerKey]common.RedeemerValue{
+		{Tag: 0, Index: 0}: {},
+	}
+	var tx common.Transaction = tmpTx
+
+	err := UtxoValidateScriptDataHash(tx, slot, ls, pp)
+	if err == nil {
+		t.Fatal("expected MissingScriptDataHashError, got nil")
+	}
+	var mErr common.MissingScriptDataHashError
+	if !errors.As(err, &mErr) {
+		t.Fatalf(
+			"expected MissingScriptDataHashError via errors.As, got %T",
+			err,
+		)
+	}
+}
+
+func TestConway_ScriptDataHash_ExtraneousScriptDataHashError_Is(t *testing.T) {
+	var slot uint64 = 0
+	ls := test_ledger.NewMockLedgerStateWithUtxos([]common.Utxo{})
+	pp := &ConwayProtocolParameters{}
+
+	// Create a transaction with a script data hash but no Plutus scripts or redeemers
+	tmpTx := &ConwayTransaction{}
+	dummyHash := common.Blake2b256{}
+	tmpTx.Body.TxScriptDataHash = &dummyHash
+	var tx common.Transaction = tmpTx
+
+	err := UtxoValidateScriptDataHash(tx, slot, ls, pp)
+	if err == nil {
+		t.Fatal("expected ExtraneousScriptDataHashError, got nil")
+	}
+	if !errors.Is(err, common.ErrExtraneousScriptDataHash) {
+		t.Fatalf(
+			"expected errors.Is(err, ErrExtraneousScriptDataHash) to be true, got false: %v",
+			err,
+		)
+	}
+}
+
+func TestConway_ScriptDataHash_ExtraneousScriptDataHashError_As(t *testing.T) {
+	var slot uint64 = 0
+	ls := test_ledger.NewMockLedgerStateWithUtxos([]common.Utxo{})
+	pp := &ConwayProtocolParameters{}
+
+	// Create a transaction with a script data hash but no Plutus scripts or redeemers
+	tmpTx := &ConwayTransaction{}
+	dummyHash := common.Blake2b256{}
+	tmpTx.Body.TxScriptDataHash = &dummyHash
+	var tx common.Transaction = tmpTx
+
+	err := UtxoValidateScriptDataHash(tx, slot, ls, pp)
+	if err == nil {
+		t.Fatal("expected ExtraneousScriptDataHashError, got nil")
+	}
+	var eErr common.ExtraneousScriptDataHashError
+	if !errors.As(err, &eErr) {
+		t.Fatalf(
+			"expected ExtraneousScriptDataHashError via errors.As, got %T",
+			err,
+		)
+	}
+}

--- a/ledger/conway/gov.go
+++ b/ledger/conway/gov.go
@@ -71,8 +71,11 @@ func (g *ConwayGovAction) UnmarshalCBOR(data []byte) error {
 	if err != nil {
 		return err
 	}
+	if actionType < 0 {
+		return fmt.Errorf("invalid governance action type: %d", actionType)
+	}
 	var tmpAction common.GovAction
-	switch actionType {
+	switch common.GovActionType(actionType) {
 	case common.GovActionTypeParameterChange:
 		tmpAction = &ConwayParameterChangeGovAction{}
 	case common.GovActionTypeHardForkInitiation:

--- a/ledger/conway/gov_test.go
+++ b/ledger/conway/gov_test.go
@@ -47,7 +47,7 @@ func TestConwayProposalProcedureCbor(t *testing.T) {
 		"addr1vx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers66hrl8",
 	)
 	require.NoError(t, err)
-	action := &common.InfoGovAction{Type: common.GovActionTypeInfo}
+	action := &common.InfoGovAction{Type: uint(common.GovActionTypeInfo)}
 
 	pp := &ConwayProposalProcedure{
 		PPDeposit:       1000000,
@@ -81,7 +81,7 @@ func TestConwayProposalProcedureCbor(t *testing.T) {
 
 func TestConwayGovActionCbor(t *testing.T) {
 	// Test CBOR encoding/decoding for CIP-1694 governance actions
-	action := &common.InfoGovAction{Type: common.GovActionTypeInfo}
+	action := &common.InfoGovAction{Type: uint(common.GovActionTypeInfo)}
 
 	ga := ConwayGovAction{Action: action}
 

--- a/ledger/error_test.go
+++ b/ledger/error_test.go
@@ -98,7 +98,9 @@ func TestScriptsNotPaidUtxo_MarshalUnmarshalCBOR(t *testing.T) {
 				originalOutput := originalUtxo.Output.(*shelley.ShelleyTransactionOutput)
 
 				// Check the amount using the interface method
-				originalAmount := new(big.Int).SetUint64(originalOutput.OutputAmount)
+				originalAmount := new(
+					big.Int,
+				).SetUint64(originalOutput.OutputAmount)
 				if decodedUtxo.Output.Amount().Cmp(originalAmount) != 0 {
 					t.Errorf(
 						"UTxO %d: Amount mismatch - expected %s, got %s",

--- a/ledger/leios/leios.go
+++ b/ledger/leios/leios.go
@@ -289,7 +289,10 @@ func decodeTxRefMap(data []byte) ([]TxReference, error) {
 		}
 		// Read key (32-byte bytestring)
 		if data[pos]>>5 != 2 {
-			return nil, fmt.Errorf("expected bytestring, got major type %d", data[pos]>>5)
+			return nil, fmt.Errorf(
+				"expected bytestring, got major type %d",
+				data[pos]>>5,
+			)
 		}
 		keyLen, n := readCborUint(data[pos:])
 		if n == 0 {
@@ -308,11 +311,16 @@ func decodeTxRefMap(data []byte) ([]TxReference, error) {
 		pos += 32
 		// Bounds check before reading value header
 		if pos >= len(data) {
-			return nil, errors.New("unexpected end of data reading value header")
+			return nil, errors.New(
+				"unexpected end of data reading value header",
+			)
 		}
 		// Read value (uint)
 		if data[pos]>>5 != 0 {
-			return nil, fmt.Errorf("expected uint, got major type %d", data[pos]>>5)
+			return nil, fmt.Errorf(
+				"expected uint, got major type %d",
+				data[pos]>>5,
+			)
 		}
 		size, n := readCborUint(data[pos:])
 		if n == 0 {

--- a/ledger/leios/leios_test.go
+++ b/ledger/leios/leios_test.go
@@ -202,7 +202,10 @@ func TestLeiosEndorserBlock_CborRoundTrip(t *testing.T) {
 	// Verify all decoded refs exist in original
 	for _, ref := range decoded.Body.TxReferences {
 		if size, ok := origRefMap[ref.TxHash]; !ok {
-			t.Errorf("Decoded TxReference %x not found in original", ref.TxHash[:8])
+			t.Errorf(
+				"Decoded TxReference %x not found in original",
+				ref.TxHash[:8],
+			)
 		} else if size != ref.TxSize {
 			t.Errorf("TxSize mismatch for %x: expected %d, got %d", ref.TxHash[:8], size, ref.TxSize)
 		}
@@ -260,7 +263,11 @@ func TestLeiosEndorserBlockFormat(t *testing.T) {
 	}
 
 	if block.Type() != BlockTypeLeiosEndorser {
-		t.Errorf("Expected block type %d, got %d", BlockTypeLeiosEndorser, block.Type())
+		t.Errorf(
+			"Expected block type %d, got %d",
+			BlockTypeLeiosEndorser,
+			block.Type(),
+		)
 	}
 	if len(block.Body.TxReferences) == 0 {
 		t.Error("TxReferences should not be empty")
@@ -280,7 +287,11 @@ func TestLeiosRankingBlockFormat(t *testing.T) {
 	}
 
 	if block.Type() != BlockTypeLeiosRanking {
-		t.Errorf("Expected block type %d, got %d", BlockTypeLeiosRanking, block.Type())
+		t.Errorf(
+			"Expected block type %d, got %d",
+			BlockTypeLeiosRanking,
+			block.Type(),
+		)
 	}
 }
 
@@ -328,7 +339,10 @@ func TestLeiosEndorserBlockLargeMap(t *testing.T) {
 
 	// Verify the CBOR starts with 4-byte map length encoding (0xba)
 	if len(cborData) < 6 || cborData[1] != 0xba {
-		t.Errorf("Expected 4-byte map length encoding (0xba), got: %x", cborData[:min(10, len(cborData))])
+		t.Errorf(
+			"Expected 4-byte map length encoding (0xba), got: %x",
+			cborData[:min(10, len(cborData))],
+		)
 	}
 
 	// Test UnmarshalCBOR can decode it back
@@ -339,7 +353,10 @@ func TestLeiosEndorserBlockLargeMap(t *testing.T) {
 
 	// Verify the data is correct
 	if len(decoded.Body.TxReferences) != 65536 {
-		t.Errorf("Expected 65536 TxReferences, got %d", len(decoded.Body.TxReferences))
+		t.Errorf(
+			"Expected 65536 TxReferences, got %d",
+			len(decoded.Body.TxReferences),
+		)
 	}
 
 	for i, ref := range decoded.Body.TxReferences {
@@ -349,7 +366,12 @@ func TestLeiosEndorserBlockLargeMap(t *testing.T) {
 			break
 		}
 		if ref.TxSize != txRefs[i].TxSize {
-			t.Errorf("TxReference %d size mismatch: expected %d, got %d", i, txRefs[i].TxSize, ref.TxSize)
+			t.Errorf(
+				"TxReference %d size mismatch: expected %d, got %d",
+				i,
+				txRefs[i].TxSize,
+				ref.TxSize,
+			)
 			break
 		}
 	}

--- a/ledger/mary/rules.go
+++ b/ledger/mary/rules.go
@@ -31,6 +31,7 @@ const (
 var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateMetadata,
 	UtxoValidateRequiredVKeyWitnesses,
+	UtxoValidateSignatures,
 	UtxoValidateOutsideValidityIntervalUtxo,
 	UtxoValidateInputSetEmptyUtxo,
 	UtxoValidateFeeTooSmallUtxo,
@@ -42,6 +43,9 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateOutputTooBigUtxo,
 	UtxoValidateOutputBootAddrAttrsTooBig,
 	UtxoValidateMaxTxSizeUtxo,
+	UtxoValidateNativeScripts,
+	UtxoValidateDelegation,
+	UtxoValidateWithdrawals,
 }
 
 func UtxoValidateRequiredVKeyWitnesses(
@@ -434,4 +438,43 @@ func UtxoValidateMetadata(
 	pp common.ProtocolParameters,
 ) error {
 	return shelley.UtxoValidateMetadata(tx, slot, ls, pp)
+}
+
+func UtxoValidateDelegation(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return shelley.UtxoValidateDelegation(tx, slot, ls, pp)
+}
+
+// UtxoValidateSignatures verifies vkey and bootstrap signatures present in the transaction.
+func UtxoValidateSignatures(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return shelley.UtxoValidateSignatures(tx, slot, ls, pp)
+}
+
+// UtxoValidateNativeScripts evaluates native scripts in the transaction.
+func UtxoValidateNativeScripts(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return allegra.UtxoValidateNativeScripts(tx, slot, ls, pp)
+}
+
+// UtxoValidateWithdrawals validates withdrawals against ledger state.
+func UtxoValidateWithdrawals(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return shelley.UtxoValidateWithdrawals(tx, slot, ls, pp)
 }

--- a/ledger/shelley/errors.go
+++ b/ledger/shelley/errors.go
@@ -110,7 +110,11 @@ func (e ValueNotConservedUtxoError) Error() string {
 	if e.Produced != nil {
 		produced = e.Produced.String()
 	}
-	return fmt.Sprintf("value not conserved: consumed %s, produced %s", consumed, produced)
+	return fmt.Sprintf(
+		"value not conserved: consumed %s, produced %s",
+		consumed,
+		produced,
+	)
 }
 
 type OutputTooSmallUtxoError struct {
@@ -177,3 +181,33 @@ type (
 type MissingVKeyWitnessesError = common.MissingVKeyWitnessesError
 
 type MissingRequiredVKeyWitnessForSignerError = common.MissingRequiredVKeyWitnessForSignerError
+
+// DelegateToUnregisteredPoolError indicates delegation to a pool that is not registered
+type DelegateToUnregisteredPoolError struct {
+	PoolKeyHash common.PoolKeyHash
+}
+
+func (e DelegateToUnregisteredPoolError) Error() string {
+	return fmt.Sprintf("delegation to unregistered pool: %x", e.PoolKeyHash[:])
+}
+
+// DelegateUnregisteredStakeCredentialError indicates delegation from an unregistered stake credential
+type DelegateUnregisteredStakeCredentialError struct {
+	Credential common.Credential
+}
+
+func (e DelegateUnregisteredStakeCredentialError) Error() string {
+	return fmt.Sprintf(
+		"delegation from unregistered stake credential: %x",
+		e.Credential.Credential[:],
+	)
+}
+
+// WithdrawalFromUnregisteredRewardAccountError indicates withdrawal from an unregistered reward account
+type WithdrawalFromUnregisteredRewardAccountError struct {
+	RewardAddress common.Address
+}
+
+func (e WithdrawalFromUnregisteredRewardAccountError) Error() string {
+	return "withdrawal from unregistered reward account: " + e.RewardAddress.String()
+}

--- a/ledger/verify_block_body.go
+++ b/ledger/verify_block_body.go
@@ -229,7 +229,11 @@ func CalculateBlockBodyHash(txsRaw [][]string) ([]byte, error) {
 	txSeqIsValidSum32Bytes := blake2b.Sum256(txSeqNonValidBytes)
 	txSeqIsValidSumBytes := txSeqIsValidSum32Bytes[:]
 
-	serializeBytes := make([]byte, 0, len(txSeqBodySumBytes)+len(txSeqWitsSumBytes)+len(txSeqMetadataSumBytes)+len(txSeqIsValidSumBytes))
+	serializeBytes := make(
+		[]byte,
+		0,
+		len(txSeqBodySumBytes)+len(txSeqWitsSumBytes)+len(txSeqMetadataSumBytes)+len(txSeqIsValidSumBytes),
+	)
 	// Ref: https://github.com/IntersectMBO/cardano-ledger/blob/9cc766a31ad6fb31f88e25a770c902d24fa32499/eras/alonzo/impl/src/Cardano/Ledger/Alonzo/TxSeq.hs#L183
 	serializeBytes = append(serializeBytes, txSeqBodySumBytes...)
 	serializeBytes = append(serializeBytes, txSeqWitsSumBytes...)


### PR DESCRIPTION
I am at `302/314 (96.2%)` passing on the conformance tests I'm doing in another branch, so I broke this off from there.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors and extends ledger validation across Shelley–Conway. Adds delegation, withdrawals, native-script evaluation, ScriptDataHash checks, and governance/committee validations with new error types and expanded state interfaces.

- New Features
  - Delegation and withdrawals: add UtxoValidateDelegation in all eras; withdrawals require registered reward accounts.
  - Scripts: evaluate native (timelock) scripts; require/forbid ScriptDataHash when appropriate; detect supplemental datums; block Conway-only features (treasury value, proposals, voting) when using Plutus V1/V2; add signature checks; enforce disjoint reference inputs in Babbage.
  - Governance/committee: validate committee hot-key auth/resign; add gov action state lookups; richer error reporting.

- Refactors
  - Extend LedgerState and test MockLedgerState for stake/pool/reward/gov queries and balances.
  - Implement NativeScript.Evaluate and fix policy-hash handling for script witnesses.
  - Add cost model presence check and new error types with clearer messages.
  - Improve formatting and tests without changing behavior.

<sup>Written for commit 03c83e6b4f22d01286d34c14b81307540a3f32c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded transaction validation across eras: signature checks, native-script evaluation with time windows, delegation & withdrawal checks, script-data and supplemental-datum rules, committee-certificate validations
  * Ledger state now exposes governance actions and reward-account queries

* **Bug Fixes**
  * New, more specific error types for clearer failure reporting
  * Validators hardened with nil-safety and disjoint-input checks to avoid panics and ambiguous failures

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->