### PR TITLE
test(protocol): leios protocols

### DIFF
--- a/protocol/leiosfetch/client_test.go
+++ b/protocol/leiosfetch/client_test.go
@@ -1,0 +1,275 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leiosfetch
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClient(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	protoOptions := protocol.ProtocolOptions{
+		ConnectionId: connId,
+	}
+
+	client := NewClient(protoOptions, nil)
+
+	require.NotNil(t, client)
+	assert.NotNil(t, client.Protocol)
+	assert.NotNil(t, client.config)
+}
+
+func TestNewClientWithConfig(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	protoOptions := protocol.ProtocolOptions{
+		ConnectionId: connId,
+	}
+	cfg := NewConfig(
+		WithTimeout(10 * time.Second),
+	)
+
+	client := NewClient(protoOptions, &cfg)
+
+	require.NotNil(t, client)
+	assert.Equal(t, 10*time.Second, client.config.Timeout)
+}
+
+func TestClientMessageHandler(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	protoOptions := protocol.ProtocolOptions{
+		ConnectionId: connId,
+	}
+	client := NewClient(protoOptions, nil)
+
+	testCases := []struct {
+		name        string
+		msg         protocol.Message
+		expectError bool
+	}{
+		{
+			name:        "Block message",
+			msg:         NewMsgBlock([]byte{0x82, 0x01, 0x02}),
+			expectError: false,
+		},
+		{
+			name:        "BlockTxs message",
+			msg:         NewMsgBlockTxs(nil),
+			expectError: false,
+		},
+		{
+			name:        "Votes message",
+			msg:         NewMsgVotes(nil),
+			expectError: false,
+		},
+		{
+			name:        "NextBlockAndTxsInRange message",
+			msg:         NewMsgNextBlockAndTxsInRange(nil, nil),
+			expectError: false,
+		},
+		{
+			name:        "LastBlockAndTxsInRange message",
+			msg:         NewMsgLastBlockAndTxsInRange(nil, nil),
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// For block-related messages, we need to drain the channels
+			// to prevent blocking. We use goroutines to consume the messages.
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				switch tc.msg.Type() {
+				case MessageTypeBlock:
+					<-client.blockResultChan
+				case MessageTypeBlockTxs:
+					<-client.blockTxsResultChan
+				case MessageTypeVotes:
+					<-client.votesResultChan
+				case MessageTypeNextBlockAndTxsInRange, MessageTypeLastBlockAndTxsInRange:
+					<-client.blockRangeResultChan
+				}
+			}()
+
+			err := client.messageHandler(tc.msg)
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Wait for the channel consumer goroutine to finish
+			select {
+			case <-done:
+			case <-time.After(100 * time.Millisecond):
+				t.Fatal("timeout waiting for channel consumer")
+			}
+		})
+	}
+}
+
+func TestClientMessageHandlerUnexpectedType(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	protoOptions := protocol.ProtocolOptions{
+		ConnectionId: connId,
+	}
+	client := NewClient(protoOptions, nil)
+
+	// Create a message with an unexpected type
+	msg := NewMsgBlockRequest(123, []byte{0x01, 0x02})
+
+	err := client.messageHandler(msg)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected message type")
+}
+
+func TestStateMap(t *testing.T) {
+	// Test that all expected states exist
+	assert.Equal(t, uint(1), StateIdle.Id)
+	assert.Equal(t, uint(2), StateBlock.Id)
+	assert.Equal(t, uint(3), StateBlockTxs.Id)
+	assert.Equal(t, uint(4), StateVotes.Id)
+	assert.Equal(t, uint(5), StateBlockRange.Id)
+	assert.Equal(t, uint(6), StateDone.Id)
+
+	// Test StateMap entries
+	assert.Contains(t, StateMap, StateIdle)
+	assert.Contains(t, StateMap, StateBlock)
+	assert.Contains(t, StateMap, StateBlockTxs)
+	assert.Contains(t, StateMap, StateVotes)
+	assert.Contains(t, StateMap, StateBlockRange)
+	assert.Contains(t, StateMap, StateDone)
+
+	// Test agency for each state
+	assert.Equal(t, protocol.AgencyClient, StateMap[StateIdle].Agency)
+	assert.Equal(t, protocol.AgencyServer, StateMap[StateBlock].Agency)
+	assert.Equal(t, protocol.AgencyServer, StateMap[StateBlockTxs].Agency)
+	assert.Equal(t, protocol.AgencyServer, StateMap[StateVotes].Agency)
+	assert.Equal(t, protocol.AgencyServer, StateMap[StateBlockRange].Agency)
+	assert.Equal(t, protocol.AgencyNone, StateMap[StateDone].Agency)
+}
+
+func TestStateTransitions(t *testing.T) {
+	// Test transitions from Idle state
+	idleEntry := StateMap[StateIdle]
+	require.Len(t, idleEntry.Transitions, 5)
+
+	expectedTransitions := map[uint8]protocol.State{
+		MessageTypeBlockRequest:      StateBlock,
+		MessageTypeBlockTxsRequest:   StateBlockTxs,
+		MessageTypeVotesRequest:      StateVotes,
+		MessageTypeBlockRangeRequest: StateBlockRange,
+		MessageTypeDone:              StateDone,
+	}
+
+	for _, trans := range idleEntry.Transitions {
+		expected, ok := expectedTransitions[trans.MsgType]
+		require.True(t, ok, "unexpected transition message type: %d", trans.MsgType)
+		assert.Equal(t, expected, trans.NewState)
+	}
+
+	// Test transitions from Block state
+	blockEntry := StateMap[StateBlock]
+	require.Len(t, blockEntry.Transitions, 1)
+	assert.Equal(t, uint8(MessageTypeBlock), blockEntry.Transitions[0].MsgType)
+	assert.Equal(t, StateIdle, blockEntry.Transitions[0].NewState)
+
+	// Test transitions from BlockRange state
+	blockRangeEntry := StateMap[StateBlockRange]
+	require.Len(t, blockRangeEntry.Transitions, 2)
+}
+
+func TestConfig(t *testing.T) {
+	// Test default config
+	cfg := NewConfig()
+	assert.Equal(t, 5*time.Second, cfg.Timeout)
+	assert.Nil(t, cfg.BlockRequestFunc)
+	assert.Nil(t, cfg.BlockTxsRequestFunc)
+	assert.Nil(t, cfg.VotesRequestFunc)
+	assert.Nil(t, cfg.BlockRangeRequestFunc)
+
+	// Test config with options
+	blockRequestCalled := false
+	blockTxsRequestCalled := false
+	votesRequestCalled := false
+	blockRangeRequestCalled := false
+
+	cfg = NewConfig(
+		WithTimeout(30*time.Second),
+		WithBlockRequestFunc(func(ctx CallbackContext, slot uint64, hash []byte) (protocol.Message, error) {
+			blockRequestCalled = true
+			return nil, nil
+		}),
+		WithBlockTxsRequestFunc(func(ctx CallbackContext, slot uint64, hash []byte, bitmaps map[uint16][8]byte) (protocol.Message, error) {
+			blockTxsRequestCalled = true
+			return nil, nil
+		}),
+		WithVotesRequestFunc(func(ctx CallbackContext, voteIds []MsgVotesRequestVoteId) (protocol.Message, error) {
+			votesRequestCalled = true
+			return nil, nil
+		}),
+		WithBlockRangeRequestFunc(func(ctx CallbackContext, start, end pcommon.Point) error {
+			blockRangeRequestCalled = true
+			return nil
+		}),
+	)
+
+	assert.Equal(t, 30*time.Second, cfg.Timeout)
+	assert.NotNil(t, cfg.BlockRequestFunc)
+	assert.NotNil(t, cfg.BlockTxsRequestFunc)
+	assert.NotNil(t, cfg.VotesRequestFunc)
+	assert.NotNil(t, cfg.BlockRangeRequestFunc)
+
+	// Test that callbacks can be invoked
+	_, _ = cfg.BlockRequestFunc(CallbackContext{}, 0, nil)
+	assert.True(t, blockRequestCalled)
+
+	_, _ = cfg.BlockTxsRequestFunc(CallbackContext{}, 0, nil, nil)
+	assert.True(t, blockTxsRequestCalled)
+
+	_, _ = cfg.VotesRequestFunc(CallbackContext{}, nil)
+	assert.True(t, votesRequestCalled)
+
+	_ = cfg.BlockRangeRequestFunc(CallbackContext{}, pcommon.Point{}, pcommon.Point{})
+	assert.True(t, blockRangeRequestCalled)
+}
+
+func TestProtocolConstants(t *testing.T) {
+	assert.Equal(t, "leios-fetch", ProtocolName)
+	assert.Equal(t, uint16(19), ProtocolId)
+}

