### PR TITLE
fix(ledger): use v2 cost models for plutus v2

### DIFF
--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -1970,7 +1970,7 @@ func UtxoValidatePlutusScripts(
 					Major: conwayPparams.ProtocolVersion.Major,
 					Minor: conwayPparams.ProtocolVersion.Minor,
 				},
-				conwayPparams.CostModels[0],
+				conwayPparams.CostModels[1],
 			)
 			if err != nil {
 				return fmt.Errorf("build evaluation context: %w", err)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use the Plutus v2 cost model for v2 scripts to ensure correct evaluation and fee calculation. Fixes an indexing error in the Conway ledger rules.

- **Bug Fixes**
  - Switch evaluation context to conwayPparams.CostModels[1] for Plutus v2.

<sup>Written for commit 065dfc1bcfbf4cea16796de78172aad2cc1536cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated PlutusV2 script cost model evaluation in transaction validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->