### PR TITLE
fix(protocol): blockfetch/txsubmission use chainsync logic

### DIFF
--- a/protocol/txsubmission/client_test.go
+++ b/protocol/txsubmission/client_test.go
@@ -1,0 +1,123 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package txsubmission_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/protocol/txsubmission"
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+	"go.uber.org/goleak"
+)
+
+type testInnerFunc func(*testing.T, *ouroboros.Connection)
+
+func runTest(
+	t *testing.T,
+	conversation []ouroboros_mock.ConversationEntry,
+	innerFunc testInnerFunc,
+	options ...ouroboros.ConnectionOptionFunc,
+) {
+	defer goleak.VerifyNone(t)
+	mockConn := ouroboros_mock.NewConnection(
+		ouroboros_mock.ProtocolRoleClient,
+		conversation,
+	)
+	// Async mock connection error handler
+	asyncErrChan := make(chan error, 1)
+	go func() {
+		err := <-mockConn.(*ouroboros_mock.Connection).ErrorChan()
+		if err != nil {
+			asyncErrChan <- fmt.Errorf("received unexpected error: %w", err)
+		}
+		close(asyncErrChan)
+	}()
+	// Build options list
+	opts := []ouroboros.ConnectionOptionFunc{
+		ouroboros.WithConnection(mockConn),
+		ouroboros.WithNetworkMagic(ouroboros_mock.MockNetworkMagic),
+		ouroboros.WithNodeToNode(true),
+	}
+	opts = append(opts, options...)
+
+	oConn, err := ouroboros.New(opts...)
+	if err != nil {
+		t.Fatalf("unexpected error when creating Ouroboros object: %s", err)
+	}
+	// Async error handler
+	go func() {
+		err, ok := <-oConn.ErrorChan()
+		if !ok {
+			return
+		}
+		// We can't call t.Fatalf() from a different Goroutine, so we panic instead
+		panic(fmt.Sprintf("unexpected Ouroboros error: %s", err))
+	}()
+	// Run test inner function
+	innerFunc(t, oConn)
+	// Wait for mock connection shutdown
+	select {
+	case err, ok := <-asyncErrChan:
+		if ok {
+			t.Fatal(err.Error())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("did not complete within timeout")
+	}
+	// Close Ouroboros connection
+	if err := oConn.Close(); err != nil {
+		t.Fatalf("unexpected error when closing Ouroboros object: %s", err)
+	}
+	// Wait for connection shutdown
+	select {
+	case <-oConn.ErrorChan():
+	case <-time.After(10 * time.Second):
+		t.Errorf("did not shutdown within timeout")
+	}
+}
+
+func TestClientStartStopStart(t *testing.T) {
+	// TxSubmission protocol can only send Done from TxIdsBlocking state,
+	// so Stop() won't send a message when called from Init or Idle state.
+	// This test verifies lifecycle works without sending Done.
+	conversation := []ouroboros_mock.ConversationEntry{
+		ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+		ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+	}
+	runTest(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			client := oConn.TxSubmission().Client
+			// Start should be idempotent
+			client.Start()
+			client.Start()
+			// Stop should work (no Done message sent since not in TxIdsBlocking state)
+			if err := client.Stop(); err != nil {
+				t.Fatalf("unexpected error when stopping client: %s", err)
+			}
+			// Start again after stop should work (#597)
+			client.Start()
+		},
+		ouroboros.WithTxSubmissionConfig(
+			txsubmission.NewConfig(),
+		),
+		// Ensure we control protocol startup in the test.
+		ouroboros.WithDelayProtocolStart(true),
+	)
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align BlockFetch and TxSubmission client lifecycles with ChainSync-style logic to fix restart issues. Start/Stop are now idempotent, and clients can be safely restarted without races or leaks.

- **Bug Fixes**
  - Added lifecycle states (new/starting/running/stopped) with locking, making Start idempotent and waiting for in-flight starts.
  - Reinitialize protocol and channels on restart and wait for previous instances to fully stop.
  - BlockFetch Stop now sends ClientDone, drains the send queue, and closes channels, with a guarded busy lock.
  - TxSubmission Stop does not send Done (per spec), tracks Init so it can be resent after restart, and includes tests validating Start → Stop → Start behavior.

<sup>Written for commit a9b888253e480e69209a1201900be03cedabd96d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved client lifecycle management with state-driven startup and shutdown logic.
  * Added ability to safely restart clients after stopping.
  * Enhanced concurrent-safety for start and stop operations.

* **Tests**
  * Added comprehensive lifecycle integration tests validating start/stop/restart scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->