### PR TITLE
fix: support alternate genesis config keys

### DIFF
--- a/ledger/alonzo/genesis.go
+++ b/ledger/alonzo/genesis.go
@@ -15,6 +15,7 @@
 package alonzo
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -107,7 +108,63 @@ type AlonzoGenesisExUnits struct {
 	Steps uint `json:"exUnitsSteps"`
 }
 
+func (u *AlonzoGenesisExUnits) UnmarshalJSON(data []byte) error {
+	// We need some custom unmarshal logic to handle alternate key names
+	tmpData := struct {
+		ExUnitsMem   uint `json:"exUnitsMem"`
+		ExUnitsSteps uint `json:"exUnitsSteps"`
+		Memory       uint `json:"memory"`
+		Steps        uint `json:"steps"`
+	}{}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&tmpData); err != nil {
+		return err
+	}
+	if tmpData.ExUnitsMem > 0 {
+		u.Mem = tmpData.ExUnitsMem
+	}
+	if tmpData.ExUnitsSteps > 0 {
+		u.Steps = tmpData.ExUnitsSteps
+	}
+	if tmpData.Memory > 0 {
+		u.Mem = tmpData.Memory
+	}
+	if tmpData.Steps > 0 {
+		u.Steps = tmpData.Steps
+	}
+	return nil
+}
+
 type AlonzoGenesisExecutionPrices struct {
 	Steps *common.GenesisRat `json:"prSteps"`
 	Mem   *common.GenesisRat `json:"prMem"`
+}
+
+func (p *AlonzoGenesisExecutionPrices) UnmarshalJSON(data []byte) error {
+	// We need some custom unmarshal logic to handle alternate key names
+	tmpData := struct {
+		PrSteps     *common.GenesisRat `json:"prSteps"`
+		PrMem       *common.GenesisRat `json:"prMem"`
+		PriceSteps  *common.GenesisRat `json:"priceSteps"`
+		PriceMemory *common.GenesisRat `json:"priceMemory"`
+	}{}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&tmpData); err != nil {
+		return err
+	}
+	if tmpData.PrSteps != nil {
+		p.Steps = tmpData.PrSteps
+	}
+	if tmpData.PrMem != nil {
+		p.Mem = tmpData.PrMem
+	}
+	if tmpData.PriceSteps != nil {
+		p.Steps = tmpData.PriceSteps
+	}
+	if tmpData.PriceMemory != nil {
+		p.Mem = tmpData.PriceMemory
+	}
+	return nil
 }

--- a/ledger/alonzo/pparams.go
+++ b/ledger/alonzo/pparams.go
@@ -221,9 +221,9 @@ func (p *AlonzoProtocolParameters) UpdateFromGenesis(
 			if !ok {
 				continue
 			}
-			if len(model) != expectedCount {
+			if len(model) < expectedCount {
 				return fmt.Errorf(
-					"incorrect param count for %s: %d",
+					"insufficient param count for %s: %d",
 					versionStr,
 					len(model),
 				)

--- a/ledger/alonzo/pparams_test.go
+++ b/ledger/alonzo/pparams_test.go
@@ -151,7 +151,7 @@ func TestInvalidCostModelFormats(t *testing.T) {
                     "addInteger-cpu-arguments-slope": 0
 		  }
                 }`,
-			expectError: "incorrect param count for PlutusV1: 4",
+			expectError: "insufficient param count for PlutusV1: 4",
 		},
 	}
 

--- a/ledger/conway/genesis.go
+++ b/ledger/conway/genesis.go
@@ -69,8 +69,8 @@ type ConwayGenesisConstitutionAnchor struct {
 }
 
 type ConwayGenesisCommittee struct {
-	Members   map[string]int `json:"members"`
-	Threshold map[string]int `json:"threshold"`
+	Members   map[string]int     `json:"members"`
+	Threshold *common.GenesisRat `json:"threshold"`
 }
 
 func NewConwayGenesisFromReader(r io.Reader) (ConwayGenesis, error) {

--- a/ledger/conway/genesis_test.go
+++ b/ledger/conway/genesis_test.go
@@ -380,9 +380,8 @@ var expectedGenesisObj = conway.ConwayGenesis{
 			"scriptHash-e8165b3328027ee0d74b1f07298cb092fd99aa7697a1436f5997f625": 580,
 			"scriptHash-f0dc2c00d92a45521267be2d5de1c485f6f9d14466d7e16062897cf7": 580,
 		},
-		Threshold: map[string]int{
-			"denominator": 3,
-			"numerator":   2,
+		Threshold: &common.GenesisRat{
+			Rat: big.NewRat(2, 3),
 		},
 	},
 }
@@ -441,7 +440,7 @@ func TestNewConwayGenesisFromReader(t *testing.T) {
     },
     "committee": {
       "members": { "key1": 1 },
-      "threshold": { "key1": 2 }
+      "threshold": 0
     }
   }`
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for alternate genesis config keys in Alonzo and switches Conway committee threshold to a rational value to improve parsing compatibility across different genesis files.

- **Bug Fixes**
  - Alonzo: custom JSON unmarshal accepts exUnitsMem/exUnitsSteps or memory/steps; prSteps/prMem or priceSteps/priceMemory.
  - Alonzo: cost model count check now only errors when params are insufficient; extra entries are allowed and the error text is updated.
  - Conway: committee.threshold now uses GenesisRat (rational) instead of a map; tests updated.

- **Migration**
  - Update any code reading committee.threshold to use *GenesisRat (numerator/denominator via Rat) instead of map access.

<sup>Written for commit 1b555186388187eb7e4c0f777eccb1c36b7de672. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced JSON unmarshalling for genesis configurations to accept alternate key names for execution units and execution prices, improving compatibility with varied data formats.

* **Changes**
  * Modified threshold representation in genesis configuration from a map-based structure to a rational number format, changing how thresholds are serialized/deserialized.
  * Relaxed validation for cost models to allow extra parameters; insufficient parameters still produce an error (message updated).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->