### PR TITLE
feat: provide cost models for Plutus script evaluation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.1
 require (
 	filippo.io/edwards25519 v1.1.0
 	github.com/blinklabs-io/ouroboros-mock v0.4.0
-	github.com/blinklabs-io/plutigo v0.0.18
+	github.com/blinklabs-io/plutigo v0.0.20
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/fxamacker/cbor/v2 v2.9.0
 	github.com/jinzhu/copier v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/bits-and-blooms/bitset v1.20.0 h1:2F+rfL86jE2d/bmw7OhqUg2Sj/1rURkBn3M
 github.com/bits-and-blooms/bitset v1.20.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blinklabs-io/ouroboros-mock v0.4.0 h1:ppOcTMnC/2f5rYYSlvNqcGfAQOIpMCSDUrNh9K6a4mY=
 github.com/blinklabs-io/ouroboros-mock v0.4.0/go.mod h1:e+Kck8bmdOuaN7IfkbVvbqAVlskXNXB95oHI3YlFG5g=
-github.com/blinklabs-io/plutigo v0.0.18 h1:axw0QVrdiqEjt+ssKs5zY2ycogZ+j5r0IETHkAda+8Q=
-github.com/blinklabs-io/plutigo v0.0.18/go.mod h1:L72ik2SFGruMCxqI5nnuMMz0TwSu9Fk+MekKynr3SPQ=
+github.com/blinklabs-io/plutigo v0.0.20 h1:WLHwEOCdquQgcfjVrWpgxjLQ7GG2vXFAq6/LWtsXutg=
+github.com/blinklabs-io/plutigo v0.0.20/go.mod h1:JwWJQOXVc3Bbb5ot05MUZOACysxTU8TsyDZ9IAJgKeA=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=

--- a/ledger/common/script.go
+++ b/ledger/common/script.go
@@ -161,6 +161,7 @@ func (s PlutusV1Script) Evaluate(
 	redeemer data.PlutusData,
 	scriptContext data.PlutusData,
 	budget ExUnits,
+	costModel cek.CostModel,
 ) (ExUnits, error) {
 	var usedExUnits ExUnits
 	var err error
@@ -200,8 +201,8 @@ func (s PlutusV1Script) Evaluate(
 		},
 		Argument: contextTerm,
 	}
-	// Execute wrapped program (1.0.0 is Plutus V1)
-	machine := cek.NewMachine[syn.DeBruijn]([3]uint32{1, 0, 0}, 200)
+	// Execute wrapped program
+	machine := cek.NewMachine[syn.DeBruijn](cek.LanguageVersionV1, 200, costModel)
 	machine.ExBudget = machineBudget
 	_, err = machine.Run(wrappedProgram)
 	if err != nil {
@@ -237,6 +238,7 @@ func (s PlutusV2Script) Evaluate(
 	redeemer data.PlutusData,
 	scriptContext data.PlutusData,
 	budget ExUnits,
+	costModel cek.CostModel,
 ) (ExUnits, error) {
 	var usedExUnits ExUnits
 	var err error
@@ -276,8 +278,8 @@ func (s PlutusV2Script) Evaluate(
 		},
 		Argument: contextTerm,
 	}
-	// Execute wrapped program (1.1.0 is Plutus V2)
-	machine := cek.NewMachine[syn.DeBruijn]([3]uint32{1, 1, 0}, 200)
+	// Execute wrapped program
+	machine := cek.NewMachine[syn.DeBruijn](cek.LanguageVersionV2, 200, costModel)
 	machine.ExBudget = machineBudget
 	_, err = machine.Run(wrappedProgram)
 	if err != nil {
@@ -309,6 +311,7 @@ func (s PlutusV3Script) RawScriptBytes() []byte {
 func (s PlutusV3Script) Evaluate(
 	scriptContext data.PlutusData,
 	budget ExUnits,
+	costModel cek.CostModel,
 ) (ExUnits, error) {
 	var usedExUnits ExUnits
 	var err error
@@ -341,8 +344,8 @@ func (s PlutusV3Script) Evaluate(
 		Function: program.Term,
 		Argument: contextTerm,
 	}
-	// Execute wrapped program (1.2.0 is Plutus V3)
-	machine := cek.NewMachine[syn.DeBruijn]([3]uint32{1, 2, 0}, 200)
+	// Execute wrapped program
+	machine := cek.NewMachine[syn.DeBruijn](cek.LanguageVersionV3, 200, costModel)
 	machine.ExBudget = machineBudget
 	_, err = machine.Run(wrappedProgram)
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Provide cost models to Plutus script evaluation so execution uses ledger-defined pricing. This makes ex-unit budgeting accurate for Plutus V1/V2/V3 under Conway.

- **New Features**
  - Evaluation methods now accept a cost model and pass it to the CEK machine for V1/V2/V3.
  - Build CEK cost models from Conway protocol parameters per language version, with clear errors on invalid/missing models.

- **Dependencies**
  - Upgrade plutigo to v0.0.20 to use the cost model API.

<sup>Written for commit 0e41f70c0c5a2774aa3c17ccc111a666a0df2f7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Plutus script execution with improved cost calculation accuracy across all protocol versions.
  * Improved Conway era protocol validation with stricter parameter verification.

* **Chores**
  * Updated external dependencies to latest stable versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->