### PR TITLE
fix: add Connection functions to specify Leios protocol configs

### DIFF
--- a/connection_options.go
+++ b/connection_options.go
@@ -21,6 +21,8 @@ import (
 	"github.com/blinklabs-io/gouroboros/protocol/blockfetch"
 	"github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	"github.com/blinklabs-io/gouroboros/protocol/keepalive"
+	"github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
+	"github.com/blinklabs-io/gouroboros/protocol/leiosnotify"
 	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
 	"github.com/blinklabs-io/gouroboros/protocol/localtxmonitor"
 	"github.com/blinklabs-io/gouroboros/protocol/localtxsubmission"
@@ -138,6 +140,20 @@ func WithChainSyncConfig(cfg chainsync.Config) ConnectionOptionFunc {
 func WithKeepAliveConfig(cfg keepalive.Config) ConnectionOptionFunc {
 	return func(c *Connection) {
 		c.keepAliveConfig = &cfg
+	}
+}
+
+// WithLeiosFetchConfig specifies LeiosFetch protocol config
+func WithLeiosFetchConfig(cfg leiosfetch.Config) ConnectionOptionFunc {
+	return func(c *Connection) {
+		c.leiosFetchConfig = &cfg
+	}
+}
+
+// WithLeiosNotifyConfig specifies LeiosNotify protocol config
+func WithLeiosNotifyConfig(cfg leiosnotify.Config) ConnectionOptionFunc {
+	return func(c *Connection) {
+		c.leiosNotifyConfig = &cfg
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added WithLeiosFetchConfig and WithLeiosNotifyConfig to configure Leios protocols on Connection. Clients can now supply LeiosFetch and LeiosNotify configs when building a Connection.

<sup>Written for commit 223ab0eaf43ff809c3d42d1ed2a646b2d2588657. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Leios protocol configuration options for fetch and notification services, extending the connection configuration system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->