### PR TITLE
fix(cbor): guard divide by zero denominator

### DIFF
--- a/cbor/tags.go
+++ b/cbor/tags.go
@@ -101,7 +101,10 @@ func (r *Rat) UnmarshalCBOR(cborData []byte) error {
 		return err
 	}
 	if len(tmpRat) != 2 {
-		return fmt.Errorf("invalid cbor.Rat: expected exactly 2 elements [numerator, denominator], got %d elements", len(tmpRat))
+		return fmt.Errorf(
+			"invalid cbor.Rat: expected exactly 2 elements [numerator, denominator], got %d elements",
+			len(tmpRat),
+		)
 	}
 	// Convert numerator to big.Int
 	tmpNum := new(big.Int)
@@ -122,6 +125,10 @@ func (r *Rat) UnmarshalCBOR(cborData []byte) error {
 		tmpDenom.SetUint64(v)
 	default:
 		return fmt.Errorf("unsupported denominator type for cbor.Rat: %T", v)
+	}
+	// Check for zero denominator
+	if tmpDenom.Sign() == 0 {
+		return errors.New("invalid cbor.Rat: denominator cannot be zero")
 	}
 	// Create new big.Rat with num/denom set to big.Int values above
 	r.Rat = new(big.Rat)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a zero-denominator guard in cbor.Rat UnmarshalCBOR to prevent divide-by-zero during CBOR decoding. Returns a clear error when the denominator is zero.

- **Bug Fixes**
  - Validate denominator != 0 before creating big.Rat and return "invalid cbor.Rat: denominator cannot be zero".

<sup>Written for commit d09701052f9d4497563afe07deec35da792aa63f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for rational number processing to detect and properly reject invalid values with improved error feedback.

* **Style**
  * Minor formatting adjustments to error messages for better consistency and readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->