### PR TITLE
fix(ledger): return error on incorrect pparam type

### DIFF
--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -2456,7 +2456,7 @@ func UtxoValidateCCVotingRestrictions(
 ) error {
 	conwayPp, ok := pp.(*ConwayProtocolParameters)
 	if !ok {
-		return nil // Not Conway params, skip validation
+		return errors.New("pparams are not expected type")
 	}
 	if !common.IsProtocolVersionAtLeast(
 		conwayPp.ProtocolVersion.Major, 0, common.ProtocolVersionVanRossem,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Return an error when UtxoValidateCCVotingRestrictions receives non-Conway protocol parameters, instead of skipping validation. This fails fast and avoids silently accepting invalid input.

<sup>Written for commit 022a88d3d05e9c1bc327b760cfa6dbe745198e6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of constitutional committee voting restrictions. The system now properly reports errors when protocol parameters lack Conway compatibility, enhancing validation robustness and providing clearer error handling for ledger operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->