### PR TITLE
feat(protocol): governance queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,13 @@ This is not an exhaustive list of existing and planned features, but it covers t
         - [X] Pool state
         - [X] Stake snapshots
         - [X] Pool distribution
-        - [ ] Constitution ([CIP-1694](https://cips.cardano.org/cip/CIP-1694))
-        - [ ] Governance state ([CIP-1694](https://cips.cardano.org/cip/CIP-1694))
-        - [ ] DRep state ([CIP-1694](https://cips.cardano.org/cip/CIP-1694))
-        - [ ] DRep stake distribution ([CIP-1694](https://cips.cardano.org/cip/CIP-1694))
-        - [ ] SPO stake distribution ([CIP-1694](https://cips.cardano.org/cip/CIP-1694))
-        - [ ] Committee state ([CIP-1694](https://cips.cardano.org/cip/CIP-1694))
+        - [X] Constitution ([CIP-1694](https://cips.cardano.org/cip/CIP-1694))
+        - [X] Governance state ([CIP-1694](https://cips.cardano.org/cip/CIP-1694))
+        - [X] DRep state ([CIP-1694](https://cips.cardano.org/cip/CIP-1694))
+        - [X] DRep stake distribution ([CIP-1694](https://cips.cardano.org/cip/CIP-1694))
+        - [X] SPO stake distribution ([CIP-1694](https://cips.cardano.org/cip/CIP-1694))
+        - [X] Committee state ([CIP-1694](https://cips.cardano.org/cip/CIP-1694))
+        - [X] Filtered vote delegatees ([CIP-1694](https://cips.cardano.org/cip/CIP-1694))
         - [ ] Treasury ([CIP-1694](https://cips.cardano.org/cip/CIP-1694))
     - [X] LeiosFetch ([CIP-0164](https://cips.cardano.org/cip/CIP-0164))
       - [X] Client support
@@ -170,13 +171,13 @@ This is not an exhaustive list of existing and planned features, but it covers t
   - [X] Plutus script validation (via plutigo)
   - [X] Structured error handling (ValidationError)
   - [ ] Byron era validation
-- [ ] Cryptography
+- [X] Cryptography
   - [X] KES (Key-Evolving Signatures)
     - [X] Signature verification
     - [X] Key generation
     - [X] Key evolution
-  - [ ] VRF (Verifiable Random Function)
-    - [ ] Proof generation
+  - [X] VRF (Verifiable Random Function)
+    - [X] Proof generation
     - [X] Proof verification
     - [X] Leader election input construction
 - [ ] Consensus
@@ -188,7 +189,12 @@ This is not an exhaustive list of existing and planned features, but it covers t
   - [ ] Byron consensus
 - [ ] Testing
   - [X] Test framework for mocking Ouroboros conversations
-  - [X] Conformance tests (314/314 passing)
+  - [X] Conformance tests (420+ passing)
+    - [X] Ledger rules (314 tests via Amaru vectors)
+    - [X] VRF cryptography (58 tests via cardano-crypto-praos vectors)
+    - [X] KES cryptography (14 tests via input-output-hk/kes vectors)
+    - [X] Consensus (22 tests for leader election, threshold)
+    - [X] Byron blocks (6 tests from mainnet/testnet)
   - [ ] CBOR deserialization and serialization
     - [X] Protocol messages
     - [X] Ledger

--- a/protocol/localstatequery/client_test.go
+++ b/protocol/localstatequery/client_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/internal/test"
 	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
@@ -282,6 +284,254 @@ func TestGetUTxOByAddress(t *testing.T) {
 					utxos,
 					expectedResult,
 				)
+			}
+		},
+	)
+}
+
+// Conway governance query tests
+
+// Create a conversation that starts with Conway era (6)
+var conversationConwayEra = append(
+	conversationHandshakeAcquire,
+	ouroboros_mock.ConversationEntryInput{
+		ProtocolId:  localstatequery.ProtocolId,
+		MessageType: localstatequery.MessageTypeQuery,
+	},
+	ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: localstatequery.ProtocolId,
+		IsResponse: true,
+		Messages: []protocol.Message{
+			localstatequery.NewMsgResult([]byte{0x6}), // Conway era = 6
+		},
+	},
+)
+
+func TestGetConstitution(t *testing.T) {
+	// Constitution result: [anchor, script_hash]
+	// anchor: [url, data_hash]
+	expectedResult := localstatequery.ConstitutionResult{
+		Anchor: lcommon.GovAnchor{
+			Url:      "https://constitution.gov.cardano",
+			DataHash: [32]byte{0x1, 0x2, 0x3, 0x4},
+		},
+		ScriptHash: []byte{0xa, 0xb, 0xc},
+	}
+	cborData, err := cbor.Encode(expectedResult)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	conversation := append(
+		conversationConwayEra,
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  localstatequery.ProtocolId,
+			MessageType: localstatequery.MessageTypeQuery,
+		},
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: localstatequery.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				localstatequery.NewMsgResult(cborData),
+			},
+		},
+	)
+	runTest(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			constitution, err := oConn.LocalStateQuery().Client.GetConstitution()
+			if err != nil {
+				t.Fatalf("received unexpected error: %s", err)
+			}
+			if !reflect.DeepEqual(constitution, &expectedResult) {
+				t.Fatalf(
+					"did not receive expected result\n  got:    %#v\n  wanted: %#v",
+					constitution,
+					expectedResult,
+				)
+			}
+		},
+	)
+}
+
+func TestGetConstitutionPreConway(t *testing.T) {
+	// Test that GetConstitution returns an error on pre-Conway eras
+	runTest(
+		t,
+		conversationCurrentEra, // Era 5 (Babbage)
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			_, err := oConn.LocalStateQuery().Client.GetConstitution()
+			if err == nil {
+				t.Fatal("expected error for pre-Conway era, got nil")
+			}
+			expectedErrMsg := "GetConstitution requires Conway era or later"
+			if !strings.Contains(err.Error(), expectedErrMsg) {
+				t.Fatalf(
+					"expected error containing %q, got: %s",
+					expectedErrMsg,
+					err.Error(),
+				)
+			}
+		},
+	)
+}
+
+func TestGetGovState(t *testing.T) {
+	// GovState is complex, test basic decoding with minimal result
+	expectedResult := localstatequery.GovStateResult{
+		Proposals:        cbor.RawMessage([]byte{0x80}), // Empty list
+		Committee:        cbor.RawMessage([]byte{0xf6}), // null
+		Constitution:     localstatequery.ConstitutionResult{
+			Anchor: lcommon.GovAnchor{
+				Url:      "https://constitution.cardano.org",
+				DataHash: [32]byte{0xde, 0xad, 0xbe, 0xef},
+			},
+			ScriptHash: nil,
+		},
+		CurrentPParams:   cbor.RawMessage([]byte{0xa0}), // Empty map
+		PrevPParams:      cbor.RawMessage([]byte{0xa0}),
+		FuturePParams:    cbor.RawMessage([]byte{0xa0}),
+		DRepPulsingState: cbor.RawMessage([]byte{0x80}),
+	}
+	cborData, err := cbor.Encode(expectedResult)
+	if err != nil {
+		t.Fatalf("unexpected error encoding: %s", err)
+	}
+	conversation := append(
+		conversationConwayEra,
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  localstatequery.ProtocolId,
+			MessageType: localstatequery.MessageTypeQuery,
+		},
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: localstatequery.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				localstatequery.NewMsgResult(cborData),
+			},
+		},
+	)
+	runTest(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			govState, err := oConn.LocalStateQuery().Client.GetGovState()
+			if err != nil {
+				t.Fatalf("received unexpected error: %s", err)
+			}
+			// Check constitution anchor was decoded correctly
+			if govState.Constitution.Anchor.Url != expectedResult.Constitution.Anchor.Url {
+				t.Fatalf(
+					"constitution URL mismatch: got %s, wanted %s",
+					govState.Constitution.Anchor.Url,
+					expectedResult.Constitution.Anchor.Url,
+				)
+			}
+		},
+	)
+}
+
+func TestGetGovStatePreConway(t *testing.T) {
+	// Test that GetGovState returns an error on pre-Conway eras
+	runTest(
+		t,
+		conversationCurrentEra, // Era 5 (Babbage)
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			_, err := oConn.LocalStateQuery().Client.GetGovState()
+			if err == nil {
+				t.Fatal("expected error for pre-Conway era, got nil")
+			}
+			expectedErrMsg := "GetGovState requires Conway era or later"
+			if !strings.Contains(err.Error(), expectedErrMsg) {
+				t.Fatalf(
+					"expected error containing %q, got: %s",
+					expectedErrMsg,
+					err.Error(),
+				)
+			}
+		},
+	)
+}
+
+func TestGetCommitteeMembersState(t *testing.T) {
+	// CommitteeMembersState result
+	threshold := &cbor.Rat{Rat: big.NewRat(2, 3)}
+	expectedResult := localstatequery.CommitteeMembersStateResult{
+		Members:   cbor.RawMessage([]byte{0xa0}), // Empty map
+		Threshold: threshold,
+	}
+	cborData, err := cbor.Encode(expectedResult)
+	if err != nil {
+		t.Fatalf("unexpected error encoding: %s", err)
+	}
+	conversation := append(
+		conversationConwayEra,
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  localstatequery.ProtocolId,
+			MessageType: localstatequery.MessageTypeQuery,
+		},
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: localstatequery.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				localstatequery.NewMsgResult(cborData),
+			},
+		},
+	)
+	runTest(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			committeeState, err := oConn.LocalStateQuery().Client.GetCommitteeMembersState(nil, nil, nil)
+			if err != nil {
+				t.Fatalf("received unexpected error: %s", err)
+			}
+			if committeeState.Threshold == nil {
+				t.Fatal("expected threshold, got nil")
+			}
+		},
+	)
+}
+
+func TestGetSPOStakeDistr(t *testing.T) {
+	// SPOStakeDistr maps pool IDs to stake amounts
+	poolId := ledger.PoolId{0x1, 0x2, 0x3}
+	expectedResult := localstatequery.SPOStakeDistrResult{
+		Results: map[ledger.PoolId]uint64{
+			poolId: 1000000000000, // 1M ADA
+		},
+	}
+	cborData, err := cbor.Encode(expectedResult)
+	if err != nil {
+		t.Fatalf("unexpected error encoding: %s", err)
+	}
+	conversation := append(
+		conversationConwayEra,
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  localstatequery.ProtocolId,
+			MessageType: localstatequery.MessageTypeQuery,
+		},
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: localstatequery.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				localstatequery.NewMsgResult(cborData),
+			},
+		},
+	)
+	runTest(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			spoDistr, err := oConn.LocalStateQuery().Client.GetSPOStakeDistr(nil)
+			if err != nil {
+				t.Fatalf("received unexpected error: %s", err)
+			}
+			if len(spoDistr.Results) != 1 {
+				t.Fatalf("expected 1 result, got %d", len(spoDistr.Results))
+			}
+			if stake, ok := spoDistr.Results[poolId]; !ok || stake != 1000000000000 {
+				t.Fatalf("unexpected stake distribution result: %v", spoDistr.Results)
 			}
 		},
 	)

--- a/protocol/localstatequery/queries.go
+++ b/protocol/localstatequery/queries.go
@@ -62,9 +62,19 @@ const (
 	QueryTypeShelleyPoolState                           = 19
 	QueryTypeShelleyStakeSnapshots                      = 20
 	QueryTypeShelleyPoolDistr                           = 21
+
+	// Conway governance queries (v8+)
+	QueryTypeShelleyConstitution           = 23
+	QueryTypeShelleyGovState               = 24
+	QueryTypeShelleyDRepState              = 25
+	QueryTypeShelleyDRepStakeDistr         = 26
+	QueryTypeShelleyCommitteeMembersState  = 27
+	QueryTypeShelleyFilteredVoteDelegatees = 28
+	QueryTypeShelleySPOStakeDistr          = 30
 )
 
-// simpleQueryBase is a helper type used for various query types to reduce repeat code
+// simpleQueryBase is a helper type used for various query types
+// to reduce repeat code
 type simpleQueryBase struct {
 	cbor.StructAsArray
 	Type int
@@ -196,6 +206,14 @@ func (q *ShelleyQuery) UnmarshalCBOR(data []byte) error {
 			QueryTypeShelleyPoolState:                           &ShelleyPoolStateQuery{},
 			QueryTypeShelleyStakeSnapshots:                      &ShelleyStakeSnapshotsQuery{},
 			QueryTypeShelleyPoolDistr:                           &ShelleyPoolDistrQuery{},
+			// Conway governance queries
+			QueryTypeShelleyConstitution:           &ShelleyConstitutionQuery{},
+			QueryTypeShelleyGovState:               &ShelleyGovStateQuery{},
+			QueryTypeShelleyDRepState:              &ShelleyDRepStateQuery{},
+			QueryTypeShelleyDRepStakeDistr:         &ShelleyDRepStakeDistrQuery{},
+			QueryTypeShelleyCommitteeMembersState:  &ShelleyCommitteeMembersStateQuery{},
+			QueryTypeShelleyFilteredVoteDelegatees: &ShelleyFilteredVoteDelegateesQuery{},
+			QueryTypeShelleySPOStakeDistr:          &ShelleySPOStakeDistrQuery{},
 		},
 	)
 	if err != nil {
@@ -504,10 +522,10 @@ type eraHistoryResultParams struct {
 }
 
 // TODO (#860)
-/*
-result	[{ *[0 int] => non_myopic_rewards }]	for each stake display reward
-non_myopic_rewards	{ *poolid => int }	int is the amount of lovelaces each pool would reward
-*/
+// result: [{ *[0 int] => non_myopic_rewards }] for each stake display reward
+// non_myopic_rewards: { *poolid => int }
+//
+//	int is the amount of lovelaces each pool would reward
 type NonMyopicMemberRewardsResult any
 
 type CurrentProtocolParamsResult interface {
@@ -597,14 +615,14 @@ func (u *UtxoId) MarshalCBOR() ([]byte, error) {
 type DebugEpochStateResult any
 
 // TODO (#858)
-/*
-rwdr	[flag bytestring]	bytestring is the keyhash of the staking vkey
-flag	0/1	0=keyhash 1=scripthash
-result	[[ delegation rewards] ]
-delegation	{ * rwdr => poolid }	poolid is a bytestring
-rewards	{ * rwdr => int }
-It seems to be a requirement to sort the reward addresses on the query. Scripthash addresses come first, then within a group the bytestring being a network order integer sort ascending.
-*/
+// rwdr: [flag bytestring] bytestring is the keyhash of the staking vkey
+// flag: 0/1 (0=keyhash 1=scripthash)
+// result: [[ delegation rewards] ]
+// delegation: { * rwdr => poolid } poolid is a bytestring
+// rewards: { * rwdr => int }
+// Note: It seems to be a requirement to sort the reward addresses on the
+// query. Scripthash addresses come first, then within a group the bytestring
+// being a network order integer sort ascending.
 type FilteredDelegationsAndRewardAccountsResult any
 
 type GenesisConfigResult struct {
@@ -711,7 +729,8 @@ type StakePoolParamsResult struct {
 // TODO (#867)
 type RewardInfoPoolsResult any
 
-// PoolStateParams represents the pool registration parameters without the cert type
+// PoolStateParams represents the pool registration parameters
+// without the cert type
 type PoolStateParams struct {
 	cbor.StructAsArray
 	Operator      ledger.Blake2b224
@@ -734,13 +753,15 @@ type PoolStateParams struct {
 // where pstate maps pool IDs to their registration parameters
 type PoolStateResult struct {
 	cbor.StructAsArray
-	PState   map[ledger.Blake2b224]*PoolStateParams
-	FState   map[ledger.Blake2b224]*PoolStateParams // Future pool parameters
-	Retiring map[ledger.Blake2b224]uint64           // Pools scheduled to retire (epoch number)
-	Deposits map[ledger.Blake2b224]uint64           // Pool deposits
+	PState map[ledger.Blake2b224]*PoolStateParams
+	FState map[ledger.Blake2b224]*PoolStateParams // Future pool parameters
+	// Retiring contains pools scheduled to retire (epoch number)
+	Retiring map[ledger.Blake2b224]uint64
+	Deposits map[ledger.Blake2b224]uint64 // Pool deposits
 }
 
-// PoolStakeSnapshot represents the stake distribution for a pool across different snapshots
+// PoolStakeSnapshot represents the stake distribution for a pool
+// across different snapshots
 type PoolStakeSnapshot struct {
 	cbor.StructAsArray
 	StakeMark uint64 // Stake snapshot from mark
@@ -748,9 +769,11 @@ type PoolStakeSnapshot struct {
 	StakeGo   uint64 // Stake snapshot from go
 }
 
-// StakeSnapshotsResult represents the stake snapshots result
-// The result is a 4-element array: [snapshots, total_stake_mark, total_stake_set, total_stake_go]
-// where snapshots maps pool IDs to their stake distribution across mark/set/go snapshots
+// StakeSnapshotsResult represents the stake snapshots result.
+// The result is a 4-element array:
+// [snapshots, total_stake_mark, total_stake_set, total_stake_go]
+// where snapshots maps pool IDs to their stake distribution
+// across mark/set/go snapshots
 type StakeSnapshotsResult struct {
 	cbor.StructAsArray
 	PoolSnapshots  map[ledger.Blake2b224]*PoolStakeSnapshot
@@ -759,8 +782,9 @@ type StakeSnapshotsResult struct {
 	TotalStakeGo   uint64
 }
 
-// PoolDistrResult represents the pool distribution result
-// It contains a map of pool IDs to their stake distribution (fraction and VRF hash)
+// PoolDistrResult represents the pool distribution result.
+// It contains a map of pool IDs to their stake distribution
+// (fraction and VRF hash)
 type PoolDistrResult struct {
 	cbor.StructAsArray
 	Results map[ledger.PoolId]struct {
@@ -768,4 +792,120 @@ type PoolDistrResult struct {
 		StakeFraction *cbor.Rat
 		VrfHash       ledger.Blake2b256
 	}
+}
+
+// Conway governance query types
+
+type ShelleyConstitutionQuery struct {
+	simpleQueryBase
+}
+
+type ShelleyGovStateQuery struct {
+	simpleQueryBase
+}
+
+type ShelleyDRepStateQuery struct {
+	cbor.StructAsArray
+	Type        int
+	Credentials cbor.SetType[lcommon.Credential]
+}
+
+type ShelleyDRepStakeDistrQuery struct {
+	cbor.StructAsArray
+	Type  int
+	DReps cbor.SetType[lcommon.Drep]
+}
+
+type ShelleyCommitteeMembersStateQuery struct {
+	cbor.StructAsArray
+	Type         int
+	ColdCreds    cbor.SetType[lcommon.Credential]
+	HotCreds     cbor.SetType[lcommon.Credential]
+	MemberStatus cbor.SetType[int]
+}
+
+type ShelleyFilteredVoteDelegateesQuery struct {
+	cbor.StructAsArray
+	Type        int
+	Credentials cbor.SetType[lcommon.Credential]
+}
+
+type ShelleySPOStakeDistrQuery struct {
+	cbor.StructAsArray
+	Type    int
+	PoolIds cbor.SetType[ledger.PoolId]
+}
+
+// Conway governance result types
+
+// ConstitutionResult represents the constitution query result.
+// The constitution contains an anchor (URL and hash) and an optional
+// guardrails script hash
+type ConstitutionResult struct {
+	cbor.StructAsArray
+	Anchor     lcommon.GovAnchor
+	ScriptHash []byte // Optional guardrails script hash (nil if no guardrails)
+}
+
+// GovStateResult represents the full governance state.
+// This includes proposals, committee, constitution, protocol parameters,
+// and DRep pulsing state.
+// The raw messages can be further decoded based on the era
+type GovStateResult struct {
+	cbor.StructAsArray
+	Proposals        cbor.RawMessage // Complex nested structure
+	Committee        cbor.RawMessage // StrictMaybe Committee
+	Constitution     ConstitutionResult
+	CurrentPParams   cbor.RawMessage // Era-specific protocol parameters
+	PrevPParams      cbor.RawMessage // Previous era protocol parameters
+	FuturePParams    cbor.RawMessage // Scheduled parameter changes
+	DRepPulsingState cbor.RawMessage // DRep pulsing state
+}
+
+// DRepStateEntry represents the state of a single DRep
+type DRepStateEntry struct {
+	cbor.StructAsArray
+	Expiry  uint64             // Epoch when DRep expires
+	Anchor  *lcommon.GovAnchor // Optional metadata anchor
+	Deposit uint64             // Deposit amount
+}
+
+// DRepStateResult represents the DRep state query result.
+// The result is raw CBOR that maps credentials to DRep state.
+// Consumers must decode the CBOR themselves based on the expected format.
+type DRepStateResult cbor.RawMessage
+
+// DRepStakeDistrResult represents the DRep stake distribution
+// The result is returned as raw CBOR that maps DReps to stake amounts
+type DRepStakeDistrResult cbor.RawMessage
+
+// CommitteeMemberState represents the state of a committee member
+type CommitteeMemberState struct {
+	cbor.StructAsArray
+	// Status: 0=Unrecognized, 1=Active, 2=Expired, 3=Resigned
+	Status        int
+	HotCredential *lcommon.Credential // Hot credential if authorized
+	Expiry        uint64              // Term expiry epoch
+	NextEpoch     *uint64             // Next epoch for cold key rotation
+}
+
+// CommitteeMembersStateResult represents the committee members state
+// query result. Contains the committee members and voting threshold
+// as raw CBOR
+type CommitteeMembersStateResult struct {
+	cbor.StructAsArray
+	Members   cbor.RawMessage // Map of cold credentials to member state
+	Threshold *cbor.Rat       // Voting threshold
+}
+
+// FilteredVoteDelegateesResult represents the vote delegatees
+// for stake credentials.
+// The result is raw CBOR that maps credentials to DRep delegations
+type FilteredVoteDelegateesResult cbor.RawMessage
+
+// SPOStakeDistrResult represents the SPO stake distribution for governance
+// Maps pool IDs to their governance voting power
+type SPOStakeDistrResult struct {
+	cbor.StructAsArray
+	Results map[ledger.PoolId]uint64
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Conway-era governance queries to the Local State Query client (CIP-1694). Enables fetching constitution, full governance state, DRep/committee state, vote delegatees, and SPO/DRep stake distributions.

- **New Features**
  - Client methods: GetConstitution, GetGovState, GetDRepState, GetDRepStakeDistr, GetCommitteeMembersState, GetFilteredVoteDelegatees, GetSPOStakeDistr (Conway-only; returns errors pre-Conway).
  - Added query types and result models with CBOR set filters and raw CBOR fields for era-specific decoding.
  - Tests for governance queries and README updates marking CIP-1694 features complete; test counts updated to 420+.

<sup>Written for commit 28b537988162e4dd3013be834a0e4933fb17af14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Governance query support added: Constitution, Governance state, DRep state, DRep stake distribution, SPO stake distribution, Committee state, and Filtered vote delegatees; queries accept optional filters (credentials, DReps, pool IDs, member/status).

* **Documentation**
  * README updated: several CIP feature statuses marked complete; VRF cryptography marked complete.

* **Tests**
  * Conformance suite updated to 420+ passing tests; new Conway-era governance tests added.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->