### PR TITLE
feat(ledger): calculate CBOR byte offsets

### DIFF
--- a/cbor/decode.go
+++ b/cbor/decode.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -171,4 +171,470 @@ func DecodeGeneric(cborData []byte, dest any) error {
 		return err
 	}
 	return nil
+}
+
+// StreamDecoder provides sequential CBOR decoding with position tracking.
+// It wraps the underlying decoder to track byte offsets of each decoded item.
+type StreamDecoder struct {
+	dec      *_cbor.Decoder
+	decMode  _cbor.DecMode // cached decode mode for reuse in Advance()
+	data     []byte
+	consumed int // bytes consumed by Advance() calls
+}
+
+// NewStreamDecoder creates a decoder for sequential CBOR item extraction with position tracking.
+func NewStreamDecoder(data []byte) (*StreamDecoder, error) {
+	decOptions := _cbor.DecOptions{
+		ExtraReturnErrors: _cbor.ExtraDecErrorUnknownField,
+		MaxNestedLevels:   256,
+	}
+	decMode, err := decOptions.DecModeWithTags(customTagSet)
+	if err != nil {
+		return nil, err
+	}
+	return &StreamDecoder{
+		dec:     decMode.NewDecoder(bytes.NewReader(data)),
+		decMode: decMode,
+		data:    data,
+	}, nil
+}
+
+// Position returns the current byte position in the stream.
+func (d *StreamDecoder) Position() int {
+	return d.consumed + d.dec.NumBytesRead()
+}
+
+// Decode decodes the next CBOR item into dest and returns its byte range.
+// Returns (startOffset, length, error).
+func (d *StreamDecoder) Decode(dest any) (int, int, error) {
+	start := d.consumed + d.dec.NumBytesRead()
+	if err := d.dec.Decode(dest); err != nil {
+		return 0, 0, err
+	}
+	end := d.consumed + d.dec.NumBytesRead()
+	return start, end - start, nil
+}
+
+// Skip skips the next CBOR item and returns its byte range.
+// Returns (startOffset, length, error).
+func (d *StreamDecoder) Skip() (int, int, error) {
+	start := d.consumed + d.dec.NumBytesRead()
+	if err := d.dec.Skip(); err != nil {
+		return 0, 0, err
+	}
+	end := d.consumed + d.dec.NumBytesRead()
+	return start, end - start, nil
+}
+
+// DecodeRaw decodes the next CBOR item and returns both its value and raw bytes.
+// Returns (startOffset, rawBytes, error).
+func (d *StreamDecoder) DecodeRaw(dest any) (int, []byte, error) {
+	absStart := d.consumed + d.dec.NumBytesRead()
+	relStart := d.dec.NumBytesRead()
+	if err := d.dec.Decode(dest); err != nil {
+		return 0, nil, err
+	}
+	relEnd := d.dec.NumBytesRead()
+	return absStart, d.data[d.consumed+relStart : d.consumed+relEnd], nil
+}
+
+// RawBytes returns the raw bytes for the given offset and length.
+func (d *StreamDecoder) RawBytes(offset, length int) []byte {
+	// Check for negative values and integer overflow
+	if offset < 0 || length < 0 {
+		return nil
+	}
+	end := offset + length
+	// Check for integer overflow: if end < offset, overflow occurred
+	if end < offset || end > len(d.data) {
+		return nil
+	}
+	return d.data[offset:end]
+}
+
+// Data returns the underlying byte slice.
+func (d *StreamDecoder) Data() []byte {
+	return d.data
+}
+
+// EOF returns true if the decoder has reached the end of the data.
+func (d *StreamDecoder) EOF() bool {
+	return d.consumed+d.dec.NumBytesRead() >= len(d.data)
+}
+
+// Advance moves the decoder position forward by n bytes without decoding.
+// This is useful for skipping past headers that were parsed manually.
+// Returns an error if n would advance past the end of data.
+func (d *StreamDecoder) Advance(n int) error {
+	if n < 0 {
+		return errors.New("cannot advance by negative amount")
+	}
+	newPos := d.consumed + d.dec.NumBytesRead() + n
+	if newPos > len(d.data) {
+		return errors.New("advance would exceed data bounds")
+	}
+	d.consumed = newPos
+	// Reinitialize decoder with remaining data, reusing cached DecMode
+	d.dec = d.decMode.NewDecoder(bytes.NewReader(d.data[d.consumed:]))
+	return nil
+}
+
+// DecodeArrayHeader decodes a CBOR array header and returns the number of elements.
+// This advances the position past the header only, not the array contents.
+// Returns (arrayLength, headerOffset, headerLength, error).
+func (d *StreamDecoder) DecodeArrayHeader() (int, int, int, error) {
+	relStart := d.dec.NumBytesRead()
+	absStart := d.consumed + relStart
+	if absStart >= len(d.data) {
+		return 0, 0, 0, errors.New("unexpected end of data")
+	}
+
+	// Parse array header manually to avoid consuming content
+	firstByte := d.data[absStart]
+	majorType := firstByte & CborTypeMask
+
+	if majorType != CborTypeArray {
+		return 0, 0, 0, fmt.Errorf("expected array (0x%x), got 0x%x", CborTypeArray, majorType)
+	}
+
+	additionalInfo := firstByte & 0x1f
+	var length int
+	var headerLen int
+
+	switch {
+	case additionalInfo < 24:
+		// Length encoded in the first byte
+		length = int(additionalInfo)
+		headerLen = 1
+	case additionalInfo == 24:
+		// 1-byte length follows
+		if absStart+2 > len(d.data) {
+			return 0, 0, 0, errors.New("unexpected end of data reading array length")
+		}
+		length = int(d.data[absStart+1])
+		headerLen = 2
+	case additionalInfo == 25:
+		// 2-byte length follows (big-endian)
+		if absStart+3 > len(d.data) {
+			return 0, 0, 0, errors.New("unexpected end of data reading array length")
+		}
+		length = int(d.data[absStart+1])<<8 | int(d.data[absStart+2])
+		headerLen = 3
+	case additionalInfo == 26:
+		// 4-byte length follows (big-endian)
+		if absStart+5 > len(d.data) {
+			return 0, 0, 0, errors.New("unexpected end of data reading array length")
+		}
+		// Read as uint32 first to avoid sign issues on 32-bit systems
+		len32 := uint32(d.data[absStart+1])<<24 | uint32(d.data[absStart+2])<<16 |
+			uint32(d.data[absStart+3])<<8 | uint32(d.data[absStart+4])
+		if len32 > uint32(math.MaxInt32) {
+			return 0, 0, 0, errors.New("array length exceeds maximum int32 value")
+		}
+		length = int(len32)
+		headerLen = 5
+	case additionalInfo == 27:
+		// 8-byte length follows (big-endian)
+		if absStart+9 > len(d.data) {
+			return 0, 0, 0, errors.New("unexpected end of data reading array length")
+		}
+		// Read as uint64 first, then check if it fits in int32
+		// Use MaxInt32 for consistency with ArrayInfo and to prevent overflow
+		// when values are later converted to uint32 for offset calculations
+		len64 := uint64(d.data[absStart+1])<<56 | uint64(d.data[absStart+2])<<48 |
+			uint64(d.data[absStart+3])<<40 | uint64(d.data[absStart+4])<<32 |
+			uint64(d.data[absStart+5])<<24 | uint64(d.data[absStart+6])<<16 |
+			uint64(d.data[absStart+7])<<8 | uint64(d.data[absStart+8])
+		if len64 > uint64(math.MaxInt32) {
+			return 0, 0, 0, errors.New("array length exceeds maximum int32 value")
+		}
+		length = int(len64)
+		headerLen = 9
+	case additionalInfo == 31:
+		// Indefinite length array - need to count elements
+		return 0, 0, 0, errors.New("indefinite length arrays not supported in header-only decode")
+	default:
+		return 0, 0, 0, fmt.Errorf("invalid array additional info: %d", additionalInfo)
+	}
+
+	// Advance the decoder position past the header
+	if err := d.Advance(headerLen); err != nil {
+		return 0, 0, 0, err
+	}
+
+	return length, absStart, headerLen, nil
+}
+
+// DecodeMapHeader decodes a CBOR map header and returns the number of key-value pairs.
+// This advances the position past the header only, not the map contents.
+// Returns (mapLength, headerOffset, headerLength, error).
+func (d *StreamDecoder) DecodeMapHeader() (int, int, int, error) {
+	relStart := d.dec.NumBytesRead()
+	absStart := d.consumed + relStart
+	if absStart >= len(d.data) {
+		return 0, 0, 0, errors.New("unexpected end of data")
+	}
+
+	firstByte := d.data[absStart]
+	majorType := firstByte & CborTypeMask
+
+	if majorType != CborTypeMap {
+		return 0, 0, 0, fmt.Errorf("expected map (0x%x), got 0x%x", CborTypeMap, majorType)
+	}
+
+	additionalInfo := firstByte & 0x1f
+	var length int
+	var headerLen int
+
+	switch {
+	case additionalInfo < 24:
+		length = int(additionalInfo)
+		headerLen = 1
+	case additionalInfo == 24:
+		if absStart+2 > len(d.data) {
+			return 0, 0, 0, errors.New("unexpected end of data reading map length")
+		}
+		length = int(d.data[absStart+1])
+		headerLen = 2
+	case additionalInfo == 25:
+		if absStart+3 > len(d.data) {
+			return 0, 0, 0, errors.New("unexpected end of data reading map length")
+		}
+		length = int(d.data[absStart+1])<<8 | int(d.data[absStart+2])
+		headerLen = 3
+	case additionalInfo == 26:
+		// 4-byte length follows (big-endian)
+		if absStart+5 > len(d.data) {
+			return 0, 0, 0, errors.New("unexpected end of data reading map length")
+		}
+		// Read as uint32 first to avoid sign issues on 32-bit systems
+		len32 := uint32(d.data[absStart+1])<<24 | uint32(d.data[absStart+2])<<16 |
+			uint32(d.data[absStart+3])<<8 | uint32(d.data[absStart+4])
+		if len32 > uint32(math.MaxInt32) {
+			return 0, 0, 0, errors.New("map length exceeds maximum int32 value")
+		}
+		length = int(len32)
+		headerLen = 5
+	case additionalInfo == 27:
+		// 8-byte length follows (big-endian)
+		if absStart+9 > len(d.data) {
+			return 0, 0, 0, errors.New("unexpected end of data reading map length")
+		}
+		// Read as uint64 first, then check if it fits in int32
+		// Use MaxInt32 for consistency with MapInfo and to prevent overflow
+		// when values are later converted to uint32 for offset calculations
+		len64 := uint64(d.data[absStart+1])<<56 | uint64(d.data[absStart+2])<<48 |
+			uint64(d.data[absStart+3])<<40 | uint64(d.data[absStart+4])<<32 |
+			uint64(d.data[absStart+5])<<24 | uint64(d.data[absStart+6])<<16 |
+			uint64(d.data[absStart+7])<<8 | uint64(d.data[absStart+8])
+		if len64 > uint64(math.MaxInt32) {
+			return 0, 0, 0, errors.New("map length exceeds maximum int32 value")
+		}
+		length = int(len64)
+		headerLen = 9
+	case additionalInfo == 31:
+		return 0, 0, 0, errors.New("indefinite length maps not supported in header-only decode")
+	default:
+		return 0, 0, 0, fmt.Errorf("invalid map additional info: %d", additionalInfo)
+	}
+
+	// Advance the decoder position past the header
+	if err := d.Advance(headerLen); err != nil {
+		return 0, 0, 0, err
+	}
+
+	return length, absStart, headerLen, nil
+}
+
+// SkipN skips n CBOR items and returns the total byte range skipped.
+// Returns (startOffset, totalLength, error).
+func (d *StreamDecoder) SkipN(n int) (int, int, error) {
+	if n <= 0 {
+		pos := d.consumed + d.dec.NumBytesRead()
+		return pos, 0, nil
+	}
+
+	start := d.consumed + d.dec.NumBytesRead()
+	for i := 0; i < n; i++ {
+		if err := d.dec.Skip(); err != nil {
+			return 0, 0, fmt.Errorf("skip item %d: %w", i, err)
+		}
+	}
+	end := d.consumed + d.dec.NumBytesRead()
+	return start, end - start, nil
+}
+
+// DecodeArrayItems decodes all items in an array, calling the callback for each.
+// The callback receives the item index, start offset, and length.
+// Returns the total array byte range (including header).
+func (d *StreamDecoder) DecodeArrayItems(
+	callback func(index int, offset int, length int, data []byte) error,
+) (int, int, error) {
+	arrayStart := d.consumed + d.dec.NumBytesRead()
+
+	// Decode as array of RawMessage to get each item's bytes
+	var items []RawMessage
+	if _, _, err := d.Decode(&items); err != nil {
+		return 0, 0, fmt.Errorf("decode array: %w", err)
+	}
+
+	arrayEnd := d.consumed + d.dec.NumBytesRead()
+
+	// Calculate actual header size from the raw bytes to handle non-canonical encodings
+	headerLen, err := cborArrayHeaderSizeFromBytes(d.data, arrayStart)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parse array header: %w", err)
+	}
+
+	// Calculate positions for each item
+	// The array header is followed by consecutive items
+	pos := arrayStart + headerLen
+	for i, item := range items {
+		itemLen := len(item)
+		if callback != nil {
+			if err := callback(i, pos, itemLen, []byte(item)); err != nil {
+				return 0, 0, err
+			}
+		}
+		pos += itemLen
+	}
+
+	return arrayStart, arrayEnd - arrayStart, nil
+}
+
+// cborArrayHeaderSizeFromBytes returns the actual size of a CBOR array header by
+// reading the bytes at the given offset. This handles non-canonical encodings correctly.
+// Returns an error for indefinite-length arrays.
+func cborArrayHeaderSizeFromBytes(data []byte, offset int) (int, error) {
+	if offset >= len(data) {
+		return 0, errors.New("unexpected end of data reading array header")
+	}
+
+	firstByte := data[offset]
+	majorType := firstByte & CborTypeMask
+
+	if majorType != CborTypeArray {
+		return 0, fmt.Errorf("expected array (0x%x), got 0x%x", CborTypeArray, majorType)
+	}
+
+	additionalInfo := firstByte & 0x1f
+
+	switch {
+	case additionalInfo < 24:
+		return 1, nil
+	case additionalInfo == 24:
+		return 2, nil
+	case additionalInfo == 25:
+		return 3, nil
+	case additionalInfo == 26:
+		return 5, nil
+	case additionalInfo == 27:
+		return 9, nil
+	case additionalInfo == 31:
+		return 0, errors.New("indefinite length arrays not supported")
+	default:
+		return 0, fmt.Errorf("invalid array additional info: %d", additionalInfo)
+	}
+}
+
+// ArrayInfo extracts array item count and header size from CBOR array data.
+// Returns (count, headerSize, isIndefinite). Count is -1 for invalid headers.
+func ArrayInfo(data []byte) (int, uint32, bool) {
+	if len(data) == 0 {
+		return -1, 0, false
+	}
+	firstByte := data[0]
+
+	// Check it's an array (major type 4)
+	if firstByte&0xe0 != CborTypeArray {
+		return -1, 0, false
+	}
+
+	additional := firstByte & 0x1f
+	switch {
+	case additional <= 23:
+		return int(additional), 1, false
+	case additional == 24 && len(data) >= 2:
+		return int(data[1]), 2, false
+	case additional == 25 && len(data) >= 3:
+		return int(uint16(data[1])<<8 | uint16(data[2])), 3, false
+	case additional == 26 && len(data) >= 5:
+		// 4-byte length - check for overflow before converting to int
+		len32 := uint32(data[1])<<24 | uint32(data[2])<<16 | uint32(data[3])<<8 | uint32(data[4])
+		if len32 > uint32(math.MaxInt32) {
+			return -1, 0, false // Too large to handle
+		}
+		return int(len32), 5, false
+	case additional == 27 && len(data) >= 9:
+		// 8-byte length (unlikely for typical data but handle for completeness)
+		len64 := uint64(data[1])<<56 | uint64(data[2])<<48 |
+			uint64(data[3])<<40 | uint64(data[4])<<32 |
+			uint64(data[5])<<24 | uint64(data[6])<<16 |
+			uint64(data[7])<<8 | uint64(data[8])
+		if len64 > uint64(math.MaxInt32) {
+			return -1, 0, false // Too large to handle
+		}
+		return int(len64), 9, false
+	case additional == 31:
+		return 0, 1, true // Indefinite length
+	default:
+		return -1, 0, false
+	}
+}
+
+// MapInfo extracts map item count and header size from CBOR map data.
+// Returns (count, headerSize, isIndefinite). Count is -1 for invalid headers.
+func MapInfo(data []byte) (int, uint32, bool) {
+	if len(data) == 0 {
+		return -1, 0, false
+	}
+	firstByte := data[0]
+
+	// Check it's a map (major type 5)
+	if firstByte&0xe0 != CborTypeMap {
+		return -1, 0, false
+	}
+
+	additional := firstByte & 0x1f
+	switch {
+	case additional <= 23:
+		return int(additional), 1, false
+	case additional == 24 && len(data) >= 2:
+		return int(data[1]), 2, false
+	case additional == 25 && len(data) >= 3:
+		return int(uint16(data[1])<<8 | uint16(data[2])), 3, false
+	case additional == 26 && len(data) >= 5:
+		// 4-byte length - check for overflow before converting to int
+		len32 := uint32(data[1])<<24 | uint32(data[2])<<16 | uint32(data[3])<<8 | uint32(data[4])
+		if len32 > uint32(math.MaxInt32) {
+			return -1, 0, false // Too large to handle
+		}
+		return int(len32), 5, false
+	case additional == 27 && len(data) >= 9:
+		// 8-byte length (unlikely for typical data but handle for completeness)
+		len64 := uint64(data[1])<<56 | uint64(data[2])<<48 |
+			uint64(data[3])<<40 | uint64(data[4])<<32 |
+			uint64(data[5])<<24 | uint64(data[6])<<16 |
+			uint64(data[7])<<8 | uint64(data[8])
+		if len64 > uint64(math.MaxInt32) {
+			return -1, 0, false // Too large to handle
+		}
+		return int(len64), 9, false
+	case additional == 31:
+		return 0, 1, true // Indefinite length
+	default:
+		return -1, 0, false
+	}
+}
+
+// ArrayHeaderSize returns the CBOR header size in bytes for an array of given length.
+func ArrayHeaderSize(length int) uint32 {
+	if length < 24 {
+		return 1 // 0x80 + length
+	} else if length < 256 {
+		return 2 // 0x98 + 1-byte length
+	} else if length < 65536 {
+		return 3 // 0x99 + 2-byte length
+	}
+	return 5 // 0x9a + 4-byte length (covers up to 2^32 elements)
 }

