### PR TITLE
perf(ledger): prealloc slices for block body

### DIFF
--- a/ledger/verify_block_body.go
+++ b/ledger/verify_block_body.go
@@ -144,9 +144,9 @@ func CalculateBlockBodyHash(
 	txsRaw [][]string,
 	invalidTxIndices []uint,
 ) ([]byte, error) {
-	txSeqBody := make([]cbor.RawMessage, 0)
-	txSeqWit := make([]cbor.RawMessage, 0)
-	auxRawData := make([]AuxData, 0)
+	txSeqBody := make([]cbor.RawMessage, 0, len(txsRaw))
+	txSeqWit := make([]cbor.RawMessage, 0, len(txsRaw))
+	auxRawData := make([]AuxData, 0, len(txsRaw))
 	for index, tx := range txsRaw {
 		if len(tx) != 3 {
 			return nil, fmt.Errorf(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preallocated slices for tx body, witness, and aux data in CalculateBlockBodyHash based on the number of transactions. This reduces allocations and speeds up block body hashing, especially on large blocks.

<sup>Written for commit 4189a81b105e4b27e4f5bf7cbb47994977fa8d0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

