### PR TITLE
fix: merging of cost models from pparams

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.1
 require (
 	filippo.io/edwards25519 v1.1.0
 	github.com/blinklabs-io/ouroboros-mock v0.4.0
-	github.com/blinklabs-io/plutigo v0.0.21
+	github.com/blinklabs-io/plutigo v0.0.22
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/fxamacker/cbor/v2 v2.9.0
 	github.com/jinzhu/copier v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/bits-and-blooms/bitset v1.20.0 h1:2F+rfL86jE2d/bmw7OhqUg2Sj/1rURkBn3M
 github.com/bits-and-blooms/bitset v1.20.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/blinklabs-io/ouroboros-mock v0.4.0 h1:ppOcTMnC/2f5rYYSlvNqcGfAQOIpMCSDUrNh9K6a4mY=
 github.com/blinklabs-io/ouroboros-mock v0.4.0/go.mod h1:e+Kck8bmdOuaN7IfkbVvbqAVlskXNXB95oHI3YlFG5g=
-github.com/blinklabs-io/plutigo v0.0.21 h1:+corf01GABIs8dKQowlYgBk5RFfj0wrficxG1LVF3Qw=
-github.com/blinklabs-io/plutigo v0.0.21/go.mod h1:JwWJQOXVc3Bbb5ot05MUZOACysxTU8TsyDZ9IAJgKeA=
+github.com/blinklabs-io/plutigo v0.0.22 h1:4O1+bac3pY2JPsIC9PvwthZWn6eFgkQ3R+z5t1rNeu8=
+github.com/blinklabs-io/plutigo v0.0.22/go.mod h1:gWmUk3afrNAwWkrHym/KjFDn63r4MAx/amtjZLkWNXM=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c/go.mod h1:tjmYdS6MLJ5/s0Fj4DbLgSbDHbEqLJrtnHecBFkdz5M=
 github.com/btcsuite/btcd v0.23.5-0.20231215221805-96c9fd8078fd/go.mod h1:nm3Bko6zh6bWP60UxwoT5LzdGJsQJaPo6HjduXq9p6A=

--- a/ledger/alonzo/pparams.go
+++ b/ledger/alonzo/pparams.go
@@ -154,7 +154,12 @@ func (p *AlonzoProtocolParameters) Update(
 		p.AdaPerUtxoByte = *paramUpdate.AdaPerUtxoByte
 	}
 	if paramUpdate.CostModels != nil {
-		p.CostModels = paramUpdate.CostModels
+		if p.CostModels == nil {
+			p.CostModels = make(map[uint][]int64)
+		}
+		for key, model := range paramUpdate.CostModels {
+			p.CostModels[key] = model
+		}
 	}
 	if paramUpdate.ExecutionCosts != nil {
 		p.ExecutionCosts = *paramUpdate.ExecutionCosts

--- a/ledger/babbage/pparams.go
+++ b/ledger/babbage/pparams.go
@@ -123,7 +123,12 @@ func (p *BabbageProtocolParameters) Update(
 		p.AdaPerUtxoByte = *paramUpdate.AdaPerUtxoByte
 	}
 	if paramUpdate.CostModels != nil {
-		p.CostModels = paramUpdate.CostModels
+		if p.CostModels == nil {
+			p.CostModels = make(map[uint][]int64)
+		}
+		for key, model := range paramUpdate.CostModels {
+			p.CostModels[key] = model
+		}
 	}
 	if paramUpdate.ExecutionCosts != nil {
 		p.ExecutionCosts = *paramUpdate.ExecutionCosts

--- a/ledger/common/script.go
+++ b/ledger/common/script.go
@@ -161,7 +161,7 @@ func (s PlutusV1Script) Evaluate(
 	redeemer data.PlutusData,
 	scriptContext data.PlutusData,
 	budget ExUnits,
-	costModel cek.CostModel,
+	evalContext *cek.EvalContext,
 ) (ExUnits, error) {
 	var usedExUnits ExUnits
 	var err error
@@ -205,7 +205,7 @@ func (s PlutusV1Script) Evaluate(
 	machine := cek.NewMachine[syn.DeBruijn](
 		cek.LanguageVersionV1,
 		200,
-		costModel,
+		evalContext,
 	)
 	machine.ExBudget = machineBudget
 	_, err = machine.Run(wrappedProgram)
@@ -242,7 +242,7 @@ func (s PlutusV2Script) Evaluate(
 	redeemer data.PlutusData,
 	scriptContext data.PlutusData,
 	budget ExUnits,
-	costModel cek.CostModel,
+	evalContext *cek.EvalContext,
 ) (ExUnits, error) {
 	var usedExUnits ExUnits
 	var err error
@@ -286,7 +286,7 @@ func (s PlutusV2Script) Evaluate(
 	machine := cek.NewMachine[syn.DeBruijn](
 		cek.LanguageVersionV2,
 		200,
-		costModel,
+		evalContext,
 	)
 	machine.ExBudget = machineBudget
 	_, err = machine.Run(wrappedProgram)
@@ -319,7 +319,7 @@ func (s PlutusV3Script) RawScriptBytes() []byte {
 func (s PlutusV3Script) Evaluate(
 	scriptContext data.PlutusData,
 	budget ExUnits,
-	costModel cek.CostModel,
+	evalContext *cek.EvalContext,
 ) (ExUnits, error) {
 	var usedExUnits ExUnits
 	var err error
@@ -356,7 +356,7 @@ func (s PlutusV3Script) Evaluate(
 	machine := cek.NewMachine[syn.DeBruijn](
 		cek.LanguageVersionV3,
 		200,
-		costModel,
+		evalContext,
 	)
 	machine.ExBudget = machineBudget
 	_, err = machine.Run(wrappedProgram)

--- a/ledger/conway/pparams.go
+++ b/ledger/conway/pparams.go
@@ -237,7 +237,12 @@ func (p *ConwayProtocolParameters) Update(
 		p.AdaPerUtxoByte = *paramUpdate.AdaPerUtxoByte
 	}
 	if paramUpdate.CostModels != nil {
-		p.CostModels = paramUpdate.CostModels
+		if p.CostModels == nil {
+			p.CostModels = make(map[uint][]int64)
+		}
+		for key, model := range paramUpdate.CostModels {
+			p.CostModels[key] = model
+		}
 	}
 	if paramUpdate.ExecutionCosts != nil {
 		p.ExecutionCosts = *paramUpdate.ExecutionCosts

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -1925,11 +1925,18 @@ func UtxoValidatePlutusScripts(
 			}
 			ctx := script.NewScriptContextV3(txInfoV3, redeemer, purpose)
 			ctxData := ctx.ToPlutusData()
-			costModel, err := cek.CostModelFromList(lang.LanguageVersionV3, conwayPparams.CostModels[2])
+			evalContext, err := cek.NewEvalContext(
+				lang.LanguageVersionV3,
+				cek.ProtoVersion{
+					Major: conwayPparams.ProtocolVersion.Major,
+					Minor: conwayPparams.ProtocolVersion.Minor,
+				},
+				conwayPparams.CostModels[2],
+			)
 			if err != nil {
-				return fmt.Errorf("build cost model: %w", err)
+				return fmt.Errorf("build evaluation context: %w", err)
 			}
-			_, execErr = s.Evaluate(ctxData, redeemerValue.ExUnits, costModel)
+			_, execErr = s.Evaluate(ctxData, redeemerValue.ExUnits, evalContext)
 		case common.PlutusV2Script:
 			// V2 scripts require a datum for spending purposes
 			if _, isSpend := purpose.(script.ScriptPurposeSpending); isSpend && datum == nil {
@@ -1950,11 +1957,18 @@ func UtxoValidatePlutusScripts(
 			// Build V1V2 context
 			ctx := script.NewScriptContextV1V2(txInfoV2, purpose)
 			ctxData := ctx.ToPlutusData()
-			costModel, err := cek.CostModelFromList(lang.LanguageVersionV2, conwayPparams.CostModels[1])
+			evalContext, err := cek.NewEvalContext(
+				lang.LanguageVersionV2,
+				cek.ProtoVersion{
+					Major: conwayPparams.ProtocolVersion.Major,
+					Minor: conwayPparams.ProtocolVersion.Minor,
+				},
+				conwayPparams.CostModels[0],
+			)
 			if err != nil {
-				return fmt.Errorf("build cost model: %w", err)
+				return fmt.Errorf("build evaluation context: %w", err)
 			}
-			_, execErr = s.Evaluate(datum, redeemerValue.Data.Data, ctxData, redeemerValue.ExUnits, costModel)
+			_, execErr = s.Evaluate(datum, redeemerValue.Data.Data, ctxData, redeemerValue.ExUnits, evalContext)
 		case common.PlutusV1Script:
 			// V1 scripts require a datum for spending purposes
 			if _, isSpend := purpose.(script.ScriptPurposeSpending); isSpend && datum == nil {
@@ -1975,11 +1989,18 @@ func UtxoValidatePlutusScripts(
 			// Build V1V2 context
 			ctx := script.NewScriptContextV1V2(txInfoV1, purpose)
 			ctxData := ctx.ToPlutusData()
-			costModel, err := cek.CostModelFromList(lang.LanguageVersionV1, conwayPparams.CostModels[0])
+			evalContext, err := cek.NewEvalContext(
+				lang.LanguageVersionV1,
+				cek.ProtoVersion{
+					Major: conwayPparams.ProtocolVersion.Major,
+					Minor: conwayPparams.ProtocolVersion.Minor,
+				},
+				conwayPparams.CostModels[0],
+			)
 			if err != nil {
-				return fmt.Errorf("build cost model: %w", err)
+				return fmt.Errorf("build evaluation context: %w", err)
 			}
-			_, execErr = s.Evaluate(datum, redeemerValue.Data.Data, ctxData, redeemerValue.ExUnits, costModel)
+			_, execErr = s.Evaluate(datum, redeemerValue.Data.Data, ctxData, redeemerValue.ExUnits, evalContext)
 		default:
 			continue
 		}


### PR DESCRIPTION
This also updates blinklabs-io/plutigo to v0.0.22

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cost model handling by merging updates from protocol parameters instead of overwriting. Switch Plutus script evaluation to use an EvalContext built from the protocol version and the correct cost model.

- **Bug Fixes**
  - Merge incoming CostModels into existing protocol parameter maps to avoid losing entries.
  - Use cek.EvalContext for Plutus V1/V2/V3 and correct cost model selection in Conway validation.

- **Dependencies**
  - Updated blinklabs-io/plutigo to v0.0.22.

<sup>Written for commit ed1988c68c2bc6257b5e04f2da500b8b08eefa21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

