### PR TITLE
docs: individual mini-protocol readmes

### DIFF
--- a/protocol/README.md
+++ b/protocol/README.md
@@ -1,0 +1,172 @@
+# Ouroboros Mini-Protocols
+
+This directory contains implementations of the Ouroboros mini-protocols used for communication between Cardano nodes and clients.
+
+## Protocol Overview
+
+| Protocol | ID | Mode | Purpose |
+|----------|-----|------|---------|
+| [Handshake](handshake/) | 0 | NtN/NtC | Version negotiation |
+| [ChainSync](chainsync/) | 2/5 | NtN/NtC | Blockchain synchronization |
+| [BlockFetch](blockfetch/) | 3 | NtN | Block retrieval |
+| [TxSubmission](txsubmission/) | 4 | NtN | Transaction propagation |
+| [LocalTxSubmission](localtxsubmission/) | 6 | NtC | Local transaction submission |
+| [LocalStateQuery](localstatequery/) | 7 | NtC | Ledger state queries |
+| [KeepAlive](keepalive/) | 8 | NtN | Connection liveness |
+| [LocalTxMonitor](localtxmonitor/) | 9 | NtC | Mempool monitoring |
+| [PeerSharing](peersharing/) | 10 | NtN | Peer discovery |
+| [MessageSubmission](messagesubmission/) | 17 | NtN | DMQ message propagation |
+| [LeiosNotify](leiosnotify/) | 18 | NtN | Leios notifications |
+| [LocalMessageSubmission](localmessagesubmission/) | 18 | NtC | Local DMQ submission |
+| [LeiosFetch](leiosfetch/) | 19 | NtN | Leios data retrieval |
+| [LocalMessageNotification](localmessagenotification/) | 19 | NtC | Local DMQ notifications |
+
+**Mode Key:**
+- **NtN**: Node-to-Node (between full nodes)
+- **NtC**: Node-to-Client (between node and wallet/application)
+
+## Protocol Architecture
+
+### State Machines
+
+Each protocol is defined by a state machine with:
+- **States**: Named protocol states with numeric IDs
+- **Agency**: Which party (Client/Server) can send messages in each state
+- **Transitions**: Valid message types that trigger state changes
+- **Timeouts**: Optional deadlines for state transitions
+
+### Agency Model
+
+The Ouroboros protocol uses an agency model where only one party can send messages at a time:
+- **Client Agency**: Client sends, server waits
+- **Server Agency**: Server sends, client waits
+- **None**: Terminal state (Done)
+
+### Common Patterns
+
+**Acquire/Release Pattern** (LocalStateQuery, LocalTxMonitor):
+```
+Idle → Acquiring → Acquired → (query) → Acquired → Release → Idle
+```
+
+**Request/Reply Pattern** (BlockFetch, PeerSharing):
+```
+Idle → Request → Busy → Reply → Idle
+```
+
+**Streaming Pattern** (ChainSync, BlockFetch):
+```
+Idle → Request → Streaming → (data)* → Done → Idle
+```
+
+**Init Pattern** (TxSubmission, MessageSubmission):
+```
+Init → Idle → (request/reply cycle)
+```
+
+## Protocol Groups
+
+### Core Synchronization
+- **Handshake**: Establishes protocol version
+- **ChainSync**: Synchronizes blockchain headers/blocks
+- **BlockFetch**: Retrieves full block bodies
+
+### Transaction Handling
+- **TxSubmission**: Node-to-node transaction propagation
+- **LocalTxSubmission**: Submit transactions to local node
+- **LocalTxMonitor**: Monitor local mempool
+
+### State & Discovery
+- **LocalStateQuery**: Query ledger state
+- **PeerSharing**: Discover new peers
+- **KeepAlive**: Maintain connection liveness
+
+### CIP-0137 (DMQ)
+- **MessageSubmission**: Node-to-node message propagation
+- **LocalMessageSubmission**: Submit messages to local node
+- **LocalMessageNotification**: Receive message notifications
+
+### Leios (Experimental)
+- **LeiosNotify**: Block/vote announcements
+- **LeiosFetch**: Block/vote retrieval
+
+## Usage
+
+### Creating a Protocol Instance
+
+```go
+import (
+    "log/slog"
+
+    "github.com/blinklabs-io/gouroboros/protocol"
+    "github.com/blinklabs-io/gouroboros/protocol/chainsync"
+)
+
+// Create protocol options
+protoOptions := protocol.ProtocolOptions{
+    ConnectionId: connId,                              // connection.ConnectionId
+    Muxer:        muxer,                               // *muxer.Muxer
+    Logger:       slog.Default(),                      // *slog.Logger
+    ErrorChan:    errorChan,                           // chan error
+    Mode:         protocol.ProtocolModeNodeToClient,
+    Role:         protocol.ProtocolRoleClient,
+    Version:      versionNumber,                       // uint16
+}
+
+// Create protocol config with callbacks
+cfg := chainsync.NewConfig(
+    chainsync.WithRollForwardFunc(handleRollForward),
+    chainsync.WithRollBackwardFunc(handleRollBackward),
+)
+
+// Create protocol instance
+cs := chainsync.New(protoOptions, &cfg)
+```
+
+### Starting the Protocol
+
+```go
+// Start the protocol
+cs.Client.Start()
+
+// Use protocol methods
+cs.Client.RequestNext()
+```
+
+## Common Configuration
+
+All protocols support these common options:
+- **Timeouts**: Per-state or operation timeouts
+- **Callbacks**: Functions called on message receipt
+- **Queue Sizes**: Receive queue capacity
+
+## Error Handling
+
+Protocols report errors through the error channel:
+```go
+errChan := make(chan error, 10)
+protoOptions := protocol.ProtocolOptions{
+    ErrorChan: errChan,
+    // ...
+}
+
+go func() {
+    for err := range errChan {
+        slog.Default().Error("Protocol error", "error", err)
+    }
+}()
+```
+
+## Limits
+
+Each protocol defines specific limits documented in its README:
+- Message sizes
+- Queue depths
+- Pipeline counts
+- Pending byte limits
+
+## References
+
+- [Ouroboros Network Specification](https://github.com/IntersectMBO/ouroboros-network)
+- [CIP-0137: Distributed Message Queue](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0137)
+- [Leios Protocol Specification](https://github.com/input-output-hk/ouroboros-leios)

--- a/protocol/blockfetch/README.md
+++ b/protocol/blockfetch/README.md
@@ -1,0 +1,137 @@
+# BlockFetch Protocol
+
+The BlockFetch protocol retrieves blocks by hash from a peer node. It is used in node-to-node communication to fetch full block bodies after discovering headers via ChainSync.
+
+## Protocol Identifiers
+
+| Property | Value |
+|----------|-------|
+| Protocol Name | `block-fetch` |
+| Protocol ID | `3` |
+| Mode | Node-to-Node |
+
+## State Machine
+
+```text
+┌──────┐  RequestRange   ┌──────┐
+│ Idle │ ───────────────►│ Busy │
+└──┬───┘                 └──┬───┘
+   │                        │
+   │ ClientDone             │ StartBatch
+   │                        │ NoBlocks
+   │                        │
+   ▼                        ▼
+┌──────┐              ┌───────────┐
+│ Done │◄─────────────│ Streaming │◄───┐
+└──────┘              └─────┬─────┘    │
+                            │          │
+                            │ Block    │
+                            └──────────┘
+                            │
+                            │ BatchDone
+                            ▼
+                       ┌──────┐
+                       │ Idle │
+                       └──────┘
+```
+
+## States
+
+| State | ID | Agency | Description |
+|-------|-----|--------|-------------|
+| **Idle** | 1 | Client | Waiting for block range request |
+| **Busy** | 2 | Server | Processing range request |
+| **Streaming** | 3 | Server | Streaming blocks to client |
+| **Done** | 4 | None | Terminal state |
+
+## Messages
+
+| Message | Type ID | Direction | Description |
+|---------|---------|-----------|-------------|
+| `RequestRange` | 0 | Client → Server | Request blocks in range |
+| `ClientDone` | 1 | Client → Server | Terminate protocol |
+| `StartBatch` | 2 | Server → Client | Begin streaming blocks |
+| `NoBlocks` | 3 | Server → Client | No blocks available for range |
+| `Block` | 4 | Server → Client | Single block in batch |
+| `BatchDone` | 5 | Server → Client | End of block batch |
+
+## State Transitions
+
+### From Idle (Client Agency)
+| Message | New State |
+|---------|-----------|
+| `RequestRange` | Busy |
+| `ClientDone` | Done |
+
+### From Busy (Server Agency)
+| Message | New State |
+|---------|-----------|
+| `StartBatch` | Streaming |
+| `NoBlocks` | Idle |
+
+### From Streaming (Server Agency)
+| Message | New State |
+|---------|-----------|
+| `Block` | Streaming |
+| `BatchDone` | Idle |
+
+## Timeouts
+
+| State | Timeout | Description |
+|-------|---------|-------------|
+| Busy | 60 seconds | Server must start batch or respond no blocks |
+| Streaming | 60 seconds | Server must send next block in batch |
+
+## Limits
+
+| Limit | Value | Description |
+|-------|-------|-------------|
+| Max Recv Queue Size | 512 | Maximum receive queue messages |
+| Default Recv Queue Size | 384 | Default queue size |
+| Streaming Max Pending Bytes | 2.5 MB | Max pending bytes in Streaming state |
+| Idle/Busy Max Pending Bytes | 64 KB | Max pending bytes in Idle/Busy states |
+
+## Configuration Options
+
+```go
+blockfetch.NewConfig(
+    blockfetch.WithBlockFunc(blockCallback),
+    blockfetch.WithBlockRawFunc(blockRawCallback),
+    blockfetch.WithBatchDoneFunc(batchDoneCallback),
+    blockfetch.WithRequestRangeFunc(requestRangeCallback),
+    blockfetch.WithBatchStartTimeout(5 * time.Second),
+    blockfetch.WithBlockTimeout(60 * time.Second),
+    blockfetch.WithRecvQueueSize(384),
+)
+```
+
+## Usage Example
+
+```go
+// Request a range of blocks
+startPoint := Point{Slot: 1000, Hash: startHash}
+endPoint := Point{Slot: 2000, Hash: endHash}
+
+client.RequestRange(startPoint, endPoint)
+
+// Blocks arrive via BlockFunc callback
+// BatchDoneFunc called when range complete
+```
+
+## Block Format
+
+Blocks are wrapped in CBOR with a type identifier:
+
+```go
+type WrappedBlock struct {
+    Type     uint   // Block type identifier (era)
+    RawBlock []byte // Raw CBOR block data
+}
+```
+
+## Notes
+
+- Used in conjunction with ChainSync (headers) + BlockFetch (bodies)
+- Blocks are streamed in order from start to end point
+- Large receive queue supports high-throughput block streaming
+- The Streaming state has a higher pending byte limit for efficiency

--- a/protocol/chainsync/README.md
+++ b/protocol/chainsync/README.md
@@ -1,0 +1,161 @@
+# ChainSync Protocol
+
+The ChainSync protocol synchronizes blockchain state between nodes by streaming headers (NtN) or blocks (NtC) from a producer to a consumer.
+
+## Protocol Identifiers
+
+| Property | Value |
+|----------|-------|
+| Protocol Name | `chain-sync` |
+| Protocol ID (NtN) | `2` |
+| Protocol ID (NtC) | `5` |
+| Mode | Node-to-Node / Node-to-Client |
+
+## State Machine
+
+```text
+                    RequestNext
+              ┌──────────────────┐
+              │                  ▼
+┌──────┐      │           ┌──────────┐
+│ Idle │──────┴──────────►│ CanAwait │◄────────┐
+└──┬───┘                  └────┬─────┘         │
+   │                           │               │
+   │ FindIntersect    AwaitReply│               │ RollForward
+   │                           │               │ RollBackward
+   │                           ▼               │ (pipeline > 1)
+   │                    ┌───────────┐          │
+   │                    │ MustReply │──────────┘
+   │                    └───────────┘
+   │                           │
+   │                           │ RollForward
+   │                           │ RollBackward
+   │                           │ (pipeline = 1)
+   │                           │
+   ▼                           ▼
+┌───────────┐           ┌──────┐
+│ Intersect │──────────►│ Idle │
+└───────────┘           └──────┘
+      │
+      │ IntersectFound
+      │ IntersectNotFound
+      ▼
+   ┌──────┐       Done      ┌──────┐
+   │ Idle │ ───────────────►│ Done │
+   └──────┘                 └──────┘
+```
+
+## States
+
+| State | ID | Agency | Description |
+|-------|-----|--------|-------------|
+| **Idle** | 1 | Client | Waiting for client request |
+| **CanAwait** | 2 | Server | Server may provide block or signal wait |
+| **MustReply** | 3 | Server | Server must provide block (no await allowed) |
+| **Intersect** | 4 | Server | Processing intersection request |
+| **Done** | 5 | None | Terminal state |
+
+## Messages
+
+| Message | Type ID | Direction | Description |
+|---------|---------|-----------|-------------|
+| `RequestNext` | 0 | Client → Server | Request next block/header |
+| `AwaitReply` | 1 | Server → Client | Signal to wait for new blocks |
+| `RollForward` | 2 | Server → Client | Provide next block/header |
+| `RollBackward` | 3 | Server → Client | Signal chain rollback |
+| `FindIntersect` | 4 | Client → Server | Find common chain point |
+| `IntersectFound` | 5 | Server → Client | Intersection found |
+| `IntersectNotFound` | 6 | Server → Client | No intersection found |
+| `Done` | 7 | Client → Server | Terminate protocol |
+
+## State Transitions
+
+### From Idle (Client Agency)
+| Message | New State | Notes |
+|---------|-----------|-------|
+| `RequestNext` | CanAwait | Increments pipeline count |
+| `FindIntersect` | Intersect | |
+| `Done` | Done | |
+
+### From CanAwait (Server Agency)
+| Message | New State | Notes |
+|---------|-----------|-------|
+| `RequestNext` | CanAwait | Increments pipeline count |
+| `AwaitReply` | MustReply | |
+| `RollForward` | Idle | When pipeline count = 1 |
+| `RollForward` | CanAwait | When pipeline count > 1 |
+| `RollBackward` | Idle | When pipeline count = 1 |
+| `RollBackward` | CanAwait | When pipeline count > 1 |
+
+### From MustReply (Server Agency)
+| Message | New State | Notes |
+|---------|-----------|-------|
+| `RollForward` | Idle | When pipeline count = 1 |
+| `RollForward` | CanAwait | When pipeline count > 1 |
+| `RollBackward` | Idle | When pipeline count = 1 |
+| `RollBackward` | CanAwait | When pipeline count > 1 |
+
+### From Intersect (Server Agency)
+| Message | New State |
+|---------|-----------|
+| `IntersectFound` | Idle |
+| `IntersectNotFound` | Idle |
+
+## Timeouts
+
+| State | Timeout | Description |
+|-------|---------|-------------|
+| Idle | 60 seconds | Client must send next request |
+| CanAwait | 300 seconds | Server must provide block or await |
+| Intersect | 5 seconds | Server must respond to intersect |
+| MustReply | 300 seconds | Server must provide block |
+
+## Limits
+
+| Limit | Value | Description |
+|-------|-------|-------------|
+| Max Pipeline Limit | 100 | Maximum pipelined requests |
+| Default Pipeline Limit | 75 | Default pipeline limit |
+| Max Recv Queue Size | 100 | Maximum receive queue size |
+| Default Recv Queue Size | 75 | Default queue size |
+| Max Pending Message Bytes | 100 KB | Maximum pending message bytes |
+
+## Pipelining
+
+ChainSync supports request pipelining for improved throughput. The client can send multiple `RequestNext` messages before receiving responses. The pipeline count tracks outstanding requests.
+
+## Configuration Options
+
+```go
+chainsync.NewConfig(
+    chainsync.WithRollBackwardFunc(rollBackwardCallback),
+    chainsync.WithRollForwardFunc(rollForwardCallback),
+    chainsync.WithRollForwardRawFunc(rollForwardRawCallback),
+    chainsync.WithFindIntersectFunc(findIntersectCallback),
+    chainsync.WithRequestNextFunc(requestNextCallback),
+    chainsync.WithIntersectTimeout(5 * time.Second),
+    chainsync.WithBlockTimeout(300 * time.Second),
+    chainsync.WithPipelineLimit(75),
+    chainsync.WithRecvQueueSize(75),
+)
+```
+
+## Usage Example
+
+```go
+// Find intersection point
+client.FindIntersect(knownPoints)
+
+// Stream blocks
+for {
+    client.RequestNext()
+    // Handle RollForward/RollBackward in callbacks
+}
+```
+
+## Notes
+
+- Node-to-Node mode streams headers only (use BlockFetch for full blocks)
+- Node-to-Client mode streams full blocks
+- Pipelining significantly improves sync performance
+- The protocol supports chain rollbacks during reorganizations

--- a/protocol/handshake/README.md
+++ b/protocol/handshake/README.md
@@ -1,0 +1,103 @@
+# Handshake Protocol
+
+The Handshake protocol negotiates protocol versions and capabilities between two Ouroboros nodes at connection establishment.
+
+## Protocol Identifiers
+
+| Property | Value |
+|----------|-------|
+| Protocol Name | `handshake` |
+| Protocol ID | `0` |
+| Mode | Node-to-Node / Node-to-Client |
+
+## State Machine
+
+```text
+┌─────────┐  ProposeVersions   ┌─────────┐
+│ Propose │ ────────────────► │ Confirm │
+└─────────┘                    └────┬────┘
+     │                              │
+     │                    AcceptVersion │
+     │                    Refuse        │
+     │                    QueryReply    │
+     │                              │
+     │                              ▼
+     │                         ┌──────┐
+     └────────────────────────►│ Done │
+                               └──────┘
+```
+
+## States
+
+| State | ID | Agency | Description |
+|-------|-----|--------|-------------|
+| **Propose** | 1 | Client | Initial state; client proposes supported versions |
+| **Confirm** | 2 | Server | Server confirms or refuses version |
+| **Done** | 3 | None | Terminal state |
+
+## Messages
+
+| Message | Type ID | Direction | Description |
+|---------|---------|-----------|-------------|
+| `ProposeVersions` | 0 | Client → Server | Propose supported protocol versions |
+| `AcceptVersion` | 1 | Server → Client | Accept a proposed version |
+| `Refuse` | 2 | Server → Client | Refuse all proposed versions |
+| `QueryReply` | 3 | Server → Client | Reply to version query |
+
+## State Transitions
+
+### From Propose (Client Agency)
+| Message | New State |
+|---------|-----------|
+| `ProposeVersions` | Confirm |
+
+### From Confirm (Server Agency)
+| Message | New State |
+|---------|-----------|
+| `AcceptVersion` | Done |
+| `Refuse` | Done |
+| `QueryReply` | Done |
+
+## Timeouts
+
+| State | Timeout | Description |
+|-------|---------|-------------|
+| Propose | 5 seconds | Client must propose versions |
+| Confirm | 5 seconds | Server must accept or refuse |
+
+## Refusal Reasons
+
+| Reason | Code | Description |
+|--------|------|-------------|
+| Version Mismatch | 0 | No compatible version found |
+| Decode Error | 1 | Failed to decode version data |
+| Refused | 2 | General refusal |
+
+## Configuration Options
+
+```go
+handshake.NewConfig(
+    handshake.WithProtocolVersionMap(versionMap),
+    handshake.WithFinishedFunc(finishedCallback),
+    handshake.WithQueryReplyFunc(queryReplyCallback),
+    handshake.WithTimeout(5 * time.Second),
+)
+```
+
+## Usage Example
+
+```go
+// Client initiates handshake with supported versions
+// Start() sends the ProposeVersions message automatically
+client.Start()
+
+// Server responds with accepted version
+// or Refuse message if no compatible version
+// Handle response via FinishedFunc callback
+```
+
+## Notes
+
+- The handshake must complete before any other protocol can be used
+- Version data contains network-specific parameters (magic number, etc.)
+- Both node-to-node and node-to-client connections use this protocol

--- a/protocol/keepalive/README.md
+++ b/protocol/keepalive/README.md
@@ -1,0 +1,117 @@
+# KeepAlive Protocol
+
+The KeepAlive protocol maintains connection liveness between nodes by exchanging periodic ping/pong messages. It detects dead connections and triggers reconnection.
+
+## Protocol Identifiers
+
+| Property | Value |
+|----------|-------|
+| Protocol Name | `keep-alive` |
+| Protocol ID | `8` |
+| Mode | Node-to-Node |
+
+## State Machine
+
+```text
+┌────────┐   KeepAlive    ┌────────┐
+│ Client │ ──────────────►│ Server │
+└────┬───┘                └───┬────┘
+     │                        │
+     │ Done                   │ KeepAliveResponse
+     │                        │
+     ▼                        ▼
+┌──────┐                 ┌────────┐
+│ Done │                 │ Client │
+└──────┘                 └────────┘
+```
+
+## States
+
+| State | ID | Agency | Description |
+|-------|-----|--------|-------------|
+| **Client** | 1 | Client | Client may send ping |
+| **Server** | 2 | Server | Server must respond with pong |
+| **Done** | 3 | None | Terminal state |
+
+## Messages
+
+| Message | Type ID | Direction | Description |
+|---------|---------|-----------|-------------|
+| `KeepAlive` | 0 | Client → Server | Ping with cookie |
+| `KeepAliveResponse` | 1 | Server → Client | Pong echoing cookie |
+| `Done` | 2 | Client → Server | Terminate protocol |
+
+## State Transitions
+
+### From Client (Client Agency)
+| Message | New State |
+|---------|-----------|
+| `KeepAlive` | Server |
+| `Done` | Done |
+
+### From Server (Server Agency)
+| Message | New State |
+|---------|-----------|
+| `KeepAliveResponse` | Client |
+
+## Timeouts
+
+| State | Timeout | Description |
+|-------|---------|-------------|
+| Client | 60 seconds | Server waiting for next ping from client |
+| Server | 10 seconds | Client waiting for pong from server |
+
+## Default Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| Period | 60 seconds | Interval between keep-alive probes |
+| Timeout | 10 seconds | Response timeout |
+
+## Configuration Options
+
+```go
+keepalive.NewConfig(
+    keepalive.WithKeepAliveFunc(keepAliveCallback),
+    keepalive.WithKeepAliveResponseFunc(responseCallback),
+    keepalive.WithDoneFunc(doneCallback),
+    keepalive.WithTimeout(10 * time.Second),
+    keepalive.WithPeriod(60 * time.Second),
+    keepalive.WithCookie(0x1234),
+)
+```
+
+## Usage Example
+
+```go
+// Client sends periodic keep-alive
+client.Start()
+
+// Automatic ping every period
+// If no response within timeout, connection is dead
+
+// Server responds to pings automatically
+server.Start()
+```
+
+## Cookie
+
+The `KeepAlive` message includes a 16-bit cookie that must be echoed in the `KeepAliveResponse`. This verifies that responses correspond to specific pings.
+
+```go
+type MsgKeepAlive struct {
+    Cookie uint16
+}
+
+type MsgKeepAliveResponse struct {
+    Cookie uint16 // Must match request
+}
+```
+
+## Notes
+
+- Both client and server roles are typically active
+- Timeout triggers connection closure
+- Cookie ensures response matches request
+- Protocol runs continuously during connection lifetime
+- Essential for detecting network partitions

--- a/protocol/leiosfetch/README.md
+++ b/protocol/leiosfetch/README.md
@@ -1,0 +1,165 @@
+# LeiosFetch Protocol
+
+The LeiosFetch protocol retrieves Leios-specific data including blocks, block transactions, votes, and block ranges. It is part of the experimental Leios high-throughput protocol suite.
+
+## Protocol Identifiers
+
+| Property | Value |
+|----------|-------|
+| Protocol Name | `leios-fetch` |
+| Protocol ID | `19` |
+| Mode | Node-to-Node |
+
+## State Machine
+
+```
+                      BlockRequest
+              ┌───────────────────────────┐
+              │                           ▼
+         ┌────┴───┐                  ┌───────┐
+         │  Idle  │                  │ Block │
+         └────┬───┘                  └───┬───┘
+              │                          │
+              │ BlockTxsRequest          │ Block
+              │                          │
+              ▼                          ▼
+         ┌──────────┐               ┌──────┐
+         │ BlockTxs │               │ Idle │
+         └────┬─────┘               └──────┘
+              │
+              │ BlockTxs
+              ▼
+         ┌──────┐
+         │ Idle │
+         └──────┘
+
+              │ VotesRequest
+              ▼
+         ┌───────┐
+         │ Votes │
+         └───┬───┘
+             │
+             │ Votes
+             ▼
+         ┌──────┐
+         │ Idle │
+         └──────┘
+
+              │ BlockRangeRequest
+              ▼
+         ┌────────────┐◄─────────────┐
+         │ BlockRange │              │
+         └─────┬──────┘              │
+               │                     │
+               │ NextBlockAndTxsInRange
+               │                     │
+               └─────────────────────┘
+               │
+               │ LastBlockAndTxsInRange
+               ▼
+         ┌──────┐         Done      ┌──────┐
+         │ Idle │ ─────────────────►│ Done │
+         └──────┘                   └──────┘
+```
+
+## States
+
+| State | ID | Agency | Description |
+|-------|-----|--------|-------------|
+| **Idle** | 1 | Client | Waiting for request |
+| **Block** | 2 | Server | Processing block request |
+| **BlockTxs** | 3 | Server | Processing block transactions request |
+| **Votes** | 4 | Server | Processing votes request |
+| **BlockRange** | 5 | Server | Streaming blocks in range |
+| **Done** | 6 | None | Terminal state |
+
+## Messages
+
+| Message | Type ID | Direction | Description |
+|---------|---------|-----------|-------------|
+| `BlockRequest` | 0 | Client → Server | Request single block |
+| `Block` | 1 | Server → Client | Block response |
+| `BlockTxsRequest` | 2 | Client → Server | Request block transactions |
+| `BlockTxs` | 3 | Server → Client | Block transactions response |
+| `VotesRequest` | 4 | Client → Server | Request votes |
+| `Votes` | 5 | Server → Client | Votes response |
+| `BlockRangeRequest` | 6 | Client → Server | Request range of blocks |
+| `LastBlockAndTxsInRange` | 7 | Server → Client | Last block in range |
+| `NextBlockAndTxsInRange` | 8 | Server → Client | Next block in range |
+| `Done` | 9 | Client → Server | Terminate protocol |
+
+## State Transitions
+
+### From Idle (Client Agency)
+| Message | New State |
+|---------|-----------|
+| `BlockRequest` | Block |
+| `BlockTxsRequest` | BlockTxs |
+| `VotesRequest` | Votes |
+| `BlockRangeRequest` | BlockRange |
+| `Done` | Done |
+
+### From Block (Server Agency)
+| Message | New State |
+|---------|-----------|
+| `Block` | Idle |
+
+### From BlockTxs (Server Agency)
+| Message | New State |
+|---------|-----------|
+| `BlockTxs` | Idle |
+
+### From Votes (Server Agency)
+| Message | New State |
+|---------|-----------|
+| `Votes` | Idle |
+
+### From BlockRange (Server Agency)
+| Message | New State |
+|---------|-----------|
+| `NextBlockAndTxsInRange` | BlockRange |
+| `LastBlockAndTxsInRange` | Idle |
+
+## Timeouts
+
+| Timeout | Default | Description |
+|---------|---------|-------------|
+| Default Timeout | 5 seconds | General request timeout |
+
+## Configuration Options
+
+```go
+leiosfetch.NewConfig(
+    leiosfetch.WithBlockRequestFunc(blockRequestCallback),
+    leiosfetch.WithBlockTxsRequestFunc(blockTxsRequestCallback),
+    leiosfetch.WithVotesRequestFunc(votesRequestCallback),
+    leiosfetch.WithBlockRangeRequestFunc(blockRangeRequestCallback),
+    leiosfetch.WithTimeout(5 * time.Second),
+)
+```
+
+## Usage Example
+
+```go
+// Request a single block
+block, err := client.BlockRequest(slot, blockId)
+
+// Request block transactions
+txs, err := client.BlockTxsRequest(slot, blockId, txFilter)
+
+// Request votes
+votes, err := client.VotesRequest(voteIds)
+
+// Request a range of blocks (blocks until all received)
+blocks, err := client.BlockRangeRequest(startPoint, endPoint)
+for _, block := range blocks {
+    // Process each block
+}
+```
+
+## Notes
+
+- Part of the experimental Leios protocol suite
+- Supports both single-item and streaming requests
+- BlockRange allows efficient bulk retrieval
+- Used in conjunction with LeiosNotify for announcements

--- a/protocol/leiosnotify/README.md
+++ b/protocol/leiosnotify/README.md
@@ -1,0 +1,116 @@
+# LeiosNotify Protocol
+
+The LeiosNotify protocol provides notifications about new Leios blocks, transactions, and votes. It is the announcement component of the experimental Leios high-throughput protocol suite.
+
+## Protocol Identifiers
+
+| Property | Value |
+|----------|-------|
+| Protocol Name | `leios-notify` |
+| Protocol ID | `18` |
+| Mode | Node-to-Node |
+
+## State Machine
+
+```
+┌──────┐  NotificationRequestNext  ┌──────┐
+│ Idle │ ─────────────────────────►│ Busy │
+└──┬───┘                           └──┬───┘
+   │                                  │
+   │ Done                             │ BlockAnnouncement
+   │                                  │ BlockOffer
+   │                                  │ BlockTxsOffer
+   │                                  │ VotesOffer
+   ▼                                  ▼
+┌──────┐                           ┌──────┐
+│ Done │                           │ Idle │
+└──────┘                           └──────┘
+```
+
+## States
+
+| State | ID | Agency | Description |
+|-------|-----|--------|-------------|
+| **Idle** | 1 | Client | Waiting for notification request |
+| **Busy** | 2 | Server | Preparing notification |
+| **Done** | 3 | None | Terminal state |
+
+## Messages
+
+| Message | Type ID | Direction | Description |
+|---------|---------|-----------|-------------|
+| `NotificationRequestNext` | 0 | Client → Server | Request next notification |
+| `BlockAnnouncement` | 1 | Server → Client | Announce new block |
+| `BlockOffer` | 2 | Server → Client | Offer block for download |
+| `BlockTxsOffer` | 3 | Server → Client | Offer block transactions |
+| `VotesOffer` | 4 | Server → Client | Offer votes for download |
+| `Done` | 5 | Client → Server | Terminate protocol |
+
+## State Transitions
+
+### From Idle (Client Agency)
+| Message | New State |
+|---------|-----------|
+| `NotificationRequestNext` | Busy |
+| `Done` | Done |
+
+### From Busy (Server Agency)
+| Message | New State |
+|---------|-----------|
+| `BlockAnnouncement` | Idle |
+| `BlockOffer` | Idle |
+| `BlockTxsOffer` | Idle |
+| `VotesOffer` | Idle |
+
+## Timeouts
+
+| Timeout | Default | Description |
+|---------|---------|-------------|
+| Default Timeout | 60 seconds | Time to receive notification |
+
+## Configuration Options
+
+```go
+leiosnotify.NewConfig(
+    leiosnotify.WithRequestNextFunc(requestNextCallback),
+    leiosnotify.WithTimeout(60 * time.Second),
+)
+```
+
+## Usage Example
+
+```go
+// Request notifications in a loop
+for {
+    notification, err := client.RequestNext()
+    if err != nil {
+        // Handle error
+        break
+    }
+
+    switch n := notification.(type) {
+    case *BlockAnnouncement:
+        // New block announced
+    case *BlockOffer:
+        // Block available for download via LeiosFetch
+    case *VotesOffer:
+        // Votes available for download
+    }
+}
+```
+
+## Notification Types
+
+| Type | Description |
+|------|-------------|
+| BlockAnnouncement | New block header announcement |
+| BlockOffer | Full block available for retrieval |
+| BlockTxsOffer | Block transactions available |
+| VotesOffer | Vote bundle available |
+
+## Notes
+
+- Client must explicitly request each notification
+- Works with LeiosFetch to retrieve announced data
+- Supports efficient push-based data dissemination
+- Part of the experimental Leios high-throughput design

--- a/protocol/localmessagenotification/README.md
+++ b/protocol/localmessagenotification/README.md
@@ -1,0 +1,135 @@
+# LocalMessageNotification Protocol
+
+The LocalMessageNotification protocol receives notifications about new messages from the local node. It is part of CIP-0137 (Distributed Message Queue) for secure off-chain messaging.
+
+## Protocol Identifiers
+
+| Property | Value |
+|----------|-------|
+| Protocol Name | `LocalMessageNotification` |
+| Protocol ID | `19` |
+| Mode | Node-to-Client |
+
+## State Machine
+
+```
+┌──────┐  RequestMessages   ┌──────────────────┐
+│ Idle │  (non-blocking)    │ BusyNonBlocking  │
+└──┬───┴───────────────────►└────────┬─────────┘
+   │                                 │
+   │ RequestMessages                 │ ReplyMessagesNonBlocking
+   │ (blocking)                      │
+   │                                 ▼
+   │                            ┌──────┐
+   │                            │ Idle │
+   │                            └──────┘
+   │
+   ▼
+┌───────────────┐
+│ BusyBlocking  │
+└───────┬───────┘
+        │
+        │ ReplyMessagesBlocking
+        ▼
+   ┌──────┐           Done       ┌──────┐
+   │ Idle │ ────────────────────►│ Done │
+   └──────┘                      └──────┘
+```
+
+## States
+
+| State | ID | Agency | Description |
+|-------|-----|--------|-------------|
+| **Idle** | 1 | Client | Waiting for message request |
+| **BusyNonBlocking** | 2 | Server | Processing non-blocking request |
+| **BusyBlocking** | 3 | Server | Processing blocking request |
+| **Done** | 4 | None | Terminal state |
+
+## Messages
+
+| Message | Type ID | Direction | Description |
+|---------|---------|-----------|-------------|
+| `RequestMessages` | 0 | Client → Server | Request messages (blocking/non-blocking) |
+| `ReplyMessagesNonBlocking` | 1 | Server → Client | Non-blocking response |
+| `ReplyMessagesBlocking` | 2 | Server → Client | Blocking response |
+| `ClientDone` | 3 | Client → Server | Terminate protocol |
+
+## State Transitions
+
+### From Idle (Client Agency)
+| Message | New State | Condition |
+|---------|-----------|-----------|
+| `RequestMessages` | BusyNonBlocking | Non-blocking request |
+| `RequestMessages` | BusyBlocking | Blocking request |
+| `ClientDone` | Done | |
+
+### From BusyNonBlocking (Server Agency)
+| Message | New State |
+|---------|-----------|
+| `ReplyMessagesNonBlocking` | Idle |
+
+### From BusyBlocking (Server Agency)
+| Message | New State |
+|---------|-----------|
+| `ReplyMessagesBlocking` | Idle |
+
+## Timeouts
+
+| State | Timeout | Description |
+|-------|---------|-------------|
+| Idle | 300 seconds | Client must send RequestMessages |
+| BusyNonBlocking | 0 (immediate) | Non-blocking returns immediately |
+| BusyBlocking | 0 (indefinite) | Blocking waits for messages |
+
+## Request Modes
+
+| Mode | Description |
+|------|-------------|
+| **Non-blocking** | Returns immediately with available messages |
+| **Blocking** | Waits until messages are available |
+
+## Configuration Options
+
+```go
+localmessagenotification.NewConfig(
+    localmessagenotification.WithReplyMessagesFunc(replyCallback),
+    localmessagenotification.WithMaxQueueSize(100),
+    localmessagenotification.WithBlockingRequestTimeout(timeout),
+    localmessagenotification.WithAuthenticator(authenticator),
+    localmessagenotification.WithTTLValidator(ttlValidator),
+)
+```
+
+## Usage Example
+
+```go
+// Configure client with reply callback
+cfg := localmessagenotification.NewConfig(
+    localmessagenotification.WithReplyMessagesFunc(func(ctx CallbackContext, messages []DmqMessage, hasMore bool) {
+        for _, msg := range messages {
+            // Handle message
+        }
+    }),
+)
+
+// Non-blocking: get available messages immediately
+err := client.RequestMessagesNonBlocking()
+
+// Blocking: wait for new messages
+err := client.RequestMessagesBlocking()
+```
+
+## Message Authentication
+
+Received messages have been validated:
+- KES signature verification
+- TTL validation
+- Message format validation
+
+## Notes
+
+- Part of CIP-0137 (Distributed Message Queue)
+- Non-blocking mode for polling
+- Blocking mode for push-style notification
+- Messages are pre-validated by the node
+- Default queue size is 100 messages

--- a/protocol/localmessagesubmission/README.md
+++ b/protocol/localmessagesubmission/README.md
@@ -1,0 +1,112 @@
+# LocalMessageSubmission Protocol
+
+The LocalMessageSubmission protocol submits authenticated messages to the local node. It is part of CIP-0137 (Distributed Message Queue) for secure off-chain messaging.
+
+## Protocol Identifiers
+
+| Property | Value |
+|----------|-------|
+| Protocol Name | `LocalMessageSubmission` |
+| Protocol ID | `18` |
+| Mode | Node-to-Client |
+
+## State Machine
+
+```
+┌──────┐   SubmitMessage   ┌──────┐
+│ Idle │ ─────────────────►│ Busy │
+└──┬───┘                   └──┬───┘
+   │                          │
+   │ Done                     │ AcceptMessage
+   │                          │ RejectMessage
+   ▼                          ▼
+┌──────┐                   ┌──────┐
+│ Done │                   │ Idle │
+└──────┘                   └──────┘
+```
+
+## States
+
+| State | ID | Agency | Description |
+|-------|-----|--------|-------------|
+| **Idle** | 1 | Client | Waiting for message submission |
+| **Busy** | 2 | Server | Processing submitted message |
+| **Done** | 3 | None | Terminal state |
+
+## Messages
+
+| Message | Type ID | Direction | Description |
+|---------|---------|-----------|-------------|
+| `SubmitMessage` | 0 | Client → Server | Submit authenticated message |
+| `AcceptMessage` | 1 | Server → Client | Message accepted |
+| `RejectMessage` | 2 | Server → Client | Message rejected |
+| `Done` | 3 | Client → Server | Terminate protocol |
+
+## State Transitions
+
+### From Idle (Client Agency)
+| Message | New State |
+|---------|-----------|
+| `SubmitMessage` | Busy |
+| `Done` | Done |
+
+### From Busy (Server Agency)
+| Message | New State |
+|---------|-----------|
+| `AcceptMessage` | Idle |
+| `RejectMessage` | Idle |
+
+## Timeouts
+
+| State | Timeout | Description |
+|-------|---------|-------------|
+| Idle | 300 seconds | Client must send SubmitMessage |
+| Busy | 30 seconds | Server must accept or reject |
+
+## Rejection Reasons
+
+Messages may be rejected for various reasons including:
+- Invalid signature
+- Expired TTL
+- Invalid message format
+- Queue full
+
+## Configuration Options
+
+```go
+localmessagesubmission.NewConfig(
+    localmessagesubmission.WithSubmitMessageFunc(submitCallback),
+    localmessagesubmission.WithAcceptMessageFunc(acceptCallback),
+    localmessagesubmission.WithRejectMessageFunc(rejectCallback),
+    localmessagesubmission.WithAuthenticator(authenticator),
+    localmessagesubmission.WithTTLValidator(ttlValidator),
+    localmessagesubmission.WithTimeout(30 * time.Second),
+)
+```
+
+## Usage Example
+
+```go
+// Submit an authenticated message
+message := &DmqMessage{
+    // Message content with signature
+}
+
+err := client.SubmitMessage(message)
+// AcceptMessage or RejectMessage via callbacks
+```
+
+## Message Authentication
+
+Messages require cryptographic authentication using KES (Key-Evolving Signatures):
+- Messages must be signed by a valid stake pool key
+- TTL (Time-To-Live) prevents replay attacks
+- Server validates signature before acceptance
+
+## Notes
+
+- Part of CIP-0137 (Distributed Message Queue)
+- Messages are authenticated using KES signatures
+- TTL validation prevents message replay
+- Default authenticator uses standard KES verification
+- Used for secure off-chain communication between nodes

--- a/protocol/localstatequery/README.md
+++ b/protocol/localstatequery/README.md
@@ -1,0 +1,162 @@
+# LocalStateQuery Protocol
+
+The LocalStateQuery protocol queries the local node's ledger state at specific chain points. It is used for wallet queries, stake information, protocol parameters, and other state queries.
+
+## Protocol Identifiers
+
+| Property | Value |
+|----------|-------|
+| Protocol Name | `local-state-query` |
+| Protocol ID | `7` |
+| Mode | Node-to-Client |
+
+## State Machine
+
+```text
+┌──────┐     Acquire/AcquireVolatileTip/     ┌───────────┐
+│ Idle │     AcquireImmutableTip             │ Acquiring │
+└──┬───┘ ─────────────────────────────────►  └─────┬─────┘
+   │                                               │
+   │ Done                             Failure      │ Acquired
+   │                                    │          │
+   ▼                                    ▼          ▼
+┌──────┐                             ┌──────┐  ┌──────────┐
+│ Done │◄────────────────────────────│ Idle │◄─│ Acquired │
+└──────┘                             └──────┘  └────┬─────┘
+                                                    │
+                        ┌───────────────────────────┤
+                        │                           │
+           Query        │    Reacquire/             │ Release
+                        │    ReacquireVolatileTip/  │
+                        │    ReacquireImmutableTip  │
+                        ▼                           │
+                 ┌──────────┐                       │
+                 │ Querying │                       │
+                 └────┬─────┘                       │
+                      │                             │
+                      │ Result                      │
+                      ▼                             ▼
+                 ┌──────────┐                  ┌──────┐
+                 │ Acquired │                  │ Idle │
+                 └──────────┘                  └──────┘
+```
+
+## States
+
+| State | ID | Agency | Description |
+|-------|-----|--------|-------------|
+| **Idle** | 1 | Client | No state acquired |
+| **Acquiring** | 2 | Server | Processing state acquisition |
+| **Acquired** | 3 | Client | State acquired, ready for queries |
+| **Querying** | 4 | Server | Processing query |
+| **Done** | 5 | None | Terminal state |
+
+## Messages
+
+| Message | Type ID | Direction | Description |
+|---------|---------|-----------|-------------|
+| `Acquire` | 0 | Client → Server | Acquire state at specific point |
+| `Acquired` | 1 | Server → Client | State successfully acquired |
+| `Failure` | 2 | Server → Client | State acquisition failed |
+| `Query` | 3 | Client → Server | Execute query on acquired state |
+| `Result` | 4 | Server → Client | Query result |
+| `Release` | 5 | Client → Server | Release acquired state |
+| `Reacquire` | 6 | Client → Server | Reacquire at different point |
+| `Done` | 7 | Client → Server | Terminate protocol |
+| `AcquireVolatileTip` | 8 | Client → Server | Acquire state at volatile tip |
+| `ReacquireVolatileTip` | 9 | Client → Server | Reacquire at volatile tip |
+| `AcquireImmutableTip` | 10 | Client → Server | Acquire state at immutable tip |
+| `ReacquireImmutableTip` | 11 | Client → Server | Reacquire at immutable tip |
+
+## State Transitions
+
+### From Idle (Client Agency)
+| Message | New State |
+|---------|-----------|
+| `Acquire` | Acquiring |
+| `AcquireVolatileTip` | Acquiring |
+| `AcquireImmutableTip` | Acquiring |
+| `Done` | Done |
+
+### From Acquiring (Server Agency)
+| Message | New State |
+|---------|-----------|
+| `Failure` | Idle |
+| `Acquired` | Acquired |
+
+### From Acquired (Client Agency)
+| Message | New State |
+|---------|-----------|
+| `Query` | Querying |
+| `Reacquire` | Acquiring |
+| `ReacquireVolatileTip` | Acquiring |
+| `ReacquireImmutableTip` | Acquiring |
+| `Release` | Idle |
+
+### From Querying (Server Agency)
+| Message | New State |
+|---------|-----------|
+| `Result` | Acquired |
+
+## Timeouts
+
+| Timeout | Default | Description |
+|---------|---------|-------------|
+| Acquire Timeout | 5 seconds | Time to acquire state |
+| Query Timeout | 180 seconds | Time to execute query |
+
+## Acquire Targets
+
+| Target | Description |
+|--------|-------------|
+| Specific Point | Acquire state at a specific slot/hash |
+| Volatile Tip | Acquire state at the current volatile tip |
+| Immutable Tip | Acquire state at the current immutable tip |
+
+## Configuration Options
+
+```go
+localstatequery.NewConfig(
+    localstatequery.WithAcquireFunc(acquireCallback),
+    localstatequery.WithQueryFunc(queryCallback),
+    localstatequery.WithReleaseFunc(releaseCallback),
+    localstatequery.WithAcquireTimeout(5 * time.Second),
+    localstatequery.WithQueryTimeout(180 * time.Second),
+)
+```
+
+## Usage Example
+
+```go
+// Acquire state at tip
+client.AcquireVolatileTip()
+
+// Wait for Acquired message
+
+// Query UTxOs for an address
+result, err := client.Query(utxosByAddressQuery)
+
+// Release state when done
+client.Release()
+```
+
+## Common Queries
+
+- **GetCurrentPParams**: Protocol parameters
+- **GetStakeDistribution**: Stake pool distribution
+- **GetUTxOByAddress**: UTxOs at specific addresses
+- **GetUTxOByTxIn**: UTxOs by transaction inputs
+- **GetEpochNo**: Current epoch number
+- **GetGenesisConfig**: Genesis configuration
+- **GetRewardInfoPools**: Pool reward information
+- **GetRewardProvenance**: Reward calculation details
+- **GetStakePools**: Registered stake pools
+- **GetStakePoolParams**: Stake pool parameters
+
+## Notes
+
+- State must be acquired before queries can be executed
+- Multiple queries can be executed on the same acquired state
+- The acquired state is a snapshot; chain may advance during queries
+- Use Reacquire to get a fresh state snapshot
+- Release state when done to free server resources

--- a/protocol/localtxmonitor/README.md
+++ b/protocol/localtxmonitor/README.md
@@ -1,0 +1,151 @@
+# LocalTxMonitor Protocol
+
+The LocalTxMonitor protocol monitors the local node's mempool. It allows clients to inspect pending transactions and mempool statistics.
+
+## Protocol Identifiers
+
+| Property | Value |
+|----------|-------|
+| Protocol Name | `local-tx-monitor` |
+| Protocol ID | `9` |
+| Mode | Node-to-Client |
+
+## State Machine
+
+```
+┌──────┐      Acquire      ┌───────────┐
+│ Idle │ ─────────────────►│ Acquiring │
+└──┬───┘                   └─────┬─────┘
+   │                             │
+   │ Done                        │ Acquired
+   │                             │
+   ▼                             ▼
+┌──────┐                   ┌──────────┐◄───────────┐
+│ Done │◄──────────────────│ Acquired │            │
+└──────┘     Release       └────┬─────┘            │
+                                │                  │
+                   ┌────────────┼────────────┐     │
+                   │            │            │     │
+         HasTx     │   NextTx   │  GetSizes  │     │
+                   │            │            │     │
+                   ▼            ▼            ▼     │
+              ┌────────────────────────────────┐   │
+              │             Busy               │   │
+              └────────────────┬───────────────┘   │
+                               │                   │
+                    ReplyHasTx │ ReplyNextTx       │
+                    ReplyGetSizes                  │
+                               │                   │
+                               └───────────────────┘
+```
+
+## States
+
+| State | ID | Agency | Description |
+|-------|-----|--------|-------------|
+| **Idle** | 1 | Client | No mempool snapshot acquired |
+| **Acquiring** | 2 | Server | Acquiring mempool snapshot |
+| **Acquired** | 3 | Client | Snapshot acquired, ready for queries |
+| **Busy** | 4 | Server | Processing query |
+| **Done** | 5 | None | Terminal state |
+
+## Messages
+
+| Message | Type ID | Direction | Description |
+|---------|---------|-----------|-------------|
+| `Done` | 0 | Client → Server | Terminate protocol |
+| `Acquire` | 1 | Client → Server | Acquire mempool snapshot |
+| `Acquired` | 2 | Server → Client | Snapshot acquired with slot number |
+| `Release` | 3 | Client → Server | Release snapshot |
+| `NextTx` | 5 | Client → Server | Get next transaction |
+| `ReplyNextTx` | 6 | Server → Client | Next transaction or empty |
+| `HasTx` | 7 | Client → Server | Check if tx is in mempool |
+| `ReplyHasTx` | 8 | Server → Client | HasTx result (bool) |
+| `GetSizes` | 9 | Client → Server | Get mempool sizes |
+| `ReplyGetSizes` | 10 | Server → Client | Mempool size information |
+
+## State Transitions
+
+### From Idle (Client Agency)
+| Message | New State |
+|---------|-----------|
+| `Acquire` | Acquiring |
+| `Done` | Done |
+
+### From Acquiring (Server Agency)
+| Message | New State |
+|---------|-----------|
+| `Acquired` | Acquired |
+
+### From Acquired (Client Agency)
+| Message | New State |
+|---------|-----------|
+| `Acquire` | Acquiring |
+| `Release` | Idle |
+| `HasTx` | Busy |
+| `NextTx` | Busy |
+| `GetSizes` | Busy |
+
+### From Busy (Server Agency)
+| Message | New State |
+|---------|-----------|
+| `ReplyHasTx` | Acquired |
+| `ReplyNextTx` | Acquired |
+| `ReplyGetSizes` | Acquired |
+
+## Timeouts
+
+| Timeout | Default | Description |
+|---------|---------|-------------|
+| Acquire Timeout | 5 seconds | Time to acquire mempool snapshot |
+| Query Timeout | 30 seconds | Time to execute query |
+
+## Configuration Options
+
+```go
+localtxmonitor.NewConfig(
+    localtxmonitor.WithGetMempoolFunc(getMempoolCallback),
+    localtxmonitor.WithAcquireTimeout(5 * time.Second),
+    localtxmonitor.WithQueryTimeout(30 * time.Second),
+)
+```
+
+## Usage Example
+
+```go
+// Acquire mempool snapshot
+err := client.Acquire()
+
+// Check if specific transaction is in mempool
+hasTx, err := client.HasTx(txId)
+
+// Iterate through mempool transactions
+for {
+    tx, err := client.NextTx()
+    if tx == nil {
+        break // No more transactions
+    }
+    // Process transaction
+}
+
+// Get mempool statistics
+capacity, size, numTxs, err := client.GetSizes()
+
+// Release snapshot
+client.Release()
+```
+
+## Mempool Size Information
+
+The `GetSizes` query returns:
+- **Capacity**: Maximum mempool capacity in bytes
+- **Size**: Current mempool size in bytes
+- **NumTxs**: Number of transactions in mempool
+
+## Notes
+
+- Mempool snapshot is consistent during queries
+- Acquire again to get updated mempool state
+- NextTx iterates through all transactions in snapshot
+- HasTx checks for specific transaction by ID
+- Release snapshot when done to free resources

--- a/protocol/localtxsubmission/README.md
+++ b/protocol/localtxsubmission/README.md
@@ -1,0 +1,107 @@
+# LocalTxSubmission Protocol
+
+The LocalTxSubmission protocol submits transactions to the local node's mempool. It is the primary method for wallets and applications to submit transactions.
+
+## Protocol Identifiers
+
+| Property | Value |
+|----------|-------|
+| Protocol Name | `local-tx-submission` |
+| Protocol ID | `6` |
+| Mode | Node-to-Client |
+
+## State Machine
+
+```
+┌──────┐    SubmitTx     ┌──────┐
+│ Idle │ ───────────────►│ Busy │
+└──────┘                 └──┬───┘
+   ▲                        │
+   │                        │ AcceptTx
+   │                        │ RejectTx
+   │                        │
+   └────────────────────────┘
+```
+
+## States
+
+| State | ID | Agency | Description |
+|-------|-----|--------|-------------|
+| **Idle** | 1 | Client | Waiting for transaction submission |
+| **Busy** | 2 | Server | Processing submitted transaction |
+| **Done** | 3 | None | Terminal state |
+
+## Messages
+
+| Message | Type ID | Direction | Description |
+|---------|---------|-----------|-------------|
+| `SubmitTx` | 0 | Client → Server | Submit a transaction |
+| `AcceptTx` | 1 | Server → Client | Transaction accepted |
+| `RejectTx` | 2 | Server → Client | Transaction rejected |
+
+## State Transitions
+
+### From Idle (Client Agency)
+| Message | New State |
+|---------|-----------|
+| `SubmitTx` | Busy |
+
+### From Busy (Server Agency)
+| Message | New State |
+|---------|-----------|
+| `AcceptTx` | Idle |
+| `RejectTx` | Idle |
+
+## Timeouts
+
+| Timeout | Default | Description |
+|---------|---------|-------------|
+| Submit Timeout | 30 seconds | Time to process transaction |
+
+## Configuration Options
+
+```go
+localtxsubmission.NewConfig(
+    localtxsubmission.WithSubmitTxFunc(submitTxCallback),
+    localtxsubmission.WithTimeout(30 * time.Second),
+)
+```
+
+## Usage Example
+
+```go
+// Submit a transaction
+err := client.SubmitTx(txEraId, txBytes)
+
+// AcceptTx or RejectTx received via callback
+```
+
+## Transaction Format
+
+Transactions are submitted with era identification:
+
+```go
+type MsgSubmitTxTransaction struct {
+    cbor.StructAsArray
+    EraId uint16   // Era identifier
+    Raw   cbor.Tag // CBOR-wrapped transaction (tag 24)
+}
+```
+
+## Rejection Reasons
+
+When a transaction is rejected, the `RejectTx` message includes detailed rejection reasons from the ledger validation, such as:
+- Insufficient funds
+- Invalid signatures
+- Script validation failure
+- Expired TTL
+- Missing UTxO inputs
+- Fee too low
+
+## Notes
+
+- Accepted transactions enter the node's mempool
+- Acceptance does not guarantee inclusion in a block
+- Rejection provides detailed validation errors
+- The protocol is stateless; each submission is independent
+- Multiple transactions can be submitted sequentially

--- a/protocol/messagesubmission/README.md
+++ b/protocol/messagesubmission/README.md
@@ -1,0 +1,163 @@
+# MessageSubmission Protocol
+
+The MessageSubmission protocol propagates authenticated messages between nodes. It is the node-to-node component of CIP-0137 (Distributed Message Queue) using a pull-based model similar to TxSubmission.
+
+## Protocol Identifiers
+
+| Property | Value |
+|----------|-------|
+| Protocol Name | `MessageSubmission` |
+| Protocol ID | `17` |
+| Mode | Node-to-Node |
+
+## State Machine
+
+```
+┌──────┐     Init      ┌──────┐
+│ Init │ ─────────────►│ Idle │◄────────────────────────┐
+└──────┘               └──┬───┘                         │
+                          │                             │
+      RequestMessageIds   │                             │ ReplyMessageIds
+      (blocking)          │                             │ ReplyMessages
+                          ▼                             │
+                   ┌───────────────────┐                │
+                   │ MessageIdsBlocking│────────────────┤
+                   └─────────┬─────────┘                │
+                             │                          │
+                             │ Done                     │
+                             ▼                          │
+                         ┌──────┐                       │
+                         │ Done │                       │
+                         └──────┘                       │
+                                                        │
+      RequestMessageIds   │                             │
+      (non-blocking)      │                             │
+                          ▼                             │
+                   ┌─────────────────────┐              │
+                   │MessageIdsNonBlocking│──────────────┤
+                   └─────────────────────┘              │
+                                                        │
+      RequestMessages     │                             │
+                          ▼                             │
+                   ┌──────────┐                         │
+                   │ Messages │─────────────────────────┘
+                   └──────────┘
+```
+
+## States
+
+| State | ID | Agency | Description |
+|-------|-----|--------|-------------|
+| **Init** | 1 | Client | Initial state before activation |
+| **Idle** | 2 | Server | Waiting for message request |
+| **MessageIdsBlocking** | 3 | Client | Client provides message IDs (blocking) |
+| **MessageIdsNonBlocking** | 4 | Client | Client provides message IDs (non-blocking) |
+| **Messages** | 5 | Client | Client provides full messages |
+| **Done** | 6 | None | Terminal state |
+
+## Messages
+
+| Message | Type ID | Direction | Description |
+|---------|---------|-----------|-------------|
+| `Init` | 0 | Client → Server | Initialize protocol |
+| `RequestMessageIds` | 1 | Server → Client | Request message IDs |
+| `ReplyMessageIds` | 2 | Client → Server | Provide message IDs |
+| `RequestMessages` | 3 | Server → Client | Request full messages |
+| `ReplyMessages` | 4 | Client → Server | Provide message bodies |
+| `Done` | 5 | Client ↔ Server | Terminate protocol |
+
+## State Transitions
+
+### From Init (Client Agency)
+| Message | New State |
+|---------|-----------|
+| `Init` | Idle |
+
+### From Idle (Server Agency)
+| Message | New State | Condition |
+|---------|-----------|-----------|
+| `RequestMessageIds` | MessageIdsBlocking | Blocking = true |
+| `RequestMessageIds` | MessageIdsNonBlocking | Blocking = false |
+| `RequestMessages` | Messages | |
+| `Done` | Done | |
+
+### From MessageIdsBlocking (Client Agency)
+| Message | New State |
+|---------|-----------|
+| `ReplyMessageIds` | Idle |
+| `Done` | Done |
+
+### From MessageIdsNonBlocking (Client Agency)
+| Message | New State |
+|---------|-----------|
+| `ReplyMessageIds` | Idle |
+| `Done` | Done |
+
+### From Messages (Client Agency)
+| Message | New State |
+|---------|-----------|
+| `ReplyMessages` | Idle |
+
+## Timeouts
+
+| State | Timeout | Description |
+|-------|---------|-------------|
+| Init | 30 seconds | Client must send Init |
+| Idle | 300 seconds | Server must request messages |
+| MessageIdsBlocking | 30 seconds | Client must reply with IDs |
+| MessageIdsNonBlocking | 0 (immediate) | Non-blocking, no timeout |
+| Messages | 30 seconds | Client must reply with messages |
+| Done | 10 seconds | Cleanup timeout |
+
+## Configuration Options
+
+```go
+messagesubmission.NewConfig(
+    messagesubmission.WithRequestMessageIdsFunc(requestIdsCallback),
+    messagesubmission.WithRequestMessagesFunc(requestMsgsCallback),
+    messagesubmission.WithReplyMessageIdsFunc(replyIdsCallback),
+    messagesubmission.WithReplyMessagesFunc(replyMsgsCallback),
+    messagesubmission.WithMaxQueueSize(100),
+    messagesubmission.WithInitTimeout(30 * time.Second),
+    messagesubmission.WithIdleTimeout(300 * time.Second),
+    messagesubmission.WithMessageIdsBlockingTimeout(30 * time.Second),
+    messagesubmission.WithMessagesTimeout(30 * time.Second),
+    messagesubmission.WithAuthenticator(authenticator),
+    messagesubmission.WithTTLValidator(ttlValidator),
+)
+```
+
+## Usage Example
+
+```go
+// Server requests message IDs (blocking mode)
+err := server.RequestMessageIdsBlocking(0, 10)
+
+// Server requests message IDs (non-blocking mode)
+err := server.RequestMessageIdsNonBlocking(0, 10)
+
+// Client provides IDs via RequestMessageIdsFunc callback
+// Client provides messages via RequestMessagesFunc callback
+
+// Server requests full messages
+err := server.RequestMessages([][]byte{msgId1})
+```
+
+## Message ID Format
+
+```go
+type MessageIDAndSize struct {
+    MessageID   []byte // Message identifier
+    SizeInBytes uint32 // Message size in bytes
+}
+```
+
+## Notes
+
+- Part of CIP-0137 (Distributed Message Queue)
+- Pull-based model (server requests, client provides)
+- Similar design to TxSubmission protocol
+- Blocking mode waits for new messages
+- Non-blocking mode returns immediately
+- Messages are authenticated with KES signatures
+- TTL prevents message replay

--- a/protocol/peersharing/README.md
+++ b/protocol/peersharing/README.md
@@ -1,0 +1,107 @@
+# PeerSharing Protocol
+
+The PeerSharing protocol enables peer discovery by allowing nodes to share known peer addresses with each other. It supports network growth and resilience.
+
+## Protocol Identifiers
+
+| Property | Value |
+|----------|-------|
+| Protocol Name | `peer-sharing` |
+| Protocol ID | `10` |
+| Mode | Node-to-Node |
+
+## State Machine
+
+```text
+┌──────┐   ShareRequest   ┌──────┐
+│ Idle │ ────────────────►│ Busy │
+└──┬───┘                  └──┬───┘
+   │                         │
+   │ Done                    │ SharePeers
+   │                         │
+   ▼                         ▼
+┌──────┐                  ┌──────┐
+│ Done │                  │ Idle │
+└──────┘                  └──────┘
+```
+
+## States
+
+| State | ID | Agency | Description |
+|-------|-----|--------|-------------|
+| **Idle** | 1 | Client | Waiting for peer request |
+| **Busy** | 2 | Server | Processing peer request |
+| **Done** | 3 | None | Terminal state |
+
+## Messages
+
+| Message | Type ID | Direction | Description |
+|---------|---------|-----------|-------------|
+| `ShareRequest` | 0 | Client → Server | Request peer addresses |
+| `SharePeers` | 1 | Server → Client | Provide peer addresses |
+| `Done` | 2 | Client → Server | Terminate protocol |
+
+## State Transitions
+
+### From Idle (Client Agency)
+| Message | New State |
+|---------|-----------|
+| `ShareRequest` | Busy |
+| `Done` | Done |
+
+### From Busy (Server Agency)
+| Message | New State |
+|---------|-----------|
+| `SharePeers` | Idle |
+
+## Timeouts
+
+| Timeout | Default | Description |
+|---------|---------|-------------|
+| Request Timeout | 5 seconds | Time to receive peer list |
+
+## Configuration Options
+
+```go
+peersharing.NewConfig(
+    peersharing.WithShareRequestFunc(shareRequestCallback),
+    peersharing.WithTimeout(5 * time.Second),
+)
+```
+
+## Usage Example
+
+```go
+// Request peers from connected node
+numPeersWanted := uint8(10)
+peers, err := client.GetPeers(numPeersWanted)
+if err != nil {
+    // Handle error
+}
+
+// peers contains list of PeerAddress
+for _, peer := range peers {
+    // Connect to new peer
+}
+```
+
+## Peer Address Format
+
+```go
+type PeerAddress struct {
+    IP   net.IP
+    Port uint16
+}
+```
+
+## Request Parameters
+
+The `ShareRequest` message includes the number of peers desired. The server responds with up to that many peer addresses from its known peer set.
+
+## Notes
+
+- Nodes share only peers they have successfully connected to
+- Responses may contain fewer peers than requested
+- Used for initial peer discovery and maintaining peer diversity
+- Privacy considerations: nodes may limit sharing
+- Complements DNS-based peer discovery

--- a/protocol/txsubmission/README.md
+++ b/protocol/txsubmission/README.md
@@ -1,0 +1,179 @@
+# TxSubmission Protocol
+
+The TxSubmission protocol propagates transactions between nodes. It uses a pull-based model where the server requests transaction IDs and bodies from the client.
+
+## Protocol Identifiers
+
+| Property | Value |
+|----------|-------|
+| Protocol Name | `tx-submission` |
+| Protocol ID | `4` |
+| Mode | Node-to-Node |
+
+## State Machine
+
+```text
+┌──────┐    Init      ┌──────┐
+│ Init │ ────────────►│ Idle │◄───────────────────┐
+└──────┘              └──┬───┘                    │
+                         │                        │
+         RequestTxIds    │                        │ ReplyTxIds
+         (blocking)      │                        │ ReplyTxs
+                         ▼                        │
+                  ┌─────────────────┐             │
+                  │ TxIdsBlocking   │─────────────┤
+                  └────────┬────────┘             │
+                           │                      │
+                           │ Done                 │
+                           ▼                      │
+                       ┌──────┐                   │
+                       │ Done │                   │
+                       └──────┘                   │
+                                                  │
+         RequestTxIds    │                        │
+         (non-blocking)  │                        │
+                         ▼                        │
+                  ┌─────────────────┐             │
+                  │ TxIdsNonblocking│─────────────┤
+                  └─────────────────┘             │
+                                                  │
+         RequestTxs      │                        │
+                         ▼                        │
+                  ┌──────────┐                    │
+                  │   Txs    │────────────────────┘
+                  └──────────┘
+```
+
+## States
+
+| State | ID | Agency | Description |
+|-------|-----|--------|-------------|
+| **Init** | 1 | Client | Initial state before protocol activation |
+| **Idle** | 2 | Server | Waiting for server to request transactions |
+| **TxIdsBlocking** | 3 | Client | Client must provide tx IDs (blocking) |
+| **TxIdsNonblocking** | 4 | Client | Client may provide tx IDs (non-blocking) |
+| **Txs** | 5 | Client | Client must provide transaction bodies |
+| **Done** | 6 | None | Terminal state |
+
+## Messages
+
+| Message | Type ID | Direction | Description |
+|---------|---------|-----------|-------------|
+| `Init` | 6 | Client → Server | Initialize protocol |
+| `RequestTxIds` | 0 | Server → Client | Request transaction IDs |
+| `ReplyTxIds` | 1 | Client → Server | Provide transaction IDs and sizes |
+| `RequestTxs` | 2 | Server → Client | Request full transactions |
+| `ReplyTxs` | 3 | Client → Server | Provide transaction bodies |
+| `Done` | 4 | Client → Server | Terminate protocol |
+
+## State Transitions
+
+### From Init (Client Agency)
+| Message | New State |
+|---------|-----------|
+| `Init` | Idle |
+
+### From Idle (Server Agency)
+| Message | New State | Condition |
+|---------|-----------|-----------|
+| `RequestTxIds` | TxIdsBlocking | Blocking = true |
+| `RequestTxIds` | TxIdsNonblocking | Blocking = false |
+| `RequestTxs` | Txs | |
+
+### From TxIdsBlocking (Client Agency)
+| Message | New State |
+|---------|-----------|
+| `ReplyTxIds` | Idle |
+| `Done` | Done |
+
+### From TxIdsNonblocking (Client Agency)
+| Message | New State |
+|---------|-----------|
+| `ReplyTxIds` | Idle |
+
+### From Txs (Client Agency)
+| Message | New State |
+|---------|-----------|
+| `ReplyTxs` | Idle |
+
+## Timeouts
+
+| State | Timeout | Description |
+|-------|---------|-------------|
+| Init | 30 seconds | Client must send Init message |
+| Idle | 300 seconds | Server must send tx request |
+| TxIdsBlocking | 60 seconds | Client must reply with tx IDs |
+| TxIdsNonblocking | 30 seconds | Client must reply with tx IDs |
+| Txs | 120 seconds | Client must reply with transactions |
+
+## Limits
+
+| Limit | Value | Description |
+|-------|-------|-------------|
+| Max Request Count | 65535 | Max transactions per request (uint16) |
+| Max Ack Count | 65535 | Max transaction acknowledgments (uint16) |
+| Default Request Limit | 1000 | Default request limit |
+| Default Ack Limit | 1000 | Default ack limit |
+
+## Request Parameters
+
+The `RequestTxIds` message includes:
+- **Blocking**: Whether to block waiting for transactions
+- **Ack**: Number of previously received transactions to acknowledge
+- **Req**: Number of new transaction IDs requested
+
+## Configuration Options
+
+```go
+txsubmission.NewConfig(
+    txsubmission.WithRequestTxIdsFunc(requestTxIdsCallback),
+    txsubmission.WithRequestTxsFunc(requestTxsCallback),
+    txsubmission.WithInitFunc(initCallback),
+    txsubmission.WithDoneFunc(doneCallback),
+    txsubmission.WithIdleTimeout(300 * time.Second),
+)
+```
+
+## Usage Example
+
+```go
+// Server requests transaction IDs (blocking mode, request 10 IDs)
+txIds, err := server.RequestTxIds(true, 10)
+
+// Client provides IDs and sizes via RequestTxIdsFunc callback
+cfg := txsubmission.NewConfig(
+    txsubmission.WithRequestTxIdsFunc(func(ctx CallbackContext, blocking bool, ack, req uint16) ([]TxIdAndSize, error) {
+        return []TxIdAndSize{
+            {TxId: txId1, Size: 256},
+            {TxId: txId2, Size: 512},
+        }, nil
+    }),
+)
+
+// Server requests full transactions
+txs, err := server.RequestTxs([]TxId{txId1, txId2})
+
+// Client provides transaction bodies via RequestTxsFunc callback
+```
+
+## Transaction ID Format
+
+```go
+type TxId struct {
+    EraId uint16   // Era identifier
+    TxId  [32]byte // Transaction hash
+}
+
+type TxIdAndSize struct {
+    TxId TxId
+    Size uint32 // Transaction size in bytes
+}
+```
+
+## Notes
+
+- Uses pull-based model (server requests, client provides)
+- Blocking mode waits for new transactions
+- Non-blocking mode returns immediately with available transactions
+- Transaction sizes are provided to help with mempool management
+- The Done message can only be sent from TxIdsBlocking state


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a protocol overview and individual READMEs for all Ouroboros mini-protocols. These docs include clear state machines, messages, timeouts, limits, and Go usage/config examples to help implement NtN and NtC flows.

- **New Features**
  - Added protocol/README.md and per-protocol docs covering core sync (Handshake, ChainSync, BlockFetch), transactions (TxSubmission, LocalTxSubmission/Monitor), state/discovery (LocalStateQuery, KeepAlive, PeerSharing), CIP-0137 DMQ (MessageSubmission, LocalMessageSubmission/Notification), and experimental Leios (Notify, Fetch).
  - Standardized each README with identifiers, agency and transitions, timeouts/limits, and concise code samples.

<sup>Written for commit fc9c5178cc31f5566d589a65323ffcf1a22d7b74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive protocol reference docs for ChainSync, BlockFetch, Handshake, KeepAlive, TxSubmission, MessageSubmission, PeerSharing, LeiosFetch, LeiosNotify, LocalTxSubmission, LocalTxMonitor, LocalStateQuery, LocalMessageNotification, LocalMessageSubmission and related protocols.
  * Each doc includes state machines, message flows, timeouts, limits, configuration guidance, usage examples, and interoperability notes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->