### PR TITLE
fix(ledger): deduplicate datum hash in script context

### DIFF
--- a/ledger/common/script/context.go
+++ b/ledger/common/script/context.go
@@ -600,11 +600,18 @@ func dataInfo(
 	if witnessSet == nil {
 		return ret
 	}
+	// Deduplicate by datum hash - same hash means same datum
+	seen := make(map[lcommon.DatumHash]struct{})
 	for _, datum := range witnessSet.PlutusData() {
+		hash := datum.Hash()
+		if _, found := seen[hash]; found {
+			continue // Skip duplicates
+		}
+		seen[hash] = struct{}{}
 		ret = append(
 			ret,
 			KeyValuePair[lcommon.DatumHash, data.PlutusData]{
-				Key:   datum.Hash(),
+				Key:   hash,
 				Value: datum.Data,
 			},
 		)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Deduplicates Plutus datum entries in the script context by datum hash to prevent duplicate key/value pairs when the same datum appears multiple times. This ensures stable lookups and reduces redundant data.

- **Bug Fixes**
  - Track seen datum hashes during dataInfo construction and skip duplicates.
  - Prevent duplicate keys in the script context that could lead to inconsistent behavior.

<sup>Written for commit 49f95f05e17be0e95da17ce2d66ba9775dde1377. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed duplicate entries in ledger data processing, resulting in cleaner output and improved system efficiency while maintaining consistent ordering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->