### PR TITLE
fix(ledger): validate address data length before access

### DIFF
--- a/ledger/common/address.go
+++ b/ledger/common/address.go
@@ -189,6 +189,9 @@ func NewByronAddressRedeem(
 }
 
 func (a *Address) populateFromBytes(data []byte) error {
+	if len(data) == 0 {
+		return errors.New("invalid address data: empty byte slice")
+	}
 	// Extract header info
 	header := data[0]
 	a.addressType = (header & AddressHeaderTypeMask) >> 4


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Validate address byte slice before reading the header in Address.populateFromBytes. Prevents panics on empty input and returns a clear error instead.

<sup>Written for commit b93c889ece376e79a8ae5cee4f22c74c40a71ce2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

