### PR TITLE
fix(consensus): use cpraos leader election

### DIFF
--- a/consensus/threshold.go
+++ b/consensus/threshold.go
@@ -16,29 +16,56 @@ package consensus
 
 import (
 	"math/big"
+	"slices"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
-// Precision constant for VRF output comparison
+// ConsensusMode represents the consensus protocol variant.
+type ConsensusMode int
+
 const (
-	// VRF output is 64 bytes (512 bits), so we compare against 2^512
-	vrfOutputBits = 512
+	// ConsensusModeCPraos is the current Praos consensus (Babbage+).
+	// Uses BLAKE2b-256("L" || vrfOutput) with 2^256 threshold.
+	ConsensusModeCPraos ConsensusMode = iota
+
+	// ConsensusModeTPraos is the transitional Praos consensus (Shelley-Alonzo).
+	// Uses raw 64-byte VRF output with 2^512 threshold.
+	ConsensusModeTPraos
 )
 
-// twoTo512 is 2^512, the upper bound for VRF output comparison
-var twoTo512 = new(big.Int).Exp(big.NewInt(2), big.NewInt(vrfOutputBits), nil)
+// Precision constants for VRF output comparison
+const (
+	// CPRAOS uses BLAKE2b-256 hash of VRF output, so we compare against 2^256
+	vrfOutputBitsCPraos = 256
+	// TPraos uses raw 64-byte VRF output, so we compare against 2^512
+	vrfOutputBitsTPraos = 512
+)
 
-// CertifiedNatThreshold computes the leadership threshold for a pool.
+// twoTo256 is 2^256, the upper bound for CPRAOS leader value comparison.
+// WARNING: These package-level big.Int values must not be mutated. Always use
+// them as read-only constants. Create new big.Int instances for calculations.
+var twoTo256 = new(big.Int).Exp(big.NewInt(2), big.NewInt(vrfOutputBitsCPraos), nil)
+
+// twoTo512 is 2^512, the upper bound for TPraos leader value comparison.
+// WARNING: This package-level big.Int value must not be mutated. Always use
+// it as a read-only constant. Create new big.Int instances for calculations.
+var twoTo512 = new(big.Int).Exp(big.NewInt(2), big.NewInt(vrfOutputBitsTPraos), nil)
+
+// CertifiedNatThreshold computes the leadership threshold for a pool using CPRAOS.
+// For TPraos compatibility, use CertifiedNatThresholdWithMode.
 //
 // The threshold is computed as:
 //
-//	T = 2^512 * (1 - (1-f)^σ)
+//	T = 2^256 * (1 - (1-f)^σ)
 //
 // Where:
 //   - f is the active slot coefficient (e.g., 0.05 on mainnet)
 //   - σ = poolStake / totalStake (the pool's relative stake)
 //
-// If the VRF output (interpreted as an unsigned integer) is less than T,
-// the pool is eligible to be a slot leader.
+// If the VRF leader value (BLAKE2b-256 hash of VRF output with "L" prefix,
+// interpreted as an unsigned integer) is less than T, the pool is eligible
+// to be a slot leader.
 //
 // This implementation uses arbitrary precision arithmetic to match
 // Cardano's ledger specification.
@@ -46,6 +73,25 @@ func CertifiedNatThreshold(
 	poolStake uint64,
 	totalStake uint64,
 	activeSlotCoeff *big.Rat,
+) *big.Int {
+	return CertifiedNatThresholdWithMode(poolStake, totalStake, activeSlotCoeff, ConsensusModeCPraos)
+}
+
+// CertifiedNatThresholdWithMode computes the leadership threshold for a pool
+// using the specified consensus mode.
+//
+// For CPRAOS (Babbage+):
+//
+//	T = 2^256 * (1 - (1-f)^σ)
+//
+// For TPraos (Shelley-Alonzo):
+//
+//	T = 2^512 * (1 - (1-f)^σ)
+func CertifiedNatThresholdWithMode(
+	poolStake uint64,
+	totalStake uint64,
+	activeSlotCoeff *big.Rat,
+	mode ConsensusMode,
 ) *big.Int {
 	if activeSlotCoeff == nil {
 		return big.NewInt(0)
@@ -78,9 +124,16 @@ func CertifiedNatThreshold(
 	// Calculate 1 - (1-f)^σ
 	probability := new(big.Rat).Sub(big.NewRat(1, 1), oneMinusFPowerSigma)
 
-	// Multiply by 2^512 and convert to integer
-	// threshold = floor(probability * 2^512)
-	threshold := new(big.Int).Mul(probability.Num(), twoTo512)
+	// Select the appropriate upper bound based on consensus mode
+	var upperBound *big.Int
+	if mode == ConsensusModeTPraos {
+		upperBound = twoTo512
+	} else {
+		upperBound = twoTo256
+	}
+
+	// threshold = floor(probability * upperBound)
+	threshold := new(big.Int).Mul(probability.Num(), upperBound)
 	threshold.Div(threshold, probability.Denom())
 
 	return threshold
@@ -133,22 +186,65 @@ func expRational(x *big.Rat) *big.Rat {
 	return result
 }
 
-// VRFOutputToInt converts a VRF output (64 bytes) to a big.Int
+// VrfLeaderValue computes the CPRAOS leader value from a VRF output.
+// This applies domain separation by hashing with "L" prefix:
+//
+//	leaderValue = BLAKE2b-256("L" || vrfOutput)
+//
+// The result is 32 bytes (256 bits) for comparison against the threshold.
+func VrfLeaderValue(vrfOutput []byte) []byte {
+	// Concatenate "L" prefix (0x4C) with VRF output for domain separation
+	data := slices.Concat([]byte{0x4C}, vrfOutput)
+	hash := common.Blake2b256Hash(data)
+	return hash.Bytes()
+}
+
+// VRFOutputToInt converts a VRF leader value (32 bytes) to a big.Int
 // for comparison against the leadership threshold.
-// The VRF output is interpreted as an unsigned big-endian integer.
+// The value is interpreted as an unsigned big-endian integer.
 func VRFOutputToInt(output []byte) *big.Int {
 	return new(big.Int).SetBytes(output)
 }
 
-// IsVRFOutputBelowThreshold checks if a VRF output is below the leadership threshold.
+// IsVRFOutputBelowThreshold checks if a VRF output is below the leadership threshold
+// using CPRAOS mode. For TPraos compatibility, use IsVRFOutputBelowThresholdWithMode.
+//
 // This is the core eligibility check for slot leadership.
-func IsVRFOutputBelowThreshold(output []byte, threshold *big.Int) bool {
+// It first computes the CPRAOS leader value (BLAKE2b-256 hash with "L" prefix)
+// then compares against the threshold.
+func IsVRFOutputBelowThreshold(vrfOutput []byte, threshold *big.Int) bool {
+	return IsVRFOutputBelowThresholdWithMode(vrfOutput, threshold, ConsensusModeCPraos)
+}
+
+// IsVRFOutputBelowThresholdWithMode checks if a VRF output is below the leadership
+// threshold using the specified consensus mode.
+//
+// For CPRAOS (Babbage+):
+//   - Computes BLAKE2b-256("L" || vrfOutput) to get 32-byte leader value
+//   - Compares against threshold (based on 2^256)
+//
+// For TPraos (Shelley-Alonzo):
+//   - Uses raw 64-byte VRF output directly
+//   - Compares against threshold (based on 2^512)
+//
+// Unknown consensus modes are treated as CPRAOS (the current default).
+func IsVRFOutputBelowThresholdWithMode(vrfOutput []byte, threshold *big.Int, mode ConsensusMode) bool {
 	if threshold == nil {
 		return false
 	}
-	if len(output) == 0 {
+	if len(vrfOutput) == 0 {
 		return false
 	}
-	vrfInt := VRFOutputToInt(output)
+
+	var leaderValue []byte
+	if mode == ConsensusModeTPraos {
+		// TPraos: use raw VRF output directly
+		leaderValue = vrfOutput
+	} else {
+		// CPRAOS (default): hash with "L" prefix
+		leaderValue = VrfLeaderValue(vrfOutput)
+	}
+
+	vrfInt := VRFOutputToInt(leaderValue)
 	return vrfInt.Cmp(threshold) < 0
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch leader election to CPRAOS by hashing the VRF output with BLAKE2b-256 ("L" prefix) and comparing against a 2^256 threshold. Adds mode-aware APIs to keep TPraos compatibility and updates tests and conformance accordingly.

- **New Features**
  - Default leader election now uses CPRAOS (BLAKE2b-256("L" || vrfOutput), 2^256 threshold).
  - Added ConsensusMode with CPRAOS and TPraos.
  - New mode-aware APIs: IsSlotLeaderWithMode, IsSlotLeaderFromComponentsWithMode, CertifiedNatThresholdWithMode, IsVRFOutputBelowThresholdWithMode.
  - Added VrfLeaderValue helper to compute CPRAOS leader value.

- **Migration**
  - If you need TPraos behavior (Shelley–Alonzo), call the WithMode variants with TPraos.
  - Thresholds are now 256-bit for CPRAOS; update any callers/tests that assumed 512-bit thresholds or raw VRF comparisons.

<sup>Written for commit d09a038440082ee2f4f27426cd4a17313bb22599. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mode-aware consensus support (CPraos and TPraos) with mode-specific leader-election and threshold behavior.

* **Bug Fixes**
  * Improved validation and error handling for leadership checks (input length, nil checks, zero-stake early returns) and clearer error messages.

* **Tests**
  * Expanded and refactored tests for CPraos/TPraos semantics, deterministic leader-value hashing, threshold math, and edge-case behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->