### PR TITLE
ci: pin action versions

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -13,5 +13,5 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1 https://github.com/actions/checkout/releases/tag/v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
       - uses: webiny/action-conventional-commits@faccb24fc2550dd15c0390d944379d2d8ed9690e # v1.3.1 https://github.com/webiny/action-conventional-commits/releases/tag/v1.3.1

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -29,9 +29,9 @@ jobs:
           - {package: "./vrf/...", fuzz: "FuzzVerifyAndHash$"}
           - {package: "./vrf/...", fuzz: "FuzzProofToHash"}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
 
-      - uses: actions/setup-go@v6.2.0
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0 https://github.com/actions/setup-go/releases/tag/v6.2.0
         with:
           go-version: '1.24'
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload crash artifacts
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0 https://github.com/actions/upload-artifact/releases/tag/v6.0.0
         with:
           name: fuzz-crashes-${{ matrix.target.fuzz }}
           path: "**/testdata/fuzz/**"

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -20,10 +20,10 @@ jobs:
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1 https://github.com/actions/checkout/releases/tag/v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
         with:
           submodules: true
-      - uses: actions/setup-go@a5f9b05d2d216f63e13859e0d847461041025775 # v5.6.0 https://github.com/actions/setup-go/releases/tag/v5.6.0
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0 https://github.com/actions/setup-go/releases/tag/v6.2.0
         with:
           go-version: ${{ matrix.go-version }}
       - name: go-test

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,8 +15,8 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1 https://github.com/actions/checkout/releases/tag/v6.0.1
-      - uses: actions/setup-go@a5f9b05d2d216f63e13859e0d847461041025775 # v5.6.0 https://github.com/actions/setup-go/releases/tag/v5.6.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0 https://github.com/actions/setup-go/releases/tag/v6.2.0
         with:
           go-version: 1.25.x
       - name: golangci-lint

--- a/.github/workflows/nilaway.yml
+++ b/.github/workflows/nilaway.yml
@@ -15,8 +15,8 @@ jobs:
     name: nilaway
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1 https://github.com/actions/checkout/releases/tag/v6.0.1
-      - uses: actions/setup-go@a5f9b05d2d216f63e13859e0d847461041025775 # v5.6.0 https://github.com/actions/setup-go/releases/tag/v5.6.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0 https://github.com/actions/setup-go/releases/tag/v6.2.0
         with:
           go-version: 1.25.x
       - name: install nilaway

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,4 +39,4 @@ jobs:
 
       # This updates the documentation on pkg.go.dev and the latest version available via the Go module proxy
       - name: Pull new module version
-        uses: andrewslotin/go-proxy-pull-action@0ef95ea50ab6c03f2f095a5102bbdecad8fd7602 # v1.3.0 https://github.com/andrewslotin/go-proxy-pull-action/releases/tag/v1.3.0
+        uses: andrewslotin/go-proxy-pull-action@e5aea3b8b3478fc5b76befda4390513868ed2dc8 # v1.4.0 https://github.com/andrewslotin/go-proxy-pull-action/releases/tag/v1.4.0

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 # IDEs
 .idea/
 .vscode/
+
+# Git worktrees
+.worktrees/


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pinned GitHub Actions to specific commit SHAs and updated to stable versions to make CI reproducible and secure. Also added .worktrees/ to .gitignore.

- **Dependencies**
  - actions/checkout updated to v6.0.2 (pinned SHA).
  - actions/setup-go pinned to v6.2.0.
  - actions/upload-artifact pinned to v6.0.0.
  - andrewslotin/go-proxy-pull-action updated to v1.4.0 (pinned SHA).

<sup>Written for commit 1e6b16b415ee05d8d6b877a7efef09b467d95a3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use newer versions for improved reliability and security across build, testing, linting, and publishing processes.
  * Added Git worktrees configuration to version control ignore rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->