### PR TITLE
test(ledger): verify pool retire/register in same tx

### DIFF
--- a/internal/test/conformance/conformance_test.go
+++ b/internal/test/conformance/conformance_test.go
@@ -2237,7 +2237,7 @@ func executeTransaction(
 			}
 
 		case *common.ResignCommitteeColdCertificate:
-			// Haskell validation: isCurrentMember || isPotentialFutureMember
+			// Cardano spec: resign is only valid for current CC members or proposed members
 			// Check that the cold credential is a current committee member
 			coldHash := c.ColdCredential.Credential
 			isCurrentMember := false
@@ -2259,7 +2259,7 @@ func executeTransaction(
 			}
 			if !isCurrentMember && !isPotentialFutureMember {
 				return false, fmt.Errorf(
-					"cannot resign: cold credential %x is not a committee member",
+					"cannot resign non-member %x",
 					coldHash[:],
 				)
 			}

--- a/ledger/alonzo/rules.go
+++ b/ledger/alonzo/rules.go
@@ -430,6 +430,8 @@ func UtxoValidateValueNotConservedUtxo(
 		switch cert.(type) {
 		case *common.StakeDeregistrationCertificate:
 			consumedValue.Add(consumedValue, new(big.Int).SetUint64(uint64(tmpPparams.KeyDeposit)))
+			// Note: PoolRetirementCertificate does NOT refund the deposit as part of the transaction.
+			// Pool deposits are refunded to the reward account at the end of the retiring epoch.
 		}
 	}
 	// Calculate produced value

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -576,6 +576,8 @@ func UtxoValidateValueNotConservedUtxo(
 		switch cert.(type) {
 		case *common.StakeDeregistrationCertificate:
 			consumedValue.Add(consumedValue, new(big.Int).SetUint64(uint64(tmpPparams.KeyDeposit)))
+			// Note: PoolRetirementCertificate does NOT refund the deposit as part of the transaction.
+			// Pool deposits are refunded to the reward account at the end of the retiring epoch.
 		}
 	}
 	// Calculate produced value

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -1011,6 +1011,8 @@ func UtxoValidateValueNotConservedUtxo(
 		case *common.StakeDeregistrationCertificate:
 			// Traditional stake deregistration uses protocol KeyDeposit parameter
 			consumedValue.Add(consumedValue, new(big.Int).SetUint64(uint64(tmpPparams.KeyDeposit)))
+			// Note: PoolRetirementCertificate does NOT refund the deposit as part of the transaction.
+			// Pool deposits are refunded at epoch boundary after the retirement epoch has passed.
 		}
 	}
 	// Add minted/burned ADA

--- a/ledger/mary/rules.go
+++ b/ledger/mary/rules.go
@@ -188,6 +188,8 @@ func UtxoValidateValueNotConservedUtxo(
 		switch cert.(type) {
 		case *common.StakeDeregistrationCertificate:
 			consumedValue.Add(consumedValue, new(big.Int).SetUint64(uint64(tmpPparams.KeyDeposit)))
+			// Note: PoolRetirementCertificate does NOT refund the deposit as part of the transaction.
+			// Pool deposits are refunded to the reward account at the end of the retiring epoch.
 		}
 	}
 	// Calculate produced value

--- a/ledger/shelley/rules.go
+++ b/ledger/shelley/rules.go
@@ -208,6 +208,8 @@ func UtxoValidateValueNotConservedUtxo(
 		switch cert.(type) {
 		case *common.StakeDeregistrationCertificate:
 			consumedValue.Add(consumedValue, new(big.Int).SetUint64(uint64(tmpPparams.KeyDeposit)))
+			// Note: PoolRetirementCertificate does NOT refund the deposit as part of the transaction.
+			// Pool deposits are refunded to the reward account at the end of the retiring epoch.
 		}
 	}
 	// Calculate produced value


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a Conway test to verify UtxoValidateValueNotConservedUtxo succeeds when a pool retires and re-registers in the same transaction, with no immediate deposit refund and no new deposit. Clarify comments across all eras that pool deposit refunds happen at the epoch boundary and simplify the committee resignation error message.

<sup>Written for commit e92904519a3a75df2ef6997235785f2de131819c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added test case covering pool retirement followed by pool re-registration within the same transaction.

* **Bug Fixes**
  * Improved error message clarity for invalid committee member resignation attempts.

* **Documentation**
  * Enhanced code documentation with clarifications on pool deposit handling and retirement behavior across ledger versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->