### PR TITLE
fix(ledger): bootstrap witnesses

### DIFF
--- a/ledger/allegra/rules.go
+++ b/ledger/allegra/rules.go
@@ -234,6 +234,11 @@ func UtxoValidateNativeScripts(
 		keyHash := common.Blake2b224Hash(vkw.Vkey)
 		keyHashes[keyHash] = true
 	}
+	// Also collect key hashes from bootstrap witnesses (Byron-era)
+	for _, bw := range witnesses.Bootstrap() {
+		keyHash := common.Blake2b224Hash(bw.PublicKey)
+		keyHashes[keyHash] = true
+	}
 
 	// Get transaction validity interval
 	validityStart := tx.ValidityIntervalStart()

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -940,13 +940,23 @@ func UtxoValidateDelegation(
 	return shelley.UtxoValidateDelegation(tx, slot, ls, pp)
 }
 
-// UtxoValidateDisjointRefInputs ensures reference inputs don't overlap with regular inputs
+// UtxoValidateDisjointRefInputs ensures reference inputs don't overlap with regular inputs.
+// This rule only applies after Babbage era (protocol version > 8).
 func UtxoValidateDisjointRefInputs(
 	tx common.Transaction,
 	slot uint64,
 	ls common.LedgerState,
 	pp common.ProtocolParameters,
 ) error {
+	// This rule only applies after Babbage era (protocol version > 8)
+	// If the parameters are BabbageProtocolParameters and version <= 8, skip validation
+	if tmpPparams, ok := pp.(*BabbageProtocolParameters); ok {
+		if tmpPparams.ProtocolMajor <= 8 {
+			return nil
+		}
+	}
+	// For ConwayProtocolParameters or newer eras, always enforce the rule
+
 	// Build a set of regular input strings for O(1) lookup
 	inputSet := make(map[string]common.TransactionInput)
 	for _, input := range tx.Inputs() {

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -2025,6 +2025,11 @@ func UtxoValidateNativeScripts(
 		keyHash := common.Blake2b224Hash(vkw.Vkey)
 		keyHashes[keyHash] = true
 	}
+	// Also collect key hashes from bootstrap witnesses (Byron-era)
+	for _, bw := range witnesses.Bootstrap() {
+		keyHash := common.Blake2b224Hash(bw.PublicKey)
+		keyHashes[keyHash] = true
+	}
 
 	// Get transaction validity interval
 	validityStart := tx.ValidityIntervalStart()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Include bootstrap witnesses in native script validation and gate the disjoint ref inputs rule to post-Babbage versions. Fixes Byron-era script checks and avoids false validation errors on v8 and earlier.

- **Bug Fixes**
  - Allegra/Conway: add bootstrap witness public keys to the key-hash set in UtxoValidateNativeScripts.
  - Babbage: run UtxoValidateDisjointRefInputs only when ProtocolMajor > 8; skip for v8 and earlier (enforced in Conway and newer).

<sup>Written for commit f30fb5ce59029e474aee0d480d8a8c13e4090946. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved native script validation to properly recognize and include Byron-era bootstrap witness types across ledger eras
  * Refined era-specific validation rules to ensure reference input constraints are enforced correctly based on protocol version

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->