### PR TITLE
fix(cbor): type check before slice

### DIFF
--- a/cbor/decode.go
+++ b/cbor/decode.go
@@ -66,8 +66,17 @@ func DecodeIdFromList(cborData []byte) (int, error) {
 	if _, err := Decode(cborData, &tmp); err != nil {
 		return 0, err
 	}
-	// Make sure that the value is actually numeric
-	switch v := tmp.Value().([]any)[0].(type) {
+	// Make sure that the value is actually a slice
+	val := tmp.Value()
+	list, ok := val.([]any)
+	if !ok {
+		return 0, fmt.Errorf("decoded value was not a list, found: %T", val)
+	}
+	if len(list) == 0 {
+		return 0, errors.New("cannot return first item from empty list")
+	}
+	// Make sure that the first item is actually numeric
+	switch v := list[0].(type) {
 	// The upstream CBOR library uses uint64 by default for numeric values
 	case uint64:
 		if v > uint64(math.MaxInt) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add type checks in DecodeIdFromList to ensure the decoded value is a list and non-empty before reading the first item. This prevents panics on non-list or empty inputs and returns clear, descriptive errors.

<sup>Written for commit facf1e750c63926338266bde7842e1fd8debf4f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation in the CBOR decode function with improved error messages for invalid input scenarios, including non-list types and empty lists, resulting in better error diagnostics when decoding fails.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->