### PR TITLE
fix(cbor): protect rat against index out of bounds

### DIFF
--- a/cbor/tags.go
+++ b/cbor/tags.go
@@ -100,6 +100,9 @@ func (r *Rat) UnmarshalCBOR(cborData []byte) error {
 	if _, err := Decode(cborData, &tmpRat); err != nil {
 		return err
 	}
+	if len(tmpRat) != 2 {
+		return fmt.Errorf("invalid cbor.Rat: expected exactly 2 elements [numerator, denominator], got %d elements", len(tmpRat))
+	}
 	// Convert numerator to big.Int
 	tmpNum := new(big.Int)
 	switch v := tmpRat[0].(type) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add bounds check to cbor.Rat UnmarshalCBOR to prevent index out of range on malformed input. Returns a clear error when the decoded array does not have exactly two elements (expected [numerator, denominator]).

<sup>Written for commit 9643273488bc6bc95c8b5153639ff8855d5d07ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation during CBOR deserialization to ensure a numeric rational is represented as exactly two elements (numerator, denominator); malformed tuples now produce a clear error instead of proceeding with invalid data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->