### PR TITLE
feat(ledger): protocol version 11 support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.1
 
 require (
 	filippo.io/edwards25519 v1.1.0
-	github.com/blinklabs-io/ouroboros-mock v0.6.0
+	github.com/blinklabs-io/ouroboros-mock v0.7.0
 	github.com/blinklabs-io/plutigo v0.0.22
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/fxamacker/cbor/v2 v2.9.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/bits-and-blooms/bitset v1.20.0 h1:2F+rfL86jE2d/bmw7OhqUg2Sj/1rURkBn3MdfoPyRVU=
 github.com/bits-and-blooms/bitset v1.20.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/ouroboros-mock v0.6.0 h1:y4s1vYOrlzpa7sUTvZSEtOi6JJWVtAZhZ7piAX3rJXY=
-github.com/blinklabs-io/ouroboros-mock v0.6.0/go.mod h1:ODwZJTTyonyId1hFeFjxvGGnlhvRZ+5IKBYAka0XWhE=
+github.com/blinklabs-io/ouroboros-mock v0.7.0 h1:IbBzOHAtjzh1PWIXy9tMB6wAS6/+HLMVtNtTFSTN4VM=
+github.com/blinklabs-io/ouroboros-mock v0.7.0/go.mod h1:ODwZJTTyonyId1hFeFjxvGGnlhvRZ+5IKBYAka0XWhE=
 github.com/blinklabs-io/plutigo v0.0.22 h1:4O1+bac3pY2JPsIC9PvwthZWn6eFgkQ3R+z5t1rNeu8=
 github.com/blinklabs-io/plutigo v0.0.22/go.mod h1:gWmUk3afrNAwWkrHym/KjFDn63r4MAx/amtjZLkWNXM=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=

--- a/ledger/common/protocol_version.go
+++ b/ledger/common/protocol_version.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+// Protocol version constants for Cardano hard forks.
+// These correspond to the major protocol version numbers.
+const (
+	ProtocolVersionShelley    uint = 2
+	ProtocolVersionAllegra    uint = 3
+	ProtocolVersionMary       uint = 4
+	ProtocolVersionAlonzo     uint = 6
+	ProtocolVersionBabbage    uint = 8
+	ProtocolVersionConway     uint = 9
+	ProtocolVersionConwayPlus uint = 10
+	ProtocolVersionVanRossem  uint = 11 // PV11 intra-era hard fork
+)
+
+// IsProtocolVersionAtLeast checks if the given protocol version (major.minor)
+// is at least the specified minimum major version.
+func IsProtocolVersionAtLeast(major, minor, minMajor uint) bool {
+	_ = minor // minor version not used in current comparison logic
+	return major >= minMajor
+}

--- a/ledger/common/protocol_version_test.go
+++ b/ledger/common/protocol_version_test.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProtocolVersionConstants(t *testing.T) {
+	// Verify known hard fork protocol versions
+	assert.Equal(t, uint(2), ProtocolVersionShelley)
+	assert.Equal(t, uint(3), ProtocolVersionAllegra)
+	assert.Equal(t, uint(4), ProtocolVersionMary)
+	assert.Equal(t, uint(6), ProtocolVersionAlonzo)
+	assert.Equal(t, uint(8), ProtocolVersionBabbage)
+	assert.Equal(t, uint(9), ProtocolVersionConway)
+	assert.Equal(t, uint(10), ProtocolVersionConwayPlus)
+	assert.Equal(t, uint(11), ProtocolVersionVanRossem)
+}
+
+func TestIsProtocolVersionAtLeast(t *testing.T) {
+	tests := []struct {
+		name     string
+		major    uint
+		minor    uint
+		target   uint
+		expected bool
+	}{
+		{"PV11 meets PV11", 11, 0, 11, true},
+		{"PV12 meets PV11", 12, 0, 11, true},
+		{"PV10 fails PV11", 10, 0, 11, false},
+		{"PV9 meets PV9", 9, 0, 9, true},
+		{"PV8 fails PV9", 8, 0, 9, false},
+		{"minor version ignored", 10, 5, 11, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsProtocolVersionAtLeast(tt.major, tt.minor, tt.target)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/ledger/common/state.go
+++ b/ledger/common/state.go
@@ -48,6 +48,9 @@ type PoolState interface {
 	PoolCurrentState(PoolKeyHash) (*PoolRegistrationCertificate, *uint64, error)
 	// IsPoolRegistered checks if a pool is currently registered
 	IsPoolRegistered(PoolKeyHash) bool
+	// IsVrfKeyInUse checks if a VRF key hash is registered by another pool.
+	// Returns (inUse, owningPoolId, error). Used for PV11+ VRF uniqueness validation.
+	IsVrfKeyInUse(vrfKeyHash Blake2b256) (bool, PoolKeyHash, error)
 }
 
 // RewardState defines the interface for reward calculation and querying

--- a/ledger/conway/errors_test.go
+++ b/ledger/conway/errors_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConway_CostModelsPresent_UnresolvedReferenceInputReturnsError(
@@ -360,4 +361,43 @@ func TestConway_ScriptDataHash_ExtraneousScriptDataHashError_As(t *testing.T) {
 			err,
 		)
 	}
+}
+
+func TestDuplicateVrfKeyError(t *testing.T) {
+	err := conway.DuplicateVrfKeyError{
+		VrfKeyHash:     common.Blake2b256{0x01},
+		NewPoolId:      common.PoolKeyHash{0x02},
+		ExistingPoolId: common.PoolKeyHash{0x03},
+	}
+	assert.Contains(t, err.Error(), "duplicate VRF key")
+}
+
+func TestCCVotingRestrictionError(t *testing.T) {
+	err := conway.CCVotingRestrictionError{
+		VoterId:     common.Blake2b224{0x01},
+		ActionId:    common.GovActionId{TransactionId: common.Blake2b256{0x02}, GovActionIdx: 1},
+		Restriction: "CC cannot vote on this action type",
+	}
+	assert.Contains(t, err.Error(), "voting restriction")
+}
+
+func TestNonMatchingWithdrawalError(t *testing.T) {
+	err := conway.NonMatchingWithdrawalError{
+		RewardAccount: common.Address{},
+		Expected:      1000,
+		Actual:        500,
+	}
+	assert.Contains(t, err.Error(), "non-matching withdrawal")
+	assert.Contains(t, err.Error(), "expected 1000")
+}
+
+func TestPPViewHashesDontMatchError(t *testing.T) {
+	err := conway.PPViewHashesDontMatchError{
+		ProvidedHash:   common.Blake2b256{0x01},
+		ComputedHash:   common.Blake2b256{0x02},
+		ExpectedPPData: []byte{0x03, 0x04},
+	}
+	assert.Contains(t, err.Error(), "protocol parameter")
+	assert.Contains(t, err.Error(), "provided")
+	assert.Contains(t, err.Error(), "computed")
 }


### PR DESCRIPTION
Closes #1477 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds protocol version 11 (VanRossem) support to the Conway ledger. Enforces new PV11 rules, improves errors, and relaxes a ref-input check for Plutus V1/V2.

- **New Features**
  - Enforce unique VRF keys across pools in PV11 (PoolValidateVrfKeyUniqueness).
  - Enforce CC voting restrictions in PV11 (no votes on NoConfidence/UpdateCommittee).
  - Skip NonDisjointRefInputs for Plutus V1/V2 transactions in PV11.
  - Add protocol version constants (incl. PV11) and IsProtocolVersionAtLeast; add clearer errors for VRF duplication, CC voting, withdrawals, and PP hash mismatches.

- **Migration**
  - Implement IsVrfKeyInUse(vrfKeyHash) in your PoolState/LedgerState to support VRF uniqueness checks.
  - Update mocks/tests to github.com/blinklabs-io/ouroboros-mock v0.7.0 if you use the mock ledger.

<sup>Written for commit d3d418b703aae6243e7b78445fcd63488e20eb1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced stake pool VRF key uniqueness across registrations
  * Added constitutional committee voting restrictions for certain governance actions
  * Improved protocol parameter hash validation with clearer error diagnostics
  * Added support for the latest protocol version (PV11) behaviors

* **Tests**
  * New tests covering the above validations and error messages

* **Chores**
  * Updated Ouroboros mock library dependency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->