### PR TITLE
fix(ledger): 160-byte overhead constant per CIP-0055

### DIFF
--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -905,7 +905,13 @@ func MinFeeTx(
 	return minFee, nil
 }
 
-// MinCoinTxOut calculates the minimum coin for a transaction output based on protocol parameters
+// MinCoinTxOut calculates the minimum coin for a transaction output based on protocol parameters.
+// Per CIP-55, the formula includes a 160-byte constant overhead to account for the transaction
+// input and UTxO map entry overhead that is not captured in the CBOR serialization.
+// Formula: minCoin = coinsPerUTxOByte * (160 + serializedOutputSize)
+// Reference: https://cips.cardano.org/cip/CIP-55
+const minUtxoOverheadBytes = 160
+
 func MinCoinTxOut(
 	txOut common.TransactionOutput,
 	pparams common.ProtocolParameters,
@@ -918,7 +924,7 @@ func MinCoinTxOut(
 	if err != nil {
 		return 0, err
 	}
-	minCoinTxOut := tmpPparams.AdaPerUtxoByte * uint64(len(txOutBytes))
+	minCoinTxOut := tmpPparams.AdaPerUtxoByte * (minUtxoOverheadBytes + uint64(len(txOutBytes)))
 	return minCoinTxOut, nil
 }
 

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -1631,7 +1631,13 @@ func MinFeeTx(
 	return minFee, nil
 }
 
-// MinCoinTxOut calculates the minimum coin for a transaction output based on protocol parameters
+// MinCoinTxOut calculates the minimum coin for a transaction output based on protocol parameters.
+// Per CIP-55, the formula includes a 160-byte constant overhead to account for the transaction
+// input and UTxO map entry overhead that is not captured in the CBOR serialization.
+// Formula: minCoin = coinsPerUTxOByte * (160 + serializedOutputSize)
+// Reference: https://cips.cardano.org/cip/CIP-55
+const minUtxoOverheadBytes = 160
+
 func MinCoinTxOut(
 	txOut common.TransactionOutput,
 	pparams common.ProtocolParameters,
@@ -1644,7 +1650,7 @@ func MinCoinTxOut(
 	if err != nil {
 		return 0, err
 	}
-	minCoinTxOut := tmpPparams.AdaPerUtxoByte * uint64(len(txOutBytes))
+	minCoinTxOut := tmpPparams.AdaPerUtxoByte * (minUtxoOverheadBytes + uint64(len(txOutBytes)))
 	return minCoinTxOut, nil
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes MinCoinTxOut to include the CIP-55 160-byte UTxO overhead, preventing underestimation of required ADA for outputs. Applies to both Babbage and Conway rules.

- **Bug Fixes**
  - Introduced minUtxoOverheadBytes = 160 and used it in MinCoinTxOut across Babbage and Conway.
  - Documented the formula (coinsPerUTxOByte * (160 + serializedOutputSize)) with a CIP-55 reference.

<sup>Written for commit 869f267e154d6f427c7cc66f17c9d5faad818045. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated minimum UTXO coin calculations to ensure accurate transaction processing across network protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->