--- a/protocol/leiosfetch/messages_test.go
+++ b/protocol/leiosfetch/messages_test.go
@@ -1,0 +1,373 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leiosfetch
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testDefinition struct {
+	Name        string
+	Message     protocol.Message
+	MessageType uint
+}
+
+func getTestDefinitions() []testDefinition {
+	return []testDefinition{
+		{
+			Name: "MsgBlockRequest",
+			Message: NewMsgBlockRequest(
+				12345,
+				[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+			),
+			MessageType: MessageTypeBlockRequest,
+		},
+		{
+			Name: "MsgBlock",
+			Message: NewMsgBlock(
+				cbor.RawMessage([]byte{0x82, 0x01, 0x02}),
+			),
+			MessageType: MessageTypeBlock,
+		},
+		{
+			Name: "MsgBlockTxsRequest",
+			Message: NewMsgBlockTxsRequest(
+				12345,
+				[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+				map[uint16][8]byte{
+					0:  {0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+					64: {0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+				},
+			),
+			MessageType: MessageTypeBlockTxsRequest,
+		},
+		{
+			Name: "MsgBlockTxs",
+			Message: NewMsgBlockTxs(
+				[]cbor.RawMessage{
+					[]byte{0x82, 0x01, 0x02},
+					[]byte{0x82, 0x03, 0x04},
+				},
+			),
+			MessageType: MessageTypeBlockTxs,
+		},
+		{
+			Name: "MsgVotesRequest",
+			Message: NewMsgVotesRequest(
+				[]MsgVotesRequestVoteId{
+					{Slot: 100, VoteIssuerId: []byte{0x01, 0x02, 0x03, 0x04}},
+					{Slot: 200, VoteIssuerId: []byte{0x05, 0x06, 0x07, 0x08}},
+				},
+			),
+			MessageType: MessageTypeVotesRequest,
+		},
+		{
+			Name: "MsgVotes",
+			Message: NewMsgVotes(
+				[]cbor.RawMessage{
+					[]byte{0x82, 0x05, 0x06},
+					[]byte{0x82, 0x07, 0x08},
+				},
+			),
+			MessageType: MessageTypeVotes,
+		},
+		{
+			Name: "MsgBlockRangeRequest",
+			Message: NewMsgBlockRangeRequest(
+				pcommon.NewPoint(
+					123,
+					[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+				),
+				pcommon.NewPoint(
+					456,
+					[]byte{0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+				),
+			),
+			MessageType: MessageTypeBlockRangeRequest,
+		},
+		{
+			Name: "MsgNextBlockAndTxsInRange",
+			Message: NewMsgNextBlockAndTxsInRange(
+				cbor.RawMessage([]byte{0x82, 0x01, 0x02}),
+				[]cbor.RawMessage{
+					[]byte{0x82, 0x03, 0x04},
+				},
+			),
+			MessageType: MessageTypeNextBlockAndTxsInRange,
+		},
+		{
+			Name: "MsgLastBlockAndTxsInRange",
+			Message: NewMsgLastBlockAndTxsInRange(
+				cbor.RawMessage([]byte{0x82, 0x09, 0x0a}),
+				[]cbor.RawMessage{
+					[]byte{0x82, 0x0b, 0x0c},
+					[]byte{0x82, 0x0d, 0x0e},
+				},
+			),
+			MessageType: MessageTypeLastBlockAndTxsInRange,
+		},
+		{
+			Name:        "MsgDone",
+			Message:     NewMsgDone(),
+			MessageType: MessageTypeDone,
+		},
+	}
+}
+
+func TestCborRoundTrip(t *testing.T) {
+	tests := getTestDefinitions()
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			// Encode the message
+			encoded, err := cbor.Encode(test.Message)
+			require.NoError(t, err, "failed to encode message to CBOR")
+
+			// Decode the message
+			decoded, err := NewMsgFromCbor(test.MessageType, encoded)
+			require.NoError(t, err, "failed to decode CBOR")
+
+			// Re-encode and compare
+			reencoded, err := cbor.Encode(decoded)
+			require.NoError(t, err, "failed to re-encode message")
+
+			assert.Equal(t, encoded, reencoded, "CBOR round-trip failed")
+		})
+	}
+}
+
+func TestDecode(t *testing.T) {
+	tests := getTestDefinitions()
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			// Encode the message first
+			encoded, err := cbor.Encode(test.Message)
+			require.NoError(t, err, "failed to encode message to CBOR")
+
+			// Decode it back
+			decoded, err := NewMsgFromCbor(test.MessageType, encoded)
+			require.NoError(t, err, "failed to decode CBOR")
+
+			// Set the raw CBOR so the comparison should succeed
+			test.Message.SetCbor(encoded)
+
+			assert.True(t, reflect.DeepEqual(decoded, test.Message),
+				"CBOR did not decode to expected message object\n  got: %#v\n  wanted: %#v",
+				decoded, test.Message)
+		})
+	}
+}
+
+func TestEncode(t *testing.T) {
+	tests := getTestDefinitions()
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			// Encode the message
+			encoded, err := cbor.Encode(test.Message)
+			require.NoError(t, err, "failed to encode message to CBOR")
+
+			// Verify it can be decoded back without error
+			_, err = NewMsgFromCbor(test.MessageType, encoded)
+			require.NoError(t, err, "failed to decode encoded message")
+		})
+	}
+}
+
+func TestMsgBlockRequest(t *testing.T) {
+	slot := uint64(123456)
+	hash := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+
+	msg := NewMsgBlockRequest(slot, hash)
+
+	assert.Equal(t, uint8(MessageTypeBlockRequest), msg.Type())
+	assert.Equal(t, slot, msg.Slot)
+	assert.Equal(t, hash, msg.Hash)
+}
+
+func TestMsgBlock(t *testing.T) {
+	blockRaw := cbor.RawMessage([]byte{0x82, 0x01, 0x02})
+
+	msg := NewMsgBlock(blockRaw)
+
+	assert.Equal(t, uint8(MessageTypeBlock), msg.Type())
+	assert.Equal(t, blockRaw, msg.BlockRaw)
+}
+
+func TestMsgBlockTxsRequest(t *testing.T) {
+	slot := uint64(123456)
+	hash := []byte{0x01, 0x02, 0x03, 0x04}
+	bitmaps := map[uint16][8]byte{
+		0: {0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+	}
+
+	msg := NewMsgBlockTxsRequest(slot, hash, bitmaps)
+
+	assert.Equal(t, uint8(MessageTypeBlockTxsRequest), msg.Type())
+	assert.Equal(t, slot, msg.Slot)
+	assert.Equal(t, hash, msg.Hash)
+	assert.Equal(t, bitmaps, msg.Bitmaps)
+}
+
+func TestMsgBlockTxs(t *testing.T) {
+	txs := []cbor.RawMessage{
+		[]byte{0x82, 0x01, 0x02},
+		[]byte{0x82, 0x03, 0x04},
+	}
+
+	msg := NewMsgBlockTxs(txs)
+
+	assert.Equal(t, uint8(MessageTypeBlockTxs), msg.Type())
+	assert.Equal(t, txs, msg.TxsRaw)
+}
+
+func TestMsgVotesRequest(t *testing.T) {
+	voteIds := []MsgVotesRequestVoteId{
+		{Slot: 100, VoteIssuerId: []byte{0x01, 0x02, 0x03, 0x04}},
+		{Slot: 200, VoteIssuerId: []byte{0x05, 0x06, 0x07, 0x08}},
+	}
+
+	msg := NewMsgVotesRequest(voteIds)
+
+	assert.Equal(t, uint8(MessageTypeVotesRequest), msg.Type())
+	assert.Equal(t, voteIds, msg.VoteIds)
+}
+
+func TestMsgVotes(t *testing.T) {
+	votes := []cbor.RawMessage{
+		[]byte{0x82, 0x05, 0x06},
+	}
+
+	msg := NewMsgVotes(votes)
+
+	assert.Equal(t, uint8(MessageTypeVotes), msg.Type())
+	assert.Equal(t, votes, msg.VotesRaw)
+}
+
+func TestMsgBlockRangeRequest(t *testing.T) {
+	start := pcommon.NewPoint(100, []byte{0x01, 0x02, 0x03, 0x04})
+	end := pcommon.NewPoint(200, []byte{0x05, 0x06, 0x07, 0x08})
+
+	msg := NewMsgBlockRangeRequest(start, end)
+
+	assert.Equal(t, uint8(MessageTypeBlockRangeRequest), msg.Type())
+	assert.Equal(t, start, msg.Start)
+	assert.Equal(t, end, msg.End)
+}
+
+func TestMsgNextBlockAndTxsInRange(t *testing.T) {
+	blockRaw := cbor.RawMessage([]byte{0x82, 0x01, 0x02})
+	txs := []cbor.RawMessage{
+		[]byte{0x82, 0x03, 0x04},
+	}
+
+	msg := NewMsgNextBlockAndTxsInRange(blockRaw, txs)
+
+	assert.Equal(t, uint8(MessageTypeNextBlockAndTxsInRange), msg.Type())
+	assert.Equal(t, blockRaw, msg.BlockRaw)
+	assert.Equal(t, txs, msg.TxsRaw)
+}
+
+func TestMsgLastBlockAndTxsInRange(t *testing.T) {
+	blockRaw := cbor.RawMessage([]byte{0x82, 0x01, 0x02})
+	txs := []cbor.RawMessage{
+		[]byte{0x82, 0x03, 0x04},
+	}
+
+	msg := NewMsgLastBlockAndTxsInRange(blockRaw, txs)
+
+	assert.Equal(t, uint8(MessageTypeLastBlockAndTxsInRange), msg.Type())
+	assert.Equal(t, blockRaw, msg.BlockRaw)
+	assert.Equal(t, txs, msg.TxsRaw)
+}
+
+func TestMsgDone(t *testing.T) {
+	msg := NewMsgDone()
+
+	assert.Equal(t, uint8(MessageTypeDone), msg.Type())
+}
+
+func TestNewMsgFromCborUnknownType(t *testing.T) {
+	// Test with unknown message type - the NewMsgFromCbor function tries to decode
+	// into a nil pointer, which results in an error
+	data := []byte{0x80} // empty array
+	msg, err := NewMsgFromCbor(999, data)
+	// When the message type is unknown, ret is nil, and cbor.Decode(data, nil) returns an error
+	assert.Error(t, err)
+	assert.Nil(t, msg)
+}
+
+func TestMsgBlockTxsRequestEmptyBitmaps(t *testing.T) {
+	slot := uint64(123)
+	hash := []byte{0x01, 0x02}
+	bitmaps := map[uint16][8]byte{}
+
+	msg := NewMsgBlockTxsRequest(slot, hash, bitmaps)
+
+	encoded, err := cbor.Encode(msg)
+	require.NoError(t, err)
+
+	decoded, err := NewMsgFromCbor(MessageTypeBlockTxsRequest, encoded)
+	require.NoError(t, err)
+
+	decodedMsg := decoded.(*MsgBlockTxsRequest)
+	assert.Equal(t, slot, decodedMsg.Slot)
+	assert.Equal(t, hash, decodedMsg.Hash)
+	assert.Equal(t, 0, len(decodedMsg.Bitmaps))
+}
+
+func TestMsgVotesRequestEmpty(t *testing.T) {
+	msg := NewMsgVotesRequest([]MsgVotesRequestVoteId{})
+
+	encoded, err := cbor.Encode(msg)
+	require.NoError(t, err)
+
+	decoded, err := NewMsgFromCbor(MessageTypeVotesRequest, encoded)
+	require.NoError(t, err)
+
+	decodedMsg := decoded.(*MsgVotesRequest)
+	assert.Equal(t, 0, len(decodedMsg.VoteIds))
+}
+
+func TestMsgBlockTxsEmpty(t *testing.T) {
+	msg := NewMsgBlockTxs([]cbor.RawMessage{})
+
+	encoded, err := cbor.Encode(msg)
+	require.NoError(t, err)
+
+	decoded, err := NewMsgFromCbor(MessageTypeBlockTxs, encoded)
+	require.NoError(t, err)
+
+	decodedMsg := decoded.(*MsgBlockTxs)
+	assert.Equal(t, 0, len(decodedMsg.TxsRaw))
+}
+
+func TestMsgVotesEmpty(t *testing.T) {
+	msg := NewMsgVotes([]cbor.RawMessage{})
+
+	encoded, err := cbor.Encode(msg)
+	require.NoError(t, err)
+
+	decoded, err := NewMsgFromCbor(MessageTypeVotes, encoded)
+	require.NoError(t, err)
+
+	decodedMsg := decoded.(*MsgVotes)
+	assert.Equal(t, 0, len(decodedMsg.VotesRaw))
+}

--- a/protocol/leiosfetch/server_test.go
+++ b/protocol/leiosfetch/server_test.go
@@ -1,0 +1,430 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leiosfetch
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewServer(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	protoOptions := protocol.ProtocolOptions{
+		ConnectionId: connId,
+	}
+
+	cfg := NewConfig()
+	server := NewServer(protoOptions, &cfg)
+
+	require.NotNil(t, server)
+	assert.NotNil(t, server.Protocol)
+	assert.NotNil(t, server.config)
+}
+
+func TestHandleBlockRequest_CallbackIsCalled(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+
+	called := false
+	expectedSlot := uint64(12345)
+	expectedHash := []byte{0x01, 0x02, 0x03, 0x04}
+
+	cfg := NewConfig(
+		WithBlockRequestFunc(func(ctx CallbackContext, slot uint64, hash []byte) (protocol.Message, error) {
+			called = true
+			assert.Equal(t, expectedSlot, slot)
+			assert.Equal(t, expectedHash, hash)
+			// Return an error to prevent attempting to send (which would hang)
+			return nil, errors.New("test: stopping before send")
+		}),
+	)
+
+	server := &Server{
+		config:          &cfg,
+		callbackContext: CallbackContext{ConnectionId: connId},
+	}
+	server.initProtocol()
+
+	msg := NewMsgBlockRequest(expectedSlot, expectedHash)
+	err := server.handleBlockRequest(msg)
+
+	// Error is expected because we return an error from the callback
+	assert.Error(t, err)
+	assert.True(t, called, "expected BlockRequestFunc to be called")
+}
+
+func TestHandleBlockRequest_NilCallback(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+
+	cfg := NewConfig()
+	server := &Server{
+		config:          &cfg,
+		callbackContext: CallbackContext{ConnectionId: connId},
+	}
+	server.initProtocol()
+
+	msg := NewMsgBlockRequest(12345, []byte{0x01, 0x02})
+	err := server.handleBlockRequest(msg)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no callback function is defined")
+}
+
+func TestHandleBlockRequest_NilConfig(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+
+	server := &Server{
+		config:          nil,
+		callbackContext: CallbackContext{ConnectionId: connId},
+	}
+	server.initProtocol()
+
+	msg := NewMsgBlockRequest(12345, []byte{0x01, 0x02})
+	err := server.handleBlockRequest(msg)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no callback function is defined")
+}
+
+func TestHandleBlockRequest_CallbackError(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+
+	expectedError := errors.New("block not found")
+	cfg := NewConfig(
+		WithBlockRequestFunc(func(ctx CallbackContext, slot uint64, hash []byte) (protocol.Message, error) {
+			return nil, expectedError
+		}),
+	)
+
+	server := &Server{
+		config:          &cfg,
+		callbackContext: CallbackContext{ConnectionId: connId},
+	}
+	server.initProtocol()
+
+	msg := NewMsgBlockRequest(12345, []byte{0x01, 0x02})
+	err := server.handleBlockRequest(msg)
+
+	assert.Error(t, err)
+	assert.Equal(t, expectedError, err)
+}
+
+func TestHandleBlockRequest_NilResponse(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+
+	cfg := NewConfig(
+		WithBlockRequestFunc(func(ctx CallbackContext, slot uint64, hash []byte) (protocol.Message, error) {
+			return nil, nil
+		}),
+	)
+
+	server := &Server{
+		config:          &cfg,
+		callbackContext: CallbackContext{ConnectionId: connId},
+	}
+	server.initProtocol()
+
+	msg := NewMsgBlockRequest(12345, []byte{0x01, 0x02})
+	err := server.handleBlockRequest(msg)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "callback returned nil")
+}
+
+func TestHandleBlockTxsRequest_CallbackIsCalled(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+
+	called := false
+	expectedSlot := uint64(12345)
+	expectedHash := []byte{0x01, 0x02, 0x03, 0x04}
+	expectedBitmaps := map[uint16][8]byte{
+		0: {0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+	}
+
+	cfg := NewConfig(
+		WithBlockTxsRequestFunc(func(ctx CallbackContext, slot uint64, hash []byte, bitmaps map[uint16][8]byte) (protocol.Message, error) {
+			called = true
+			assert.Equal(t, expectedSlot, slot)
+			assert.Equal(t, expectedHash, hash)
+			assert.Equal(t, expectedBitmaps, bitmaps)
+			// Return an error to prevent attempting to send (which would hang)
+			return nil, errors.New("test: stopping before send")
+		}),
+	)
+
+	server := &Server{
+		config:          &cfg,
+		callbackContext: CallbackContext{ConnectionId: connId},
+	}
+	server.initProtocol()
+
+	msg := NewMsgBlockTxsRequest(expectedSlot, expectedHash, expectedBitmaps)
+	err := server.handleBlockTxsRequest(msg)
+
+	// Error is expected because we return an error from the callback
+	assert.Error(t, err)
+	assert.True(t, called, "expected BlockTxsRequestFunc to be called")
+}
+
+func TestHandleBlockTxsRequest_NilCallback(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+
+	cfg := NewConfig()
+	server := &Server{
+		config:          &cfg,
+		callbackContext: CallbackContext{ConnectionId: connId},
+	}
+	server.initProtocol()
+
+	msg := NewMsgBlockTxsRequest(12345, []byte{0x01, 0x02}, nil)
+	err := server.handleBlockTxsRequest(msg)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no callback function is defined")
+}
+
+func TestHandleVotesRequest_CallbackIsCalled(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+
+	called := false
+	expectedVoteIds := []MsgVotesRequestVoteId{
+		{Slot: 100, VoteIssuerId: []byte{0x01, 0x02, 0x03, 0x04}},
+	}
+
+	cfg := NewConfig(
+		WithVotesRequestFunc(func(ctx CallbackContext, voteIds []MsgVotesRequestVoteId) (protocol.Message, error) {
+			called = true
+			assert.Equal(t, expectedVoteIds, voteIds)
+			// Return an error to prevent attempting to send (which would hang)
+			return nil, errors.New("test: stopping before send")
+		}),
+	)
+
+	server := &Server{
+		config:          &cfg,
+		callbackContext: CallbackContext{ConnectionId: connId},
+	}
+	server.initProtocol()
+
+	msg := NewMsgVotesRequest(expectedVoteIds)
+	err := server.handleVotesRequest(msg)
+
+	// Error is expected because we return an error from the callback
+	assert.Error(t, err)
+	assert.True(t, called, "expected VotesRequestFunc to be called")
+}
+
+func TestHandleVotesRequest_NilCallback(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+
+	cfg := NewConfig()
+	server := &Server{
+		config:          &cfg,
+		callbackContext: CallbackContext{ConnectionId: connId},
+	}
+	server.initProtocol()
+
+	msg := NewMsgVotesRequest(nil)
+	err := server.handleVotesRequest(msg)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no callback function is defined")
+}
+
+func TestHandleBlockRangeRequest_Callback(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+
+	called := false
+	expectedStart := pcommon.NewPoint(100, []byte{0x01, 0x02, 0x03, 0x04})
+	expectedEnd := pcommon.NewPoint(200, []byte{0x05, 0x06, 0x07, 0x08})
+
+	cfg := NewConfig(
+		WithBlockRangeRequestFunc(func(ctx CallbackContext, start, end pcommon.Point) error {
+			called = true
+			assert.Equal(t, expectedStart, start)
+			assert.Equal(t, expectedEnd, end)
+			return nil
+		}),
+	)
+
+	server := &Server{
+		config:          &cfg,
+		callbackContext: CallbackContext{ConnectionId: connId},
+	}
+	server.initProtocol()
+
+	msg := NewMsgBlockRangeRequest(expectedStart, expectedEnd)
+	err := server.handleBlockRangeRequest(msg)
+
+	assert.NoError(t, err)
+	assert.True(t, called, "expected BlockRangeRequestFunc to be called")
+}
+
+func TestHandleBlockRangeRequest_NilCallback(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+
+	cfg := NewConfig()
+	server := &Server{
+		config:          &cfg,
+		callbackContext: CallbackContext{ConnectionId: connId},
+	}
+	server.initProtocol()
+
+	msg := NewMsgBlockRangeRequest(pcommon.Point{}, pcommon.Point{})
+	err := server.handleBlockRangeRequest(msg)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no callback function is defined")
+}
+
+func TestServerMessageHandler_UnexpectedType(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	protoOptions := protocol.ProtocolOptions{
+		ConnectionId: connId,
+	}
+
+	cfg := NewConfig()
+	server := NewServer(protoOptions, &cfg)
+
+	// Create a message with an unexpected type for the server
+	msg := NewMsgBlock([]byte{0x82, 0x01, 0x02})
+
+	err := server.messageHandler(msg)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected message type")
+}
+
+func TestServerMessageHandler_AllTypes(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	protoOptions := protocol.ProtocolOptions{
+		ConnectionId: connId,
+	}
+
+	// Create a config with all callbacks that return errors to prevent send attempts
+	cfg := NewConfig(
+		WithBlockRequestFunc(func(ctx CallbackContext, slot uint64, hash []byte) (protocol.Message, error) {
+			return nil, errors.New("test: callback error")
+		}),
+		WithBlockTxsRequestFunc(func(ctx CallbackContext, slot uint64, hash []byte, bitmaps map[uint16][8]byte) (protocol.Message, error) {
+			return nil, errors.New("test: callback error")
+		}),
+		WithVotesRequestFunc(func(ctx CallbackContext, voteIds []MsgVotesRequestVoteId) (protocol.Message, error) {
+			return nil, errors.New("test: callback error")
+		}),
+		WithBlockRangeRequestFunc(func(ctx CallbackContext, start, end pcommon.Point) error {
+			return errors.New("test: callback error")
+		}),
+	)
+
+	server := NewServer(protoOptions, &cfg)
+
+	testCases := []struct {
+		name string
+		msg  protocol.Message
+	}{
+		{
+			name: "BlockRequest",
+			msg:  NewMsgBlockRequest(12345, []byte{0x01, 0x02}),
+		},
+		{
+			name: "BlockTxsRequest",
+			msg:  NewMsgBlockTxsRequest(12345, []byte{0x01, 0x02}, nil),
+		},
+		{
+			name: "VotesRequest",
+			msg:  NewMsgVotesRequest(nil),
+		},
+		{
+			name: "BlockRangeRequest",
+			msg:  NewMsgBlockRangeRequest(pcommon.Point{}, pcommon.Point{}),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := server.messageHandler(tc.msg)
+			// These will return errors from the callback
+			// but we're testing that the message handler routes to the correct handler
+			assert.Error(t, err)
+			assert.NotContains(t, err.Error(), "unexpected message type")
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	protoOptions := protocol.ProtocolOptions{
+		ConnectionId: connId,
+	}
+	cfg := NewConfig()
+
+	leiosFetch := New(protoOptions, &cfg)
+
+	require.NotNil(t, leiosFetch)
+	assert.NotNil(t, leiosFetch.Client)
+	assert.NotNil(t, leiosFetch.Server)
+}

--- a/protocol/leiosnotify/client_test.go
+++ b/protocol/leiosnotify/client_test.go
@@ -1,0 +1,339 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leiosnotify
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClient(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	protoOptions := protocol.ProtocolOptions{
+		ConnectionId: connId,
+	}
+
+	client := NewClient(protoOptions, nil)
+
+	require.NotNil(t, client)
+	assert.NotNil(t, client.Protocol)
+	assert.NotNil(t, client.config)
+}
+
+func TestNewClientWithConfig(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	protoOptions := protocol.ProtocolOptions{
+		ConnectionId: connId,
+	}
+	cfg := NewConfig(
+		WithTimeout(30 * time.Second),
+	)
+
+	client := NewClient(protoOptions, &cfg)
+
+	require.NotNil(t, client)
+	assert.Equal(t, 30*time.Second, client.config.Timeout)
+}
+
+func TestClientMessageHandler(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	protoOptions := protocol.ProtocolOptions{
+		ConnectionId: connId,
+	}
+	client := NewClient(protoOptions, nil)
+
+	testCases := []struct {
+		name        string
+		msg         protocol.Message
+		expectError bool
+	}{
+		{
+			name:        "BlockAnnouncement message",
+			msg:         NewMsgBlockAnnouncement([]byte{0x82, 0x01, 0x02}),
+			expectError: false,
+		},
+		{
+			name:        "BlockOffer message",
+			msg:         NewMsgBlockOffer(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+			expectError: false,
+		},
+		{
+			name:        "BlockTxsOffer message",
+			msg:         NewMsgBlockTxsOffer(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+			expectError: false,
+		},
+		{
+			name:        "VotesOffer message",
+			msg:         NewMsgVotesOffer(nil),
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// For notification messages, we need to drain the channel
+			// to prevent blocking. We use a goroutine to consume the message.
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				<-client.requestNextChan
+			}()
+
+			err := client.messageHandler(tc.msg)
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Wait for the channel consumer goroutine to finish
+			select {
+			case <-done:
+			case <-time.After(100 * time.Millisecond):
+				t.Fatal("timeout waiting for channel consumer")
+			}
+		})
+	}
+}
+
+func TestClientMessageHandlerUnexpectedType(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	protoOptions := protocol.ProtocolOptions{
+		ConnectionId: connId,
+	}
+	client := NewClient(protoOptions, nil)
+
+	// Create a message with an unexpected type
+	msg := NewMsgNotificationRequestNext()
+
+	err := client.messageHandler(msg)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected message type")
+}
+
+func TestStateMap(t *testing.T) {
+	// Test that all expected states exist
+	assert.Equal(t, uint(1), StateIdle.Id)
+	assert.Equal(t, uint(2), StateBusy.Id)
+	assert.Equal(t, uint(3), StateDone.Id)
+
+	// Test StateMap entries
+	assert.Contains(t, StateMap, StateIdle)
+	assert.Contains(t, StateMap, StateBusy)
+	assert.Contains(t, StateMap, StateDone)
+
+	// Test agency for each state
+	assert.Equal(t, protocol.AgencyClient, StateMap[StateIdle].Agency)
+	assert.Equal(t, protocol.AgencyServer, StateMap[StateBusy].Agency)
+	assert.Equal(t, protocol.AgencyNone, StateMap[StateDone].Agency)
+}
+
+func TestStateTransitions(t *testing.T) {
+	// Test transitions from Idle state
+	idleEntry := StateMap[StateIdle]
+	require.Len(t, idleEntry.Transitions, 2)
+
+	expectedTransitions := map[uint8]protocol.State{
+		MessageTypeNotificationRequestNext: StateBusy,
+		MessageTypeDone:                    StateDone,
+	}
+
+	for _, trans := range idleEntry.Transitions {
+		expected, ok := expectedTransitions[trans.MsgType]
+		require.True(t, ok, "unexpected transition message type: %d", trans.MsgType)
+		assert.Equal(t, expected, trans.NewState)
+	}
+
+	// Test transitions from Busy state
+	busyEntry := StateMap[StateBusy]
+	require.Len(t, busyEntry.Transitions, 4)
+
+	expectedBusyTransitions := map[uint8]protocol.State{
+		MessageTypeBlockAnnouncement: StateIdle,
+		MessageTypeBlockOffer:        StateIdle,
+		MessageTypeBlockTxsOffer:     StateIdle,
+		MessageTypeVotesOffer:        StateIdle,
+	}
+
+	for _, trans := range busyEntry.Transitions {
+		expected, ok := expectedBusyTransitions[trans.MsgType]
+		require.True(t, ok, "unexpected transition message type: %d", trans.MsgType)
+		assert.Equal(t, expected, trans.NewState)
+	}
+}
+
+func TestConfig(t *testing.T) {
+	// Test default config
+	cfg := NewConfig()
+	assert.Equal(t, 60*time.Second, cfg.Timeout)
+	assert.Nil(t, cfg.RequestNextFunc)
+
+	// Test config with options
+	requestNextCalled := false
+
+	cfg = NewConfig(
+		WithTimeout(120*time.Second),
+		WithRequestNextFunc(func(ctx CallbackContext) (protocol.Message, error) {
+			requestNextCalled = true
+			return nil, nil
+		}),
+	)
+
+	assert.Equal(t, 120*time.Second, cfg.Timeout)
+	assert.NotNil(t, cfg.RequestNextFunc)
+
+	// Test that callback can be invoked
+	_, _ = cfg.RequestNextFunc(CallbackContext{})
+	assert.True(t, requestNextCalled)
+}
+
+func TestProtocolConstants(t *testing.T) {
+	assert.Equal(t, "leios-notify", ProtocolName)
+	assert.Equal(t, uint16(18), ProtocolId)
+}
+
+func TestClientHandleBlockAnnouncement(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	protoOptions := protocol.ProtocolOptions{
+		ConnectionId: connId,
+	}
+	client := NewClient(protoOptions, nil)
+
+	msg := NewMsgBlockAnnouncement([]byte{0x82, 0x01, 0x02})
+
+	// Start a goroutine to receive the message
+	received := make(chan protocol.Message, 1)
+	go func() {
+		received <- <-client.requestNextChan
+	}()
+
+	client.handleBlockAnnouncement(msg)
+
+	select {
+	case receivedMsg := <-received:
+		assert.Equal(t, msg, receivedMsg)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timeout waiting for message")
+	}
+}
+
+func TestClientHandleBlockOffer(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	protoOptions := protocol.ProtocolOptions{
+		ConnectionId: connId,
+	}
+	client := NewClient(protoOptions, nil)
+
+	msg := NewMsgBlockOffer(12345, []byte{0x01, 0x02, 0x03, 0x04})
+
+	// Start a goroutine to receive the message
+	received := make(chan protocol.Message, 1)
+	go func() {
+		received <- <-client.requestNextChan
+	}()
+
+	client.handleBlockOffer(msg)
+
+	select {
+	case receivedMsg := <-received:
+		assert.Equal(t, msg, receivedMsg)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timeout waiting for message")
+	}
+}
+
+func TestClientHandleBlockTxsOffer(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	protoOptions := protocol.ProtocolOptions{
+		ConnectionId: connId,
+	}
+	client := NewClient(protoOptions, nil)
+
+	msg := NewMsgBlockTxsOffer(12345, []byte{0x01, 0x02, 0x03, 0x04})
+
+	// Start a goroutine to receive the message
+	received := make(chan protocol.Message, 1)
+	go func() {
+		received <- <-client.requestNextChan
+	}()
+
+	client.handleBlockTxsOffer(msg)
+
+	select {
+	case receivedMsg := <-received:
+		assert.Equal(t, msg, receivedMsg)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timeout waiting for message")
+	}
+}
+
+func TestClientHandleVotesOffer(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	protoOptions := protocol.ProtocolOptions{
+		ConnectionId: connId,
+	}
+	client := NewClient(protoOptions, nil)
+
+	msg := NewMsgVotesOffer([]MsgVotesOfferVote{
+		{Slot: 100, VoteIssuerId: []byte{0x01, 0x02, 0x03, 0x04}},
+	})
+
+	// Start a goroutine to receive the message
+	received := make(chan protocol.Message, 1)
+	go func() {
+		received <- <-client.requestNextChan
+	}()
+
+	client.handleVotesOffer(msg)
+
+	select {
+	case receivedMsg := <-received:
+		assert.Equal(t, msg, receivedMsg)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timeout waiting for message")
+	}
+}

--- a/protocol/leiosnotify/messages_test.go
+++ b/protocol/leiosnotify/messages_test.go
@@ -1,0 +1,231 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leiosnotify
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testDefinition struct {
+	Name        string
+	Message     protocol.Message
+	MessageType uint
+}
+
+func getTestDefinitions() []testDefinition {
+	return []testDefinition{
+		{
+			Name:        "MsgNotificationRequestNext",
+			Message:     NewMsgNotificationRequestNext(),
+			MessageType: MessageTypeNotificationRequestNext,
+		},
+		{
+			Name: "MsgBlockAnnouncement",
+			Message: NewMsgBlockAnnouncement(
+				cbor.RawMessage([]byte{0x82, 0x01, 0x02}),
+			),
+			MessageType: MessageTypeBlockAnnouncement,
+		},
+		{
+			Name: "MsgBlockOffer",
+			Message: NewMsgBlockOffer(
+				12345,
+				[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+			),
+			MessageType: MessageTypeBlockOffer,
+		},
+		{
+			Name: "MsgBlockTxsOffer",
+			Message: NewMsgBlockTxsOffer(
+				67890,
+				[]byte{0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+			),
+			MessageType: MessageTypeBlockTxsOffer,
+		},
+		{
+			Name: "MsgVotesOffer",
+			Message: NewMsgVotesOffer(
+				[]MsgVotesOfferVote{
+					{Slot: 100, VoteIssuerId: []byte{0x01, 0x02, 0x03, 0x04}},
+					{Slot: 200, VoteIssuerId: []byte{0x05, 0x06, 0x07, 0x08}},
+				},
+			),
+			MessageType: MessageTypeVotesOffer,
+		},
+		{
+			Name:        "MsgDone",
+			Message:     NewMsgDone(),
+			MessageType: MessageTypeDone,
+		},
+	}
+}
+
+func TestCborRoundTrip(t *testing.T) {
+	tests := getTestDefinitions()
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			// Encode the message
+			encoded, err := cbor.Encode(test.Message)
+			require.NoError(t, err, "failed to encode message to CBOR")
+
+			// Decode the message
+			decoded, err := NewMsgFromCbor(test.MessageType, encoded)
+			require.NoError(t, err, "failed to decode CBOR")
+
+			// Re-encode and compare
+			reencoded, err := cbor.Encode(decoded)
+			require.NoError(t, err, "failed to re-encode message")
+
+			assert.Equal(t, encoded, reencoded, "CBOR round-trip failed")
+		})
+	}
+}
+
+func TestDecode(t *testing.T) {
+	tests := getTestDefinitions()
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			// Encode the message first
+			encoded, err := cbor.Encode(test.Message)
+			require.NoError(t, err, "failed to encode message to CBOR")
+
+			// Decode it back
+			decoded, err := NewMsgFromCbor(test.MessageType, encoded)
+			require.NoError(t, err, "failed to decode CBOR")
+
+			// Set the raw CBOR so the comparison should succeed
+			test.Message.SetCbor(encoded)
+
+			assert.True(t, reflect.DeepEqual(decoded, test.Message),
+				"CBOR did not decode to expected message object\n  got: %#v\n  wanted: %#v",
+				decoded, test.Message)
+		})
+	}
+}
+
+func TestEncode(t *testing.T) {
+	tests := getTestDefinitions()
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			// Encode the message
+			encoded, err := cbor.Encode(test.Message)
+			require.NoError(t, err, "failed to encode message to CBOR")
+
+			// Verify it can be decoded back without error
+			_, err = NewMsgFromCbor(test.MessageType, encoded)
+			require.NoError(t, err, "failed to decode encoded message")
+		})
+	}
+}
+
+func TestMsgNotificationRequestNext(t *testing.T) {
+	msg := NewMsgNotificationRequestNext()
+
+	assert.Equal(t, uint8(MessageTypeNotificationRequestNext), msg.Type())
+}
+
+func TestMsgBlockAnnouncement(t *testing.T) {
+	blockHeaderRaw := cbor.RawMessage([]byte{0x82, 0x01, 0x02})
+
+	msg := NewMsgBlockAnnouncement(blockHeaderRaw)
+
+	assert.Equal(t, uint8(MessageTypeBlockAnnouncement), msg.Type())
+	assert.Equal(t, blockHeaderRaw, msg.BlockHeaderRaw)
+}
+
+func TestMsgBlockOffer(t *testing.T) {
+	slot := uint64(123456)
+	hash := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+
+	msg := NewMsgBlockOffer(slot, hash)
+
+	assert.Equal(t, uint8(MessageTypeBlockOffer), msg.Type())
+	assert.Equal(t, slot, msg.Slot)
+	assert.Equal(t, hash, msg.Hash)
+}
+
+func TestMsgBlockTxsOffer(t *testing.T) {
+	slot := uint64(123456)
+	hash := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+
+	msg := NewMsgBlockTxsOffer(slot, hash)
+
+	assert.Equal(t, uint8(MessageTypeBlockTxsOffer), msg.Type())
+	assert.Equal(t, slot, msg.Slot)
+	assert.Equal(t, hash, msg.Hash)
+}
+
+func TestMsgVotesOffer(t *testing.T) {
+	votes := []MsgVotesOfferVote{
+		{Slot: 100, VoteIssuerId: []byte{0x01, 0x02, 0x03, 0x04}},
+		{Slot: 200, VoteIssuerId: []byte{0x05, 0x06, 0x07, 0x08}},
+	}
+
+	msg := NewMsgVotesOffer(votes)
+
+	assert.Equal(t, uint8(MessageTypeVotesOffer), msg.Type())
+	assert.Equal(t, votes, msg.Votes)
+}
+
+func TestMsgDone(t *testing.T) {
+	msg := NewMsgDone()
+
+	assert.Equal(t, uint8(MessageTypeDone), msg.Type())
+}
+
+func TestNewMsgFromCborUnknownType(t *testing.T) {
+	// Test with unknown message type - the NewMsgFromCbor function tries to decode
+	// into a nil pointer, which results in an error
+	data := []byte{0x80} // empty array
+	msg, err := NewMsgFromCbor(999, data)
+	// When the message type is unknown, ret is nil, and cbor.Decode(data, nil) returns an error
+	assert.Error(t, err)
+	assert.Nil(t, msg)
+}
+
+func TestMsgVotesOfferEmpty(t *testing.T) {
+	msg := NewMsgVotesOffer([]MsgVotesOfferVote{})
+
+	encoded, err := cbor.Encode(msg)
+	require.NoError(t, err)
+
+	decoded, err := NewMsgFromCbor(MessageTypeVotesOffer, encoded)
+	require.NoError(t, err)
+
+	decodedMsg := decoded.(*MsgVotesOffer)
+	assert.Equal(t, 0, len(decodedMsg.Votes))
+}
+
+func TestMsgBlockAnnouncementEmpty(t *testing.T) {
+	// Create a message with empty block header
+	msg := NewMsgBlockAnnouncement(cbor.RawMessage{})
+
+	encoded, err := cbor.Encode(msg)
+	require.NoError(t, err)
+
+	decoded, err := NewMsgFromCbor(MessageTypeBlockAnnouncement, encoded)
+	require.NoError(t, err)
+
+	decodedMsg := decoded.(*MsgBlockAnnouncement)
+	// After CBOR round-trip, empty RawMessage may decode differently
+	// so we just check it's not nil
+	assert.NotNil(t, decodedMsg)
+}

