### PR TITLE
fix(protocol): chainsync pipeline defaults using bare struct

### DIFF
--- a/protocol/chainsync/client.go
+++ b/protocol/chainsync/client.go
@@ -77,8 +77,16 @@ func NewClient(
 		tmpCfg := NewConfig()
 		cfg = &tmpCfg
 	}
+	// Apply defaults for zero values to handle Config{} created without NewConfig()
+	config := *cfg
+	if config.PipelineLimit == 0 {
+		config.PipelineLimit = DefaultPipelineLimit
+	}
+	if config.RecvQueueSize == 0 {
+		config.RecvQueueSize = DefaultRecvQueueSize
+	}
 	c := &Client{
-		config:                cfg,
+		config:                &config,
 		protoOptions:          protoOptions,
 		stateContext:          stateContext,
 		lifecycleState:        clientStateNew,

--- a/protocol/chainsync/server.go
+++ b/protocol/chainsync/server.go
@@ -38,8 +38,17 @@ func NewServer(
 	protoOptions protocol.ProtocolOptions,
 	cfg *Config,
 ) *Server {
+	// Apply defaults for zero values to handle Config{} created without NewConfig()
+	var config *Config
+	if cfg != nil {
+		configCopy := *cfg
+		if configCopy.RecvQueueSize == 0 {
+			configCopy.RecvQueueSize = DefaultRecvQueueSize
+		}
+		config = &configCopy
+	}
 	s := &Server{
-		config: cfg,
+		config: config,
 		// Save these for re-use later
 		protoOptions: protoOptions,
 		stateContext: stateContext,


### PR DESCRIPTION
Closes #1299 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply sane defaults for chainsync pipeline and recv queue when a bare Config{} is passed to Client/Server. Prevents sync stalls caused by zero PipelineLimit.

- **Bug Fixes**
  - Client copies cfg and sets defaults for zero PipelineLimit and RecvQueueSize.
  - Server sets a default RecvQueueSize when zero.
  - Tests verify defaults, preserve explicit values, and cover nil config behavior.

<sup>Written for commit 3ed2f8b8244d34b1767311fd04ad99205d13f960. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Initialization now consistently applies sensible default configuration values when zero-valued configs are provided, for both client and server instances.

* **Tests**
  * Added tests verifying defaults are applied and that explicit non-zero configuration values are preserved during initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->