--- a/ledger/block.go
+++ b/ledger/block.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -85,4 +85,68 @@ func NewBlockHeaderFromCbor(blockType uint, data []byte) (BlockHeader, error) {
 	default:
 		return nil, fmt.Errorf("unknown node-to-node block type: %d", blockType)
 	}
+}
+
+// Type aliases for offset structures
+type (
+	BlockWithOffsets        = common.BlockWithOffsets
+	BlockTransactionOffsets = common.BlockTransactionOffsets
+	TransactionLocation     = common.TransactionLocation
+	ByteRange               = common.ByteRange
+)
+
+// NewBlockFromCborWithOffsets decodes a block and extracts CBOR byte offsets.
+// This is the recommended way to decode blocks when offset information is needed for
+// efficient CBOR extraction (e.g., for storing offset references instead of copying CBOR).
+//
+// The function performs two passes over the block data:
+// 1. Streaming pass: Extracts byte offsets for all transactions, outputs, witnesses, and metadata
+// 2. Era-specific decode: Decodes the block using the appropriate era decoder
+//
+// Both passes are fast since the block data is in CPU cache. This approach maintains
+// clean separation between offset extraction (era-agnostic) and block decoding (era-specific).
+//
+// Parameters:
+//   - blockType: The block type ID (e.g., BlockTypeConway)
+//   - data: Raw block CBOR bytes
+//   - config: Optional verification config (e.g., to skip body hash validation)
+//
+// Returns:
+//   - BlockWithOffsets containing both the decoded block and offset information
+//   - error if decoding fails
+func NewBlockFromCborWithOffsets(
+	blockType uint,
+	data []byte,
+	config ...common.VerifyConfig,
+) (*BlockWithOffsets, error) {
+	// Use the streaming decoder to extract offsets
+	decoder, err := common.NewStreamingBlockDecoder(data)
+	if err != nil {
+		return nil, fmt.Errorf("create streaming decoder: %w", err)
+	}
+
+	offsets, err := decoder.DecodeWithOffsets()
+	if err != nil {
+		return nil, fmt.Errorf("extract offsets: %w", err)
+	}
+
+	// Decode the block using the standard decoder
+	block, err := NewBlockFromCbor(blockType, data, config...)
+	if err != nil {
+		return nil, fmt.Errorf("decode block: %w", err)
+	}
+
+	return &BlockWithOffsets{
+		Block:   block,
+		Offsets: offsets,
+	}, nil
+}
+
+// ExtractTransactionOffsets extracts byte offsets for all transactions in a block.
+// This is a convenience alias for common.ExtractTransactionOffsets.
+//
+// Use NewBlockFromCborWithOffsets when you also need to decode the block,
+// as it is more efficient than decoding and extracting offsets separately.
+func ExtractTransactionOffsets(cborData []byte) (*BlockTransactionOffsets, error) {
+	return common.ExtractTransactionOffsets(cborData)
 }

