### PR TITLE
fix(ledger): correct plutus script context encoding

### DIFF
--- a/ledger/common/script.go
+++ b/ledger/common/script.go
@@ -208,13 +208,14 @@ func (s PlutusV1Script) Evaluate(
 		evalContext,
 	)
 	machine.ExBudget = machineBudget
-	_, err = machine.Run(wrappedProgram)
-	if err != nil {
-		return usedExUnits, fmt.Errorf("execute script: %w", err)
-	}
+	_, runErr := machine.Run(wrappedProgram)
+	// Always calculate consumed budget, even on error
 	consumedBudget := machineBudget.Sub(&machine.ExBudget)
 	usedExUnits.Memory = consumedBudget.Mem
 	usedExUnits.Steps = consumedBudget.Cpu
+	if runErr != nil {
+		return usedExUnits, fmt.Errorf("execute script: %w", runErr)
+	}
 	return usedExUnits, nil
 }
 
@@ -289,13 +290,14 @@ func (s PlutusV2Script) Evaluate(
 		evalContext,
 	)
 	machine.ExBudget = machineBudget
-	_, err = machine.Run(wrappedProgram)
-	if err != nil {
-		return usedExUnits, fmt.Errorf("execute script: %w", err)
-	}
+	_, runErr := machine.Run(wrappedProgram)
+	// Always calculate consumed budget, even on error
 	consumedBudget := machineBudget.Sub(&machine.ExBudget)
 	usedExUnits.Memory = consumedBudget.Mem
 	usedExUnits.Steps = consumedBudget.Cpu
+	if runErr != nil {
+		return usedExUnits, fmt.Errorf("execute script: %w", runErr)
+	}
 	return usedExUnits, nil
 }
 
@@ -359,13 +361,14 @@ func (s PlutusV3Script) Evaluate(
 		evalContext,
 	)
 	machine.ExBudget = machineBudget
-	_, err = machine.Run(wrappedProgram)
-	if err != nil {
-		return usedExUnits, fmt.Errorf("execute script: %w", err)
-	}
+	_, runErr := machine.Run(wrappedProgram)
+	// Always calculate consumed budget, even on error
 	consumedBudget := machineBudget.Sub(&machine.ExBudget)
 	usedExUnits.Memory = consumedBudget.Mem
 	usedExUnits.Steps = consumedBudget.Cpu
+	if runErr != nil {
+		return usedExUnits, fmt.Errorf("execute script: %w", runErr)
+	}
 	return usedExUnits, nil
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix Plutus script context encoding to match Plutus V2 and always return accurate ex-units, even when evaluation fails. Also correct Value encoding by omitting ADA in mint-only contexts.

- Bug Fixes
  - Encode TxInInfo/TxOutRef per Plutus V2: TxOutRef = Constr 0 [TxId, Integer], TxId = Constr 0 [ByteString].
  - Value encoding: omit ADA for txInfoMint; always include ADA for outputs (zero allowed).
  - Evaluation (V1/V2/V3): compute and return consumed budget before propagating errors.

<sup>Written for commit 365b4899eee96bb279b8de6eac68342b0c0fe9f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Script execution now correctly calculates and reports resource consumption metrics even when script execution encounters errors, ensuring accurate tracking of actual resource usage in all scenarios.

* **Improvements**
  * Transaction data structure representation updated to align with PlutusV2 standard format requirements, improving compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->