### PR TITLE
perf(kes): allocation and caching optimizations

### DIFF
--- a/kes/kes.go
+++ b/kes/kes.go
@@ -162,18 +162,12 @@ func (s Sum0KesSig) Verify(
 
 // HashPair computes the Blake2b-256 hash of two public keys concatenated
 func HashPair(l ed25519.PublicKey, r ed25519.PublicKey) ed25519.PublicKey {
-	h, err := blake2b.New(32, nil)
-	if err != nil {
-		panic(
-			fmt.Sprintf(
-				"unexpected error creating empty blake2b hash: %s",
-				err,
-			),
-		)
-	}
-	h.Write(l[:])
-	h.Write(r[:])
-	return h.Sum(nil)
+	// Stack-allocate input buffer: 32 bytes left + 32 bytes right
+	var input [64]byte
+	copy(input[:32], l)
+	copy(input[32:], r)
+	sum := blake2b.Sum256(input[:])
+	return sum[:]
 }
 
 // SignatureSize returns the size of a KES signature for a given depth.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reduce allocations and add public key caching to speed up KES operations. This lowers memory churn in hashing/seed expansion and avoids recomputing the public key.

- **Refactors**
  - Use stack buffers and blake2b.Sum256 in HashPair and expandSeed to remove heap allocations.
  - Cache the public key in SecretKey during KeyGen; PublicKey returns the cache with a compute fallback for older keys; Update preserves the cache.
  - Generate the right subtree key in place during updates to avoid intermediate allocations.

<sup>Written for commit 328fec76209e14ed666c7237ce032cf2b071b9b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized hashing operations and memory allocation patterns for improved performance.
  * Enhanced internal key generation and update operations to reduce computational overhead and memory usage.

* **Documentation**
  * Updated function documentation to clarify caching behavior and backward compatibility guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->