--- a/ledger/common/common.go
+++ b/ledger/common/common.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -802,6 +802,743 @@ func ExtractAndSetTransactionCbor(
 	}
 
 	return nil
+}
+
+// ByteRange represents a byte offset and length within block CBOR.
+type ByteRange struct {
+	Offset uint32 // Byte offset within block CBOR
+	Length uint32 // Length in bytes
+}
+
+// TransactionLocation represents the byte location of a transaction within block CBOR.
+type TransactionLocation struct {
+	Body     ByteRange // Location of transaction body within block CBOR
+	Witness  ByteRange // Location of witness set within block CBOR
+	Metadata ByteRange // Location of metadata within block CBOR (zero if no metadata)
+
+	// Outputs contains byte locations for each transaction output (UTxO)
+	// Index matches the output index within the transaction
+	Outputs []ByteRange
+
+	// Witness set component offsets (Alonzo+ era)
+	// These map content hashes to their locations within the block
+
+	// Datums maps datum hash to its byte location
+	Datums map[Blake2b256]ByteRange
+
+	// Redeemers maps redeemer key to its byte location
+	Redeemers map[RedeemerKey]ByteRange
+
+	// Scripts maps script hash to its byte location
+	// Includes native scripts, Plutus V1/V2/V3 scripts
+	Scripts map[ScriptHash]ByteRange
+}
+
+// BlockTransactionOffsets contains byte offset information for all transactions in a block.
+type BlockTransactionOffsets struct {
+	// Transactions maps transaction index to its location information
+	Transactions []TransactionLocation
+}
+
+// ExtractTransactionOffsets extracts byte offsets for all transactions in a block.
+// This enables efficient CBOR extraction from block data without full deserialization.
+//
+// The function parses the block CBOR structure to find where each transaction body,
+// witness set, and metadata starts and ends within the raw block bytes.
+func ExtractTransactionOffsets(cborData []byte) (*BlockTransactionOffsets, error) {
+	// First pass: decode block as array of RawMessages to get component boundaries
+	var blockArray []cbor.RawMessage
+	if _, err := cbor.Decode(cborData, &blockArray); err != nil {
+		return nil, fmt.Errorf("failed to decode block array: %w", err)
+	}
+	if len(blockArray) < 3 {
+		// Block doesn't have separated components (e.g., Byron EBB)
+		// Return empty slice instead of nil to prevent nil pointer dereference
+		return &BlockTransactionOffsets{Transactions: []TransactionLocation{}}, nil
+	}
+
+	// Calculate header size by finding where blockArray[0] starts
+	// CBOR array header is 1 byte for arrays < 24 elements, more for larger
+	arrayHeaderSize := cborArrayHeaderSize(len(blockArray))
+
+	// blockArray[0] is the header, blockArray[1] is tx bodies, blockArray[2] is witnesses
+	// blockArray[3] is metadata (if present)
+	headerOffset := arrayHeaderSize
+	txBodiesOffset := headerOffset + uint32(len(blockArray[0]))    // #nosec G115 -- Cardano block segments are <<4GiB
+	witnessesOffset := txBodiesOffset + uint32(len(blockArray[1])) // #nosec G115 -- Cardano block segments are <<4GiB
+	var metadataOffset uint32
+	if len(blockArray) > 3 {
+		metadataOffset = witnessesOffset + uint32(len(blockArray[2])) // #nosec G115 -- Cardano block segments are <<4GiB
+	}
+
+	// Parse transaction bodies array
+	var txBodiesRaw []cbor.RawMessage
+	if _, err := cbor.Decode([]byte(blockArray[1]), &txBodiesRaw); err != nil {
+		return nil, fmt.Errorf("failed to decode transaction bodies: %w", err)
+	}
+
+	// Parse witness sets array
+	var witnessesRaw []cbor.RawMessage
+	if _, err := cbor.Decode([]byte(blockArray[2]), &witnessesRaw); err != nil {
+		return nil, fmt.Errorf("failed to decode witness sets: %w", err)
+	}
+
+	// Validate that transaction bodies and witness sets have matching lengths
+	if len(txBodiesRaw) != len(witnessesRaw) {
+		return nil, fmt.Errorf(
+			"mismatched transaction bodies (%d) and witness sets (%d)",
+			len(txBodiesRaw),
+			len(witnessesRaw),
+		)
+	}
+
+	// Parse metadata map (keyed by transaction index)
+	// Metadata is stored as a CBOR map: {tx_index: metadata, ...}
+	metadataByTxIdx := make(map[uint32]struct {
+		offset uint32
+		length uint32
+	})
+	if len(blockArray) > 3 && len(blockArray[3]) > 1 {
+		// Extract metadata offsets by parsing the map structure
+		// Ignore errors - metadata extraction is best-effort
+		// Some blocks may have unusual metadata structures
+		_ = extractMetadataOffsets(
+			[]byte(blockArray[3]),
+			metadataOffset,
+			metadataByTxIdx,
+		)
+	}
+
+	// Build transaction locations
+	result := &BlockTransactionOffsets{
+		Transactions: make([]TransactionLocation, len(txBodiesRaw)),
+	}
+
+	// Calculate body offsets within the tx bodies array
+	bodiesArrayHeader := cborArrayHeaderSize(len(txBodiesRaw))
+	bodyPos := txBodiesOffset + bodiesArrayHeader
+	for i, rawBody := range txBodiesRaw {
+		bodyLen := uint32(len(rawBody)) // #nosec G115 -- Cardano block segments are <<4GiB
+		result.Transactions[i].Body = ByteRange{
+			Offset: bodyPos,
+			Length: bodyLen,
+		}
+
+		// Extract output offsets from transaction body
+		extractOutputOffsets([]byte(rawBody), bodyPos, &result.Transactions[i])
+
+		bodyPos += bodyLen
+	}
+
+	// Calculate witness offsets within the witnesses array
+	witnessArrayHeader := cborArrayHeaderSize(len(witnessesRaw))
+	witnessPos := witnessesOffset + witnessArrayHeader
+	for i, rawWitness := range witnessesRaw {
+		if i < len(result.Transactions) {
+			result.Transactions[i].Witness = ByteRange{
+				Offset: witnessPos,
+				Length: uint32(len(rawWitness)), // #nosec G115 -- Cardano block segments are <<4GiB
+			}
+
+			// Extract datum, redeemer, and script offsets from witness set
+			extractWitnessComponentOffsets(
+				[]byte(rawWitness),
+				witnessPos,
+				&result.Transactions[i],
+			)
+		}
+		witnessPos += uint32(len(rawWitness)) // #nosec G115 -- Cardano block segments are <<4GiB
+	}
+
+	// Assign metadata offsets
+	for i := range result.Transactions {
+		// #nosec G115 -- transaction index bounded by block size
+		if meta, ok := metadataByTxIdx[uint32(i)]; ok {
+			result.Transactions[i].Metadata = ByteRange{
+				Offset: meta.offset,
+				Length: meta.length,
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// Witness set map keys (Alonzo+ era)
+const (
+	witnessKeyVkeyWitnesses    = 0
+	witnessKeyNativeScripts    = 1
+	witnessKeyBootstrapWitness = 2
+	witnessKeyPlutusV1Scripts  = 3
+	witnessKeyPlutusData       = 4 // Datums
+	witnessKeyRedeemers        = 5
+	witnessKeyPlutusV2Scripts  = 6
+	witnessKeyPlutusV3Scripts  = 7
+)
+
+// extractOutputOffsets parses a transaction body to find output CBOR positions.
+// This uses streaming decode to track positions of each output within the body.
+// The bodyData is the raw CBOR of the transaction body (a map).
+// The bodyOffset is the absolute offset of bodyData within the block.
+func extractOutputOffsets(
+	bodyData []byte,
+	bodyOffset uint32,
+	loc *TransactionLocation,
+) {
+	if len(bodyData) < 2 {
+		return
+	}
+
+	// Transaction body is a CBOR map with numeric keys
+	// Key 1 contains the outputs array
+	count, headerSize, indefinite := cborMapInfo(bodyData)
+	if count < 0 && !indefinite {
+		return
+	}
+
+	// Create a stream decoder for the body content (after map header)
+	bodyStream, err := cbor.NewStreamDecoder(bodyData[headerSize:])
+	if err != nil {
+		return
+	}
+
+	// Scan through map key-value pairs looking for key 1 (outputs)
+	for i := 0; indefinite || i < count; i++ {
+		// Check for break byte in indefinite maps
+		if indefinite {
+			pos := bodyStream.Position()
+			checkPos := int(headerSize) + pos
+			if checkPos >= len(bodyData) || bodyData[checkPos] == 0xff {
+				break
+			}
+		}
+
+		// Decode map key
+		var key uint64
+		if _, _, err := bodyStream.Decode(&key); err != nil {
+			return
+		}
+
+		if key == 1 {
+			// Found the outputs array - decode it with position tracking
+			valueStart := bodyStream.Position()
+
+			// Decode outputs as array of RawMessage
+			var outputsRaw []cbor.RawMessage
+			if _, _, err := bodyStream.Decode(&outputsRaw); err != nil {
+				return
+			}
+
+			// Calculate the absolute offset of the outputs array
+			// #nosec G115 -- valueStart is position within a Cardano tx body, well under 4GiB
+			outputsArrayOffset := bodyOffset + headerSize + uint32(valueStart)
+			outputsArrayHeader := uint32(cborArrayHeaderSize(len(outputsRaw)))
+
+			// Track position within outputs array
+			outputPos := outputsArrayOffset + outputsArrayHeader
+
+			// Record each output's position
+			loc.Outputs = make([]ByteRange, len(outputsRaw))
+			for j, rawOutput := range outputsRaw {
+				outputLen := uint32(len(rawOutput)) // #nosec G115 -- Cardano outputs are <<4GiB
+				loc.Outputs[j] = ByteRange{
+					Offset: outputPos,
+					Length: outputLen,
+				}
+				outputPos += outputLen
+			}
+
+			return // Found outputs, done with this body
+		}
+
+		// Skip the value for this key
+		if _, _, err := bodyStream.Skip(); err != nil {
+			return
+		}
+	}
+}
+
+// extractWitnessComponentOffsets parses a witness set and extracts byte offsets
+// for datums, redeemers, and scripts using streaming decoding.
+func extractWitnessComponentOffsets(
+	witnessData []byte,
+	baseOffset uint32,
+	loc *TransactionLocation,
+) {
+	if len(witnessData) < 2 {
+		return
+	}
+
+	// Initialize maps with small capacity hints
+	loc.Datums = make(map[Blake2b256]ByteRange, 4)
+	loc.Redeemers = make(map[RedeemerKey]ByteRange, 4)
+	loc.Scripts = make(map[ScriptHash]ByteRange, 4)
+
+	// Get map info from header
+	count, headerSize, indefinite := cborMapInfo(witnessData)
+	if count < 0 && !indefinite {
+		return
+	}
+
+	// Use streaming decoder starting after the map header
+	dec, err := cbor.NewStreamDecoder(witnessData[headerSize:])
+	if err != nil {
+		return
+	}
+
+	// Process each key-value pair in CBOR order
+	for i := 0; indefinite || i < count; i++ {
+		// Check for break byte in indefinite maps
+		if indefinite {
+			pos := dec.Position()
+			if int(headerSize)+pos >= len(witnessData) || witnessData[int(headerSize)+pos] == 0xff {
+				break
+			}
+		}
+
+		// Decode the key
+		var key uint64
+		if _, _, err := dec.Decode(&key); err != nil {
+			return
+		}
+
+		// Get value position and bytes
+		valueOffset, valueBytes, err := dec.DecodeRaw(new(cbor.RawMessage))
+		if err != nil {
+			return
+		}
+
+		absOffset := baseOffset + headerSize + uint32(valueOffset) // #nosec G115
+
+		switch key {
+		case witnessKeyPlutusData:
+			extractDatumOffsets(valueBytes, absOffset, loc.Datums)
+
+		case witnessKeyRedeemers:
+			extractRedeemerOffsets(valueBytes, absOffset, loc.Redeemers)
+
+		case witnessKeyNativeScripts:
+			extractScriptArrayOffsets(valueBytes, absOffset, ScriptRefTypeNativeScript, loc.Scripts)
+
+		case witnessKeyPlutusV1Scripts:
+			extractScriptArrayOffsets(valueBytes, absOffset, ScriptRefTypePlutusV1, loc.Scripts)
+
+		case witnessKeyPlutusV2Scripts:
+			extractScriptArrayOffsets(valueBytes, absOffset, ScriptRefTypePlutusV2, loc.Scripts)
+
+		case witnessKeyPlutusV3Scripts:
+			extractScriptArrayOffsets(valueBytes, absOffset, ScriptRefTypePlutusV3, loc.Scripts)
+		}
+	}
+}
+
+// extractDatumOffsets extracts datum hash -> offset mappings from a datum array using streaming decoding.
+// The datum structure is an array of datums: [ datum_cbor, datum_cbor, ... ]
+// Each datum's hash is computed via blake2b-256 of its CBOR encoding.
+func extractDatumOffsets(datumArrayData []byte, baseOffset uint32, result map[Blake2b256]ByteRange) {
+	if len(datumArrayData) < 1 {
+		return
+	}
+
+	// Get array info from header
+	count, headerSize, indefinite := cborArrayInfo(datumArrayData)
+	if count < 0 && !indefinite {
+		return // Invalid array header
+	}
+
+	// Use streaming decoder starting after the array header
+	dec, err := cbor.NewStreamDecoder(datumArrayData[headerSize:])
+	if err != nil {
+		return
+	}
+
+	// Process each datum in the array
+	for i := 0; indefinite || i < count; i++ {
+		// Check for break byte in indefinite arrays
+		if indefinite {
+			pos := dec.Position()
+			if int(headerSize)+pos >= len(datumArrayData) {
+				break
+			}
+			if datumArrayData[int(headerSize)+pos] == 0xff {
+				break
+			}
+		}
+
+		// Get datum position and raw bytes
+		datumOffset, datumBytes, err := dec.DecodeRaw(new(cbor.RawMessage))
+		if err != nil {
+			return
+		}
+
+		// Compute datum hash: blake2b-256 of the datum CBOR
+		computed := blake2b.Sum256(datumBytes)
+		var hash Blake2b256
+		copy(hash[:], computed[:])
+
+		result[hash] = ByteRange{
+			Offset: baseOffset + headerSize + uint32(datumOffset), // #nosec G115 -- Cardano block segments are <<4GiB
+			Length: uint32(len(datumBytes)),                       // #nosec G115 -- Cardano block segments are <<4GiB
+		}
+	}
+}
+
+// extractRedeemerOffsets extracts redeemer key -> offset mappings.
+// Redeemers can be either an array (Alonzo-Babbage) or map (Conway+).
+func extractRedeemerOffsets(redeemerData []byte, baseOffset uint32, result map[RedeemerKey]ByteRange) {
+	if len(redeemerData) < 1 {
+		return
+	}
+
+	// Check if it's a map or array by looking at the first byte (CBOR major type)
+	firstByte := redeemerData[0]
+	majorType := firstByte & 0xe0
+
+	switch majorType {
+	case 0x80:
+		// It's an array (Alonzo-Babbage format): [[purpose, index, data, exunits], ...]
+		// Major type 4 = 0x80-0x9f (including 0x9f for indefinite length)
+		extractRedeemerArrayOffsets(redeemerData, baseOffset, result)
+	case 0xa0:
+		// It's a map (Conway+ format): {[purpose, index]: [data, exunits], ...}
+		// Major type 5 = 0xa0-0xbf (including 0xbf for indefinite length)
+		extractRedeemerMapOffsets(redeemerData, baseOffset, result)
+	}
+}
+
+// extractRedeemerMapOffsets handles the map format for redeemers using streaming decoding.
+// Map format (Conway+): {[purpose, index]: [data, exunits], ...}
+func extractRedeemerMapOffsets(redeemerData []byte, baseOffset uint32, result map[RedeemerKey]ByteRange) {
+	count, headerSize, indefinite := cborMapInfo(redeemerData)
+	if count < 0 && !indefinite {
+		return
+	}
+
+	dec, err := cbor.NewStreamDecoder(redeemerData[headerSize:])
+	if err != nil {
+		return
+	}
+
+	for i := 0; indefinite || i < count; i++ {
+		// Check for break byte in indefinite maps
+		if indefinite {
+			pos := dec.Position()
+			if int(headerSize)+pos >= len(redeemerData) || redeemerData[int(headerSize)+pos] == 0xff {
+				break
+			}
+		}
+
+		// Decode key as [purpose, index]
+		var keyPair []uint64
+		if _, _, err := dec.Decode(&keyPair); err != nil || len(keyPair) < 2 {
+			return
+		}
+
+		key := RedeemerKey{
+			Tag:   RedeemerTag(keyPair[0]), // #nosec G115 -- redeemer tag is a small enum value
+			Index: uint32(keyPair[1]),      // #nosec G115 -- redeemer index bounded by transaction size
+		}
+
+		// Get value position and bytes: value is [data, exunits]
+		valueOffset, valueBytes, err := dec.DecodeRaw(new(cbor.RawMessage))
+		if err != nil {
+			return
+		}
+
+		// Parse the value array to find the data element's position within it
+		// Get array header size first, then create decoder starting after the header
+		_, valueHeaderSize, _ := cborArrayInfo(valueBytes)
+		if int(valueHeaderSize) >= len(valueBytes) {
+			continue
+		}
+		valueDec, err := cbor.NewStreamDecoder(valueBytes[valueHeaderSize:])
+		if err != nil {
+			continue
+		}
+
+		// Get first element (data) position - decoder now starts at the first element
+		dataOffset, dataLen, err := valueDec.Skip()
+		if err != nil {
+			continue
+		}
+
+		result[key] = ByteRange{
+			Offset: baseOffset + headerSize + uint32(valueOffset) + valueHeaderSize + uint32(dataOffset), // #nosec G115
+			Length: uint32(dataLen),                                                                      // #nosec G115
+		}
+	}
+}
+
+// extractRedeemerArrayOffsets handles the array format for redeemers (Alonzo-Babbage) using streaming decoding.
+// Array format: [[purpose, index, data, exunits], ...]
+func extractRedeemerArrayOffsets(redeemerData []byte, baseOffset uint32, result map[RedeemerKey]ByteRange) {
+	count, headerSize, indefinite := cborArrayInfo(redeemerData)
+	if count < 0 && !indefinite {
+		return
+	}
+
+	dec, err := cbor.NewStreamDecoder(redeemerData[headerSize:])
+	if err != nil {
+		return
+	}
+
+	for i := 0; indefinite || i < count; i++ {
+		// Check for break byte in indefinite arrays
+		if indefinite {
+			pos := dec.Position()
+			if int(headerSize)+pos >= len(redeemerData) || redeemerData[int(headerSize)+pos] == 0xff {
+				break
+			}
+		}
+
+		// Get the redeemer element's position and bytes
+		elemOffset, elemBytes, err := dec.DecodeRaw(new(cbor.RawMessage))
+		if err != nil {
+			return
+		}
+
+		// Parse the redeemer array [purpose, index, data, exunits] using streaming
+		// Get inner array header size first, then create decoder starting after the header
+		_, innerHeaderSize, _ := cborArrayInfo(elemBytes)
+		if int(innerHeaderSize) >= len(elemBytes) {
+			continue
+		}
+		elemDec, err := cbor.NewStreamDecoder(elemBytes[innerHeaderSize:])
+		if err != nil {
+			continue
+		}
+
+		// Decode purpose and index - decoder now starts at the first element
+		var purpose, index uint64
+		if _, _, err := elemDec.Decode(&purpose); err != nil {
+			continue
+		}
+		if _, _, err := elemDec.Decode(&index); err != nil {
+			continue
+		}
+
+		key := RedeemerKey{
+			Tag:   RedeemerTag(purpose), // #nosec G115 -- redeemer tag is a small enum value
+			Index: uint32(index),        // #nosec G115 -- redeemer index bounded by transaction size
+		}
+
+		// Get the data element's position (parts[2])
+		dataOffset, dataLen, err := elemDec.Skip()
+		if err != nil {
+			continue
+		}
+
+		result[key] = ByteRange{
+			Offset: baseOffset + headerSize + uint32(elemOffset) + innerHeaderSize + uint32(dataOffset), // #nosec G115
+			Length: uint32(dataLen),                                                                     // #nosec G115
+		}
+	}
+}
+
+// cborArrayInfo extracts array item count and header size from CBOR array data.
+// Returns (count, headerSize, isIndefinite). Count is -1 for invalid headers.
+func cborArrayInfo(data []byte) (int, uint32, bool) {
+	if len(data) == 0 {
+		return -1, 0, false
+	}
+	firstByte := data[0]
+
+	// Check it's an array (major type 4)
+	if firstByte&0xe0 != 0x80 {
+		return -1, 0, false
+	}
+
+	additional := firstByte & 0x1f
+	switch {
+	case additional <= 23:
+		return int(additional), 1, false
+	case additional == 24 && len(data) >= 2:
+		return int(data[1]), 2, false
+	case additional == 25 && len(data) >= 3:
+		return int(uint16(data[1])<<8 | uint16(data[2])), 3, false
+	case additional == 26 && len(data) >= 5:
+		// 4-byte length - check for overflow before converting to int
+		len32 := uint32(data[1])<<24 | uint32(data[2])<<16 | uint32(data[3])<<8 | uint32(data[4])
+		if len32 > uint32(math.MaxInt32) {
+			return -1, 0, false // Too large to handle
+		}
+		return int(len32), 5, false
+	case additional == 27 && len(data) >= 9:
+		// 8-byte length (unlikely for Cardano blocks but handle for completeness)
+		len64 := uint64(data[1])<<56 | uint64(data[2])<<48 |
+			uint64(data[3])<<40 | uint64(data[4])<<32 |
+			uint64(data[5])<<24 | uint64(data[6])<<16 |
+			uint64(data[7])<<8 | uint64(data[8])
+		if len64 > uint64(math.MaxInt32) {
+			return -1, 0, false // Too large to handle
+		}
+		return int(len64), 9, false
+	case additional == 31:
+		return 0, 1, true // Indefinite length
+	default:
+		return -1, 0, false
+	}
+}
+
+// extractScriptArrayOffsets extracts script hash -> offset mappings from a script array.
+// The scriptType parameter specifies the Cardano script type prefix used in hashing:
+// 0x00 = native script, 0x01 = PlutusV1, 0x02 = PlutusV2, 0x03 = PlutusV3
+func extractScriptArrayOffsets(scriptArrayData []byte, baseOffset uint32, scriptType byte, result map[ScriptHash]ByteRange) {
+	if len(scriptArrayData) < 1 {
+		return
+	}
+
+	var scripts []cbor.RawMessage
+	if _, err := cbor.Decode(scriptArrayData, &scripts); err != nil {
+		return
+	}
+
+	// Determine header size based on actual encoding
+	// 0x9f indicates indefinite-length array (header = 1 byte)
+	var arrayHeaderSize uint32
+	if scriptArrayData[0] == 0x9f {
+		arrayHeaderSize = 1
+	} else {
+		_, arrayHeaderSize, _ = cborArrayInfo(scriptArrayData)
+	}
+	pos := arrayHeaderSize
+
+	for _, scriptRaw := range scripts {
+		scriptBytes := []byte(scriptRaw)
+
+		// Compute script hash: blake2b-224(prefix || script_cbor)
+		// This matches the Hash() method on Script types
+		hashKey := Blake2b224Hash(slices.Concat([]byte{scriptType}, scriptBytes))
+
+		result[hashKey] = ByteRange{
+			Offset: baseOffset + pos,
+			Length: uint32(len(scriptBytes)), // #nosec G115 -- Cardano block segments are <<4GiB
+		}
+
+		pos += uint32(len(scriptBytes)) // #nosec G115 -- Cardano block segments are <<4GiB
+	}
+}
+
+// extractMetadataOffsets parses a CBOR map to extract value offsets using streaming decoding.
+// The metadata map has transaction indices as keys and metadata as values.
+func extractMetadataOffsets(
+	mapData []byte,
+	baseOffset uint32,
+	result map[uint32]struct {
+		offset uint32
+		length uint32
+	},
+) error {
+	if len(mapData) == 0 {
+		return nil
+	}
+
+	// Get map item count from header
+	count, headerSize, indefinite := cborMapInfo(mapData)
+	if count < 0 {
+		return nil // Invalid map header
+	}
+
+	// Use streaming decoder starting after the map header
+	dec, err := cbor.NewStreamDecoder(mapData[headerSize:])
+	if err != nil {
+		return err
+	}
+
+	// For indefinite maps, we don't know the count upfront
+	// Process until we hit the break byte (0xff) or run out of data
+	for i := 0; indefinite || i < count; i++ {
+		// Check for break byte in indefinite maps
+		if indefinite {
+			pos := dec.Position()
+			if int(headerSize)+pos >= len(mapData) {
+				break
+			}
+			if mapData[int(headerSize)+pos] == 0xff {
+				break // End of indefinite map
+			}
+		}
+
+		// Decode the key (transaction index)
+		var txIdx uint64
+		if _, _, err := dec.Decode(&txIdx); err != nil {
+			return err
+		}
+
+		// Get position and skip the value to get its byte range
+		valueOffset, valueLen, err := dec.Skip()
+		if err != nil {
+			return err
+		}
+
+		// #nosec G115 -- transaction index bounded by block size, Cardano block segments are <<4GiB
+		result[uint32(txIdx)] = struct {
+			offset uint32
+			length uint32
+		}{
+			offset: baseOffset + headerSize + uint32(valueOffset),
+			length: uint32(valueLen),
+		}
+	}
+
+	return nil
+}
+
+// cborMapInfo extracts map item count and header size from CBOR map data.
+// Returns (count, headerSize, isIndefinite). Count is -1 for invalid headers.
+func cborMapInfo(data []byte) (int, uint32, bool) {
+	if len(data) == 0 {
+		return -1, 0, false
+	}
+	firstByte := data[0]
+
+	// Check it's a map (major type 5)
+	if firstByte&0xe0 != 0xa0 {
+		return -1, 0, false
+	}
+
+	additional := firstByte & 0x1f
+	switch {
+	case additional <= 23:
+		return int(additional), 1, false
+	case additional == 24 && len(data) >= 2:
+		return int(data[1]), 2, false
+	case additional == 25 && len(data) >= 3:
+		return int(uint16(data[1])<<8 | uint16(data[2])), 3, false
+	case additional == 26 && len(data) >= 5:
+		// 4-byte length - check for overflow before converting to int
+		len32 := uint32(data[1])<<24 | uint32(data[2])<<16 | uint32(data[3])<<8 | uint32(data[4])
+		if len32 > uint32(math.MaxInt32) {
+			return -1, 0, false // Too large to handle
+		}
+		return int(len32), 5, false
+	case additional == 27 && len(data) >= 9:
+		// 8-byte length (unlikely for Cardano blocks but handle for completeness)
+		len64 := uint64(data[1])<<56 | uint64(data[2])<<48 |
+			uint64(data[3])<<40 | uint64(data[4])<<32 |
+			uint64(data[5])<<24 | uint64(data[6])<<16 |
+			uint64(data[7])<<8 | uint64(data[8])
+		if len64 > uint64(math.MaxInt32) {
+			return -1, 0, false // Too large to handle
+		}
+		return int(len64), 9, false
+	case additional == 31:
+		return 0, 1, true // Indefinite length
+	default:
+		return -1, 0, false
+	}
+}
+
+// cborArrayHeaderSize returns the CBOR header size in bytes for an array of given length.
+func cborArrayHeaderSize(length int) uint32 {
+	if length < 24 {
+		return 1 // 0x80 + length
+	} else if length < 256 {
+		return 2 // 0x98 + 1-byte length
+	} else if length < 65536 {
+		return 3 // 0x99 + 2-byte length
+	}
+	return 5 // 0x9a + 4-byte length (covers up to 2^32 elements)
 }
 
 type MissingTransactionMetadataError struct {

--- a/ledger/common/streaming_decode.go
+++ b/ledger/common/streaming_decode.go
@@ -1,0 +1,448 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+)
+
+// BlockWithOffsets pairs a decoded block with its pre-computed CBOR offsets.
+// This enables efficient extraction of transaction/UTxO data without re-parsing.
+type BlockWithOffsets struct {
+	// Block is the fully decoded block
+	Block Block
+
+	// Offsets contains byte positions for all transactions and their components
+	Offsets *BlockTransactionOffsets
+}
+
+// OutputLocation represents the byte location of a transaction output within block CBOR.
+type OutputLocation struct {
+	// TxIndex is the transaction index within the block
+	TxIndex int
+
+	// OutputIndex is the output index within the transaction
+	OutputIndex int
+
+	// Range is the byte range of the output CBOR
+	Range ByteRange
+}
+
+// BlockOutputOffsets contains byte offsets for all outputs in a block.
+type BlockOutputOffsets struct {
+	// Outputs maps (tx_index, output_index) to byte location
+	Outputs []OutputLocation
+}
+
+// StreamingBlockDecoder decodes blocks while capturing CBOR byte offsets.
+// This is more efficient than decoding and extracting offsets separately.
+type StreamingBlockDecoder struct {
+	data    []byte
+	stream  *cbor.StreamDecoder
+	offsets *BlockTransactionOffsets
+}
+
+// NewStreamingBlockDecoder creates a decoder for the given block CBOR.
+func NewStreamingBlockDecoder(data []byte) (*StreamingBlockDecoder, error) {
+	stream, err := cbor.NewStreamDecoder(data)
+	if err != nil {
+		return nil, fmt.Errorf("create stream decoder: %w", err)
+	}
+
+	return &StreamingBlockDecoder{
+		data:   data,
+		stream: stream,
+		offsets: &BlockTransactionOffsets{
+			Transactions: nil, // Will be allocated when we know the count
+		},
+	}, nil
+}
+
+// DecodeWithOffsets decodes the block and extracts all CBOR offsets in a single pass.
+// This is the main entry point for streaming block decoding.
+//
+// The function:
+// 1. Parses the block array structure
+// 2. Extracts transaction body, witness, and metadata positions
+// 3. Extracts output positions within each transaction body
+// 4. Returns offsets for efficient later extraction
+//
+// Note: The actual Block struct is created by calling the appropriate era-specific
+// decoder on the raw data. This function focuses on offset extraction.
+func (d *StreamingBlockDecoder) DecodeWithOffsets() (*BlockTransactionOffsets, error) {
+	// Decode block as array of RawMessage to get component boundaries
+	var blockArray []cbor.RawMessage
+	blockStart, blockLen, err := d.stream.Decode(&blockArray)
+	if err != nil {
+		return nil, fmt.Errorf("decode block array: %w", err)
+	}
+	_ = blockLen // Used for validation if needed
+
+	if len(blockArray) < 3 {
+		// Byron EBB or other minimal block format
+		// Return empty slice instead of nil to prevent nil pointer dereference
+		d.offsets.Transactions = []TransactionLocation{}
+		return d.offsets, nil
+	}
+
+	// Calculate component offsets within the block
+	// Block structure: [header, tx_bodies[], witnesses[], metadata_map, invalid_txs[]]
+	arrayHeaderSize := cborArrayHeaderSize(len(blockArray))
+
+	// Track positions as we walk through the block
+	// #nosec G115 -- Cardano block components are well under 4GiB
+	pos := uint32(blockStart) + uint32(arrayHeaderSize)
+
+	// Skip header (blockArray[0])
+	// #nosec G115 -- block header <<4GiB
+	headerLen := uint32(len(blockArray[0]))
+	pos += headerLen
+
+	// Extract transaction bodies array (blockArray[1])
+	txBodiesOffset := pos
+	// #nosec G115 -- tx bodies <<4GiB
+	txBodiesLen := uint32(len(blockArray[1]))
+
+	// Extract witness sets array (blockArray[2])
+	witnessesOffset := txBodiesOffset + txBodiesLen
+	// #nosec G115 -- witnesses <<4GiB
+	witnessesLen := uint32(len(blockArray[2]))
+
+	// Extract metadata map offset (blockArray[3] if present)
+	var metadataOffset uint32
+	if len(blockArray) > 3 {
+		metadataOffset = witnessesOffset + witnessesLen
+	}
+
+	// Parse transaction bodies to get individual positions
+	var txBodiesRaw []cbor.RawMessage
+	if _, err := cbor.Decode([]byte(blockArray[1]), &txBodiesRaw); err != nil {
+		return nil, fmt.Errorf("decode transaction bodies: %w", err)
+	}
+
+	// Parse witness sets
+	var witnessesRaw []cbor.RawMessage
+	if _, err := cbor.Decode([]byte(blockArray[2]), &witnessesRaw); err != nil {
+		return nil, fmt.Errorf("decode witness sets: %w", err)
+	}
+
+	// Validate that transaction bodies and witness sets have matching lengths
+	if len(txBodiesRaw) != len(witnessesRaw) {
+		return nil, fmt.Errorf(
+			"mismatched transaction bodies (%d) and witness sets (%d)",
+			len(txBodiesRaw),
+			len(witnessesRaw),
+		)
+	}
+
+	// Parse metadata map for per-transaction metadata positions
+	metadataByTxIdx := make(map[uint32]struct {
+		offset uint32
+		length uint32
+	})
+	if len(blockArray) > 3 && len(blockArray[3]) > 1 {
+		_ = extractMetadataOffsets(
+			[]byte(blockArray[3]),
+			metadataOffset,
+			metadataByTxIdx,
+		)
+	}
+
+	// Allocate transaction locations
+	d.offsets.Transactions = make([]TransactionLocation, len(txBodiesRaw))
+
+	// Calculate individual transaction body offsets
+	bodiesArrayHeader := uint32(cborArrayHeaderSize(len(txBodiesRaw)))
+	bodyPos := txBodiesOffset + bodiesArrayHeader
+
+	for i, rawBody := range txBodiesRaw {
+		// #nosec G115 -- tx body <<4GiB
+		bodyLen := uint32(len(rawBody))
+		d.offsets.Transactions[i].Body = ByteRange{
+			Offset: bodyPos,
+			Length: bodyLen,
+		}
+
+		// Extract output offsets from this transaction body
+		d.extractOutputOffsets(i, []byte(rawBody), bodyPos)
+
+		bodyPos += bodyLen
+	}
+
+	// Calculate individual witness set offsets
+	witnessArrayHeader := uint32(cborArrayHeaderSize(len(witnessesRaw)))
+	witnessPos := witnessesOffset + witnessArrayHeader
+
+	for i, rawWitness := range witnessesRaw {
+		// #nosec G115 -- witness set <<4GiB
+		witnessLen := uint32(len(rawWitness))
+		if i < len(d.offsets.Transactions) {
+			d.offsets.Transactions[i].Witness = ByteRange{
+				Offset: witnessPos,
+				Length: witnessLen,
+			}
+
+			// Extract datum, redeemer, and script offsets
+			extractWitnessComponentOffsets(
+				[]byte(rawWitness),
+				witnessPos,
+				&d.offsets.Transactions[i],
+			)
+		}
+		witnessPos += witnessLen
+	}
+
+	// Assign metadata offsets
+	for i := range d.offsets.Transactions {
+		// #nosec G115 -- tx index <<4 billion
+		if meta, ok := metadataByTxIdx[uint32(i)]; ok {
+			d.offsets.Transactions[i].Metadata = ByteRange{
+				Offset: meta.offset,
+				Length: meta.length,
+			}
+		}
+	}
+
+	return d.offsets, nil
+}
+
+// extractOutputOffsets parses a transaction body to find output CBOR positions.
+// This uses streaming decode to track positions of each output within the body.
+func (d *StreamingBlockDecoder) extractOutputOffsets(
+	txIndex int,
+	bodyData []byte,
+	bodyOffset uint32,
+) {
+	// Transaction body is a CBOR map with numeric keys
+	// Key 1 contains the outputs array
+	// We need to find the outputs array and get positions of each output
+
+	if len(bodyData) < 2 {
+		return
+	}
+
+	// Parse the transaction body map
+	count, headerSize, indefinite := cborMapInfo(bodyData)
+	if count < 0 && !indefinite {
+		return
+	}
+
+	// Create a stream decoder for the body content (after map header)
+	bodyStream, err := cbor.NewStreamDecoder(bodyData[headerSize:])
+	if err != nil {
+		return
+	}
+
+	// Scan through map key-value pairs looking for key 1 (outputs)
+	for i := 0; indefinite || i < count; i++ {
+		// Check for break byte in indefinite maps
+		if indefinite {
+			pos := bodyStream.Position()
+			checkPos := int(headerSize) + pos
+			if checkPos >= len(bodyData) || bodyData[checkPos] == 0xff {
+				break
+			}
+		}
+
+		// Decode map key
+		var key uint64
+		keyStart, keyLen, err := bodyStream.Decode(&key)
+		if err != nil {
+			return
+		}
+		_ = keyStart
+		_ = keyLen
+
+		if key == 1 {
+			// Found the outputs array - decode it with position tracking
+			valueStart := bodyStream.Position()
+
+			// Decode outputs as array of RawMessage
+			var outputsRaw []cbor.RawMessage
+			_, _, err := bodyStream.Decode(&outputsRaw)
+			if err != nil {
+				return
+			}
+
+			// Calculate the absolute offset of the outputs array
+			// #nosec G115 -- Cardano tx body offsets are well under 4GiB
+			outputsArrayOffset := bodyOffset + uint32(headerSize) + uint32(valueStart)
+			outputsArrayHeader := uint32(cborArrayHeaderSize(len(outputsRaw)))
+
+			// Track position within outputs array
+			outputPos := outputsArrayOffset + outputsArrayHeader
+
+			// Record each output's position
+			if d.offsets.Transactions[txIndex].Outputs == nil {
+				d.offsets.Transactions[txIndex].Outputs = make([]ByteRange, len(outputsRaw))
+			}
+
+			for j, rawOutput := range outputsRaw {
+				// #nosec G115 -- Cardano outputs are <<4GiB
+				outputLen := uint32(len(rawOutput))
+				d.offsets.Transactions[txIndex].Outputs[j] = ByteRange{
+					Offset: outputPos,
+					Length: outputLen,
+				}
+				outputPos += outputLen
+			}
+
+			return // Found outputs, done with this body
+		}
+
+		// Skip the value for this key
+		if _, _, err := bodyStream.Skip(); err != nil {
+			return
+		}
+	}
+}
+
+// DecodeBlockWithOffsets decodes a block and extracts CBOR offsets.
+// This performs two passes: one for offset extraction, one for block decoding.
+//
+// Parameters:
+//   - blockType: The block type ID (e.g., BlockTypeConway)
+//   - data: Raw block CBOR bytes
+//   - decodeBlock: Function to decode the block into its typed struct
+//
+// Returns:
+//   - BlockWithOffsets containing both the decoded block and offset information
+//   - error if decoding fails
+func DecodeBlockWithOffsets(
+	blockType uint,
+	data []byte,
+	decodeBlock func(uint, []byte) (Block, error),
+) (*BlockWithOffsets, error) {
+	// First, extract offsets using streaming decoder
+	decoder, err := NewStreamingBlockDecoder(data)
+	if err != nil {
+		return nil, fmt.Errorf("create streaming decoder: %w", err)
+	}
+
+	offsets, err := decoder.DecodeWithOffsets()
+	if err != nil {
+		return nil, fmt.Errorf("extract offsets: %w", err)
+	}
+
+	// Then decode the block using the era-specific decoder
+	// This is still needed because the streaming decoder doesn't fully
+	// populate the block struct - it focuses on offset extraction
+	block, err := decodeBlock(blockType, data)
+	if err != nil {
+		return nil, fmt.Errorf("decode block: %w", err)
+	}
+
+	return &BlockWithOffsets{
+		Block:   block,
+		Offsets: offsets,
+	}, nil
+}
+
+// ExtractOutputCbor extracts the raw CBOR for a specific output from block data.
+// This uses pre-computed offsets for efficient extraction without re-parsing.
+func ExtractOutputCbor(
+	blockData []byte,
+	offsets *BlockTransactionOffsets,
+	txIndex int,
+	outputIndex int,
+) ([]byte, error) {
+	// Validate inputs
+	if offsets == nil {
+		return nil, errors.New("offsets is nil")
+	}
+	if txIndex < 0 {
+		return nil, fmt.Errorf("transaction index %d is negative", txIndex)
+	}
+	if outputIndex < 0 {
+		return nil, fmt.Errorf("output index %d is negative", outputIndex)
+	}
+	if txIndex >= len(offsets.Transactions) {
+		return nil, fmt.Errorf("transaction index %d out of range", txIndex)
+	}
+
+	txLoc := offsets.Transactions[txIndex]
+	if outputIndex >= len(txLoc.Outputs) {
+		return nil, fmt.Errorf("output index %d out of range for transaction %d", outputIndex, txIndex)
+	}
+
+	outputRange := txLoc.Outputs[outputIndex]
+
+	// Check for overflow in offset + length calculation
+	end := uint64(outputRange.Offset) + uint64(outputRange.Length)
+	if end > uint64(len(blockData)) {
+		return nil, errors.New("output range exceeds block data")
+	}
+
+	return blockData[outputRange.Offset : outputRange.Offset+outputRange.Length], nil
+}
+
+// ExtractTransactionBodyCbor extracts the raw CBOR for a transaction body.
+func ExtractTransactionBodyCbor(
+	blockData []byte,
+	offsets *BlockTransactionOffsets,
+	txIndex int,
+) ([]byte, error) {
+	// Validate inputs
+	if offsets == nil {
+		return nil, errors.New("offsets is nil")
+	}
+	if txIndex < 0 {
+		return nil, fmt.Errorf("transaction index %d is negative", txIndex)
+	}
+	if txIndex >= len(offsets.Transactions) {
+		return nil, fmt.Errorf("transaction index %d out of range", txIndex)
+	}
+
+	bodyRange := offsets.Transactions[txIndex].Body
+
+	// Check for overflow in offset + length calculation
+	end := uint64(bodyRange.Offset) + uint64(bodyRange.Length)
+	if end > uint64(len(blockData)) {
+		return nil, errors.New("body range exceeds block data")
+	}
+
+	return blockData[bodyRange.Offset : bodyRange.Offset+bodyRange.Length], nil
+}
+
+// ExtractWitnessCbor extracts the raw CBOR for a transaction witness set.
+func ExtractWitnessCbor(
+	blockData []byte,
+	offsets *BlockTransactionOffsets,
+	txIndex int,
+) ([]byte, error) {
+	// Validate inputs
+	if offsets == nil {
+		return nil, errors.New("offsets is nil")
+	}
+	if txIndex < 0 {
+		return nil, fmt.Errorf("transaction index %d is negative", txIndex)
+	}
+	if txIndex >= len(offsets.Transactions) {
+		return nil, fmt.Errorf("transaction index %d out of range", txIndex)
+	}
+
+	witnessRange := offsets.Transactions[txIndex].Witness
+
+	// Check for overflow in offset + length calculation
+	end := uint64(witnessRange.Offset) + uint64(witnessRange.Length)
+	if end > uint64(len(blockData)) {
+		return nil, errors.New("witness range exceeds block data")
+	}
+
+	return blockData[witnessRange.Offset : witnessRange.Offset+witnessRange.Length], nil
+}

--- a/ledger/common/streaming_decode_test.go
+++ b/ledger/common/streaming_decode_test.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamingBlockDecoder(t *testing.T) {
+	// Test with a minimal valid CBOR block structure
+	// Block structure: [header, tx_bodies[], witnesses[], metadata_map, invalid_txs[]]
+
+	// This is a simplified test - in production, use real block data
+	// For now, test that the decoder handles the basic structure
+
+	t.Run("empty block array", func(t *testing.T) {
+		// CBOR array with 5 empty elements: [[], [], [], {}, []]
+		// 85 = array(5)
+		// 80 = array(0) - header placeholder
+		// 80 = array(0) - tx bodies
+		// 80 = array(0) - witnesses
+		// a0 = map(0) - metadata
+		// 80 = array(0) - invalid txs
+		data := []byte{0x85, 0x80, 0x80, 0x80, 0xa0, 0x80}
+
+		decoder, err := common.NewStreamingBlockDecoder(data)
+		require.NoError(t, err, "creating decoder should succeed")
+
+		offsets, err := decoder.DecodeWithOffsets()
+		require.NoError(t, err, "decoding should succeed")
+
+		assert.NotNil(t, offsets, "offsets should not be nil")
+		assert.Empty(t, offsets.Transactions, "should have no transactions")
+	})
+
+	t.Run("invalid CBOR", func(t *testing.T) {
+		data := []byte{0xff, 0xff, 0xff}
+
+		decoder, err := common.NewStreamingBlockDecoder(data)
+		require.NoError(t, err, "creating decoder should succeed")
+
+		_, err = decoder.DecodeWithOffsets()
+		assert.Error(t, err, "decoding invalid CBOR should fail")
+	})
+}
+
+func TestExtractOutputCbor(t *testing.T) {
+	t.Run("valid extraction", func(t *testing.T) {
+		// Create mock block data and offsets
+		blockData := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09}
+		offsets := &common.BlockTransactionOffsets{
+			Transactions: []common.TransactionLocation{
+				{
+					Body: common.ByteRange{Offset: 0, Length: 4},
+					Outputs: []common.ByteRange{
+						{Offset: 2, Length: 2}, // bytes 0x02, 0x03
+						{Offset: 4, Length: 3}, // bytes 0x04, 0x05, 0x06
+					},
+				},
+			},
+		}
+
+		// Extract first output
+		output0, err := common.ExtractOutputCbor(blockData, offsets, 0, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []byte{0x02, 0x03}, output0)
+
+		// Extract second output
+		output1, err := common.ExtractOutputCbor(blockData, offsets, 0, 1)
+		require.NoError(t, err)
+		assert.Equal(t, []byte{0x04, 0x05, 0x06}, output1)
+	})
+
+	t.Run("transaction index out of range", func(t *testing.T) {
+		blockData := []byte{0x00, 0x01, 0x02, 0x03}
+		offsets := &common.BlockTransactionOffsets{
+			Transactions: []common.TransactionLocation{},
+		}
+
+		_, err := common.ExtractOutputCbor(blockData, offsets, 0, 0)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "transaction index")
+	})
+
+	t.Run("output index out of range", func(t *testing.T) {
+		blockData := []byte{0x00, 0x01, 0x02, 0x03}
+		offsets := &common.BlockTransactionOffsets{
+			Transactions: []common.TransactionLocation{
+				{
+					Outputs: []common.ByteRange{},
+				},
+			},
+		}
+
+		_, err := common.ExtractOutputCbor(blockData, offsets, 0, 0)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "output index")
+	})
+}
+
+func TestExtractTransactionBodyCbor(t *testing.T) {
+	blockData := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}
+	offsets := &common.BlockTransactionOffsets{
+		Transactions: []common.TransactionLocation{
+			{
+				Body: common.ByteRange{Offset: 2, Length: 4}, // bytes 0x02-0x05
+			},
+		},
+	}
+
+	body, err := common.ExtractTransactionBodyCbor(blockData, offsets, 0)
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x02, 0x03, 0x04, 0x05}, body)
+}
+
+func TestExtractWitnessCbor(t *testing.T) {
+	blockData := []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}
+	offsets := &common.BlockTransactionOffsets{
+		Transactions: []common.TransactionLocation{
+			{
+				Witness: common.ByteRange{Offset: 3, Length: 3}, // bytes 0x03-0x05
+			},
+		},
+	}
+
+	witness, err := common.ExtractWitnessCbor(blockData, offsets, 0)
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0x03, 0x04, 0x05}, witness)
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CBOR byte offset calculation for all transactions in a block to enable fast partial CBOR extraction without full deserialization. Adds per-output ranges and a streaming decoder/API to collect offsets while decoding blocks.