--- a/protocol/leiosnotify/server_test.go
+++ b/protocol/leiosnotify/server_test.go
@@ -1,0 +1,286 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leiosnotify
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewServer(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	protoOptions := protocol.ProtocolOptions{
+		ConnectionId: connId,
+	}
+
+	cfg := NewConfig()
+	server := NewServer(protoOptions, &cfg)
+
+	require.NotNil(t, server)
+	assert.NotNil(t, server.Protocol)
+	assert.NotNil(t, server.config)
+}
+
+func TestHandleRequestNext_CallbackIsCalled(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+
+	called := false
+
+	cfg := NewConfig(
+		WithRequestNextFunc(func(ctx CallbackContext) (protocol.Message, error) {
+			called = true
+			// Return an error to prevent attempting to send (which would hang)
+			return nil, errors.New("test: stopping before send")
+		}),
+	)
+
+	server := &Server{
+		config:          &cfg,
+		callbackContext: CallbackContext{ConnectionId: connId},
+	}
+	server.initProtocol()
+
+	err := server.handleRequestNext()
+
+	// Error is expected because we return an error from the callback
+	assert.Error(t, err)
+	assert.True(t, called, "expected RequestNextFunc to be called")
+}
+
+func TestHandleRequestNext_NilCallback(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+
+	cfg := NewConfig()
+	server := &Server{
+		config:          &cfg,
+		callbackContext: CallbackContext{ConnectionId: connId},
+	}
+	server.initProtocol()
+
+	err := server.handleRequestNext()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no callback function is defined")
+}
+
+func TestHandleRequestNext_NilConfig(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+
+	server := &Server{
+		config:          nil,
+		callbackContext: CallbackContext{ConnectionId: connId},
+	}
+	server.initProtocol()
+
+	err := server.handleRequestNext()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no callback function is defined")
+}
+
+func TestHandleRequestNext_CallbackError(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+
+	expectedError := errors.New("no notifications available")
+	cfg := NewConfig(
+		WithRequestNextFunc(func(ctx CallbackContext) (protocol.Message, error) {
+			return nil, expectedError
+		}),
+	)
+
+	server := &Server{
+		config:          &cfg,
+		callbackContext: CallbackContext{ConnectionId: connId},
+	}
+	server.initProtocol()
+
+	err := server.handleRequestNext()
+
+	assert.Error(t, err)
+	assert.Equal(t, expectedError, err)
+}
+
+func TestHandleRequestNext_NilResponse(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+
+	cfg := NewConfig(
+		WithRequestNextFunc(func(ctx CallbackContext) (protocol.Message, error) {
+			return nil, nil
+		}),
+	)
+
+	server := &Server{
+		config:          &cfg,
+		callbackContext: CallbackContext{ConnectionId: connId},
+	}
+	server.initProtocol()
+
+	err := server.handleRequestNext()
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "callback returned nil")
+}
+
+func TestServerMessageHandler_UnexpectedType(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	protoOptions := protocol.ProtocolOptions{
+		ConnectionId: connId,
+	}
+
+	cfg := NewConfig()
+	server := NewServer(protoOptions, &cfg)
+
+	// Create a message with an unexpected type for the server
+	msg := NewMsgBlockOffer(12345, []byte{0x01, 0x02})
+
+	err := server.messageHandler(msg)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected message type")
+}
+
+func TestServerMessageHandler_RequestNext(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	protoOptions := protocol.ProtocolOptions{
+		ConnectionId: connId,
+	}
+
+	called := false
+	cfg := NewConfig(
+		WithRequestNextFunc(func(ctx CallbackContext) (protocol.Message, error) {
+			called = true
+			// Return an error to prevent attempting to send (which would hang without a muxer)
+			return nil, errors.New("test: callback error")
+		}),
+	)
+
+	server := NewServer(protoOptions, &cfg)
+
+	msg := NewMsgNotificationRequestNext()
+	err := server.messageHandler(msg)
+
+	// Error is expected because callback returns error
+	assert.Error(t, err)
+	assert.True(t, called, "expected callback to be called")
+}
+
+func TestNew(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	protoOptions := protocol.ProtocolOptions{
+		ConnectionId: connId,
+	}
+	cfg := NewConfig()
+
+	leiosNotify := New(protoOptions, &cfg)
+
+	require.NotNil(t, leiosNotify)
+	assert.NotNil(t, leiosNotify.Client)
+	assert.NotNil(t, leiosNotify.Server)
+}
+
+func TestServerCallbackContext(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	protoOptions := protocol.ProtocolOptions{
+		ConnectionId: connId,
+	}
+	cfg := NewConfig()
+
+	server := NewServer(protoOptions, &cfg)
+
+	// Verify callback context is set correctly
+	assert.Equal(t, connId, server.callbackContext.ConnectionId)
+	assert.Equal(t, server, server.callbackContext.Server)
+}
+
+func TestCallbackResponseTypes(t *testing.T) {
+	// Test that the config callback types work correctly
+	// We test that the callbacks can be set and invoked properly
+
+	testCases := []struct {
+		name     string
+		response protocol.Message
+	}{
+		{
+			name:     "BlockAnnouncement response",
+			response: NewMsgBlockAnnouncement(cbor.RawMessage{0x82, 0x01, 0x02}),
+		},
+		{
+			name:     "BlockOffer response",
+			response: NewMsgBlockOffer(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+		},
+		{
+			name:     "BlockTxsOffer response",
+			response: NewMsgBlockTxsOffer(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+		},
+		{
+			name: "VotesOffer response",
+			response: NewMsgVotesOffer([]MsgVotesOfferVote{
+				{Slot: 100, VoteIssuerId: []byte{0x01, 0x02, 0x03, 0x04}},
+			}),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := NewConfig(
+				WithRequestNextFunc(func(ctx CallbackContext) (protocol.Message, error) {
+					return tc.response, nil
+				}),
+			)
+
+			// Test that we can invoke the callback and get the expected response
+			resp, err := cfg.RequestNextFunc(CallbackContext{})
+			require.NoError(t, err)
+			assert.Equal(t, tc.response, resp)
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add comprehensive unit tests for Leios Fetch (protocol 19) and Leios Notify (protocol 18). Tests cover client/server handlers, CBOR encoding/decoding, state maps and transitions, configuration callbacks, and error paths (unexpected types, nil callbacks/responses) to improve coverage and prevent regressions.

<sup>Written for commit e3d651d09a9d65479ffdaf9659bba9f3ce6f2d7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for leiosfetch and leiosnotify protocol implementations, including client initialization, message encoding/decoding, server request handling, state transitions, and error scenarios across multiple message types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->