### PR TITLE
test: connection options and cbor generic funcs

### DIFF
--- a/connection_test.go
+++ b/connection_test.go
@@ -16,11 +16,22 @@ package ouroboros_test
 
 import (
 	"fmt"
+	"log/slog"
 	"testing"
 	"time"
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/protocol/blockfetch"
+	"github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	"github.com/blinklabs-io/gouroboros/protocol/keepalive"
+	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+	"github.com/blinklabs-io/gouroboros/protocol/localtxmonitor"
+	"github.com/blinklabs-io/gouroboros/protocol/localtxsubmission"
+	"github.com/blinklabs-io/gouroboros/protocol/peersharing"
+	"github.com/blinklabs-io/gouroboros/protocol/txsubmission"
 	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
 
@@ -81,4 +92,205 @@ func TestDoubleClose(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Errorf("did not shutdown within timeout")
 	}
+}
+
+func TestConnectionOptions(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	testCases := []struct {
+		name   string
+		option ouroboros.ConnectionOptionFunc
+	}{
+		{"WithNetworkMagic", ouroboros.WithNetworkMagic(12345)},
+		{"WithServer", ouroboros.WithServer(true)},
+		{"WithNodeToNode", ouroboros.WithNodeToNode(true)},
+		{"WithKeepAlive", ouroboros.WithKeepAlive(true)},
+		{"WithDelayMuxerStart", ouroboros.WithDelayMuxerStart(true)},
+		{"WithDelayProtocolStart", ouroboros.WithDelayProtocolStart(true)},
+		{"WithFullDuplex", ouroboros.WithFullDuplex(true)},
+		{"WithPeerSharing", ouroboros.WithPeerSharing(true)},
+		{"WithLogger", ouroboros.WithLogger(slog.Default())},
+		{"WithErrorChan", ouroboros.WithErrorChan(make(chan error, 10))},
+		{"WithNetwork", ouroboros.WithNetwork(ouroboros.NetworkMainnet)},
+		{"WithBlockFetchConfig", ouroboros.WithBlockFetchConfig(blockfetch.Config{})},
+		{"WithChainSyncConfig", ouroboros.WithChainSyncConfig(chainsync.Config{})},
+		{"WithKeepAliveConfig", ouroboros.WithKeepAliveConfig(keepalive.Config{})},
+		{"WithLocalStateQueryConfig", ouroboros.WithLocalStateQueryConfig(localstatequery.Config{})},
+		{"WithLocalTxMonitorConfig", ouroboros.WithLocalTxMonitorConfig(localtxmonitor.Config{})},
+		{"WithLocalTxSubmissionConfig", ouroboros.WithLocalTxSubmissionConfig(localtxsubmission.Config{})},
+		{"WithPeerSharingConfig", ouroboros.WithPeerSharingConfig(peersharing.Config{})},
+		{"WithTxSubmissionConfig", ouroboros.WithTxSubmissionConfig(txsubmission.Config{})},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn, err := ouroboros.New(tc.option)
+			require.NoError(t, err)
+			require.NotNil(t, conn)
+		})
+	}
+}
+
+func TestConnectionOptionCombinations(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	// Test applying multiple options in sequence
+	options := []ouroboros.ConnectionOptionFunc{
+		ouroboros.WithNetworkMagic(12345),
+		ouroboros.WithServer(false),
+		ouroboros.WithNodeToNode(true),
+		ouroboros.WithKeepAlive(true),
+		ouroboros.WithDelayMuxerStart(false),
+		ouroboros.WithFullDuplex(true),
+		ouroboros.WithPeerSharing(true),
+		ouroboros.WithLogger(slog.Default()),
+	}
+
+	conn, err := ouroboros.New(options...)
+	require.NoError(t, err, "should create connection with multiple options")
+	require.NotNil(t, conn, "connection should not be nil")
+}
+
+func TestConnectionErrorChan(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	// Test with provided error channel
+	customErrChan := make(chan error, 10)
+	conn, err := ouroboros.New(ouroboros.WithErrorChan(customErrChan))
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	// ErrorChan should return the provided channel
+	errChan := conn.ErrorChan()
+	assert.NotNil(t, errChan, "ErrorChan should not be nil")
+}
+
+func TestConnectionErrorChanDefault(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	// Test without providing error channel - should create default
+	conn, err := ouroboros.New()
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	errChan := conn.ErrorChan()
+	assert.NotNil(t, errChan, "ErrorChan should not be nil even without explicit config")
+}
+
+func TestConnectionMuxerBeforeSetup(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	// Connection without actual network connection should have nil muxer
+	conn, err := ouroboros.New()
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	muxer := conn.Muxer()
+	assert.Nil(t, muxer, "Muxer should be nil before connection setup")
+}
+
+func TestConnectionIdBeforeSetup(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	// Connection without actual network connection should have zero ID
+	conn, err := ouroboros.New()
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	id := conn.Id()
+	assert.Nil(t, id.LocalAddr, "LocalAddr should be nil before connection setup")
+	assert.Nil(t, id.RemoteAddr, "RemoteAddr should be nil before connection setup")
+}
+
+func TestConnectionProtocolGettersBeforeSetup(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	// Protocol getters should return nil before connection setup
+	conn, err := ouroboros.New()
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	assert.Nil(t, conn.BlockFetch(), "BlockFetch should be nil before setup")
+	assert.Nil(t, conn.ChainSync(), "ChainSync should be nil before setup")
+	assert.Nil(t, conn.Handshake(), "Handshake should be nil before setup")
+	assert.Nil(t, conn.KeepAlive(), "KeepAlive should be nil before setup")
+	assert.Nil(t, conn.LeiosFetch(), "LeiosFetch should be nil before setup")
+	assert.Nil(t, conn.LeiosNotify(), "LeiosNotify should be nil before setup")
+	assert.Nil(t, conn.LocalStateQuery(), "LocalStateQuery should be nil before setup")
+	assert.Nil(t, conn.LocalTxMonitor(), "LocalTxMonitor should be nil before setup")
+	assert.Nil(t, conn.LocalTxSubmission(), "LocalTxSubmission should be nil before setup")
+	assert.Nil(t, conn.PeerSharing(), "PeerSharing should be nil before setup")
+	assert.Nil(t, conn.TxSubmission(), "TxSubmission should be nil before setup")
+}
+
+func TestConnectionProtocolGettersAfterSetup(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	mockConn := ouroboros_mock.NewConnection(
+		ouroboros_mock.ProtocolRoleClient,
+		[]ouroboros_mock.ConversationEntry{
+			ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+			ouroboros_mock.ConversationEntryHandshakeNtCResponse,
+		},
+	)
+	conn, err := ouroboros.New(
+		ouroboros.WithConnection(mockConn),
+		ouroboros.WithNetworkMagic(ouroboros_mock.MockNetworkMagic),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	go func() {
+		for range conn.ErrorChan() {
+			// drain errors
+		}
+	}()
+
+	// NtC protocols should be initialized after handshake
+	assert.NotNil(t, conn.ChainSync())
+	assert.NotNil(t, conn.Handshake())
+	assert.NotNil(t, conn.LocalTxSubmission())
+
+	// NtN protocols should be nil in NtC mode
+	assert.Nil(t, conn.BlockFetch())
+	assert.Nil(t, conn.TxSubmission())
+
+	// Muxer and ID should be valid after setup
+	assert.NotNil(t, conn.Muxer())
+	id := conn.Id()
+	assert.NotNil(t, id.LocalAddr)
+	assert.NotNil(t, id.RemoteAddr)
+
+	err = conn.Close()
+	assert.NoError(t, err)
+}
+
+func TestConnectionProtocolVersion(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	mockConn := ouroboros_mock.NewConnection(
+		ouroboros_mock.ProtocolRoleClient,
+		[]ouroboros_mock.ConversationEntry{
+			ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+			ouroboros_mock.ConversationEntryHandshakeNtCResponse,
+		},
+	)
+	conn, err := ouroboros.New(
+		ouroboros.WithConnection(mockConn),
+		ouroboros.WithNetworkMagic(ouroboros_mock.MockNetworkMagic),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	go func() {
+		for range conn.ErrorChan() {
+			// drain errors
+		}
+	}()
+
+	version, _ := conn.ProtocolVersion()
+	assert.NotZero(t, version, "Protocol version should be non-zero after handshake")
+
+	err = conn.Close()
+	assert.NoError(t, err)
 }

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -1158,6 +1158,11 @@ func UtxoValidateScriptDataHash(
 	computedHash := common.Blake2b256Hash(hashInput)
 
 	// Compare with declared hash
+	// Note: declaredHash is guaranteed non-nil here due to earlier checks,
+	// but we add an explicit check to satisfy static analysis
+	if declaredHash == nil {
+		return common.MissingScriptDataHashError{}
+	}
 	if *declaredHash != computedHash {
 		return common.ScriptDataHashMismatchError{
 			Declared: *declaredHash,

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -746,6 +746,11 @@ func UtxoValidateScriptDataHash(
 	computedHash := common.Blake2b256Hash(hashInput)
 
 	// Compare with declared hash
+	// Note: declaredHash is guaranteed non-nil here due to earlier checks,
+	// but we add an explicit check to satisfy static analysis
+	if declaredHash == nil {
+		return common.MissingScriptDataHashError{}
+	}
 	if *declaredHash != computedHash {
 		return common.ScriptDataHashMismatchError{
 			Declared: *declaredHash,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add unit tests for connection options and CBOR generic encode/decode. Cover type validation, round-trip and cache behavior, option combinations, error channel defaults, muxer/ID before setup, protocol getters before/after mock handshake, and protocol version.

<sup>Written for commit a3320eb875fa3347a4d820b7760dd42fb88329dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hash validation robustness by adding defensive nil-checks to prevent potential nil pointer dereferences during script data hash comparison operations.

* **Tests**
  * Expanded test coverage for CBOR encoding/decoding with round-trip validation and type caching verification.
  * Added comprehensive test suite for connection protocol options, error handling, and state transitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->