### PR TITLE
feat(ledger): plutus data list type

### DIFF
--- a/ledger/alonzo/rules.go
+++ b/ledger/alonzo/rules.go
@@ -759,7 +759,7 @@ func UtxoValidateScriptDataHash(
 
 	wits := tmpTx.WitnessSet
 	hasRedeemers := len(wits.WsRedeemers.Redeemers) > 0
-	hasDatums := len(wits.WsPlutusData) > 0
+	hasDatums := len(wits.WsPlutusData.Items) > 0
 
 	// Determine which Plutus versions are used (Alonzo only has PlutusV1)
 	usedVersions := make(map[uint]struct{})
@@ -794,25 +794,37 @@ func UtxoValidateScriptDataHash(
 
 	// Compute the expected ScriptDataHash
 	// ScriptDataHash = blake2b256(redeemers_cbor || datums_cbor || langviews_cbor)
+	//
+	// Use preserved CBOR bytes from the original transaction for exact byte-for-byte match.
+	// The hash was computed by the original submitter using their CBOR encoding.
 
-	// Get preserved CBOR bytes for redeemers
 	redeemersCbor := wits.WsRedeemers.Cbor()
 	if len(redeemersCbor) == 0 {
 		// Fall back to re-encoding if no preserved CBOR
+		// Note: Must encode empty slice explicitly, as nil encodes as 0xf6 (CBOR null)
+		// but the spec expects 0x80 (empty array) for empty redeemers
 		var err error
-		redeemersCbor, err = cbor.Encode(wits.WsRedeemers)
+		if wits.WsRedeemers.Redeemers == nil {
+			redeemersCbor, err = cbor.Encode([]AlonzoRedeemer{})
+		} else {
+			redeemersCbor, err = cbor.Encode(wits.WsRedeemers.Redeemers)
+		}
 		if err != nil {
 			return err
 		}
 	}
 
-	// Encode datums as CBOR (only if non-empty)
+	// Get datums CBOR using preserved bytes (only if non-empty)
 	var datumsCbor []byte
 	if hasDatums {
-		var err error
-		datumsCbor, err = cbor.Encode(wits.WsPlutusData)
-		if err != nil {
-			return err
+		datumsCbor = wits.WsPlutusData.Cbor()
+		if len(datumsCbor) == 0 {
+			// Fall back to re-encoding if no preserved CBOR
+			var err error
+			datumsCbor, err = cbor.Encode(wits.WsPlutusData.Items)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -813,7 +813,7 @@ type BabbageTransactionWitnessSet struct {
 	WsNativeScripts    []common.NativeScript     `cbor:"1,keyasint,omitempty"`
 	BootstrapWitnesses []common.BootstrapWitness `cbor:"2,keyasint,omitempty"`
 	WsPlutusV1Scripts  []common.PlutusV1Script   `cbor:"3,keyasint,omitempty"`
-	WsPlutusData       []common.Datum            `cbor:"4,keyasint,omitempty"`
+	WsPlutusData       alonzo.PlutusDataList     `cbor:"4,keyasint,omitempty"`
 	WsRedeemers        alonzo.AlonzoRedeemers    `cbor:"5,keyasint,omitempty"`
 	WsPlutusV2Scripts  []common.PlutusV2Script   `cbor:"6,keyasint,omitempty"`
 }
@@ -852,9 +852,9 @@ func (w *BabbageTransactionWitnessSet) MarshalCBOR() ([]byte, error) {
 
 	// Convert WsPlutusData to IndefLengthList
 	var plutusDataIndefList cbor.IndefLengthList
-	if len(w.WsPlutusData) > 0 {
-		plutusDataIndefList = make(cbor.IndefLengthList, len(w.WsPlutusData))
-		for i, datum := range w.WsPlutusData {
+	if len(w.WsPlutusData.Items) > 0 {
+		plutusDataIndefList = make(cbor.IndefLengthList, len(w.WsPlutusData.Items))
+		for i, datum := range w.WsPlutusData.Items {
 			plutusDataIndefList[i] = datum
 		}
 	}
@@ -898,7 +898,7 @@ func (w BabbageTransactionWitnessSet) PlutusV3Scripts() []common.PlutusV3Script 
 }
 
 func (w BabbageTransactionWitnessSet) PlutusData() []common.Datum {
-	return w.WsPlutusData
+	return w.WsPlutusData.Items
 }
 
 func (w BabbageTransactionWitnessSet) Redeemers() common.TransactionWitnessRedeemers {

--- a/ledger/common/script.go
+++ b/ledger/common/script.go
@@ -529,8 +529,9 @@ func (n *NativeScript) Evaluate(
 
 	case *NativeScriptInvalidHereafter:
 		// Transaction is only valid before this slot
-		// The tx must end before the script's slot requirement
-		return validityEnd < s.Slot
+		// The tx must end at or before the script's slot requirement
+		// TTL = X means tx valid at slots [start, X), which is entirely within [0, X)
+		return validityEnd <= s.Slot
 
 	default:
 		return false

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -698,8 +698,10 @@ func UtxoValidateScriptDataHash(
 
 	// Compute the expected ScriptDataHash
 	// ScriptDataHash = blake2b256(redeemers_cbor || datums_cbor || langviews_cbor)
+	//
+	// Use preserved CBOR bytes from the original transaction for exact byte-for-byte match.
+	// The hash was computed by the original submitter using their CBOR encoding.
 
-	// Get preserved CBOR bytes for redeemers
 	redeemersCbor := wits.WsRedeemers.Cbor()
 	if len(redeemersCbor) == 0 {
 		// Fall back to re-encoding if no preserved CBOR


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add PlutusDataList to preserve CBOR encoding of Plutus datums, ensuring exact ScriptDataHash computation in Alonzo and Babbage. Also fixes InvalidHereafter TTL logic.

- **New Features**
  - Introduced PlutusDataList (stores preserved CBOR and datum items); witness sets now use it. PlutusData() still returns []common.Datum.
  - ScriptDataHash validation now prefers preserved CBOR for redeemers and datums, with fallback re-encoding that correctly treats empty arrays (not nil).

- **Bug Fixes**
  - NativeScript InvalidHereafter now treats TTL as “at or before” the slot (<=).

<sup>Written for commit 9567ff78dad5ec44efce4e4ec7b5fc76d6016f76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected native script validation logic for time-to-live (TTL) slot boundaries to use inclusive comparison.

* **Refactor**
  * Improved CBOR preservation for Plutus data to ensure accurate script data hash computation.
  * Enhanced ScriptDataHash computation to prioritize preserved CBOR bytes from original transactions for byte-for-byte matching accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->