- **New Features**
  - Single-pass offset extraction via common.StreamingBlockDecoder; combined decode+offsets helper NewBlockFromCborWithOffsets; adds ExtractOutputCbor/ExtractTransactionBodyCbor/ExtractWitnessCbor; TransactionLocation now includes per-output ranges.
  - Types/APIs: ByteRange, TransactionLocation, BlockTransactionOffsets, BlockWithOffsets, cbor.StreamDecoder, and ExtractTransactionOffsets. Witness offsets for datums by hash, redeemers by key (map and array), scripts by hash (native, Plutus V1/V2/V3). Supports Alonzo+ and Conway; metadata best-effort.

<sup>Written for commit 1f2337ae9dbfbdc5534ad89d32e5a8e6054143a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-transaction CBOR offsets for bodies, witnesses, metadata and nested components (outputs, datums, redeemers, scripts).
  * Position-aware CBOR streaming API with raw-byte access, header/array helpers, item iteration, and single-pass offset extraction.
  * Helpers to extract raw CBOR slices and a combined decode+offsets workflow returning both decoded block and offsets.

* **Bug Fixes / Errors**
  * New explicit error types for missing or conflicting transaction metadata.

* **Tests**
  * Added tests for streaming decoding and extraction helpers; test helper for genesis value creation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->