### PR TITLE
test: memory profiling

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,44 @@
+name: Benchmarks
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:  # Allow manual triggering
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0 https://github.com/actions/setup-go/releases/tag/v6.2.0
+        with:
+          go-version: '1.24'
+
+      - name: Run benchmarks
+        run: |
+          set -o pipefail
+          go test -bench=. -benchmem -count=5 -timeout=30m -run='^$' \
+            ./vrf/... \
+            ./kes/... \
+            ./consensus/... \
+            ./cbor/... \
+            ./pipeline/... \
+            ./ledger/... \
+            ./internal/bench/... \
+            2>&1 | tee benchmark.txt
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0 https://github.com/actions/upload-artifact/releases/tag/v6.0.0
+        with:
+          name: benchmark-${{ github.sha }}-${{ github.run_number }}
+          path: benchmark.txt
+          retention-days: 30

--- a/internal/bench/BASELINES.md
+++ b/internal/bench/BASELINES.md
@@ -1,0 +1,233 @@
+# Memory Allocation Baselines
+
+**Last Updated**: 2026-02-22
+**Go Version**: 1.24+
+**Platform**: linux/amd64
+
+## Overview
+
+This document tracks memory allocation baselines for key validation paths in gouroboros. These baselines serve three purposes:
+
+1. **Regression Detection**: Allocation regressions are caught by `TestAllocationRegression` tests; benchmark thresholds (>20% allocs, >20% time, >50% bytes) are aspirational targets for future CI enforcement (see [Regression Thresholds](#regression-thresholds))
+2. **Optimization Tracking**: Measure impact of performance improvements
+3. **Contributor Guidance**: Set expectations for new code
+
+All baseline values were captured after the completion of optimization work in PRs #1496-1503 and #1529.
+
+---
+
+## Current Baselines
+
+### VRF Operations (`vrf/`)
+
+| Operation | Allocs | Bytes | Time | Notes |
+|-----------|--------|-------|------|-------|
+| VRF KeyGen | 2 | 64 B | ~75us | Seed processing only |
+| VRF Prove | 11 | 736 B | ~760us | Scalar multiplication |
+| VRF Verify | 11 | 816 B | ~950us | Full verification |
+| VRF VerifyAndHash | 11 | 816 B | ~955us | Verify + hash extraction |
+| VRF ProofToHash | 2 | 224 B | ~38us | Hash extraction only |
+| MkInputVrf | 3 | 464 B | ~1.4us | VRF input creation |
+
+### KES Operations (`kes/`)
+
+| Operation | Allocs | Bytes | Time | Notes |
+|-----------|--------|-------|------|-------|
+| KES KeyGen (depth=6) | 255 | 8800 B | ~5ms | Cardano standard depth |
+| KES Sign (depth=6) | 1 | 448 B | ~180us | Single allocation |
+| KES Update (depth=6) | 3 | 736 B | ~78us | Key evolution |
+| KES Verify (depth=6) | 6 | 192 B | ~243us | Signature verification |
+| KES VerifySignedKES | 12 | 616 B | ~265us | Full verification path |
+| KES NewSumKesFromBytes (depth=6) | 6 | 424 B | ~1.1us | Signature deserialization |
+| KES HashPair | 1 | 32 B | ~843ns | Blake2b hash |
+
+### Block Validation (`internal/bench/`)
+
+| Operation | Era | Allocs | Bytes | Time | Notes |
+|-----------|-----|--------|-------|------|-------|
+| Block Validation | Shelley | 461 | 101 KB | ~2.4ms | Full validation |
+| Block Validation | Allegra | 1092 | 246 KB | ~3.1ms | |
+| Block Validation | Mary | 1136 | 236 KB | ~3.0ms | |
+| Block Validation | Alonzo | 1382 | 365 KB | ~3.5ms | |
+| Block Validation | Babbage | 5709 | 1014 KB | ~7.0ms | Largest blocks |
+| Block Validation | Conway | 2672 | 487 KB | ~4.4ms | |
+| Block Validation (pre-parsed) | All Eras | 20 | 1.5 KB | ~0.9ms | Skip decode |
+| VRF Verification | All Eras | 10 | 608 B | ~0.9ms | Block VRF check |
+| KES Verification | All Eras | 12 | 616 B | ~270us | Block KES check |
+| Body Hash | Shelley | 15 | 10 KB | ~42us | |
+| Body Hash | Babbage | 19 | 83 KB | ~328us | Largest body |
+| Body Hash | Conway | 18 | 39 KB | ~153us | |
+
+### Block Decode (`internal/bench/`)
+
+| Operation | Era | Allocs | Bytes | Throughput | Notes |
+|-----------|-----|--------|-------|------------|-------|
+| CBOR Decode | Byron | 500 | 89 KB | 5.5 MB/s | |
+| CBOR Decode | Shelley | 441 | 100 KB | 8.2 MB/s | |
+| CBOR Decode | Allegra | 1072 | 245 KB | 6.7 MB/s | |
+| CBOR Decode | Mary | 1116 | 235 KB | 5.2 MB/s | |
+| CBOR Decode | Alonzo | 1362 | 363 KB | 6.4 MB/s | |
+| CBOR Decode | Babbage | 5689 | 1014 KB | 3.5 MB/s | |
+| CBOR Decode | Conway | 2652 | 485 KB | 3.5 MB/s | |
+| Parallel Decode | Byron | 500 | 89 KB | 19.6 MB/s | |
+| Parallel Decode | Shelley | 441 | 100 KB | 35.8 MB/s | |
+| Parallel Decode | Babbage | 5690 | 1005 KB | 25.2 MB/s | |
+
+### Transaction Validation (`internal/bench/`)
+
+| Operation | Era | Allocs | Bytes | Time | Notes |
+|-----------|-----|--------|-------|------|-------|
+| Tx Validation | Shelley | 64 | 5.3 KB | ~605us | Simple tx |
+| Tx Validation | Allegra | 32 | 3.7 KB | ~600us | |
+| Tx Validation | Mary | 42 | 4.5 KB | ~553us | |
+| Tx Validation | Alonzo | 44 | 5.3 KB | ~371us | |
+| Tx Validation | Babbage | 310 | 22.1 KB | ~1.4ms | |
+| Tx Validation | Conway | 220 | 18.7 KB | ~1.8ms | |
+| Value Balance | Shelley | 9 | 216 B | ~1.2us | |
+| Value Balance | Alonzo | 21 | 624 B | ~3.0us | |
+| Witness Validation | Shelley | 13 | 624 B | ~3.1us | |
+| Witness Validation | Alonzo | 28 | 6.5 KB | ~33us | |
+
+### Consensus / Leader Election (`internal/bench/`)
+
+| Operation | Allocs | Bytes | Time | Notes |
+|-----------|--------|-------|------|-------|
+| CertifiedNatThreshold | 1221-1224 | 163-168 KB | ~4.1ms | big.Rat arithmetic |
+| VrfLeaderValue | 4 | 528 B | ~1.6us | Blake2b hash |
+| VRFOutputToInt | 1 | 64 B | ~139ns | big.Int conversion |
+| IsSlotLeader | 1240-1244 | 165-169 KB | ~5.3ms | Full leader check |
+| IsVRFOutputBelowThreshold | 5 | 592 B | ~1.8us | Threshold comparison |
+| Full Leader Election Workflow | 1242 | 167 KB | ~5.4ms | Complete flow |
+
+---
+
+## How to Update Baselines
+
+### Run All Benchmarks
+
+```bash
+# VRF benchmarks
+go test -bench=. -benchmem ./vrf/... -run=^$ 2>&1 | tee vrf_bench.txt
+
+# KES benchmarks
+go test -bench=. -benchmem ./kes/... -run=^$ 2>&1 | tee kes_bench.txt
+
+# Internal benchmarks (block, tx, consensus, CBOR)
+go test -bench=. -benchmem ./internal/bench/... -run=^$ 2>&1 | tee internal_bench.txt
+```
+
+### Compare Against Previous Run
+
+```bash
+# Install benchstat if needed
+go install golang.org/x/perf/cmd/benchstat@latest
+
+# Compare old vs new
+benchstat old_bench.txt new_bench.txt
+```
+
+### Generate Memory Profile
+
+```bash
+# CPU profile
+go test -bench=BenchmarkBlockValidation -cpuprofile=cpu.prof ./internal/bench/...
+
+# Memory profile
+go test -bench=BenchmarkBlockValidation -memprofile=mem.prof ./internal/bench/...
+
+# Analyze
+go tool pprof -http=localhost:8080 mem.prof
+```
+
+### Extract Specific Values
+
+```bash
+# Get allocation counts for VRF Verify
+go test -bench='BenchmarkVerify/Valid' -benchmem ./vrf/... -run=^$ | grep allocs
+
+# Get allocation counts for block validation
+go test -bench='BenchmarkBlockValidation/Era_Conway' -benchmem ./internal/bench/... -run=^$
+```
+
+---
+
+## Optimization History
+
+### Merged PRs (2026-01)
+
+| PR | Focus Area | Impact |
+|----|------------|--------|
+| #1496 | KES optimizations | Reduced allocs in key operations |
+| #1497 | VRF scalar ops | Improved scalar multiplication |
+| #1498 | Block body prealloc | Reduced body decode allocs |
+| #1499 | Byron merkle buffers | Fixed buffer reuse in merkle tree |
+| #1500 | Fixed nonce buffers | Reduced MkInputVrf allocs |
+| #1501 | Plutus context prealloc | Reduced Plutus context building |
+| #1502 | VRF leader value | Optimized leader value computation |
+| #1503 | big.Rat reuse | Reduced threshold calculation allocs |
+| #1529 | CBOR EncMode/DecMode cache | 46-49% faster encode/decode |
+
+### Pre-Optimization Estimates (for reference)
+
+| Operation | Est. Before | Current | Reduction |
+|-----------|-------------|---------|-----------|
+| VRF Verify | ~15 allocs | 11 allocs | ~27% |
+| KES Verify (depth=6) | ~12 allocs | 6 allocs | ~50% |
+| MkInputVrf | ~5 allocs | 3 allocs | ~40% |
+| Threshold Calc | ~2000 allocs | ~1220 allocs | ~39% |
+
+---
+
+## Regression Thresholds
+
+### Aspirational Regression Thresholds
+
+These thresholds guide manual review and future CI enforcement.
+Currently, regression detection is handled by `TestAllocationRegression`
+tests in `regression_test.go`, not by the benchmark CI workflow.
+
+| Metric | Threshold | Rationale |
+|--------|-----------|-----------|
+| Allocation Count | +20% | Catches allocation leaks |
+| Bytes Allocated | +50% | Allows some flexibility for features |
+| Time (ns/op) | +20% | Catches performance regressions |
+
+### Critical Paths
+
+These operations are performance-critical and have stricter monitoring:
+
+| Operation | Max Allocs | Rationale |
+|-----------|------------|-----------|
+| VRF Verify | 15 | Block validation hot path |
+| KES VerifySignedKES | 15 | Block validation hot path |
+| MkInputVrf | 5 | Called for every slot check |
+| Body Hash | 25 | Called for every block |
+
+### How to Request Threshold Increase
+
+If a PR legitimately increases allocations:
+
+1. Document the reason in the PR description
+2. Update this file with new baseline values
+3. Request reviewer approval for threshold increase
+
+---
+
+## Benchmark Environment Notes
+
+- **CPU Scaling**: Disable CPU frequency scaling for consistent results
+- **Parallel Tests**: Use `-p 1` to avoid contention in parallel benchmarks
+- **Warmup**: Run benchmarks twice; use second run for baselines
+- **Count**: Use `-count=5` and benchstat for statistical significance
+
+```bash
+# Recommended benchmark command for baselines
+go test -bench=. -benchmem -count=5 -p=1 ./internal/bench/... 2>&1 | tee bench.txt
+```
+
+---
+
+## Related Documentation
+
+- [README.md](README.md) - Benchmark package documentation
+- [PROFILING.md](PROFILING.md) - Profiling guide

--- a/internal/bench/PROFILING.md
+++ b/internal/bench/PROFILING.md
@@ -1,0 +1,399 @@
+# Profiling Guide
+
+This guide covers how to profile Gouroboros for CPU usage, memory allocations, and performance optimization.
+
+## Prerequisites
+
+```bash
+# Install benchstat for benchmark comparison
+go install golang.org/x/perf/cmd/benchstat@latest
+
+# pprof is included with Go
+go tool pprof --help
+```
+
+## Quick Start
+
+```bash
+# Generate CPU profile
+go test -bench=BenchmarkBlockValidation -run=^$ -cpuprofile=cpu.prof ./internal/bench/...
+
+# Generate memory profile
+go test -bench=BenchmarkBlockValidation -run=^$ -memprofile=mem.prof ./internal/bench/...
+
+# Interactive web UI (recommended)
+go tool pprof -http=localhost:8080 cpu.prof
+```
+
+## Generating Profiles
+
+### CPU Profiling
+
+CPU profiles identify hot code paths and functions consuming the most CPU time.
+
+```bash
+# Profile specific benchmark
+go test -bench=BenchmarkConsensusIsSlotLeader -run=^$ -cpuprofile=cpu.prof ./internal/bench/...
+
+# Profile with longer runtime for more samples
+go test -bench=BenchmarkConsensusIsSlotLeader -run=^$ -benchtime=10s -cpuprofile=cpu.prof ./internal/bench/...
+
+# Profile all benchmarks
+go test -bench=. -run=^$ -cpuprofile=cpu.prof ./internal/bench/...
+```
+
+### Memory Profiling
+
+Memory profiles show allocation counts and bytes per function.
+
+```bash
+# Allocation profile (recommended)
+go test -bench=BenchmarkConsensusThreshold -run=^$ -memprofile=mem.prof ./internal/bench/...
+
+# Also capture allocation rate
+go test -bench=BenchmarkConsensusThreshold -run=^$ -memprofile=mem.prof -memprofilerate=1 ./internal/bench/...
+```
+
+### Block Profile
+
+Block profiles show where goroutines block waiting on synchronization.
+
+```bash
+go test -bench=BenchmarkCBORDecodeBlock -run=^$ -blockprofile=block.prof ./internal/bench/...
+```
+
+### Mutex Profile
+
+Mutex profiles show contention on sync primitives.
+
+```bash
+go test -bench=BenchmarkCBORDecodeBlockParallel -run=^$ -mutexprofile=mutex.prof ./internal/bench/...
+```
+
+### Trace
+
+Execution traces provide detailed timing for goroutines, GC, and syscalls.
+
+```bash
+go test -bench=BenchmarkCBORDecodeBlockParallel -run=^$ -trace=trace.out ./internal/bench/...
+
+# View trace
+go tool trace trace.out
+```
+
+## Analyzing Profiles
+
+### Interactive Web UI
+
+The web UI is the most powerful way to explore profiles:
+
+```bash
+go tool pprof -http=localhost:8080 cpu.prof
+```
+
+Key views:
+- **Graph**: Call graph with node sizes proportional to time/memory
+- **Flame Graph**: Hierarchical view of call stacks
+- **Top**: Functions sorted by resource usage
+- **Source**: Annotated source code
+
+### Command Line
+
+For quick analysis or scripting:
+
+```bash
+# Top 20 functions by CPU time
+go tool pprof -top cpu.prof
+
+# Top 20 by cumulative time
+go tool pprof -top -cum cpu.prof
+
+# Show specific function
+go tool pprof -focus=CertifiedNatThreshold cpu.prof
+
+# Memory allocations (count)
+go tool pprof -alloc_objects mem.prof
+
+# Memory allocations (bytes)
+go tool pprof -alloc_space mem.prof
+
+# In-use memory (live objects)
+go tool pprof -inuse_objects mem.prof
+```
+
+### Interactive Mode
+
+```bash
+go tool pprof cpu.prof
+
+# In the pprof prompt:
+(pprof) top20              # Top 20 functions
+(pprof) top20 -cum         # By cumulative time
+(pprof) list functionName  # Show source with annotations
+(pprof) web                # Open graph in browser
+(pprof) weblist funcName   # Open annotated source in browser
+```
+
+## Key Profiling Scenarios
+
+### Finding CPU Hotspots
+
+```bash
+# Generate profile
+go test -bench=BenchmarkBlockValidation -run=^$ -cpuprofile=cpu.prof ./internal/bench/...
+
+# Open web UI
+go tool pprof -http=localhost:8080 cpu.prof
+```
+
+Look for:
+- Wide nodes in the flame graph (high self time)
+- Deep stacks (expensive call chains)
+- Unexpected functions in hot paths
+
+### Finding Memory Allocations
+
+```bash
+# Generate profile
+go test -bench=BenchmarkConsensusThreshold -run=^$ -memprofile=mem.prof ./internal/bench/...
+
+# View allocations
+go tool pprof -alloc_objects -http=localhost:8080 mem.prof
+```
+
+Look for:
+- High allocation counts per function
+- Large allocations in loops
+- Escaped variables (heap vs stack)
+
+### Investigating Allocation Escape
+
+```bash
+# See escape analysis decisions
+go build -gcflags='-m -m' ./consensus/... 2>&1 | grep -E '(escapes|does not escape)'
+
+# More verbose
+go build -gcflags='-m=2' ./consensus/... 2>&1 | head -100
+```
+
+Common escape causes:
+- Returning pointers to local variables
+- Storing pointers in interfaces
+- Closures capturing variables
+- Slices/maps that grow
+
+### Comparing Before/After
+
+```bash
+# Baseline
+go test -bench=BenchmarkConsensusThreshold -run=^$ -memprofile=baseline.prof ./internal/bench/...
+
+# After optimization
+go test -bench=BenchmarkConsensusThreshold -run=^$ -memprofile=optimized.prof ./internal/bench/...
+
+# Compare (requires go 1.21+)
+go tool pprof -base baseline.prof optimized.prof
+(pprof) top -diff
+```
+
+## Common Optimization Patterns
+
+Based on performance work in Gouroboros, these patterns have proven effective:
+
+### 1. Object Reuse with sync.Pool
+
+Effective for frequently allocated/deallocated objects:
+
+```go
+var bufferPool = sync.Pool{
+    New: func() interface{} {
+        return make([]byte, 4096)
+    },
+}
+
+func process() {
+    buf := bufferPool.Get().([]byte)
+    defer bufferPool.Put(buf)
+    // Use buf...
+}
+```
+
+**When to use**: High allocation rate, short-lived objects, consistent size.
+
+**Caution**: Don't use for objects that vary significantly in size.
+
+### 2. Pre-allocated Slices
+
+Avoid repeated slice growth:
+
+```go
+// Before (multiple allocations)
+var result []Item
+for _, x := range inputs {
+    result = append(result, process(x))
+}
+
+// After (single allocation)
+result := make([]Item, 0, len(inputs))
+for _, x := range inputs {
+    result = append(result, process(x))
+}
+```
+
+### 3. Fixed-Size Buffers
+
+For predictable-size operations:
+
+```go
+// Before (heap allocation)
+buf := make([]byte, 32)
+
+// After (stack allocation - may be optimized by compiler)
+var buf [32]byte
+```
+
+### 4. big.Int/big.Rat Reuse
+
+Mathematical operations create many intermediates:
+
+```go
+// Before (new allocation each call)
+func threshold(a, b *big.Int) *big.Int {
+    result := new(big.Int)
+    return result.Mul(a, b)
+}
+
+// After (reuse provided buffer)
+func threshold(a, b, result *big.Int) *big.Int {
+    return result.Mul(a, b)
+}
+```
+
+### 5. CBOR Mode Caching
+
+CBOR encoding/decoding modes are expensive to create:
+
+```go
+// Before (created per call)
+func encode(v interface{}) ([]byte, error) {
+    em, _ := cbor.EncOptions{}.EncMode()
+    return em.Marshal(v)
+}
+
+// After (cached)
+var encMode cbor.EncMode
+var encModeOnce sync.Once
+
+func encode(v interface{}) ([]byte, error) {
+    encModeOnce.Do(func() {
+        encMode, _ = cbor.EncOptions{}.EncMode()
+    })
+    return encMode.Marshal(v)
+}
+```
+
+### 6. Avoiding Interface Conversions
+
+Interface boxing causes allocations:
+
+```go
+// Before (allocates for interface{})
+func process(v interface{}) { ... }
+process(myInt)
+
+// After (generic, no allocation)
+func process[T any](v T) { ... }
+process(myInt)
+```
+
+## Profiling in Production
+
+### HTTP Endpoint
+
+Add pprof HTTP handlers:
+
+```go
+import _ "net/http/pprof"
+
+func main() {
+    go func() {
+        log.Println(http.ListenAndServe("localhost:6060", nil))
+    }()
+    // ... rest of application
+}
+```
+
+Access profiles:
+- `http://localhost:6060/debug/pprof/` - Index
+- `http://localhost:6060/debug/pprof/profile?seconds=30` - CPU
+- `http://localhost:6060/debug/pprof/heap` - Memory
+- `http://localhost:6060/debug/pprof/goroutine` - Goroutines
+
+### Continuous Profiling
+
+For production monitoring, consider:
+- [Pyroscope](https://pyroscope.io/)
+- [Parca](https://www.parca.dev/)
+- [Google Cloud Profiler](https://cloud.google.com/profiler)
+
+## Gouroboros-Specific Notes
+
+### Key Validation Paths
+
+Priority paths for profiling (highest impact):
+
+| Path | Package | Entry Point |
+|------|---------|-------------|
+| Block validation | `ledger/` | `VerifyBlock()` |
+| Transaction validation | `ledger/*/rules.go` | `VerifyTransaction()` |
+| VRF verification | `vrf/` | `Verify()`, `VerifyAndHash()` |
+| KES verification | `kes/` | `VerifySignedKES()` |
+| Leader election | `consensus/` | `IsSlotLeader()`, `CertifiedNatThreshold()` |
+| CBOR decode | `cbor/` | `Decode()`, `NewBlockFromCbor()` |
+
+### Historical Optimizations
+
+Merged optimization branches and their impact:
+
+| Optimization | PR | Reduction |
+|--------------|-----|-----------|
+| big.Rat reuse | #1503 | ~40 allocs -> ~10 |
+| Fixed nonce buffers | #1500 | 3 allocs -> 0 |
+| Plutus context prealloc | #1501 | Variable |
+| Block body prealloc | #1498 | Variable |
+| VRF leader value | #1502 | ~5 allocs -> 1 |
+| CBOR mode caching | #1529 | 46-49% faster |
+
+### Benchmark Comparison
+
+Always compare against baseline before optimization:
+
+```bash
+# Establish baseline
+git checkout main
+go test -bench=. -run=^$ -benchmem -count=5 ./internal/bench/... | tee baseline.txt
+
+# Test optimization
+git checkout my-optimization-branch
+go test -bench=. -run=^$ -benchmem -count=5 ./internal/bench/... | tee optimized.txt
+
+# Compare
+benchstat baseline.txt optimized.txt
+```
+
+## Resources
+
+### Go Documentation
+- [Diagnostics](https://go.dev/doc/diagnostics)
+- [pprof](https://pkg.go.dev/net/http/pprof)
+- [runtime/pprof](https://pkg.go.dev/runtime/pprof)
+- [Profiling Go Programs (blog)](https://go.dev/blog/pprof)
+
+### Tools
+- [benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat)
+- [go-torch](https://github.com/uber-archive/go-torch) (flame graphs, older tool)
+- [pprof](https://github.com/google/pprof) (standalone)
+
+### Related Project Documentation
+- `internal/bench/README.md` - Benchmark suite documentation
+- `internal/bench/BASELINES.md` - Memory allocation baselines

--- a/internal/bench/README.md
+++ b/internal/bench/README.md
@@ -1,0 +1,474 @@
+# Benchmark Suite
+
+This package provides comprehensive benchmarks for memory profiling and performance measurement across Gouroboros validation paths.
+
+## Quick Start
+
+```bash
+# Run all benchmarks in this package
+go test -bench=. -benchmem ./internal/bench/...
+
+# Run specific benchmark
+go test -bench=BenchmarkConsensusThreshold -benchmem ./internal/bench/...
+
+# Compare two runs (requires benchstat)
+go test -bench=. -benchmem -count=5 ./internal/bench/... | tee new.txt
+benchstat old.txt new.txt
+```
+
+## Package Structure
+
+```text
+internal/bench/
+  helpers.go              # Benchmark utilities and fixture loaders
+  helpers_test.go         # Tests for helpers
+  block_bench_test.go     # Block validation benchmarks
+  cbor_bench_test.go      # CBOR decode benchmarks
+  tx_bench_test.go        # Transaction benchmarks
+  consensus_bench_test.go # Consensus/leader election benchmarks
+  script_bench_test.go    # Script execution benchmarks
+  regression_test.go      # Allocation regression tests
+  profile_test.go         # Profiling integration (build tag: profile)
+  README.md               # This file
+  BASELINES.md            # Memory allocation baselines
+  PROFILING.md            # Profiling guide
+  testdata/               # Test fixtures (blocks, transactions)
+```
+
+## Available Benchmarks
+
+### Block Benchmarks (`block_bench_test.go`)
+
+| Benchmark | Description |
+|-----------|-------------|
+| `BenchmarkBlockValidation` | Full block validation (VRF, KES, body hash) by era |
+| `BenchmarkBlockValidationPreParsed` | Validation with pre-parsed blocks |
+| `BenchmarkBlockVRFVerification` | VRF verification isolated by era |
+| `BenchmarkBlockKESVerification` | KES verification isolated by era |
+| `BenchmarkBlockBodyHash` | Body hash validation by era |
+| `BenchmarkBlockDecode` | Block CBOR decoding by era |
+| `BenchmarkBlockDecodeWithBodyHash` | Block decoding with body hash validation |
+| `BenchmarkMkInputVrf` | VRF input creation for leader election |
+| `BenchmarkVerifyKesComponents` | Full KES components verification |
+| `BenchmarkHeaderCborEncode` | Header body CBOR encoding for KES |
+
+### CBOR Benchmarks (`cbor_bench_test.go`)
+
+| Benchmark | Description |
+|-----------|-------------|
+| `BenchmarkCBORDecodeBlock` | Block CBOR decoding by era |
+| `BenchmarkCBORDecodeBlockParallel` | Parallel block decoding throughput |
+| `BenchmarkCBORDecodeTx` | Transaction CBOR decoding by era |
+| `BenchmarkCBORDecodeTxParallel` | Parallel transaction decoding |
+| `BenchmarkCBOREncodeBlock` | Block CBOR encoding by era |
+| `BenchmarkCBOREncodeTx` | Transaction CBOR encoding by era |
+| `BenchmarkCBORDecodeRaw` | Low-level cbor.Decode overhead |
+| `BenchmarkCBOREncode` | Low-level cbor.Encode (Small/Medium/Large) |
+| `BenchmarkCBORRoundTrip` | Decode + encode cycle by era |
+| `BenchmarkCBORDecodeBlockWithOffsets` | Block decoding with TX offset extraction |
+
+### Transaction Benchmarks (`tx_bench_test.go`)
+
+| Benchmark | Description |
+|-----------|-------------|
+| `BenchmarkTxDecode` | Transaction CBOR decoding by era |
+| `BenchmarkTxHash` | Transaction hash calculation |
+| `BenchmarkTxInputs` | Transaction input iteration |
+| `BenchmarkTxOutputs` | Transaction output iteration |
+| `BenchmarkTxFee` | Transaction fee retrieval |
+| `BenchmarkTxMetadata` | Transaction metadata retrieval |
+| `BenchmarkTxCbor` | Transaction CBOR bytes retrieval |
+| `BenchmarkTxUtxorpc` | Transaction Utxorpc conversion |
+| `BenchmarkTxProducedUtxos` | Produced UTXO enumeration |
+| `BenchmarkTxConsumedUtxos` | Consumed UTXO enumeration |
+| `BenchmarkTxBlockIteration` | Iterate all transactions in a block |
+
+### Consensus Benchmarks (`consensus_bench_test.go`)
+
+| Benchmark | Description |
+|-----------|-------------|
+| `BenchmarkConsensusThreshold` | Certified natural threshold calculation |
+| `BenchmarkConsensusThresholdWithMode` | Threshold for CPraos vs TPraos modes |
+| `BenchmarkConsensusLeaderValue` | VRF leader value computation (BLAKE2b-256) |
+| `BenchmarkConsensusVRFOutputToInt` | VRF output to big.Int conversion |
+| `BenchmarkConsensusIsSlotLeader` | Full leader election check |
+| `BenchmarkConsensusIsSlotLeaderFromComponents` | Leader check from pre-computed components |
+| `BenchmarkConsensusMkInputVrf` | VRF input (nonce) creation |
+| `BenchmarkConsensusIsVRFOutputBelowThreshold` | Threshold comparison |
+| `BenchmarkConsensusFullLeaderElectionWorkflow` | Complete leader election workflow |
+| `BenchmarkConsensusParallelThreshold` | Concurrent threshold calculations |
+
+### Script Benchmarks (`script_bench_test.go`)
+
+| Benchmark | Description |
+|-----------|-------------|
+| `BenchmarkNativeScriptEvaluate` | Native script evaluation (Pubkey/All/Any/NofK/Timelock) |
+| `BenchmarkNativeScriptEvaluateDepth` | Nested script evaluation at various depths |
+| `BenchmarkNativeScriptEvaluateWorstCase` | Worst-case branch checking |
+| `BenchmarkPlutusScriptDeserialize` | Plutus script deserialization (V1/V2/V3) |
+| `BenchmarkPlutusScriptHash` | Plutus script hash computation |
+| `BenchmarkNativeScriptHash` | Native script hash computation |
+| `BenchmarkNativeScriptCBOR` | Native script CBOR encode/decode |
+
+### Other Package Benchmarks
+
+Additional benchmarks are located in their respective packages:
+
+| Package | File | Focus |
+|---------|------|-------|
+| `vrf/` | `benchmark_test.go` | VRF key generation, prove, verify |
+| `kes/` | `benchmark_test.go` | KES key generation, sign, verify, update |
+| `pipeline/` | `benchmark_test.go` | Block processing pipeline throughput |
+
+## Running Benchmarks
+
+### Basic Commands
+
+```bash
+# Run all benchmarks with memory stats
+go test -bench=. -benchmem ./internal/bench/...
+
+# Run benchmarks in all packages
+go test -bench=. -benchmem ./...
+
+# Run with verbose output
+go test -bench=. -benchmem -v ./internal/bench/...
+
+# Run specific benchmark pattern
+go test -bench=BenchmarkConsensus -benchmem ./internal/bench/...
+```
+
+### Common Flags
+
+| Flag | Description | Example |
+|------|-------------|---------|
+| `-bench=<regex>` | Run benchmarks matching pattern | `-bench=Threshold` |
+| `-benchmem` | Report memory allocations | Always recommended |
+| `-benchtime=<d>` | Run each benchmark for duration | `-benchtime=5s` |
+| `-count=<n>` | Run each benchmark n times | `-count=5` |
+| `-cpu=<list>` | Specify GOMAXPROCS values | `-cpu=1,2,4,8` |
+| `-cpuprofile=<file>` | Write CPU profile | `-cpuprofile=cpu.prof` |
+| `-memprofile=<file>` | Write memory profile | `-memprofile=mem.prof` |
+| `-timeout=<d>` | Test timeout | `-timeout=30m` |
+
+### Multiple Run Comparison
+
+For reliable performance comparisons, run benchmarks multiple times:
+
+```bash
+# Install benchstat
+go install golang.org/x/perf/cmd/benchstat@latest
+
+# Run baseline
+go test -bench=. -benchmem -count=5 ./internal/bench/... | tee baseline.txt
+
+# Make changes, then run again
+go test -bench=. -benchmem -count=5 ./internal/bench/... | tee new.txt
+
+# Compare results
+benchstat baseline.txt new.txt
+```
+
+## Interpreting Results
+
+### Output Format
+
+```text
+BenchmarkConsensusThreshold/1pct-16    876543    1234 ns/op    256 B/op    8 allocs/op
+```
+
+| Field | Meaning |
+|-------|---------|
+| `876543` | Number of iterations completed |
+| `1234 ns/op` | Nanoseconds per operation |
+| `256 B/op` | Bytes allocated per operation |
+| `8 allocs/op` | Heap allocations per operation |
+
+### Aspirational Performance Targets
+
+These are aspirational targets for future optimization work. Current baselines
+are documented in `BASELINES.md`.
+
+| Operation | Target Allocs | Notes |
+|-----------|---------------|-------|
+| VRF Verify | 4-8 | After opt/vrf-combined |
+| KES Verify | 6-12 | After opt/kes-combined |
+| Threshold Calc | 10-15 | After opt/threshold-allocs |
+| Leader Check | 15-20 | Composite of above |
+| MkInputVrf | 0 | After opt/nonce-buffers |
+
+### benchstat Output
+
+```text
+name                  old time/op    new time/op    delta
+ConsensusThreshold    1.23us +-2%    0.89us +-1%   -27.64%  (p=0.008 n=5+5)
+
+name                  old alloc/op   new alloc/op   delta
+ConsensusThreshold     256B +- 0%     128B +- 0%   -50.00%  (p=0.008 n=5+5)
+```
+
+- `delta` shows percentage change
+- `+-` shows variance
+- `p=0.008` is statistical significance (lower is better)
+- `n=5+5` means 5 runs of each version
+
+## Helper Functions
+
+The `helpers.go` file provides utilities for benchmarks:
+
+### Ledger State
+
+```go
+// Basic mock ledger state
+ls := bench.BenchLedgerState()
+
+// With specific UTXOs
+ls := bench.BenchLedgerStateWithUtxos(utxos)
+
+// With custom UTXO lookup
+ls := bench.BenchLedgerStateWithUtxoFunc(func(input common.TransactionInput) (common.Utxo, error) {
+    return myUtxo, nil
+})
+```
+
+### Block Fixtures
+
+```go
+// Load block fixture for an era
+fixture, err := bench.LoadBlockFixture("conway", "default")
+
+// Must variant (panics on error, use in init/setup)
+fixture := bench.MustLoadBlockFixture("conway", "default")
+
+// Access fixture data
+block := fixture.Block
+cbor := fixture.Cbor
+blockType := fixture.BlockType
+```
+
+### Era Utilities
+
+```go
+// Get all era names
+eras := bench.EraNames()  // ["byron", "shelley", ..., "conway"]
+
+// Get post-Byron eras (for Praos benchmarks)
+eras := bench.PostByronEraNames()  // ["shelley", ..., "conway"]
+
+// Convert era name to block type
+blockType, err := bench.BlockTypeFromEra("conway")
+```
+
+## Adding New Benchmarks
+
+### Structure
+
+1. Create a new file `<category>_bench_test.go`
+2. Use sub-benchmarks for variants (`b.Run()`)
+3. Always call `b.ReportAllocs()`
+4. Reset timer after setup (`b.ResetTimer()`)
+
+### Template
+
+```go
+// Copyright 2026 Blink Labs Software
+// ... license header ...
+
+package bench
+
+import (
+    "testing"
+)
+
+// BenchmarkMyOperation benchmarks [description].
+func BenchmarkMyOperation(b *testing.B) {
+    // Setup (not measured)
+    fixture := MustLoadBlockFixture("conway", "default")
+
+    variants := []struct {
+        name string
+        // variant parameters
+    }{
+        {"Small", /* ... */},
+        {"Large", /* ... */},
+    }
+
+    for _, v := range variants {
+        b.Run(v.name, func(b *testing.B) {
+            b.ReportAllocs()
+            b.ResetTimer()
+            for i := 0; i < b.N; i++ {
+                // Operation to benchmark
+                _ = myOperation(fixture.Block)
+            }
+        })
+    }
+}
+```
+
+### Naming Conventions
+
+- Top-level: `Benchmark<Component><Operation>` (e.g., `BenchmarkConsensusThreshold`)
+- Sub-benchmarks: descriptive variant names (e.g., `1pct`, `10pct`, `Large`, `Small`)
+- Use underscores for hierarchical names (e.g., `Era_Conway`, `TxType_Simple`)
+
+### Best Practices
+
+1. **Isolate setup from measurement**: Do expensive setup before `b.ResetTimer()`
+2. **Avoid allocations in loop**: Pre-allocate test data outside the benchmark loop
+3. **Use realistic data**: Load fixtures from real blocks/transactions
+4. **Test multiple variants**: Include edge cases and typical cases
+5. **Document allocations**: Note expected allocation counts in comments
+6. **Prevent compiler optimization**: Use result (e.g., assign to package-level var)
+
+### Parallel Benchmarks
+
+For concurrency testing:
+
+```go
+func BenchmarkParallelOperation(b *testing.B) {
+    b.ReportAllocs()
+    b.RunParallel(func(pb *testing.PB) {
+        for pb.Next() {
+            _ = myOperation()
+        }
+    })
+}
+```
+
+## Profiling Integration
+
+### Using the Profile Script
+
+The easiest way to generate profiles is with the helper script:
+
+```bash
+# Make the script executable (first time only)
+chmod +x scripts/profile.sh
+
+# Profile block validation (CPU + memory)
+./scripts/profile.sh block both
+
+# Profile CBOR decode with web UI
+./scripts/profile.sh cbor both --view
+
+# Profile all components
+./scripts/profile.sh all both
+
+# Show help
+./scripts/profile.sh --help
+```
+
+### Available Profile Tests
+
+Profile tests are guarded by the `profile` build tag (see `profile_test.go`):
+
+| Component | Test Name | Description |
+|-----------|-----------|-------------|
+| block | `TestProfileBlockValidation` | Full block validation (VRF, KES, body hash) |
+| cbor | `TestProfileCBORDecode` | CBOR deserialization for all eras |
+| vrf | `TestProfileVRF` | VRF prove/verify operations |
+| consensus | `TestProfileConsensus` | Leader election computations |
+| bodyhash | `TestProfileBodyHash` | Block body hash validation |
+| script | `TestProfileNativeScript` | Native script evaluation |
+
+### Running Profile Tests Directly
+
+```bash
+# Generate CPU and memory profiles for block validation
+go test -tags=profile -run=TestProfileBlockValidation \
+    -cpuprofile=cpu_block.prof -memprofile=mem_block.prof \
+    ./internal/bench/...
+
+# Analyze with pprof web UI
+go tool pprof -http=localhost:8080 cpu_block.prof
+go tool pprof -http=localhost:8081 mem_block.prof
+```
+
+### Generate Profiles from Benchmarks
+
+```bash
+# CPU profile
+go test -bench=BenchmarkConsensusIsSlotLeader -cpuprofile=cpu.prof ./internal/bench/...
+go tool pprof -http=localhost:8080 cpu.prof
+
+# Memory profile
+go test -bench=BenchmarkConsensusIsSlotLeader -memprofile=mem.prof ./internal/bench/...
+go tool pprof -http=localhost:8081 mem.prof
+```
+
+### Comparing Profiles
+
+```bash
+# Compare two profiles (before/after optimization)
+go tool pprof -base=old.prof new.prof
+
+# Text-based top functions
+go tool pprof -top cpu.prof
+go tool pprof -top -alloc_space mem.prof
+```
+
+See `PROFILING.md` in this directory for detailed profiling guidance.
+
+## Regression Testing
+
+Allocation regression tests ensure optimization gains are maintained:
+
+```go
+func TestAllocationRegression(t *testing.T) {
+    allocs := testing.AllocsPerRun(100, func() {
+        _ = myOperation()
+    })
+    if allocs > 10 {
+        t.Errorf("allocations regressed: %.0f > 10", allocs)
+    }
+}
+```
+
+## CI Benchmark Results
+
+### Workflow Artifacts
+
+The benchmark CI workflow (`.github/workflows/benchmark.yml`) runs on push to `main`
+only (and via manual `workflow_dispatch`). It does not run on pull requests.
+
+Each run produces a single file, `benchmark.txt`, containing the output of
+`go test -bench=. -benchmem -count=5` across the core packages (vrf, kes,
+consensus, cbor, pipeline, ledger, internal/bench).
+
+1. **Location**: GitHub Actions > Workflows > Benchmarks > Run > Artifacts
+2. **Artifact name**: `benchmark-<commit-sha>-<run-number>`
+3. **Contents**: `benchmark.txt` (single file)
+4. **Retention**: 30 days
+
+To download an artifact:
+
+1. Navigate to the repository on GitHub
+2. Click "Actions" tab
+3. Select the "Benchmarks" workflow
+4. Click on the specific run you are interested in
+5. Scroll down to "Artifacts" section
+6. Download `benchmark.txt`
+
+### Regression Detection
+
+The CI workflow does not perform automatic comparison or threshold checking.
+Regression detection is currently handled at test time by the
+`TestAllocationRegression` tests in `regression_test.go`, which assert that
+allocation counts stay within acceptable limits.
+
+See `BASELINES.md` for the per-era memory allocation baselines that serve as
+aspirational CI regression thresholds for future workflow enhancements.
+
+### GitHub Pages (Optional)
+
+When enabled, historical benchmark data is available with interactive trend charts.
+See `.github/workflows/benchmark.yml` for setup instructions.
+
+## Related Documentation
+
+- `PROFILING.md` - Detailed profiling guide (in this directory)
+- `BASELINES.md` - Memory allocation baselines (in this directory)
+- `vrf/README.md` - VRF package documentation
+- `kes/README.md` - KES package documentation
+- `consensus/README.md` - Consensus package documentation

--- a/internal/bench/block_bench_test.go
+++ b/internal/bench/block_bench_test.go
@@ -1,0 +1,615 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bench
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/internal/testdata"
+	"github.com/blinklabs-io/gouroboros/kes"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/blinklabs-io/gouroboros/vrf"
+)
+
+// Default Cardano mainnet parameters
+const (
+	// slotsPerKesPeriod is 129600 on mainnet (1.5 days in slots)
+	defaultSlotsPerKesPeriod = 129600
+)
+
+// kesData holds pre-extracted KES verification data for a block.
+type kesData struct {
+	name      string
+	bodyCbor  []byte
+	signature []byte
+	hotVkey   []byte
+	kesPeriod uint64
+	slot      uint64
+}
+
+// extractKesData extracts KES verification data from post-Byron blocks.
+// Blocks whose headers cannot be CBOR-encoded are skipped; their names are
+// returned in the skipped slice so callers can surface missing-era coverage.
+func extractKesData(blocks []blockData) ([]kesData, []string) {
+	result := make([]kesData, 0, len(blocks))
+	var skipped []string
+
+	for _, bd := range blocks {
+		header := bd.block.Header()
+		var bodyCbor []byte
+		var sig []byte
+		var hotVkey []byte
+		var kesPeriod uint64
+		var err error
+
+		switch h := header.(type) {
+		case *shelley.ShelleyBlockHeader:
+			bodyCbor, err = cbor.Encode(h.Body)
+			if err != nil {
+				skipped = append(skipped, bd.name)
+				continue
+			}
+			sig = h.Signature
+			hotVkey = h.Body.OpCertHotVkey
+			kesPeriod = uint64(h.Body.OpCertKesPeriod)
+		case *allegra.AllegraBlockHeader:
+			bodyCbor, err = cbor.Encode(h.Body)
+			if err != nil {
+				skipped = append(skipped, bd.name)
+				continue
+			}
+			sig = h.Signature
+			hotVkey = h.Body.OpCertHotVkey
+			kesPeriod = uint64(h.Body.OpCertKesPeriod)
+		case *mary.MaryBlockHeader:
+			bodyCbor, err = cbor.Encode(h.Body)
+			if err != nil {
+				skipped = append(skipped, bd.name)
+				continue
+			}
+			sig = h.Signature
+			hotVkey = h.Body.OpCertHotVkey
+			kesPeriod = uint64(h.Body.OpCertKesPeriod)
+		case *alonzo.AlonzoBlockHeader:
+			bodyCbor, err = cbor.Encode(h.Body)
+			if err != nil {
+				skipped = append(skipped, bd.name)
+				continue
+			}
+			sig = h.Signature
+			hotVkey = h.Body.OpCertHotVkey
+			kesPeriod = uint64(h.Body.OpCertKesPeriod)
+		case *babbage.BabbageBlockHeader:
+			bodyCbor, err = cbor.Encode(h.Body)
+			if err != nil {
+				skipped = append(skipped, bd.name)
+				continue
+			}
+			sig = h.Signature
+			hotVkey = h.Body.OpCert.HotVkey
+			kesPeriod = uint64(h.Body.OpCert.KesPeriod)
+		case *conway.ConwayBlockHeader:
+			bodyCbor, err = cbor.Encode(h.Body)
+			if err != nil {
+				skipped = append(skipped, bd.name)
+				continue
+			}
+			sig = h.Signature
+			hotVkey = h.Body.OpCert.HotVkey
+			kesPeriod = uint64(h.Body.OpCert.KesPeriod)
+		default:
+			skipped = append(skipped, bd.name)
+			continue
+		}
+
+		result = append(result, kesData{
+			name:      bd.name,
+			bodyCbor:  bodyCbor,
+			signature: sig,
+			hotVkey:   hotVkey,
+			kesPeriod: kesPeriod,
+			slot:      header.SlotNumber(),
+		})
+	}
+	return result, skipped
+}
+
+// benchConfig returns a VerifyConfig suitable for benchmarks.
+// It skips transaction and stake pool validation since we're focusing on
+// block-level validation (VRF, KES, body hash).
+func benchConfig() common.VerifyConfig {
+	return common.VerifyConfig{
+		SkipBodyHashValidation:    false,
+		SkipTransactionValidation: true,
+		SkipStakePoolValidation:   true,
+	}
+}
+
+// blockData holds parsed block information for benchmarks.
+type blockData struct {
+	name      string
+	blockType uint
+	cbor      []byte
+	block     ledger.Block
+}
+
+// loadTestBlocks loads all test blocks from testdata.
+// It panics if any block fails to load.
+func loadTestBlocks() []blockData {
+	testBlocks := testdata.GetTestBlocks()
+	result := make([]blockData, 0, len(testBlocks))
+
+	for _, tb := range testBlocks {
+		// Skip Byron for VRF/KES benchmarks as it uses different validation
+		block, err := ledger.NewBlockFromCbor(
+			tb.BlockType,
+			tb.Cbor,
+			benchConfig(),
+		)
+		if err != nil {
+			panic("failed to load " + tb.Name + " block: " + err.Error())
+		}
+		result = append(result, blockData{
+			name:      tb.Name,
+			blockType: tb.BlockType,
+			cbor:      tb.Cbor,
+			block:     block,
+		})
+	}
+	return result
+}
+
+// getPostByronBlocks filters out Byron blocks since they use different
+// validation.
+func getPostByronBlocks(blocks []blockData) []blockData {
+	result := make([]blockData, 0, len(blocks))
+	for _, b := range blocks {
+		if b.blockType != ledger.BlockTypeByronMain &&
+			b.blockType != ledger.BlockTypeByronEbb {
+			result = append(result, b)
+		}
+	}
+	return result
+}
+
+// BenchmarkBlockValidation benchmarks block decode + KES + body hash validation
+// by era.
+// Note: VRF verification is not included because test blocks lack matching
+// epoch nonces.  Using a dummy eta0 would cause VerifyBlock to return on VRF
+// failure and skip KES/body-hash checks entirely.  Instead we call the
+// individual validation components so the benchmark measures real work.
+func BenchmarkBlockValidation(b *testing.B) {
+	blocks := loadTestBlocks()
+	postByronBlocks := getPostByronBlocks(blocks)
+
+	for _, bd := range postByronBlocks {
+		b.Run("Era_"+bd.name, func(b *testing.B) {
+			cfg := benchConfig()
+			cfg.SkipBodyHashValidation = true
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				block, err := ledger.NewBlockFromCbor(
+					bd.blockType,
+					bd.cbor,
+					cfg,
+				)
+				if err != nil {
+					b.Fatal(err)
+				}
+
+				// KES verification
+				valid, err := ledger.VerifyKes(
+					block.Header(),
+					defaultSlotsPerKesPeriod,
+				)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if !valid {
+					b.Fatal("KES verification returned false")
+				}
+
+				// Body hash validation
+				era := block.Era()
+				minLength := 4
+				if era.Id >= alonzo.EraAlonzo.Id {
+					minLength = 5
+				}
+				err = common.ValidateBlockBodyHash(
+					block.Cbor(),
+					block.BlockBodyHash(),
+					era.Name,
+					minLength,
+				)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkBlockValidationPreParsed benchmarks KES + body hash validation
+// with pre-parsed blocks.
+// This isolates the validation cost from parsing overhead.
+// Note: VRF verification is excluded because test blocks lack matching epoch
+// nonces, which would cause VerifyBlock to return on VRF failure and skip the
+// KES/body-hash checks entirely.
+func BenchmarkBlockValidationPreParsed(b *testing.B) {
+	blocks := loadTestBlocks()
+	postByronBlocks := getPostByronBlocks(blocks)
+
+	for _, bd := range postByronBlocks {
+		b.Run("Era_"+bd.name, func(b *testing.B) {
+			// Pre-compute era-specific parameters
+			era := bd.block.Era()
+			minLength := 4
+			if era.Id >= alonzo.EraAlonzo.Id {
+				minLength = 5
+			}
+			blockCbor := bd.block.Cbor()
+			bodyHash := bd.block.BlockBodyHash()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				// KES verification
+				valid, err := ledger.VerifyKes(
+					bd.block.Header(),
+					defaultSlotsPerKesPeriod,
+				)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if !valid {
+					b.Fatal("KES verification returned false")
+				}
+
+				// Body hash validation
+				err = common.ValidateBlockBodyHash(
+					blockCbor,
+					bodyHash,
+					era.Name,
+					minLength,
+				)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkBlockVRFVerification benchmarks VRF verification isolated from other
+// validation.
+func BenchmarkBlockVRFVerification(b *testing.B) {
+	blocks := loadTestBlocks()
+	postByronBlocks := getPostByronBlocks(blocks)
+
+	// Pre-extract VRF data for each block
+	type vrfData struct {
+		name   string
+		vrfKey []byte
+		proof  []byte
+		output []byte
+		slot   uint64
+	}
+
+	vrfDataList := make([]vrfData, 0, len(postByronBlocks))
+
+	for _, bd := range postByronBlocks {
+		header := bd.block.Header()
+		var vrfResult common.VrfResult
+		var vrfKey []byte
+
+		switch h := header.(type) {
+		case *shelley.ShelleyBlockHeader:
+			vrfResult = h.Body.LeaderVrf
+			vrfKey = h.Body.VrfKey
+		case *allegra.AllegraBlockHeader:
+			vrfResult = h.Body.LeaderVrf
+			vrfKey = h.Body.VrfKey
+		case *mary.MaryBlockHeader:
+			vrfResult = h.Body.LeaderVrf
+			vrfKey = h.Body.VrfKey
+		case *alonzo.AlonzoBlockHeader:
+			vrfResult = h.Body.LeaderVrf
+			vrfKey = h.Body.VrfKey
+		case *babbage.BabbageBlockHeader:
+			vrfResult = h.Body.VrfResult
+			vrfKey = h.Body.VrfKey
+		case *conway.ConwayBlockHeader:
+			vrfResult = h.Body.VrfResult
+			vrfKey = h.Body.VrfKey
+		default:
+			continue
+		}
+
+		vrfDataList = append(vrfDataList, vrfData{
+			name:   bd.name,
+			vrfKey: vrfKey,
+			proof:  vrfResult.Proof,
+			output: vrfResult.Output,
+			slot:   header.SlotNumber(),
+		})
+	}
+
+	// Create test eta0 (32 bytes of zeros). This intentionally does not
+	// match the real epoch nonce, so VRF verification will fail. We use
+	// a fixed all-zero value because this benchmark isolates VRF
+	// cryptographic performance (Verify call cost), not correctness.
+	eta0 := make([]byte, 32)
+
+	for _, vd := range vrfDataList {
+		b.Run("Era_"+vd.name, func(b *testing.B) {
+			// Pre-compute the VRF input message
+			vrfMsg := vrf.MkInputVrf(int64(vd.slot), eta0)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				valid, err := vrf.Verify(vd.vrfKey, vd.proof, vd.output, vrfMsg)
+				if err != nil {
+					b.Fatalf("VRF verify failed: %v", err)
+				}
+				benchSink = valid
+			}
+		})
+	}
+}
+
+// BenchmarkBlockKESVerification benchmarks KES verification isolated from other
+// validation.
+func BenchmarkBlockKESVerification(b *testing.B) {
+	blocks := loadTestBlocks()
+	postByronBlocks := getPostByronBlocks(blocks)
+
+	kesDataList, skipped := extractKesData(postByronBlocks)
+	if len(skipped) > 0 {
+		b.Logf("skipped blocks: %v", skipped)
+	}
+
+	for _, kd := range kesDataList {
+		b.Run("Era_"+kd.name, func(b *testing.B) {
+			currentKesPeriod := kd.slot / defaultSlotsPerKesPeriod
+			if currentKesPeriod < kd.kesPeriod {
+				b.Skipf(
+					"slot-derived KES period %d < cert KES period %d",
+					currentKesPeriod,
+					kd.kesPeriod,
+				)
+				return
+			}
+			t := currentKesPeriod - kd.kesPeriod
+
+			// Pre-validate
+			if !kes.VerifySignedKES(kd.hotVkey, t, kd.bodyCbor, kd.signature) {
+				b.Skipf("KES verification failed for %s", kd.name)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchSink = kes.VerifySignedKES(
+					kd.hotVkey,
+					t,
+					kd.bodyCbor,
+					kd.signature,
+				)
+			}
+		})
+	}
+}
+
+// BenchmarkBlockBodyHash benchmarks body hash validation isolated from other
+// validation.
+func BenchmarkBlockBodyHash(b *testing.B) {
+	blocks := loadTestBlocks()
+	postByronBlocks := getPostByronBlocks(blocks)
+
+	// Pre-extract body hash data for each block
+	type bodyHashData struct {
+		name         string
+		cbor         []byte
+		expectedHash common.Blake2b256
+		eraName      string
+		minLength    int
+	}
+
+	bodyHashDataList := make([]bodyHashData, 0, len(postByronBlocks))
+
+	for _, bd := range postByronBlocks {
+		era := bd.block.Era()
+		minLength := 4
+		if era.Id >= alonzo.EraAlonzo.Id {
+			minLength = 5
+		}
+
+		bodyHashDataList = append(bodyHashDataList, bodyHashData{
+			name:         bd.name,
+			cbor:         bd.cbor,
+			expectedHash: bd.block.BlockBodyHash(),
+			eraName:      era.Name,
+			minLength:    minLength,
+		})
+	}
+
+	for _, bhd := range bodyHashDataList {
+		b.Run("Era_"+bhd.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				err := common.ValidateBlockBodyHash(
+					bhd.cbor,
+					bhd.expectedHash,
+					bhd.eraName,
+					bhd.minLength,
+				)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkBlockDecode benchmarks block CBOR decoding by era.
+// This isolates parsing performance from validation.
+func BenchmarkBlockDecode(b *testing.B) {
+	blocks := testdata.GetTestBlocks()
+
+	for _, tb := range blocks {
+		b.Run("Era_"+tb.Name, func(b *testing.B) {
+			// Use config that skips body hash to isolate decode performance
+			cfg := common.VerifyConfig{
+				SkipBodyHashValidation:    true,
+				SkipTransactionValidation: true,
+				SkipStakePoolValidation:   true,
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := ledger.NewBlockFromCbor(tb.BlockType, tb.Cbor, cfg)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkBlockDecodeWithBodyHash benchmarks block decoding with body hash
+// validation.
+func BenchmarkBlockDecodeWithBodyHash(b *testing.B) {
+	blocks := testdata.GetTestBlocks()
+
+	for _, tb := range blocks {
+		// Skip Byron as it doesn't have body hash validation
+		if tb.BlockType == ledger.BlockTypeByronMain ||
+			tb.BlockType == ledger.BlockTypeByronEbb {
+			continue
+		}
+
+		b.Run("Era_"+tb.Name, func(b *testing.B) {
+			cfg := common.VerifyConfig{
+				SkipBodyHashValidation:    false,
+				SkipTransactionValidation: true,
+				SkipStakePoolValidation:   true,
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := ledger.NewBlockFromCbor(tb.BlockType, tb.Cbor, cfg)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkMkInputVrf benchmarks VRF input creation for leader election.
+// This is the vrf.MkInputVrf function used in block validation.
+func BenchmarkMkInputVrf(b *testing.B) {
+	blocks := loadTestBlocks()
+	postByronBlocks := getPostByronBlocks(blocks)
+
+	eta0 := make([]byte, 32)
+	for i := range eta0 {
+		eta0[i] = byte(i)
+	}
+
+	for _, bd := range postByronBlocks {
+		b.Run("Era_"+bd.name, func(b *testing.B) {
+			slot := int64(bd.block.Header().SlotNumber())
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = vrf.MkInputVrf(slot, eta0)
+			}
+		})
+	}
+}
+
+// BenchmarkVerifyKesComponents benchmarks the full KES components verification.
+// This matches what VerifyBlock calls internally.
+func BenchmarkVerifyKesComponents(b *testing.B) {
+	blocks := loadTestBlocks()
+	postByronBlocks := getPostByronBlocks(blocks)
+
+	kesDataList, skipped := extractKesData(postByronBlocks)
+	if len(skipped) > 0 {
+		b.Logf("skipped blocks: %v", skipped)
+	}
+
+	for _, kd := range kesDataList {
+		b.Run("Era_"+kd.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				verified, err := ledger.VerifyKesComponents(
+					kd.bodyCbor,
+					kd.signature,
+					kd.hotVkey,
+					kd.kesPeriod,
+					kd.slot,
+					defaultSlotsPerKesPeriod,
+				)
+				if err != nil {
+					b.Fatalf("KES verify failed: %v", err)
+				}
+				if !verified {
+					b.Fatalf("KES verification returned false")
+				}
+				benchSink = verified
+			}
+		})
+	}
+}
+
+// BenchmarkHeaderCborEncode benchmarks CBOR encoding of header bodies.
+// This is required for KES verification.
+func BenchmarkHeaderCborEncode(b *testing.B) {
+	blocks := loadTestBlocks()
+	postByronBlocks := getPostByronBlocks(blocks)
+
+	for _, bd := range postByronBlocks {
+		b.Run("Era_"+bd.name, func(b *testing.B) {
+			header := bd.block.Header()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := ledger.GetHeaderBodyCbor(header)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/internal/bench/cbor_bench_test.go
+++ b/internal/bench/cbor_bench_test.go
@@ -1,0 +1,394 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bench
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/internal/testdata"
+	"github.com/blinklabs-io/gouroboros/ledger"
+)
+
+// Transaction CBOR test data from ledger/tx_test.go
+// These are real mainnet transactions representing various eras
+//
+//nolint:lll // Long hex strings are test fixtures - cannot be wrapped
+var (
+	byronTxCborHex   = "82838080a080"
+	shelleyTxCborHex = "83a5008182582086e5ea8e926955f7b35e94c7a8a7ce9837928752bdf7c2a099bfeb56de0f9c6e01018182583901beea25bc9b21865d0b6fd7b61033cea4e5ab97378fcf53305f178b581c644bf11e7528a7e230125a8b7a1dbceea8ee033aea783fd94e3be71b0000000e15f87186021a001c4b7a031a0044c57804828a03581ccc1008a2bff95e4fa408a8d8d4adfac342120307e0fb3c713fce88345820df5b4f160800ea24e4e328b12e0598653591330f0afa86b71d081ba21be777d71b0000000df84758001a1443fd00d81e82111901f4581de11c644bf11e7528a7e230125a8b7a1dbceea8ee033aea783fd94e3be781581c1c644bf11e7528a7e230125a8b7a1dbceea8ee033aea783fd94e3be7848400191f9144d161aec5f68400191f9244d161aec5f68400191f9144640b0c2ef68400191f9244640b0c2ef682782268747470733a2f2f6265747465727374616b652e636f6d2f62706f6f6c2e6a736f6e5820b5b2bc313684b4410d091b374b42a18701dde1b1365037490f94d8c5b473d42f83028200581c1c644bf11e7528a7e230125a8b7a1dbceea8ee033aea783fd94e3be7581ccc1008a2bff95e4fa408a8d8d4adfac342120307e0fb3c713fce8834a10083825820722391106ef912f0cdbe2e1353b9c370fb55e8d197ff9e97662ae95cf21a32a95840b70df72a21791ac1648c83b926c7604623e81696d857ce3da48ad0a1f3a8c59787a9104268eba8cb0420db34c5b4a2c0219c7a6e7b6f274a824653ebd797bd028258204cd4ea9234d75f088b21015e6f15b4aca66cd02394678e9d9563dc6d89305190584012cee31daa17c580bc0b8b0462b24cc2589a8fdb74005baa04022349e6257909d42ea10ba2e7fbfbe8974f74bf564c1aa2e1fe5ff36eab9b958f296c7d8db00682582050b9afde3642819ddad24be4bfbf9b7b08b00aa1254b4f9eb9bce779e977cb5258400097a1b083ff4fe74edb7486c7a2dbcbfccf83bacb819b7fad7bb3849575dca41f516bb77b8c4c78420704774658f7654d7c4314793daaccbdb68689c2bd8003f6"
+	allegraTxCborHex = "83a500818258207c685f9d47332cee3c54afba19b6e2bb8ab402c4bb29cef2353ec178ced2501b010181825839013181113a038b59ab33a32e4db71e57562c08183c95fe0dcdd9600068ba98d33801b8794c5b20efe7f740a43a1c82e9ca02f10f6c20ffa5e81a04ce7af2021a00032acd031a00fd221904818a03581c6d9ce533e4874ff84f89a0f1d2f8a26c0838898ba16fcf66aa790c9e58203d5023f152e4c230c71fe09165ea754b484cfc7557fa8fd48b792cbf2edf42271b000000746a5288001a1443fd00d81e82011828581de10122c6ccb1533c9992ff08a9029b7b5a016d5c08d31a4963cd027afc82581c50980d844ceff6882f9d56fa94bc21c932e336c4136df1ecc91951a1581cba98d33801b8794c5b20efe7f740a43a1c82e9ca02f10f6c20ffa5e88183011917706c36322e3131362e3138322e3682782a68747470733a2f2f377275332e636f6d2f6d657461646174612f747275655f3038323032302e6a736f6e58207778c9ba2c70915cbd67783d0a1d20df2b16469ec3b178b90ec2aef4ddceca35a10085825820dd767642628c78208833b8e3fae2e2896fda0293eecbd1a13bfbef7b088462ed584058a59c7f50b28e36759e10e6616ddffb245d21256111d9d7c50a91491301786309470f1714026d2e951562c40fbc7877826238a8b2260b4aeeee456e56bbc108825820ae621ba88e58d56cefd82f454360b33527bf2b8b958ce0392bae644bf444dbc55840f7a42f2afdbcc5176fdcdb28de9d723c0e38290381a65468cc4d223d73bed2893e4fe87a71564eb8a6f9367a1e86dc034aa35fcfa44d1530dddbfc762522fa0d825820cecd648d4e4bd55d92eb0e8d28d217a65b0d1d609b904b28ef77d1ba6edd26e358403e7d28b9686b1af9d9c004e7d0cdb9618e8356a1ec4b61231b9c71e4c673aa2cb6ad689ac1d941ed5878113fc792f3d1e49c0ccd9d09ea69b776fe49dfbb39028258206a6be24f4c436aebea0fce9a3ed03666c4d66fbd66857f7ff8504a44061642485840e4c009d38b9d2c86ef3c019b8d3d9d973e108035bb41a71c71f44e682631ed095972075e2a0daf607b12f5bc414d4fb343f34b1752299e84b68233dccf53f90882582009fbfe452aef3d3ad946e45192a676761e8cb408f49636531272c180dec0364b584081cb9a113aa5fbd654bcb7d34df0e8b8340ba03bdafdb69d0906e817b7da0d0b6a6cba882fb4424579a614d13466115d905f9558a9d947e495dbd22cbc14d409f6"
+	maryTxCborHex    = "83a50081825820377732953cbd7eb824e58291dd08599cfcfe6eedb49f590633610674fc3c33c50001818258390187acac5a3d0b41cd1c5e8c03af5be782f261f21beed70970ddee0873ae34f9d442c7f1a01de9f2dd520791122d6fbf3968c5f8328e9091331a597dbcf1021a0002fd99031a025c094a04828a03581c27b1b4470c84db78ce1ffbfff77bb068abb4e47d43cb6009caaa352358204a7537ce9eeaba1c650261f167827b4e12dd403c4bf13c56b2cba06288f7e9ab1a59682f001a1443fd00d81e82011864581de1ae34f9d442c7f1a01de9f2dd520791122d6fbf3968c5f8328e90913381581cae34f9d442c7f1a01de9f2dd520791122d6fbf3968c5f8328e9091338183011917706e33342e3139382e3234312e323336827468747470733a2f2f6769742e696f2f4a7543786e5820fa77d30bb41e2998233245d269ff5763ecf4371388214943ecef277cae45492783028200581cae34f9d442c7f1a01de9f2dd520791122d6fbf3968c5f8328e909133581c27b1b4470c84db78ce1ffbfff77bb068abb4e47d43cb6009caaa3523a10083825820922a22d07c0ca148105760cb767ece603574ea465d6697c87da8207c8936ebea58405594a100197379c0de715de0b5304e0546e661dae2f36b12173cc150a42215356a5600bf0c02954f02ce3620cfb7f12c23a19328fd00dd1194b4f363675ef407825820727c1891d01cf29ccd1146528221827dcf00a093498509404af77a8b15d77c925840f52e0e1403167212b11fe5d87b7cfdb2f39e5384979ac3625917127ad46763d864a7fcb7147c7b85322ada7ba8fe91c0b5152c74ef4ff0c8132b125e681af50382582073c16f2b67ff85307c4c5935bad1389b9ead473419dbad20f5d5e6436982992b58400572eed773b9a199fd486ebe61b480f05803d107ea97ff649f28b8874d3117f890f80657cbb6eea0d833c21e4e8bc7f1a27cddb9e24fc1ed79b04ddbdcd11d0ff6"
+	alonzoTxCborHex  = "84a400838258203650540ca26b22596543862300899b7e51af75f933dd70c8bc717e6f9346d5bc018258207cd6c8a610c6b89782b05266138840491def8a5b1dedc169eb5f48f83c811c5800825820a90046b2c507d970350dd101f80cae88099eb9c16ff58dc2ca3141cebe14b7d601018282581d61a17caf4da8995968c9afa0baf2d5b53cdcb9ce00e9f6fcb442b3dae61a002dc6c082583901f361a13e63dfa5a0e9ea26320b27bca5ab944564c823425841c075f2c342a4c6c2ddb549715b4c6e58b36043639297c0b3d2c381562865b0821a0dd83fa5b4581c01e3c1b5e7ce94a556bead799ca036bc0c84bc16674dbeff6f2f04e0a14f4242426574614c61727665314e723301581c0d9cb6eff0cb4e8df5b9b44a4af445dd1245d48eaa6b9be04482c2ada14f4242426574614c61727665314e723201581c11cca1d26fc711f4119122dcafbf371d014aec3fb94aae5b18060694a14b424242657461456767303909581c36ef74427e125936104d8aeb85e19c25b4b7cc610a39f9092e755178a14b424242657461456767303308581c5de5d32c2ad78fcd07444a859a6ee13f53a026271773396340c4252ea14b424242657461456767303809581c6377c2c3e02818ec06daa91d27c98dfc2f9920c43d39c172fe294b41a14b424242657461456767303509581c6e6c6a46823e4ac4a61a9bcdcee5a32cb23a525c31792e63248bbb46a1504242426574614c6172766530304e723201581c716c311894af097cc07b4be39ae56153a995d5a1b268eda0eecfb8e1a1504242426574614c6172766530304e723701581c82c7122974aff4a6d9f26162898d5d9847bdd205f0ff8e6dc05c3b47a14d4242426574614c61727665303001581c835fade7ad9e2fb1938a807185c7a056086b70b6799392c31e7b7248a14b424242657461456767303409581c84f306c414a9a54f06045aedf1729e7166dd617bc66cb7a4ffe860a8a14b424242657461456767303209581c87921b425a0467f6b91e8ff67f94139f06836f1bd1a92711eb64d3bba1504242426574614c6172766530304e723601581c92b68843d0b714c0c5dfbdd11780f356f9a40eb189b38bb7f73b875fa1504242426574614c6172766530304e723501581caa093a4d6922ef15ea9d25d3382d1081b6d64731db8e47a74bff26f0a14b424242657461456767313009581cb71cecdd7dac01afb2dcf562311bcd2023690aec9b4634cd92f0a1bca14f4242426574614c61727665314e723101581cc4e9a75d751901fc531705fb6a19af8116bc33a7aa34496878cda14da1504242426574614c6172766530304e723401581cccbd38f09601415028647dd65895d27ba635ce9ff3fe49437596ff52a14b424242657461456767303709581cd2f7ab6723239cf8095ea6865b7d24f641ba011763336450641199a1a14b424242657461456767303109581ce19178a4757457dd76be8a12b51cda5f9fde90ef9e4ffce0912b51a8a14b424242657461456767303609581ce1b91ebf52575643fd8ee4963065a3284723501d65355ef2e1f32cd3a1504242426574614c6172766530304e723301021a00038115031a02613161a10083825820cc6834b6867893cb053c638622e2b574ebc9a6183c6b521431d58fceec155a7e58409f1cfeb1377f6c6ad27ab71f6e7ab993fab537a7855e92163433b817da34f310660584930fa5506a364471a0c8d069c906ccb63d10c32b94f00996f1be681c0d82582074b4821f97da974ca2b4c7b14421e587a1eddf90ff9b914507e4011fe8d3409d584077ad90d93a2ffc410fa5502056039073d4c270fdbde7c77d81e8e6ffaf22a2197e613838e0591fd176917cc2df1f1f97fc256ed15a70247fa5f2c24168b5e10d82582021f8ac17f9995e8334da3c5dce41bec5cd28019c98d4f3b79bb18138867e593c5840efcd97da471dd6e2337564e17158bf54a094ee999b860600e0ece23d135d191bbdc66466faf801714bac1ddbb454375f477246b01baf535cebde843bcb03cd05f5f6"
+	babbageTxCborHex = "84a40081825820e8f54ff4cfcb14a11995995e99b8445b977badaf1f13130ba7f9140e2d8ef40f01018282581d6124d274bfd913b241a8cca20c6977775718fddb8f3763f1d365c854451a001e848082583901c7cfad58a5cbce2a0460f304a3b47df1a3f5ad17f118ed1b07c929c1245fce8a5f9aa0ccc732a20a39630205a74e2500014544b80d7c62c51a009f1df5021a00028cad031a050ef54da10081825820f9e738c0a455f79529e807e2382da4392d8c57636ca1fccef9414186af07e05958406a219088d2b13beff7006780f210b403666e3f20e04a4a3dc560091e255e5e5c2366a0187936026a63017b23c3c498801475c718edaccde0b3c568557052ad0cf5f6"
+	conwayTxCborHex  = "84a500d9010281825820279184037d249e397d97293738370756da559718fcdefae9924834840046b37b01018282583900923d4b64e1d730a4baf3e6dc433a9686983940f458363f37aad7a1a9568b72f85522e4a17d44a45cd021b9741b55d7cbc635c911625b015e1a00a9867082583900923d4b64e1d730a4baf3e6dc433a9686983940f458363f37aad7a1a9568b72f85522e4a17d44a45cd021b9741b55d7cbc635c911625b015e1b00000001267d7b04021a0002938d031a04e304e70800a100d9010281825820b829480e5d5827d2e1bd7c89176a5ca125c30812e54be7dbdf5c47c835a17f3d5840b13a76e7f2b19cde216fcad55ceeeb489ebab3dcf63ef1539ac4f535dece00411ee55c9b8188ef04b4aa3c72586e4a0ec9b89949367d7270fdddad3b18731403f5f6"
+)
+
+// TestBlock contains pre-decoded block data for benchmarks
+type testBlockData struct {
+	name      string
+	blockType uint
+	cbor      []byte
+}
+
+// Pre-loaded block data for benchmarks (initialized in init)
+var testBlocks = make([]testBlockData, 0)
+
+// Pre-loaded transaction data for benchmarks
+type testTxData struct {
+	name   string
+	txType uint
+	cbor   []byte
+}
+
+var testTxs = make([]testTxData, 0)
+
+func init() {
+	// Load block test data from internal/testdata
+	for _, tb := range testdata.GetTestBlocks() {
+		testBlocks = append(testBlocks, testBlockData{
+			name:      tb.Name,
+			blockType: tb.BlockType,
+			cbor:      tb.Cbor,
+		})
+	}
+
+	// Load transaction test data
+	testTxs = []testTxData{
+		{
+			name:   "Byron",
+			txType: ledger.TxTypeByron,
+			cbor:   testdata.MustDecodeHex(byronTxCborHex),
+		},
+		{
+			name:   "Shelley",
+			txType: ledger.TxTypeShelley,
+			cbor:   testdata.MustDecodeHex(shelleyTxCborHex),
+		},
+		{
+			name:   "Allegra",
+			txType: ledger.TxTypeAllegra,
+			cbor:   testdata.MustDecodeHex(allegraTxCborHex),
+		},
+		{
+			name:   "Mary",
+			txType: ledger.TxTypeMary,
+			cbor:   testdata.MustDecodeHex(maryTxCborHex),
+		},
+		{
+			name:   "Alonzo",
+			txType: ledger.TxTypeAlonzo,
+			cbor:   testdata.MustDecodeHex(alonzoTxCborHex),
+		},
+		{
+			name:   "Babbage",
+			txType: ledger.TxTypeBabbage,
+			cbor:   testdata.MustDecodeHex(babbageTxCborHex),
+		},
+		{
+			name:   "Conway",
+			txType: ledger.TxTypeConway,
+			cbor:   testdata.MustDecodeHex(conwayTxCborHex),
+		},
+	}
+}
+
+// BenchmarkCBORDecodeBlock benchmarks CBOR block decoding by era.
+// Uses real mainnet blocks from internal/testdata to measure actual decode
+// performance.
+func BenchmarkCBORDecodeBlock(b *testing.B) {
+	for _, tb := range testBlocks {
+		b.Run(tb.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(tb.cbor)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := ledger.NewBlockFromCbor(tb.blockType, tb.cbor)
+				if err != nil {
+					b.Fatalf("failed to decode %s block: %v", tb.name, err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkCBORDecodeBlockParallel benchmarks parallel block decoding.
+// This measures throughput under concurrent load.
+func BenchmarkCBORDecodeBlockParallel(b *testing.B) {
+	for _, tb := range testBlocks {
+		b.Run(tb.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(tb.cbor)))
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					_, err := ledger.NewBlockFromCbor(tb.blockType, tb.cbor)
+					if err != nil {
+						b.Errorf("failed to decode %s block: %v", tb.name, err)
+						return
+					}
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkCBORDecodeTx benchmarks CBOR transaction decoding by era.
+// Uses real mainnet transactions to measure decode performance.
+func BenchmarkCBORDecodeTx(b *testing.B) {
+	for _, tx := range testTxs {
+		b.Run(tx.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(tx.cbor)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := ledger.NewTransactionFromCbor(tx.txType, tx.cbor)
+				if err != nil {
+					b.Fatalf("failed to decode %s tx: %v", tx.name, err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkCBORDecodeTxParallel benchmarks parallel transaction decoding.
+func BenchmarkCBORDecodeTxParallel(b *testing.B) {
+	for _, tx := range testTxs {
+		b.Run(tx.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(tx.cbor)))
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					_, err := ledger.NewTransactionFromCbor(tx.txType, tx.cbor)
+					if err != nil {
+						b.Errorf("failed to decode %s tx: %v", tx.name, err)
+						return
+					}
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkCBOREncodeBlock benchmarks CBOR block encoding by era.
+// Pre-decodes blocks and then re-encodes them via cbor.Encode to measure
+// actual serialization performance (not cached byte retrieval).
+func BenchmarkCBOREncodeBlock(b *testing.B) {
+	for _, tb := range testBlocks {
+		// Pre-decode the block
+		block, err := ledger.NewBlockFromCbor(tb.blockType, tb.cbor)
+		if err != nil {
+			b.Fatalf("failed to pre-decode %s block: %v", tb.name, err)
+		}
+
+		b.Run(tb.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				result, err := cbor.Encode(block)
+				if err != nil {
+					b.Fatalf("failed to encode %s block: %v", tb.name, err)
+				}
+				if len(result) == 0 {
+					b.Fatalf("empty CBOR result for %s block", tb.name)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkCBOREncodeTx benchmarks CBOR transaction encoding by era.
+// Pre-decodes transactions and then re-encodes them via cbor.Encode to measure
+// actual serialization performance (not cached byte retrieval).
+func BenchmarkCBOREncodeTx(b *testing.B) {
+	for _, tx := range testTxs {
+		// Pre-decode the transaction
+		transaction, err := ledger.NewTransactionFromCbor(tx.txType, tx.cbor)
+		if err != nil {
+			b.Fatalf("failed to pre-decode %s tx: %v", tx.name, err)
+		}
+
+		b.Run(tx.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				result, err := cbor.Encode(transaction)
+				if err != nil {
+					b.Fatalf("failed to encode %s tx: %v", tx.name, err)
+				}
+				if len(result) == 0 {
+					b.Fatalf("empty CBOR result for %s tx", tx.name)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkCBORDecodeRaw benchmarks low-level cbor.Decode for simple types.
+// This isolates the CBOR decoder overhead from ledger type construction.
+func BenchmarkCBORDecodeRaw(b *testing.B) {
+	if len(testBlocks) == 0 {
+		b.Fatal("no test blocks available")
+	}
+	// Use the smallest block for raw decode benchmarking
+	smallestBlock := testBlocks[0]
+	for _, tb := range testBlocks {
+		if len(tb.cbor) < len(smallestBlock.cbor) {
+			smallestBlock = tb
+		}
+	}
+
+	b.Run("RawValue", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(smallestBlock.cbor)))
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var v cbor.Value
+			_, err := cbor.Decode(smallestBlock.cbor, &v)
+			if err != nil {
+				b.Fatalf("failed to decode: %v", err)
+			}
+		}
+	})
+
+	b.Run("RawMessage", func(b *testing.B) {
+		b.ReportAllocs()
+		b.SetBytes(int64(len(smallestBlock.cbor)))
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var v cbor.RawMessage
+			_, err := cbor.Decode(smallestBlock.cbor, &v)
+			if err != nil {
+				b.Fatalf("failed to decode: %v", err)
+			}
+		}
+	})
+}
+
+// BenchmarkCBOREncode benchmarks low-level cbor.Encode for various data sizes.
+func BenchmarkCBOREncode(b *testing.B) {
+	// Small: simple map
+	smallData := map[string]int{"a": 1, "b": 2, "c": 3}
+
+	// Medium: nested structure
+	mediumData := map[string]any{
+		"inputs":  [][]byte{{1, 2, 3}, {4, 5, 6}},
+		"outputs": []map[string]any{{"addr": "abc", "value": 1000}},
+		"fee":     42,
+	}
+
+	// Large: array of maps (simulating tx outputs)
+	largeData := make([]map[string]any, 100)
+	for i := range largeData {
+		largeData[i] = map[string]any{
+			"address": make([]byte, 57),
+			"value":   uint64(i * 1000000),
+			"assets":  map[string]uint64{"token1": 100, "token2": 200},
+		}
+	}
+
+	b.Run("Small", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := cbor.Encode(smallData)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("Medium", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := cbor.Encode(mediumData)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("Large", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := cbor.Encode(largeData)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkCBORRoundTrip benchmarks decode + encode cycle.
+// This measures the complete serialization overhead using actual re-encoding
+// via cbor.Encode (not cached byte retrieval).
+func BenchmarkCBORRoundTrip(b *testing.B) {
+	for _, tb := range testBlocks {
+		b.Run(tb.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(tb.cbor)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				block, err := ledger.NewBlockFromCbor(tb.blockType, tb.cbor)
+				if err != nil {
+					b.Fatalf("failed to decode: %v", err)
+				}
+				result, err := cbor.Encode(block)
+				if err != nil {
+					b.Fatalf("failed to encode: %v", err)
+				}
+				if len(result) == 0 {
+					b.Fatal("empty encode result")
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkCBORDecodeBlockWithOffsets benchmarks block decoding with offset
+// extraction.
+// This uses the streaming decoder to extract transaction offsets.
+// Note: Byron blocks have a different structure and are not supported by the
+// streaming decoder.
+func BenchmarkCBORDecodeBlockWithOffsets(b *testing.B) {
+	for _, tb := range testBlocks {
+		// Skip Byron - its structure is incompatible with the streaming offset
+		// decoder
+		if tb.blockType == ledger.BlockTypeByronMain || tb.blockType == ledger.BlockTypeByronEbb {
+			continue
+		}
+		b.Run(tb.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(tb.cbor)))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := ledger.NewBlockFromCborWithOffsets(
+					tb.blockType,
+					tb.cbor,
+				)
+				if err != nil {
+					b.Fatalf(
+						"failed to decode %s block with offsets: %v",
+						tb.name,
+						err,
+					)
+				}
+			}
+		})
+	}
+}

--- a/internal/bench/consensus_bench_test.go
+++ b/internal/bench/consensus_bench_test.go
@@ -1,0 +1,326 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bench
+
+import (
+	"math/big"
+	"sync/atomic"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/consensus"
+	"github.com/blinklabs-io/gouroboros/vrf"
+)
+
+// Pre-computed test data for consensus benchmarks
+var (
+	// VRF keys for leader election benchmarks
+	benchVRFSeed   = []byte("consensus_bench_seed_for_vrf_32!")
+	benchVRFSigner *consensus.SimpleVRFSigner
+
+	// Epoch nonce (eta0) - 32 bytes
+	benchEpochNonce = make([]byte, 32)
+
+	// Pre-computed VRF output for threshold comparison benchmarks
+	benchVRFOutput []byte
+
+	// Active slot coefficient (mainnet uses 1/20 = 0.05)
+	benchActiveSlotCoeff = big.NewRat(1, 20)
+)
+
+func init() {
+	var err error
+	benchVRFSigner, err = consensus.NewSimpleVRFSigner(benchVRFSeed)
+	if err != nil {
+		panic("failed to create benchmark VRF signer: " + err.Error())
+	}
+
+	// Initialize epoch nonce with deterministic data
+	for i := range benchEpochNonce {
+		benchEpochNonce[i] = byte(i * 7)
+	}
+
+	// Pre-compute a VRF output for threshold comparison
+	vrfInput := vrf.MkInputVrf(50_000_000, benchEpochNonce)
+	_, benchVRFOutput, err = benchVRFSigner.Prove(vrfInput)
+	if err != nil {
+		panic("failed to generate benchmark VRF output: " + err.Error())
+	}
+}
+
+// consensusSink prevents compiler dead-code elimination in benchmarks.
+var consensusSink interface{}
+
+// consensusParallelSink is an atomic sink for use in RunParallel benchmarks
+// to avoid data races when multiple goroutines store results concurrently.
+var consensusParallelSink atomic.Value
+
+// BenchmarkConsensusThreshold benchmarks CertifiedNatThreshold with various
+// stake ratios.
+// This is the core function for computing leadership probability thresholds.
+func BenchmarkConsensusThreshold(b *testing.B) {
+	stakes := []struct {
+		name       string
+		poolStake  uint64
+		totalStake uint64
+	}{
+		{"1pct", 1_000_000_000, 100_000_000_000},
+		{"10pct", 10_000_000_000, 100_000_000_000},
+		{"50pct", 50_000_000_000, 100_000_000_000},
+	}
+
+	for _, s := range stakes {
+		b.Run(s.name, func(b *testing.B) {
+			activeSlotCoeff := big.NewRat(1, 20) // fresh per sub-benchmark
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				consensusSink = consensus.CertifiedNatThreshold(
+					s.poolStake,
+					s.totalStake,
+					activeSlotCoeff,
+				)
+			}
+		})
+	}
+}
+
+// BenchmarkConsensusThresholdWithMode benchmarks threshold calculation for both
+// CPRAOS (Babbage+) and TPraos (Shelley-Alonzo) consensus modes.
+func BenchmarkConsensusThresholdWithMode(b *testing.B) {
+	poolStake := uint64(10_000_000_000)
+	totalStake := uint64(100_000_000_000)
+
+	modes := []struct {
+		name string
+		mode consensus.ConsensusMode
+	}{
+		{"CPraos", consensus.ConsensusModeCPraos},
+		{"TPraos", consensus.ConsensusModeTPraos},
+	}
+
+	for _, m := range modes {
+		b.Run(m.name, func(b *testing.B) {
+			activeSlotCoeff := big.NewRat(1, 20) // fresh per sub-benchmark
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				consensusSink = consensus.CertifiedNatThresholdWithMode(
+					poolStake,
+					totalStake,
+					activeSlotCoeff,
+					m.mode,
+				)
+			}
+		})
+	}
+}
+
+// BenchmarkConsensusLeaderValue benchmarks VrfLeaderValue computation.
+// This computes BLAKE2b-256("L" || vrfOutput) for CPRAOS leader election.
+func BenchmarkConsensusLeaderValue(b *testing.B) {
+	// Standard 64-byte VRF output
+	vrfOutput := make([]byte, 64)
+	for i := range vrfOutput {
+		vrfOutput[i] = byte(i)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		consensusSink = consensus.VrfLeaderValue(vrfOutput)
+	}
+}
+
+// BenchmarkConsensusVRFOutputToInt benchmarks conversion of VRF leader value to
+// big.Int.
+func BenchmarkConsensusVRFOutputToInt(b *testing.B) {
+	leaderValue := consensus.VrfLeaderValue(benchVRFOutput)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		consensusSink = consensus.VRFOutputToInt(leaderValue)
+	}
+}
+
+// BenchmarkConsensusIsSlotLeader benchmarks the full leader election check.
+// This includes VRF input creation, proof generation, threshold calculation,
+// and eligibility comparison.
+//
+// Note: This benchmark is intentionally sequential (not RunParallel) because
+// the shared benchActiveSlotCoeff (*big.Rat) would race under concurrent use.
+// See BenchmarkConsensusParallelThreshold for the parallel-safe pattern.
+func BenchmarkConsensusIsSlotLeader(b *testing.B) {
+	if benchVRFSigner == nil {
+		b.Fatal("benchVRFSigner not initialized")
+	}
+
+	stakes := []struct {
+		name       string
+		poolStake  uint64
+		totalStake uint64
+	}{
+		{"1pct", 1_000_000_000, 100_000_000_000},
+		{"10pct", 10_000_000_000, 100_000_000_000},
+		{"50pct", 50_000_000_000, 100_000_000_000},
+	}
+
+	for _, s := range stakes {
+		b.Run(s.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				slot := uint64(50_000_000 + i)
+				_, err := consensus.IsSlotLeader(
+					slot,
+					benchEpochNonce,
+					s.poolStake,
+					s.totalStake,
+					benchActiveSlotCoeff,
+					benchVRFSigner,
+				)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkConsensusIsSlotLeaderFromComponents benchmarks leader election from
+// pre-computed VRF output and threshold components.
+func BenchmarkConsensusIsSlotLeaderFromComponents(b *testing.B) {
+	stakes := []struct {
+		name       string
+		poolStake  uint64
+		totalStake uint64
+	}{
+		{"1pct", 1_000_000_000, 100_000_000_000},
+		{"10pct", 10_000_000_000, 100_000_000_000},
+		{"50pct", 50_000_000_000, 100_000_000_000},
+	}
+
+	for _, s := range stakes {
+		b.Run(s.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				consensusSink = consensus.IsSlotLeaderFromComponents(
+					benchVRFOutput,
+					s.poolStake,
+					s.totalStake,
+					benchActiveSlotCoeff,
+				)
+			}
+		})
+	}
+}
+
+// BenchmarkConsensusMkInputVrf benchmarks VRF input creation (nonce
+// computation).
+// This is the first step in leader election: creating the VRF input from
+// slot number and epoch nonce.
+func BenchmarkConsensusMkInputVrf(b *testing.B) {
+	slots := []struct {
+		name string
+		slot int64
+	}{
+		{"LowSlot", 1000},
+		{"MidSlot", 50_000_000},
+		{"HighSlot", 140_000_000},
+	}
+
+	for _, s := range slots {
+		b.Run(s.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				consensusSink = vrf.MkInputVrf(s.slot, benchEpochNonce)
+			}
+		})
+	}
+}
+
+// BenchmarkConsensusIsVRFOutputBelowThreshold benchmarks the threshold
+// comparison.
+func BenchmarkConsensusIsVRFOutputBelowThreshold(b *testing.B) {
+	threshold := consensus.CertifiedNatThreshold(
+		10_000_000_000,
+		100_000_000_000,
+		benchActiveSlotCoeff,
+	)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		consensusSink = consensus.IsVRFOutputBelowThreshold(benchVRFOutput, threshold)
+	}
+}
+
+// BenchmarkConsensusFullLeaderElectionWorkflow benchmarks the complete leader
+// election workflow from slot to eligibility determination.
+func BenchmarkConsensusFullLeaderElectionWorkflow(b *testing.B) {
+	if benchVRFSigner == nil {
+		b.Fatal("benchVRFSigner not initialized")
+	}
+
+	poolStake := uint64(10_000_000_000)
+	totalStake := uint64(100_000_000_000)
+	baseSlot := int64(50_000_000)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		slot := baseSlot + int64(i)
+
+		// Step 1: Create VRF input
+		vrfInput := vrf.MkInputVrf(slot, benchEpochNonce)
+
+		// Step 2: Generate VRF proof
+		_, output, err := benchVRFSigner.Prove(vrfInput)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		// Step 3: Compute threshold
+		threshold := consensus.CertifiedNatThreshold(
+			poolStake,
+			totalStake,
+			benchActiveSlotCoeff,
+		)
+
+		// Step 4: Check eligibility
+		consensusSink = consensus.IsVRFOutputBelowThreshold(output, threshold)
+	}
+}
+
+// BenchmarkConsensusParallelThreshold benchmarks concurrent threshold
+// calculations.
+func BenchmarkConsensusParallelThreshold(b *testing.B) {
+	poolStake := uint64(10_000_000_000)
+	totalStake := uint64(100_000_000_000)
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		// Each goroutine gets its own Rat to avoid data races.
+		activeSlotCoeff := big.NewRat(1, 20)
+		var result *big.Int
+		for pb.Next() {
+			result = consensus.CertifiedNatThreshold(
+				poolStake,
+				totalStake,
+				activeSlotCoeff,
+			)
+		}
+		consensusParallelSink.Store(result)
+	})
+}

--- a/internal/bench/helpers.go
+++ b/internal/bench/helpers.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package bench provides benchmark utilities and test fixtures for memory
+// profiling.
+package bench
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/internal/testdata"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+)
+
+// BenchLedgerState returns a mock ledger state suitable for
+// benchmarks. It provides a minimal ledger state with mainnet
+// network ID and a configurable UTXO lookup function.
+func BenchLedgerState() common.LedgerState {
+	return mockledger.NewLedgerStateBuilder().
+		WithNetworkId(common.AddressNetworkMainnet).
+		Build()
+}
+
+// BenchLedgerStateWithUtxos returns a mock ledger state with the provided
+// UTXOs.
+func BenchLedgerStateWithUtxos(utxos []common.Utxo) common.LedgerState {
+	return mockledger.NewLedgerStateBuilder().
+		WithNetworkId(common.AddressNetworkMainnet).
+		WithUtxos(utxos).
+		Build()
+}
+
+// BenchLedgerStateWithUtxoFunc returns a mock ledger state with a
+// custom UTXO lookup function.
+func BenchLedgerStateWithUtxoFunc(
+	fn func(common.TransactionInput) (common.Utxo, error),
+) common.LedgerState {
+	return mockledger.NewLedgerStateBuilder().
+		WithNetworkId(common.AddressNetworkMainnet).
+		WithUtxoById(fn).
+		Build()
+}
+
+// BenchProtocolParams returns a minimal ProtocolParameters suitable for
+// benchmarks and profiling tests. It uses a zero-value Shelley protocol
+// parameters struct with the required rational fields initialized to avoid
+// nil dereferences if Utxorpc() is ever called.
+func BenchProtocolParams() common.ProtocolParameters {
+	zeroRat := &cbor.Rat{Rat: big.NewRat(0, 1)}
+	return &shelley.ShelleyProtocolParameters{
+		A0:  zeroRat,
+		Rho: zeroRat,
+		Tau: zeroRat,
+	}
+}
+
+// BlockFixture contains a pre-loaded block for benchmarking.
+type BlockFixture struct {
+	Name      string
+	Era       string
+	BlockType uint
+	Cbor      []byte
+	Block     common.Block
+}
+
+// LoadBlockFixture loads a test block for the given era.
+// The era should be one of: "byron", "shelley", "allegra",
+// "mary", "alonzo", "babbage", "conway". The name parameter
+// is currently unused but reserved for future fixture variants.
+func LoadBlockFixture(era, name string) (*BlockFixture, error) {
+	blockType, err := BlockTypeFromEra(era)
+	if err != nil {
+		return nil, err
+	}
+
+	blockCbor, err := blockCborFromEra(era)
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := ledger.NewBlockFromCbor(blockType, blockCbor)
+	if err != nil {
+		return nil, fmt.Errorf("decode %s block: %w", era, err)
+	}
+
+	return &BlockFixture{
+		Name:      name,
+		Era:       era,
+		BlockType: blockType,
+		Cbor:      blockCbor,
+		Block:     block,
+	}, nil
+}
+
+// MustLoadBlockFixture loads a test block and panics on error.
+// Use this in benchmark init() or setup code.
+func MustLoadBlockFixture(era, name string) *BlockFixture {
+	fixture, err := LoadBlockFixture(era, name)
+	if err != nil {
+		panic(fmt.Sprintf("failed to load %s block fixture: %v", era, err))
+	}
+	return fixture
+}
+
+// eraInfo holds the block type, transaction type, and block hex for an era.
+type eraInfo struct {
+	blockType uint
+	txType    uint
+	blockHex  string
+}
+
+// eraLookup maps lowercase era names to their type constants and test data.
+var eraLookup = map[string]eraInfo{
+	"byron":   {ledger.BlockTypeByronMain, ledger.TxTypeByron, testdata.ByronBlockHex},
+	"shelley": {ledger.BlockTypeShelley, ledger.TxTypeShelley, testdata.ShelleyBlockHex},
+	"allegra": {ledger.BlockTypeAllegra, ledger.TxTypeAllegra, testdata.AllegraBlockHex},
+	"mary":    {ledger.BlockTypeMary, ledger.TxTypeMary, testdata.MaryBlockHex},
+	"alonzo":  {ledger.BlockTypeAlonzo, ledger.TxTypeAlonzo, testdata.AlonzoBlockHex},
+	"babbage": {ledger.BlockTypeBabbage, ledger.TxTypeBabbage, testdata.BabbageBlockHex},
+	"conway":  {ledger.BlockTypeConway, ledger.TxTypeConway, testdata.ConwayBlockHex},
+}
+
+// BlockTypeFromEra returns the ledger block type constant for the given era
+// name.
+func BlockTypeFromEra(era string) (uint, error) {
+	info, ok := eraLookup[strings.ToLower(era)]
+	if !ok {
+		return 0, fmt.Errorf("unknown era: %s", era)
+	}
+	return info.blockType, nil
+}
+
+// TxTypeFromEra returns the ledger transaction type constant
+// for the given era name.
+func TxTypeFromEra(era string) (uint, error) {
+	info, ok := eraLookup[strings.ToLower(era)]
+	if !ok {
+		return 0, fmt.Errorf("unknown era: %s", era)
+	}
+	return info.txType, nil
+}
+
+// supportedEraNames is the authoritative ordered list of era names.
+// Update this list when adding new eras to eraLookup.
+var supportedEraNames = []string{
+	"byron",
+	"shelley",
+	"allegra",
+	"mary",
+	"alonzo",
+	"babbage",
+	"conway",
+}
+
+// EraNames returns the list of supported era names for benchmarking.
+// The explicit ordering matters for consistent benchmark output.
+func EraNames() []string {
+	return supportedEraNames
+}
+
+// PostByronEraNames returns era names excluding Byron (for Praos-era
+// benchmarks).
+func PostByronEraNames() []string {
+	return supportedEraNames[1:]
+}
+
+// blockCborFromEra returns the raw CBOR bytes for the given
+// era's test block.
+func blockCborFromEra(era string) ([]byte, error) {
+	info, ok := eraLookup[strings.ToLower(era)]
+	if !ok {
+		return nil, fmt.Errorf("unknown era: %s", era)
+	}
+	return testdata.MustDecodeHex(info.blockHex), nil
+}

--- a/internal/bench/helpers_test.go
+++ b/internal/bench/helpers_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bench
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/internal/testdata"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBenchLedgerState(t *testing.T) {
+	ls := BenchLedgerState()
+	require.NotNil(t, ls)
+	// Mainnet network ID is 1
+	assert.Equal(t, uint(1), ls.NetworkId())
+}
+
+func TestBlockTypeFromEra(t *testing.T) {
+	tests := []struct {
+		era      string
+		expected uint
+		wantErr  bool
+	}{
+		{"byron", ledger.BlockTypeByronMain, false},
+		{"shelley", ledger.BlockTypeShelley, false},
+		{"allegra", ledger.BlockTypeAllegra, false},
+		{"mary", ledger.BlockTypeMary, false},
+		{"alonzo", ledger.BlockTypeAlonzo, false},
+		{"babbage", ledger.BlockTypeBabbage, false},
+		{"conway", ledger.BlockTypeConway, false},
+		{"Conway", ledger.BlockTypeConway, false}, // case insensitive
+		{"BYRON", ledger.BlockTypeByronMain, false},  // case insensitive
+		{"unknown", 0, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.era, func(t *testing.T) {
+			blockType, err := BlockTypeFromEra(tc.era)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, blockType)
+			}
+		})
+	}
+}
+
+func TestTxTypeFromEra(t *testing.T) {
+	tests := []struct {
+		era      string
+		expected uint
+		wantErr  bool
+	}{
+		{"byron", ledger.TxTypeByron, false},
+		{"shelley", ledger.TxTypeShelley, false},
+		{"allegra", ledger.TxTypeAllegra, false},
+		{"mary", ledger.TxTypeMary, false},
+		{"alonzo", ledger.TxTypeAlonzo, false},
+		{"babbage", ledger.TxTypeBabbage, false},
+		{"conway", ledger.TxTypeConway, false},
+		{"Conway", ledger.TxTypeConway, false},    // case insensitive
+		{"BYRON", ledger.TxTypeByron, false},       // case insensitive
+		{"unknown", 0, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.era, func(t *testing.T) {
+			txType, err := TxTypeFromEra(tc.era)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, txType)
+			}
+		})
+	}
+}
+
+func TestLoadBlockFixture(t *testing.T) {
+	for _, era := range EraNames() {
+		t.Run(era, func(t *testing.T) {
+			fixture, err := LoadBlockFixture(era, "default")
+			require.NoError(t, err)
+			require.NotNil(t, fixture)
+
+			assert.Equal(t, era, fixture.Era)
+			assert.NotNil(t, fixture.Block)
+			assert.NotEmpty(t, fixture.Cbor)
+		})
+	}
+}
+
+func TestLoadBlockFixture_UnknownEra(t *testing.T) {
+	_, err := LoadBlockFixture("unknown", "default")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown era")
+}
+
+func TestMustLoadBlockFixture_Panics(t *testing.T) {
+	assert.Panics(t, func() {
+		MustLoadBlockFixture("unknown", "default")
+	})
+}
+
+func TestEraNames(t *testing.T) {
+	eras := EraNames()
+	assert.Len(t, eras, 7)
+	assert.Contains(t, eras, "byron")
+	assert.Contains(t, eras, "conway")
+}
+
+func TestPostByronEraNames(t *testing.T) {
+	eras := PostByronEraNames()
+	assert.Len(t, eras, 6)
+	assert.NotContains(t, eras, "byron")
+	assert.Contains(t, eras, "shelley")
+	assert.Contains(t, eras, "conway")
+}
+
+func TestGetTestBlocks(t *testing.T) {
+	blocks := testdata.GetTestBlocks()
+	assert.Len(t, blocks, 7)
+
+	// Verify all eras are present
+	eraNames := make(map[string]bool)
+	for _, block := range blocks {
+		eraNames[block.Name] = true
+	}
+
+	assert.True(t, eraNames["Byron"])
+	assert.True(t, eraNames["Shelley"])
+	assert.True(t, eraNames["Allegra"])
+	assert.True(t, eraNames["Mary"])
+	assert.True(t, eraNames["Alonzo"])
+	assert.True(t, eraNames["Babbage"])
+	assert.True(t, eraNames["Conway"])
+}

--- a/internal/bench/profile_test.go
+++ b/internal/bench/profile_test.go
@@ -1,0 +1,550 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build profile
+
+// Package bench provides profiling integration tests for gouroboros.
+//
+// These tests are designed to generate pprof profiles for analysis of CPU and
+// memory usage in key validation paths. They are guarded by the "profile" build
+// tag so they don't run in normal test suites.
+//
+// Usage:
+//
+//	# Generate CPU profile for block validation
+//	go test -tags=profile -run=TestProfileBlockValidation \
+//	    -cpuprofile=cpu_block.prof ./internal/bench/...
+//
+//	# Generate memory profile for CBOR decode
+//	go test -tags=profile -run=TestProfileCBORDecode \
+//	    -memprofile=mem_cbor.prof ./internal/bench/...
+//
+//	# Analyze profiles
+//	go tool pprof -http=localhost:8080 cpu_block.prof
+//	go tool pprof -http=localhost:8081 mem_cbor.prof
+package bench
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/consensus"
+	"github.com/blinklabs-io/gouroboros/internal/testdata"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/blinklabs-io/gouroboros/vrf"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// profileIterations is the number of iterations to run for each profile
+	// test.
+	// Higher values produce more accurate profiles but take longer to run.
+	profileIterations = 1000
+)
+
+// TestProfileBlockValidation generates CPU/memory profiles for block
+// validation.
+// Run with -cpuprofile and/or -memprofile flags to capture profiles.
+//
+// Example:
+//
+//	go test -tags=profile -run=TestProfileBlockValidation \
+//	    -cpuprofile=cpu_block.prof -memprofile=mem_block.prof \
+//	    ./internal/bench/...
+func TestProfileBlockValidation(t *testing.T) {
+	blocks := testdata.GetTestBlocks()
+
+	// Create a config that skips validation steps requiring ledger state
+	// This focuses profiling on the core decode + hash validation path
+	config := common.VerifyConfig{
+		SkipTransactionValidation: true,
+		SkipStakePoolValidation:   true,
+		// Keep body hash validation enabled - this is a key validation path
+		SkipBodyHashValidation: false,
+	}
+
+	// Pre-decode all blocks to ensure they're valid
+	decodedBlocks := make([]ledger.Block, len(blocks))
+	for i, block := range blocks {
+		decoded, err := ledger.NewBlockFromCbor(block.BlockType, block.Cbor)
+		require.NoError(t, err, "failed to pre-decode %s block", block.Name)
+		decodedBlocks[i] = decoded
+	}
+
+	// Dummy epoch nonce (hex encoded) for VRF verification
+	eta0Hex := hex.EncodeToString(make([]byte, 32))
+	slotsPerKes := uint64(129600) // Mainnet value
+
+	t.Run("AllEras", func(t *testing.T) {
+		// Pre-loop: call VerifyBlock once per block to log whether each
+		// succeeds or fails. Errors are expected because we use a dummy
+		// epoch nonce, so VRF verification will fail.
+		for j, block := range decodedBlocks {
+			if blocks[j].BlockType == ledger.BlockTypeByronMain ||
+				blocks[j].BlockType == ledger.BlockTypeByronEbb {
+				continue
+			}
+			_, _, _, _, err := ledger.VerifyBlock(
+				block,
+				eta0Hex,
+				slotsPerKes,
+				config,
+			)
+			if err != nil {
+				t.Logf(
+					"VerifyBlock error for %s (expected with dummy VRF input): %v",
+					blocks[j].Name,
+					err,
+				)
+			}
+		}
+
+		// Hot loop: errors are expected (dummy VRF nonce), and we still
+		// exercise the code path up to the point of failure, which is
+		// the target of this profile. We capture the first error to
+		// confirm we are hitting the expected code path.
+		var firstErr error
+		for i := 0; i < profileIterations; i++ {
+			for j, block := range decodedBlocks {
+				if blocks[j].BlockType == ledger.BlockTypeByronMain ||
+					blocks[j].BlockType == ledger.BlockTypeByronEbb {
+					continue
+				}
+				_, _, _, _, err := ledger.VerifyBlock(
+					block,
+					eta0Hex,
+					slotsPerKes,
+					config,
+				)
+				if err != nil && firstErr == nil {
+					firstErr = err
+				}
+			}
+		}
+		if firstErr != nil {
+			t.Logf(
+				"VerifyBlock error in hot loop (expected): %v",
+				firstErr,
+			)
+		}
+	})
+
+	// Also run per-era to isolate performance characteristics
+	for idx, block := range blocks {
+		// Skip Byron for Praos-era validation
+		if block.BlockType == ledger.BlockTypeByronMain ||
+			block.BlockType == ledger.BlockTypeByronEbb {
+			continue
+		}
+
+		t.Run(block.Name, func(t *testing.T) {
+			decoded := decodedBlocks[idx]
+
+			// Pre-loop: single call to log whether verification succeeds or
+			// fails. Errors are expected with the dummy epoch nonce.
+			_, _, _, _, err := ledger.VerifyBlock(
+				decoded,
+				eta0Hex,
+				slotsPerKes,
+				config,
+			)
+			if err != nil {
+				t.Logf(
+					"VerifyBlock error (expected with dummy VRF input): %v",
+					err,
+				)
+			}
+
+			// Hot loop: errors are expected (dummy VRF nonce) and we
+			// capture the first to confirm the expected code path.
+			var loopErr error
+			for i := 0; i < profileIterations; i++ {
+				_, _, _, _, err = ledger.VerifyBlock(
+					decoded,
+					eta0Hex,
+					slotsPerKes,
+					config,
+				)
+				if err != nil && loopErr == nil {
+					loopErr = err
+				}
+			}
+			if loopErr != nil {
+				t.Logf(
+					"VerifyBlock error in hot loop (expected): %v",
+					loopErr,
+				)
+			}
+		})
+	}
+}
+
+// TestProfileTxValidation generates profiles for transaction validation rules.
+// This exercises the per-era UtxoValidationRules against transactions extracted
+// from test blocks.
+//
+// Example:
+//
+//	go test -tags=profile -run=TestProfileTxValidation \
+//	    -cpuprofile=cpu_txval.prof -memprofile=mem_txval.prof \
+//	    ./internal/bench/...
+func TestProfileTxValidation(t *testing.T) {
+	blocks := testdata.GetTestBlocks()
+
+	// BenchLedgerState provides a minimal mock ledger state suitable for
+	// profiling. We use the bench helper rather than MockLedgerState from
+	// internal/test/ledger because profiling tests need a lightweight,
+	// self-contained state without full test framework dependencies.
+	ls := BenchLedgerState()
+	pp := BenchProtocolParams()
+
+	for _, block := range blocks {
+		// Skip Byron - no UTXO validation rules for Byron era
+		if block.BlockType == ledger.BlockTypeByronMain ||
+			block.BlockType == ledger.BlockTypeByronEbb {
+			continue
+		}
+
+		decoded, err := ledger.NewBlockFromCbor(block.BlockType, block.Cbor)
+		require.NoError(t, err, "failed to decode %s block", block.Name)
+
+		txs := decoded.Transactions()
+		if len(txs) == 0 {
+			t.Logf("skipping %s: no transactions in block", block.Name)
+			continue
+		}
+
+		// Select the era-appropriate validation rules
+		var rules []common.UtxoValidationRuleFunc
+		switch decoded.Era().Id {
+		case shelley.EraShelley.Id:
+			rules = shelley.UtxoValidationRules
+		case allegra.EraAllegra.Id:
+			rules = allegra.UtxoValidationRules
+		case mary.EraMary.Id:
+			rules = mary.UtxoValidationRules
+		case alonzo.EraAlonzo.Id:
+			rules = alonzo.UtxoValidationRules
+		case babbage.EraBabbage.Id:
+			rules = babbage.UtxoValidationRules
+		case conway.EraConway.Id:
+			rules = conway.UtxoValidationRules
+		default:
+			t.Logf(
+				"skipping %s: unsupported era for validation rules",
+				block.Name,
+			)
+			continue
+		}
+
+		t.Run(block.Name, func(t *testing.T) {
+			tx := txs[0]
+			slot := decoded.SlotNumber()
+
+			// Pre-loop: log whether validation passes or fails. Errors are
+			// expected because the mock ledger state does not contain the
+			// UTXOs referenced by real mainnet transactions.
+			err := common.VerifyTransaction(tx, slot, ls, pp, rules)
+			if err != nil {
+				t.Logf(
+					"VerifyTransaction error (expected with mock state): %v",
+					err,
+				)
+			}
+
+			// Hot loop: exercise the validation rule code path.
+			// Errors are expected and discarded for consistent profiling.
+			for i := 0; i < profileIterations; i++ {
+				_ = common.VerifyTransaction(tx, slot, ls, pp, rules)
+			}
+		})
+	}
+}
+
+// TestProfileCBORDecode generates profiles for CBOR decoding of blocks.
+// This isolates the CBOR deserialization overhead from validation logic.
+//
+// Example:
+//
+//	go test -tags=profile -run=TestProfileCBORDecode \
+//	    -cpuprofile=cpu_cbor.prof -memprofile=mem_cbor.prof \
+//	    ./internal/bench/...
+func TestProfileCBORDecode(t *testing.T) {
+	blocks := testdata.GetTestBlocks()
+
+	t.Run("AllEras", func(t *testing.T) {
+		for i := 0; i < profileIterations; i++ {
+			for _, block := range blocks {
+				_, err := ledger.NewBlockFromCbor(block.BlockType, block.Cbor)
+				if err != nil {
+					t.Fatalf("decode %s block error: %v", block.Name, err)
+				}
+			}
+		}
+	})
+
+	// Per-era profiling
+	for _, block := range blocks {
+		t.Run(block.Name, func(t *testing.T) {
+			for i := 0; i < profileIterations; i++ {
+				_, err := ledger.NewBlockFromCbor(block.BlockType, block.Cbor)
+				if err != nil {
+					t.Fatalf("decode %s block error: %v", block.Name, err)
+				}
+			}
+		})
+	}
+}
+
+// TestProfileVRF generates profiles for VRF operations.
+// This focuses on the cryptographic primitives used in leader election.
+//
+// Example:
+//
+//	go test -tags=profile -run=TestProfileVRF \
+//	    -cpuprofile=cpu_vrf.prof -memprofile=mem_vrf.prof \
+//	    ./internal/bench/...
+func TestProfileVRF(t *testing.T) {
+	// Generate VRF keys for testing (seed must be exactly 32 bytes)
+	seed := []byte("test_seed_for_vrf_profiling!32!!")
+	pk, sk, err := vrf.KeyGen(seed)
+	require.NoError(t, err, "VRF KeyGen failed")
+
+	// Test message (simulates slot + nonce input)
+	alpha := make([]byte, 64)
+	for i := range alpha {
+		alpha[i] = byte(i)
+	}
+
+	// Generate a proof for verification tests
+	proof, hash, err := vrf.Prove(sk, alpha)
+	require.NoError(t, err, "VRF Prove failed")
+
+	t.Run("Prove", func(t *testing.T) {
+		for i := 0; i < profileIterations; i++ {
+			_, _, err := vrf.Prove(sk, alpha)
+			if err != nil {
+				t.Fatalf("VRF Prove failed: %v", err)
+			}
+		}
+	})
+
+	t.Run("Verify", func(t *testing.T) {
+		for i := 0; i < profileIterations; i++ {
+			valid, err := vrf.Verify(pk, proof, hash, alpha)
+			if err != nil {
+				t.Fatalf("VRF Verify failed: %v", err)
+			}
+			if !valid {
+				t.Fatal("VRF Verify returned false for valid proof")
+			}
+		}
+	})
+
+	t.Run("MkInputVrf", func(t *testing.T) {
+		eta0 := make([]byte, 32)
+		for i := range eta0 {
+			eta0[i] = byte(i * 7)
+		}
+		slot := int64(50_000_000)
+
+		for i := 0; i < profileIterations; i++ {
+			_ = vrf.MkInputVrf(slot, eta0)
+		}
+	})
+
+	t.Run("FullLeaderCheck", func(t *testing.T) {
+		eta0 := make([]byte, 32)
+		for i := range eta0 {
+			eta0[i] = byte(i * 7)
+		}
+
+		for i := 0; i < profileIterations; i++ {
+			slot := int64(50_000_000 + i)
+			vrfInput := vrf.MkInputVrf(slot, eta0)
+
+			proof, _, err := vrf.Prove(sk, vrfInput)
+			if err != nil {
+				t.Fatalf("VRF Prove failed: %v", err)
+			}
+
+			_, err = vrf.VerifyAndHash(pk, proof, vrfInput)
+			if err != nil {
+				t.Fatalf("VRF VerifyAndHash failed: %v", err)
+			}
+		}
+	})
+}
+
+// TestProfileConsensus generates profiles for consensus operations.
+// This focuses on leader election and threshold calculations.
+//
+// Example:
+//
+//	go test -tags=profile -run=TestProfileConsensus \
+//	    -cpuprofile=cpu_consensus.prof -memprofile=mem_consensus.prof \
+//	    ./internal/bench/...
+func TestProfileConsensus(t *testing.T) {
+	t.Run("LeaderValueComputation", func(t *testing.T) {
+		// Generate VRF proof output (seed must be exactly 32 bytes)
+		seed := []byte("consensus_profile_test_seed_32!!")
+		_, sk, err := vrf.KeyGen(seed)
+		require.NoError(t, err, "VRF KeyGen failed")
+
+		eta0 := make([]byte, 32)
+		for i := range eta0 {
+			eta0[i] = byte(i * 3)
+		}
+
+		for i := 0; i < profileIterations; i++ {
+			slot := int64(100_000_000 + i)
+			vrfInput := vrf.MkInputVrf(slot, eta0)
+
+			_, hash, err := vrf.Prove(sk, vrfInput)
+			if err != nil {
+				t.Fatalf("VRF Prove failed: %v", err)
+			}
+
+			// Compute leader value from VRF output
+			_ = consensus.VrfLeaderValue(hash)
+		}
+	})
+}
+
+// TestProfileBodyHash generates profiles for block decode and body hash access.
+// This profiles CBOR decoding and the BlockBodyHash() accessor; it does NOT
+// profile full body-hash validation (which is done by ledger.VerifyBlock).
+//
+// Example:
+//
+//	go test -tags=profile -run=TestProfileBodyHash \
+//	    -cpuprofile=cpu_bodyhash.prof -memprofile=mem_bodyhash.prof \
+//	    ./internal/bench/...
+func TestProfileBodyHash(t *testing.T) {
+	blocks := testdata.GetTestBlocks()
+
+	for _, block := range blocks {
+		// Skip Byron - uses different body hash mechanism
+		if block.BlockType == ledger.BlockTypeByronMain ||
+			block.BlockType == ledger.BlockTypeByronEbb {
+			continue
+		}
+
+		t.Run(block.Name, func(t *testing.T) {
+			// Profile CBOR decode + body hash access.
+			// NewBlockFromCbor only decodes CBOR; it does not validate the
+			// body hash. Full body-hash validation is performed by
+			// ledger.VerifyBlock. This loop profiles decode + accessing
+			// BlockBodyHash() (compute/access, not verify).
+			for i := 0; i < profileIterations; i++ {
+				decoded, err := ledger.NewBlockFromCbor(
+					block.BlockType,
+					block.Cbor,
+				)
+				if err != nil {
+					t.Fatalf("decode %s block error: %v", block.Name, err)
+				}
+				// Access body hash to ensure it's computed
+				_ = decoded.BlockBodyHash()
+			}
+		})
+	}
+}
+
+// TestProfileNativeScript generates profiles for native script evaluation.
+// This tests the recursive script evaluation path using constructed scripts.
+//
+// Example:
+//
+//	go test -tags=profile -run=TestProfileNativeScript \
+//	    -cpuprofile=cpu_script.prof -memprofile=mem_script.prof \
+//	    ./internal/bench/...
+func TestProfileNativeScript(t *testing.T) {
+	// Key hashes map containing test keys
+	keyHashes := map[common.Blake2b224]bool{
+		testKeyHash1: true,
+		testKeyHash2: true,
+		testKeyHash3: true,
+	}
+
+	// Test slot and validity interval
+	slot := uint64(100_000_000)
+	validityStart := uint64(99_000_000)
+	validityEnd := uint64(101_000_000)
+
+	t.Run("ScriptType_Pubkey", func(t *testing.T) {
+		script := createPubkeyScript(testKeyHash1)
+		for i := 0; i < profileIterations; i++ {
+			_ = script.Evaluate(slot, validityStart, validityEnd, keyHashes)
+		}
+	})
+
+	t.Run("ScriptType_All", func(t *testing.T) {
+		script := createAllScript(
+			createPubkeyScript(testKeyHash1),
+			createPubkeyScript(testKeyHash2),
+			createPubkeyScript(testKeyHash3),
+		)
+		for i := 0; i < profileIterations; i++ {
+			_ = script.Evaluate(slot, validityStart, validityEnd, keyHashes)
+		}
+	})
+
+	t.Run("ScriptType_Any", func(t *testing.T) {
+		script := createAnyScript(
+			createPubkeyScript(testKeyHash1),
+			createPubkeyScript(testKeyHash2),
+			createPubkeyScript(testKeyHash3),
+		)
+		for i := 0; i < profileIterations; i++ {
+			_ = script.Evaluate(slot, validityStart, validityEnd, keyHashes)
+		}
+	})
+
+	t.Run("ScriptType_NofK", func(t *testing.T) {
+		script := createNofKScript(2,
+			createPubkeyScript(testKeyHash1),
+			createPubkeyScript(testKeyHash2),
+			createPubkeyScript(testKeyHash3),
+		)
+		for i := 0; i < profileIterations; i++ {
+			_ = script.Evaluate(slot, validityStart, validityEnd, keyHashes)
+		}
+	})
+
+	t.Run("ScriptType_Timelock", func(t *testing.T) {
+		script := createAllScript(
+			createInvalidBeforeScript(validityStart),
+			createInvalidHereafterScript(validityEnd+1000),
+			createPubkeyScript(testKeyHash1),
+		)
+		for i := 0; i < profileIterations; i++ {
+			_ = script.Evaluate(slot, validityStart, validityEnd, keyHashes)
+		}
+	})
+
+	t.Run("NestedDepth5", func(t *testing.T) {
+		script := createNestedScript(5, "All")
+		for i := 0; i < profileIterations; i++ {
+			_ = script.Evaluate(slot, validityStart, validityEnd, keyHashes)
+		}
+	})
+}

--- a/internal/bench/regression_test.go
+++ b/internal/bench/regression_test.go
@@ -1,0 +1,524 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package bench provides allocation regression tests and benchmarks for
+// gouroboros.
+package bench
+
+import (
+	"fmt"
+	"math/big"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/consensus"
+	"github.com/blinklabs-io/gouroboros/internal/testdata"
+	"github.com/blinklabs-io/gouroboros/kes"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/vrf"
+	"github.com/stretchr/testify/require"
+)
+
+// Pre-computed test data for allocation regression tests.
+// These are initialized once to avoid including setup allocations in tests.
+var (
+	// VRF test data
+	vrfSeed       = []byte("test_seed_for_vrf_testing!!!_32!")
+	vrfPK         []byte
+	vrfSK         []byte
+	vrfProof      []byte
+	vrfOutput     []byte
+	vrfAlpha      = []byte("vrf test message for regression")
+	vrfEpochNonce = make([]byte, 32)
+
+	// KES test data
+	// NOTE: "lenght" is intentionally misspelled to match canonical test vector
+	kesSeed = []byte(
+		"test string of 32 byte of lenght",
+	) // 32-byte seed for KES key generation
+	kesSK      *kes.SecretKey
+	kesPK      []byte
+	kesSig     []byte
+	kesMessage = []byte("kes test message for regression")
+
+	// Consensus test data
+	poolStake       = uint64(1_000_000_000)   // 1B lovelace
+	totalStake      = uint64(100_000_000_000) // 100B lovelace
+	activeSlotCoeff = big.NewRat(1, 20)       // 0.05
+
+	// Block test data (loaded lazily via conwayBlockOnce)
+	conwayBlockCbor []byte
+	conwayBlockOnce sync.Once
+)
+
+func init() {
+	var err error
+
+	// Initialize VRF test data
+	vrfPK, vrfSK, err = vrf.KeyGen(vrfSeed)
+	if err != nil {
+		panic("failed to generate VRF keys: " + err.Error())
+	}
+	vrfProof, vrfOutput, err = vrf.Prove(vrfSK, vrfAlpha)
+	if err != nil {
+		panic("failed to generate VRF proof: " + err.Error())
+	}
+	for i := range vrfEpochNonce {
+		vrfEpochNonce[i] = byte(i)
+	}
+
+	// Initialize KES test data
+	kesSK, kesPK, err = kes.KeyGen(kes.CardanoKesDepth, kesSeed)
+	if err != nil {
+		panic("failed to generate KES keys: " + err.Error())
+	}
+	kesSig, err = kes.Sign(kesSK, 0, kesMessage)
+	if err != nil {
+		panic("failed to generate KES signature: " + err.Error())
+	}
+}
+
+// getThresholdMultiplier returns the allocation threshold multiplier from
+// environment. Default is 1.0 (no adjustment). Set
+// GOUROBOROS_ALLOC_THRESHOLD_MULTIPLIER to override.
+func getThresholdMultiplier() float64 {
+	if v := os.Getenv("GOUROBOROS_ALLOC_THRESHOLD_MULTIPLIER"); v != "" {
+		m, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr,
+				"WARNING: invalid GOUROBOROS_ALLOC_THRESHOLD_MULTIPLIER=%q: %v, using default 1.0\n",
+				v, err)
+			return 1.0
+		}
+		if m <= 0 {
+			fmt.Fprintf(os.Stderr,
+				"WARNING: GOUROBOROS_ALLOC_THRESHOLD_MULTIPLIER=%q must be positive, using default 1.0\n",
+				v)
+			return 1.0
+		}
+		return m
+	}
+	return 1.0
+}
+
+// TestAllocationRegression tests that key paths don't exceed allocation limits.
+// This helps catch allocation regressions before they are merged.
+//
+// To adjust thresholds temporarily (e.g., during optimization work):
+//
+//	GOUROBOROS_ALLOC_THRESHOLD_MULTIPLIER=1.5 go test
+//
+// -run=TestAllocationRegression ./internal/bench/...
+func TestAllocationRegression(t *testing.T) {
+	multiplier := getThresholdMultiplier()
+
+	tests := []struct {
+		name      string
+		fn        func() any
+		maxAllocs int64
+	}{
+		// Current baselines with 10% headroom:
+		// VRFVerify: 11 allocs (measured 2026-02-10)
+		{"VRFVerify", vrfVerifyOnce, 12},
+		// KESVerify: 12 allocs (measured 2026-02-10)
+		{"KESVerify", kesVerifyOnce, 14},
+		// LeaderCheck: 1225 allocs - includes Taylor series for threshold calc
+		// (measured 2026-02-10)
+		{"LeaderCheck", leaderCheckOnce, 1350},
+		// CBORBlockDecode (Conway): 2652 allocs (measured 2026-02-10)
+		{"CBORBlockDecode", cborBlockDecodeOnce, 3000},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Run the function once to warm up (cache effects, lazy init)
+			_ = tc.fn()
+
+			// Measure allocations over 100 runs
+			allocs := testing.AllocsPerRun(100, func() {
+				_ = tc.fn()
+			})
+
+			adjustedLimit := float64(tc.maxAllocs) * multiplier
+			if allocs > adjustedLimit {
+				t.Errorf(
+					"%s: %.0f allocs > %.0f limit (base: %d, multiplier: %.2f)",
+					tc.name,
+					allocs,
+					adjustedLimit,
+					tc.maxAllocs,
+					multiplier,
+				)
+			} else {
+				t.Logf("%s: %.0f allocs (limit: %.0f)", tc.name, allocs, adjustedLimit)
+			}
+		})
+	}
+}
+
+// TestAllocationBaselines runs extended allocation measurements and reports
+// the actual allocation counts for each operation. This is useful for
+// establishing new baselines or investigating allocation changes.
+func TestAllocationBaselines(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping baseline test in short mode")
+	}
+
+	tests := []struct {
+		name string
+		fn   func() any
+	}{
+		{"VRFVerify", vrfVerifyOnce},
+		{"VRFProve", vrfProveOnce},
+		{"VRFMkInputVrf", vrfMkInputVrfOnce},
+		{"KESVerify", kesVerifyOnce},
+		{"LeaderCheck", leaderCheckOnce},
+		{"ThresholdCalc", thresholdCalcOnce},
+		{"CBORBlockDecode", cborBlockDecodeOnce},
+	}
+
+	t.Log("Allocation baselines (1000 iterations):")
+	for _, tc := range tests {
+		// Warm up
+		_ = tc.fn()
+
+		allocs := testing.AllocsPerRun(1000, func() {
+			_ = tc.fn()
+		})
+
+		t.Logf("  %s: %.2f allocs/op", tc.name, allocs)
+	}
+}
+
+// vrfVerifyOnce performs a single VRF verification.
+func vrfVerifyOnce() any {
+	valid, err := vrf.Verify(vrfPK, vrfProof, vrfOutput, vrfAlpha)
+	if err != nil || !valid {
+		panic("VRF verification failed")
+	}
+	return valid
+}
+
+// vrfProveOnce performs a single VRF proof generation.
+func vrfProveOnce() any {
+	proof, output, err := vrf.Prove(vrfSK, vrfAlpha)
+	if err != nil {
+		panic("VRF proof generation failed: " + err.Error())
+	}
+	return [][]byte{proof, output}
+}
+
+// vrfMkInputVrfOnce performs a single VRF input creation.
+func vrfMkInputVrfOnce() any {
+	return vrf.MkInputVrf(50_000_000, vrfEpochNonce)
+}
+
+// kesVerifyOnce performs a single KES signature verification.
+func kesVerifyOnce() any {
+	valid := kes.VerifySignedKES(kesPK, 0, kesMessage, kesSig)
+	if !valid {
+		panic("KES verification failed")
+	}
+	return valid
+}
+
+// leaderCheckOnce performs a single leader election check using pre-computed
+// components (no VRF signing, just threshold calculation and comparison).
+func leaderCheckOnce() any {
+	return consensus.IsSlotLeaderFromComponents(
+		vrfOutput,
+		poolStake,
+		totalStake,
+		activeSlotCoeff,
+	)
+}
+
+// thresholdCalcOnce performs a single threshold calculation.
+func thresholdCalcOnce() any {
+	return consensus.CertifiedNatThreshold(
+		poolStake,
+		totalStake,
+		activeSlotCoeff,
+	)
+}
+
+// loadConwayBlock lazily loads the Conway block CBOR from testdata.
+func loadConwayBlock() {
+	conwayBlockOnce.Do(func() {
+		for _, block := range testdata.GetTestBlocks() {
+			if block.Name == "Conway" {
+				conwayBlockCbor = block.Cbor
+				return
+			}
+		}
+	})
+}
+
+// cborBlockDecodeOnce performs a single Conway block CBOR decode.
+func cborBlockDecodeOnce() any {
+	loadConwayBlock()
+	if conwayBlockCbor == nil {
+		panic("Conway block not found in testdata")
+	}
+	block, err := ledger.NewBlockFromCbor(
+		ledger.BlockTypeConway,
+		conwayBlockCbor,
+	)
+	if err != nil {
+		panic("block decode failed: " + err.Error())
+	}
+	return block
+}
+
+// TestRegressionVRF verifies VRF allocation regression with detailed breakdown.
+func TestRegressionVRF(t *testing.T) {
+	multiplier := getThresholdMultiplier()
+
+	t.Run("Verify", func(t *testing.T) {
+		// Validate operation works before measuring allocations
+		valid, err := vrf.Verify(vrfPK, vrfProof, vrfOutput, vrfAlpha)
+		require.NoError(t, err)
+		require.True(t, valid, "VRF verification should succeed")
+
+		var lastValid bool
+		var lastErr error
+		allocs := testing.AllocsPerRun(100, func() {
+			lastValid, lastErr = vrf.Verify(
+				vrfPK, vrfProof, vrfOutput, vrfAlpha,
+			)
+		})
+		require.NoError(t, lastErr)
+		require.True(t, lastValid, "VRF Verify should succeed")
+		limit := 12.0 * multiplier // Baseline: 11 allocs
+		require.LessOrEqualf(t, allocs, limit,
+			"VRF Verify: %.0f allocs exceeds limit %.0f", allocs, limit)
+		t.Logf("VRF Verify: %.0f allocs (limit: %.0f)", allocs, limit)
+	})
+
+	t.Run("VerifyAndHash", func(t *testing.T) {
+		// Validate operation works before measuring allocations
+		output, err := vrf.VerifyAndHash(vrfPK, vrfProof, vrfAlpha)
+		require.NoError(t, err)
+		require.NotNil(t, output, "VRF VerifyAndHash should return output")
+
+		var lastErr error
+		allocs := testing.AllocsPerRun(100, func() {
+			_, lastErr = vrf.VerifyAndHash(
+				vrfPK, vrfProof, vrfAlpha,
+			)
+		})
+		require.NoError(t, lastErr)
+		limit := 12.0 * multiplier // Baseline: 11 allocs
+		require.LessOrEqualf(t, allocs, limit,
+			"VRF VerifyAndHash: %.0f allocs exceeds limit %.0f", allocs, limit)
+		t.Logf("VRF VerifyAndHash: %.0f allocs (limit: %.0f)", allocs, limit)
+	})
+
+	t.Run("Prove", func(t *testing.T) {
+		// Validate operation works before measuring allocations
+		proof, output, err := vrf.Prove(vrfSK, vrfAlpha)
+		require.NoError(t, err)
+		require.NotNil(t, proof, "VRF Prove should return proof")
+		require.NotNil(t, output, "VRF Prove should return output")
+
+		var lastErr error
+		allocs := testing.AllocsPerRun(100, func() {
+			_, _, lastErr = vrf.Prove(vrfSK, vrfAlpha)
+		})
+		require.NoError(t, lastErr)
+		limit := 15.0 * multiplier // Baseline: 13 allocs
+		require.LessOrEqualf(t, allocs, limit,
+			"VRF Prove: %.0f allocs exceeds limit %.0f", allocs, limit)
+		t.Logf("VRF Prove: %.0f allocs (limit: %.0f)", allocs, limit)
+	})
+
+	t.Run("MkInputVrf", func(t *testing.T) {
+		allocs := testing.AllocsPerRun(100, func() {
+			_ = vrf.MkInputVrf(50_000_000, vrfEpochNonce)
+		})
+		limit := 5.0 * multiplier // Baseline: 4 allocs
+		require.LessOrEqualf(t, allocs, limit,
+			"VRF MkInputVrf: %.0f allocs exceeds limit %.0f", allocs, limit)
+		t.Logf("VRF MkInputVrf: %.0f allocs (limit: %.0f)", allocs, limit)
+	})
+}
+
+// TestRegressionKES verifies KES allocation regression with detailed breakdown.
+func TestRegressionKES(t *testing.T) {
+	multiplier := getThresholdMultiplier()
+
+	t.Run("VerifySignedKES", func(t *testing.T) {
+		// Validate operation works before measuring allocations
+		valid := kes.VerifySignedKES(kesPK, 0, kesMessage, kesSig)
+		require.True(t, valid, "KES verification should succeed")
+
+		allocs := testing.AllocsPerRun(100, func() {
+			_ = kes.VerifySignedKES(kesPK, 0, kesMessage, kesSig)
+		})
+		limit := 12.0 * multiplier
+		require.LessOrEqualf(
+			t,
+			allocs,
+			limit,
+			"KES VerifySignedKES: %.0f allocs exceeds limit %.0f",
+			allocs,
+			limit,
+		)
+		t.Logf("KES VerifySignedKES: %.0f allocs (limit: %.0f)", allocs, limit)
+	})
+
+	t.Run("NewSumKesFromBytes", func(t *testing.T) {
+		// Validate deserialization succeeds before measuring allocations
+		_, err := kes.NewSumKesFromBytes(kes.CardanoKesDepth, kesSig)
+		require.NoError(t, err, "NewSumKesFromBytes should succeed")
+
+		allocs := testing.AllocsPerRun(100, func() {
+			_, _ = kes.NewSumKesFromBytes(kes.CardanoKesDepth, kesSig)
+		})
+		limit := 8.0 * multiplier
+		require.LessOrEqualf(
+			t,
+			allocs,
+			limit,
+			"KES NewSumKesFromBytes: %.0f allocs exceeds limit %.0f",
+			allocs,
+			limit,
+		)
+		t.Logf(
+			"KES NewSumKesFromBytes: %.0f allocs (limit: %.0f)",
+			allocs,
+			limit,
+		)
+	})
+}
+
+// TestRegressionConsensus verifies consensus allocation regression.
+func TestRegressionConsensus(t *testing.T) {
+	multiplier := getThresholdMultiplier()
+
+	t.Run("CertifiedNatThreshold", func(t *testing.T) {
+		allocs := testing.AllocsPerRun(100, func() {
+			_ = consensus.CertifiedNatThreshold(
+				poolStake,
+				totalStake,
+				activeSlotCoeff,
+			)
+		})
+		// Baseline: 1220 allocs - uses Taylor series with big.Rat operations
+		limit := 1350.0 * multiplier
+		require.LessOrEqualf(
+			t,
+			allocs,
+			limit,
+			"CertifiedNatThreshold: %.0f allocs exceeds limit %.0f",
+			allocs,
+			limit,
+		)
+		t.Logf(
+			"CertifiedNatThreshold: %.0f allocs (limit: %.0f)",
+			allocs,
+			limit,
+		)
+	})
+
+	t.Run("IsSlotLeaderFromComponents", func(t *testing.T) {
+		allocs := testing.AllocsPerRun(100, func() {
+			_ = consensus.IsSlotLeaderFromComponents(
+				vrfOutput, poolStake, totalStake, activeSlotCoeff)
+		})
+		// Baseline: 1225 allocs - includes threshold calculation
+		limit := 1350.0 * multiplier
+		require.LessOrEqualf(
+			t,
+			allocs,
+			limit,
+			"IsSlotLeaderFromComponents: %.0f allocs exceeds limit %.0f",
+			allocs,
+			limit,
+		)
+		t.Logf(
+			"IsSlotLeaderFromComponents: %.0f allocs (limit: %.0f)",
+			allocs,
+			limit,
+		)
+	})
+
+	t.Run("VrfLeaderValue", func(t *testing.T) {
+		allocs := testing.AllocsPerRun(100, func() {
+			_ = consensus.VrfLeaderValue(vrfOutput)
+		})
+		limit := 5.0 * multiplier // Baseline: 4 allocs
+		require.LessOrEqualf(t, allocs, limit,
+			"VrfLeaderValue: %.0f allocs exceeds limit %.0f", allocs, limit)
+		t.Logf("VrfLeaderValue: %.0f allocs (limit: %.0f)", allocs, limit)
+	})
+}
+
+// TestRegressionCBOR verifies CBOR decode allocation regression.
+func TestRegressionCBOR(t *testing.T) {
+	multiplier := getThresholdMultiplier()
+	blocks := testdata.GetTestBlocks()
+
+	// Expected allocation limits by era (measured 2026-02-10 + 10% headroom)
+	limits := map[string]int64{
+		"Byron":   550,  // Baseline: 500
+		"Shelley": 485,  // Baseline: 441
+		"Allegra": 1180, // Baseline: 1072
+		"Mary":    1230, // Baseline: 1116
+		"Alonzo":  1500, // Baseline: 1362
+		"Babbage": 6260, // Baseline: 5688
+		"Conway":  2920, // Baseline: 2652
+	}
+
+	for _, block := range blocks {
+		t.Run(block.Name, func(t *testing.T) {
+			limit, ok := limits[block.Name]
+			if !ok {
+				t.Skipf("no limit defined for %s", block.Name)
+			}
+
+			// Validate decode works before measuring allocations
+			_, err := ledger.NewBlockFromCbor(block.BlockType, block.Cbor)
+			require.NoError(
+				t,
+				err,
+				"%s block decode should succeed",
+				block.Name,
+			)
+
+			allocs := testing.AllocsPerRun(100, func() {
+				_, _ = ledger.NewBlockFromCbor(block.BlockType, block.Cbor)
+			})
+
+			adjustedLimit := float64(limit) * multiplier
+			require.LessOrEqualf(
+				t,
+				allocs,
+				adjustedLimit,
+				"%s block decode: %.0f allocs exceeds limit %.0f",
+				block.Name,
+				allocs,
+				adjustedLimit,
+			)
+			t.Logf(
+				"%s: %.0f allocs (limit: %.0f)",
+				block.Name,
+				allocs,
+				adjustedLimit,
+			)
+		})
+	}
+}

--- a/internal/bench/script_bench_test.go
+++ b/internal/bench/script_bench_test.go
@@ -1,0 +1,568 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bench
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/plutigo/syn"
+)
+
+// Test key hashes for benchmarks (28 bytes each)
+var (
+	testKeyHash1 = common.Blake2b224{
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+		0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+		0x19, 0x1a, 0x1b, 0x1c,
+	}
+	testKeyHash2 = common.Blake2b224{
+		0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+		0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30,
+		0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
+		0x39, 0x3a, 0x3b, 0x3c,
+	}
+	testKeyHash3 = common.Blake2b224{
+		0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
+		0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f, 0x50,
+		0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
+		0x59, 0x5a, 0x5b, 0x5c,
+	}
+)
+
+// marshalNativeScript encodes a native script struct to CBOR and unmarshals it
+// back into a NativeScript. Panics on encode/unmarshal errors.
+func marshalNativeScript(script interface{}) common.NativeScript {
+	data, err := cbor.Encode(script)
+	if err != nil {
+		panic("failed to encode native script: " + err.Error())
+	}
+	var ns common.NativeScript
+	if err := ns.UnmarshalCBOR(data); err != nil {
+		panic("failed to unmarshal native script: " + err.Error())
+	}
+	return ns
+}
+
+// createPubkeyScript creates a native script requiring a specific key signature
+func createPubkeyScript(keyHash common.Blake2b224) common.NativeScript {
+	script := common.NativeScriptPubkey{
+		Type: 0,
+		Hash: keyHash[:],
+	}
+	return marshalNativeScript(&script)
+}
+
+// createAllScript creates a native script requiring all nested scripts to pass
+func createAllScript(scripts ...common.NativeScript) common.NativeScript {
+	script := common.NativeScriptAll{
+		Type:    1,
+		Scripts: scripts,
+	}
+	return marshalNativeScript(&script)
+}
+
+// createAnyScript creates a native script requiring at least one nested script
+// to pass
+func createAnyScript(scripts ...common.NativeScript) common.NativeScript {
+	script := common.NativeScriptAny{
+		Type:    2,
+		Scripts: scripts,
+	}
+	return marshalNativeScript(&script)
+}
+
+// createNofKScript creates a native script requiring N of K scripts to pass
+func createNofKScript(
+	n uint,
+	scripts ...common.NativeScript,
+) common.NativeScript {
+	script := common.NativeScriptNofK{
+		Type:    3,
+		N:       n,
+		Scripts: scripts,
+	}
+	return marshalNativeScript(&script)
+}
+
+// createInvalidBeforeScript creates a timelock script valid at/after a slot
+func createInvalidBeforeScript(slot uint64) common.NativeScript {
+	script := common.NativeScriptInvalidBefore{
+		Type: 4,
+		Slot: slot,
+	}
+	return marshalNativeScript(&script)
+}
+
+// createInvalidHereafterScript creates a timelock script valid before a slot
+func createInvalidHereafterScript(slot uint64) common.NativeScript {
+	script := common.NativeScriptInvalidHereafter{
+		Type: 5,
+		Slot: slot,
+	}
+	return marshalNativeScript(&script)
+}
+
+// createNestedScript creates a nested script structure at a given depth
+func createNestedScript(depth int, scriptType string) common.NativeScript {
+	if depth <= 1 {
+		return createPubkeyScript(testKeyHash1)
+	}
+
+	// Create child scripts
+	child1 := createNestedScript(depth-1, scriptType)
+	child2 := createNestedScript(depth-1, scriptType)
+	child3 := createNestedScript(depth-1, scriptType)
+
+	switch scriptType {
+	case "All":
+		return createAllScript(child1, child2, child3)
+	case "Any":
+		return createAnyScript(child1, child2, child3)
+	case "NofK":
+		return createNofKScript(2, child1, child2, child3)
+	default:
+		return createAllScript(child1, child2, child3)
+	}
+}
+
+// BenchmarkNativeScriptEvaluate benchmarks native script evaluation
+func BenchmarkNativeScriptEvaluate(b *testing.B) {
+	// Common benchmark parameters
+	slot := uint64(1000000)
+	validityStart := uint64(900000)
+	validityEnd := uint64(1100000)
+
+	// Key hashes map containing test keys
+	keyHashes := map[common.Blake2b224]bool{
+		testKeyHash1: true,
+		testKeyHash2: true,
+		testKeyHash3: true,
+	}
+
+	// Benchmark Pubkey script (single key check)
+	b.Run("ScriptType_Pubkey", func(b *testing.B) {
+		script := createPubkeyScript(testKeyHash1)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = script.Evaluate(slot, validityStart, validityEnd, keyHashes)
+		}
+	})
+
+	// Benchmark All script (conjunction) with 3 pubkey scripts
+	b.Run("ScriptType_All", func(b *testing.B) {
+		script := createAllScript(
+			createPubkeyScript(testKeyHash1),
+			createPubkeyScript(testKeyHash2),
+			createPubkeyScript(testKeyHash3),
+		)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = script.Evaluate(slot, validityStart, validityEnd, keyHashes)
+		}
+	})
+
+	// Benchmark Any script (disjunction) with 3 pubkey scripts
+	b.Run("ScriptType_Any", func(b *testing.B) {
+		script := createAnyScript(
+			createPubkeyScript(testKeyHash1),
+			createPubkeyScript(testKeyHash2),
+			createPubkeyScript(testKeyHash3),
+		)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = script.Evaluate(slot, validityStart, validityEnd, keyHashes)
+		}
+	})
+
+	// Benchmark NofK script (threshold) with 2-of-3
+	b.Run("ScriptType_NofK", func(b *testing.B) {
+		script := createNofKScript(2,
+			createPubkeyScript(testKeyHash1),
+			createPubkeyScript(testKeyHash2),
+			createPubkeyScript(testKeyHash3),
+		)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = script.Evaluate(slot, validityStart, validityEnd, keyHashes)
+		}
+	})
+
+	// Benchmark Timelock scripts (validity interval)
+	b.Run("ScriptType_Timelock/InvalidBefore", func(b *testing.B) {
+		script := createInvalidBeforeScript(validityStart)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = script.Evaluate(slot, validityStart, validityEnd, keyHashes)
+		}
+	})
+
+	b.Run("ScriptType_Timelock/InvalidHereafter", func(b *testing.B) {
+		script := createInvalidHereafterScript(validityEnd + 1000)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = script.Evaluate(slot, validityStart, validityEnd, keyHashes)
+		}
+	})
+
+	// Benchmark combined timelock script
+	b.Run("ScriptType_Timelock/Combined", func(b *testing.B) {
+		script := createAllScript(
+			createInvalidBeforeScript(validityStart),
+			createInvalidHereafterScript(validityEnd+1000),
+			createPubkeyScript(testKeyHash1),
+		)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = script.Evaluate(slot, validityStart, validityEnd, keyHashes)
+		}
+	})
+}
+
+// BenchmarkNativeScriptEvaluateDepth benchmarks native script evaluation at
+// various depths
+func BenchmarkNativeScriptEvaluateDepth(b *testing.B) {
+	slot := uint64(1000000)
+	validityStart := uint64(900000)
+	validityEnd := uint64(1100000)
+	keyHashes := map[common.Blake2b224]bool{
+		testKeyHash1: true,
+		testKeyHash2: true,
+		testKeyHash3: true,
+	}
+
+	depths := []int{1, 3, 5}
+	scriptTypes := []string{"All", "Any", "NofK"}
+
+	for _, scriptType := range scriptTypes {
+		for _, depth := range depths {
+			name := fmt.Sprintf("%s/Depth%d", scriptType, depth)
+			b.Run(name, func(b *testing.B) {
+				script := createNestedScript(depth, scriptType)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					_ = script.Evaluate(
+						slot,
+						validityStart,
+						validityEnd,
+						keyHashes,
+					)
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkNativeScriptEvaluateWorstCase benchmarks worst-case native script
+// evaluation
+// where all branches must be checked
+func BenchmarkNativeScriptEvaluateWorstCase(b *testing.B) {
+	slot := uint64(1000000)
+	validityStart := uint64(900000)
+	validityEnd := uint64(1100000)
+
+	// Only testKeyHash3 is present - forces checking all branches in Any
+	keyHashes := map[common.Blake2b224]bool{
+		testKeyHash3: true,
+	}
+
+	// Missing key hash for worst case
+	missingKeyHash := common.Blake2b224{
+		0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99,
+		0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99,
+		0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99,
+		0x99, 0x99, 0x99, 0x99,
+	}
+
+	// Any script where the matching script is last (worst case)
+	b.Run("Any/MatchLast", func(b *testing.B) {
+		script := createAnyScript(
+			createPubkeyScript(missingKeyHash),
+			createPubkeyScript(missingKeyHash),
+			createPubkeyScript(testKeyHash3),
+		)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = script.Evaluate(slot, validityStart, validityEnd, keyHashes)
+		}
+	})
+
+	// All script where the failing script is last (worst case)
+	b.Run("All/FailLast", func(b *testing.B) {
+		script := createAllScript(
+			createPubkeyScript(testKeyHash3),
+			createPubkeyScript(testKeyHash3),
+			createPubkeyScript(missingKeyHash),
+		)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = script.Evaluate(slot, validityStart, validityEnd, keyHashes)
+		}
+	})
+
+	// NofK where we need to check all to find N passing
+	b.Run("NofK/CheckAll", func(b *testing.B) {
+		script := createNofKScript(2,
+			createPubkeyScript(missingKeyHash),
+			createPubkeyScript(testKeyHash3),
+			createPubkeyScript(testKeyHash3),
+		)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = script.Evaluate(slot, validityStart, validityEnd, keyHashes)
+		}
+	})
+}
+
+// PlutusV3 script bytes from test vectors (a minimal "always succeeds" script)
+// This is a real PlutusV3 script from the codebase tests
+var testPlutusV3ScriptHex = "587f01010032323232323225333002323232323253" +
+	"330073370e900118041baa0011323232533300a3370e900018059baa00513232" +
+	"533300f301100214a22c6eb8c03c004c030dd50028b18069807001180600098" +
+	"049baa00116300a300b0023009001300900230070013004375400229309b2b2" +
+	"b9a5573aaae7955cfaba157441"
+
+// PlutusV1 and V2 use the same test script as V3 for benchmarking purposes
+// The script is CBOR-wrapped UPLC bytecode. The structure is:
+// [CBOR bytestring tag] [length] [UPLC flat-encoded program]
+var testPlutusV1ScriptHex = testPlutusV3ScriptHex
+var testPlutusV2ScriptHex = testPlutusV3ScriptHex
+
+// BenchmarkPlutusScriptDeserialize benchmarks Plutus script deserialization
+// using plutigo
+func BenchmarkPlutusScriptDeserialize(b *testing.B) {
+	// Decode test script bytes
+	plutusV3Bytes, err := hex.DecodeString(testPlutusV3ScriptHex)
+	if err != nil {
+		b.Fatalf("failed to decode PlutusV3 script hex: %v", err)
+	}
+
+	plutusV1Bytes, err := hex.DecodeString(testPlutusV1ScriptHex)
+	if err != nil {
+		b.Fatalf("failed to decode PlutusV1 script hex: %v", err)
+	}
+
+	plutusV2Bytes, err := hex.DecodeString(testPlutusV2ScriptHex)
+	if err != nil {
+		b.Fatalf("failed to decode PlutusV2 script hex: %v", err)
+	}
+
+	b.Run("PlutusV1", func(b *testing.B) {
+		script := common.PlutusV1Script(plutusV1Bytes)
+
+		// Get inner script bytes (CBOR unwrap)
+		var innerScript []byte
+		if _, err := cbor.Decode(script, &innerScript); err != nil {
+			b.Fatalf("failed to decode CBOR wrapper: %v", err)
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := syn.Decode[syn.DeBruijn](innerScript)
+			if err != nil {
+				b.Fatalf("failed to deserialize PlutusV1 script: %v", err)
+			}
+		}
+	})
+
+	b.Run("PlutusV2", func(b *testing.B) {
+		script := common.PlutusV2Script(plutusV2Bytes)
+
+		// Get inner script bytes (CBOR unwrap)
+		var innerScript []byte
+		if _, err := cbor.Decode(script, &innerScript); err != nil {
+			b.Fatalf("failed to decode CBOR wrapper: %v", err)
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := syn.Decode[syn.DeBruijn](innerScript)
+			if err != nil {
+				b.Fatalf("failed to deserialize PlutusV2 script: %v", err)
+			}
+		}
+	})
+
+	b.Run("PlutusV3", func(b *testing.B) {
+		script := common.PlutusV3Script(plutusV3Bytes)
+
+		// Get inner script bytes (CBOR unwrap)
+		var innerScript []byte
+		if _, err := cbor.Decode(script, &innerScript); err != nil {
+			b.Fatalf("failed to decode CBOR wrapper: %v", err)
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := syn.Decode[syn.DeBruijn](innerScript)
+			if err != nil {
+				b.Fatalf("failed to deserialize PlutusV3 script: %v", err)
+			}
+		}
+	})
+}
+
+// BenchmarkPlutusScriptHash benchmarks Plutus script hash computation
+func BenchmarkPlutusScriptHash(b *testing.B) {
+	plutusV1Bytes, err := hex.DecodeString(testPlutusV1ScriptHex)
+	if err != nil {
+		b.Fatalf("failed to decode PlutusV1 hex: %v", err)
+	}
+	plutusV3Bytes, err := hex.DecodeString(testPlutusV3ScriptHex)
+	if err != nil {
+		b.Fatalf("failed to decode PlutusV3 hex: %v", err)
+	}
+
+	b.Run("PlutusV1", func(b *testing.B) {
+		script := common.PlutusV1Script(plutusV1Bytes)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = script.Hash()
+		}
+	})
+
+	b.Run("PlutusV3", func(b *testing.B) {
+		script := common.PlutusV3Script(plutusV3Bytes)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = script.Hash()
+		}
+	})
+}
+
+// BenchmarkNativeScriptHash benchmarks native script hash computation
+func BenchmarkNativeScriptHash(b *testing.B) {
+	b.Run("Pubkey", func(b *testing.B) {
+		script := createPubkeyScript(testKeyHash1)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = script.Hash()
+		}
+	})
+
+	b.Run("All/Depth3", func(b *testing.B) {
+		script := createNestedScript(3, "All")
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = script.Hash()
+		}
+	})
+
+	b.Run("Any/Depth3", func(b *testing.B) {
+		script := createNestedScript(3, "Any")
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = script.Hash()
+		}
+	})
+
+	b.Run("NofK/Depth3", func(b *testing.B) {
+		script := createNestedScript(3, "NofK")
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = script.Hash()
+		}
+	})
+}
+
+// BenchmarkNativeScriptCBOR benchmarks native script CBOR
+// serialization/deserialization
+func BenchmarkNativeScriptCBOR(b *testing.B) {
+	// Encode benchmarks measure the cached-byte fast path of MarshalCBOR.
+	// NativeScripts created via UnmarshalCBOR retain their raw CBOR bytes,
+	// so MarshalCBOR returns those directly without re-serializing.
+	// This reflects real-world behavior where scripts are decoded from blocks.
+	b.Run("Encode_CachedPath/Pubkey", func(b *testing.B) {
+		script := createPubkeyScript(testKeyHash1)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := cbor.Encode(&script)
+			if err != nil {
+				b.Fatalf("failed to encode: %v", err)
+			}
+		}
+	})
+
+	b.Run("Encode_CachedPath/All_Depth3", func(b *testing.B) {
+		script := createNestedScript(3, "All")
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := cbor.Encode(&script)
+			if err != nil {
+				b.Fatalf("failed to encode: %v", err)
+			}
+		}
+	})
+
+	b.Run("Decode/Pubkey", func(b *testing.B) {
+		script := createPubkeyScript(testKeyHash1)
+		data, err := cbor.Encode(&script)
+		if err != nil {
+			b.Fatalf("failed to encode script: %v", err)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var ns common.NativeScript
+			err := ns.UnmarshalCBOR(data)
+			if err != nil {
+				b.Fatalf("failed to decode: %v", err)
+			}
+		}
+	})
+
+	b.Run("Decode/All_Depth3", func(b *testing.B) {
+		script := createNestedScript(3, "All")
+		data, err := cbor.Encode(&script)
+		if err != nil {
+			b.Fatalf("failed to encode script: %v", err)
+		}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var ns common.NativeScript
+			err := ns.UnmarshalCBOR(data)
+			if err != nil {
+				b.Fatalf("failed to decode: %v", err)
+			}
+		}
+	})
+}

--- a/internal/bench/testdata/README.md
+++ b/internal/bench/testdata/README.md
@@ -1,0 +1,76 @@
+# Benchmark Test Data
+
+This directory contains test fixtures for memory profiling benchmarks.
+
+## Directory Structure
+
+```text
+testdata/
+  blocks/           # Block CBOR fixtures (future use)
+  transactions/     # Transaction CBOR fixtures (future use)
+```
+
+## Current Fixture Source
+
+The benchmark infrastructure currently uses block fixtures from `internal/testdata/`:
+
+| Era     | Source File         | Block Hash                                                         |
+|---------|--------------------|--------------------------------------------------------------------|
+| Byron   | byron_block.hex    | 1451a0dbf16cfeddf4991a838961df1b08a68f43a19c0eb3b36cc4029c77a2d8   |
+| Shelley | shelley_block.hex  | 2308cdd4c0bf8b8bf92523bdd1dd31640c0f42ff079d985fcc07c36cbf915c2b   |
+| Allegra | allegra_block.hex  | 8115134ab013f6a5fd88fd2a10825177a2eedcde31cb2f1f35e492df469cf9a8   |
+| Mary    | mary_block.hex     | d36ab36f451e9fcbd4247daef45ce5be9a4b918fce5ee97a63b8aeac606fca03   |
+| Alonzo  | alonzo_block.hex   | 1d7974cb01cc9e3fbe9dd7594795a36b21cb1deb2f1b70a0625332c91bd7e5a7   |
+| Babbage | babbage_block.hex  | db19fcfaba30607e363113b0a13616e6a9da5aa48b86ec2c033786f0a2e13f7d   |
+| Conway  | conway_block.hex   | 27807a70215e3e018eec9be8c619c692e06a78ebcb63daf90d7abe823f3bbf47   |
+
+All blocks are real mainnet blocks fetched from [cexplorer.io](https://cexplorer.io).
+
+## Adding New Fixtures
+
+To add a new block fixture:
+
+1. Fetch the block CBOR from a Cardano node or block explorer
+2. Save as hex-encoded file: `testdata/blocks/<era>/<name>.hex`
+3. Register in `internal/bench/helpers.go` if needed
+
+Example fixture format:
+```text
+# blocks/conway/governance.hex
+# Conway block with governance actions
+# Slot: 159835207
+# Hash: 27807a70215e3e018eec9be8c619c692e06a78ebcb63daf90d7abe823f3bbf47
+820685828a1a00...
+```
+
+## Transaction Fixtures
+
+Transaction fixtures should follow the same pattern:
+
+```text
+testdata/transactions/<era>/<name>.hex
+```
+
+Categories:
+- `simple` - Single input/output, no scripts
+- `multisig` - Native multisig scripts
+- `plutusv1` - PlutusV1 script transaction
+- `plutusv2` - PlutusV2 script transaction
+- `plutusv3` - PlutusV3 script transaction
+- `governance` - Conway governance actions
+- `large` - Maximum inputs/outputs
+
+## Usage
+
+```go
+import "github.com/blinklabs-io/gouroboros/internal/bench"
+
+// Load a block fixture
+fixture := bench.MustLoadBlockFixture("conway", "default")
+
+// Access the decoded block
+block := fixture.Block
+
+// Access raw CBOR
+cbor := fixture.Cbor
+```

--- a/internal/bench/tx_bench_test.go
+++ b/internal/bench/tx_bench_test.go
@@ -1,0 +1,281 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bench
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+)
+
+// benchSink prevents compiler dead-code elimination in benchmarks.
+var benchSink interface{}
+
+// BenchmarkTxDecode benchmarks transaction CBOR decoding by era.
+func BenchmarkTxDecode(b *testing.B) {
+	for _, era := range PostByronEraNames() {
+		fixture := MustLoadBlockFixture(era, "default")
+		txs := fixture.Block.Transactions()
+		if len(txs) == 0 {
+			continue
+		}
+		txCbor := txs[0].Cbor()
+		if len(txCbor) == 0 {
+			continue
+		}
+
+		txType, err := TxTypeFromEra(era)
+		if err != nil {
+			b.Fatalf("TxTypeFromEra failed for %s: %v", era, err)
+		}
+
+		b.Run("Era_"+era, func(b *testing.B) {
+			// Pre-validate that decoding succeeds before measuring
+			tx, err := ledger.NewTransactionFromCbor(txType, txCbor)
+			if err != nil {
+				b.Fatalf(
+					"NewTransactionFromCbor failed for %s: %v",
+					era,
+					err,
+				)
+			}
+			benchSink = tx
+
+			b.SetBytes(int64(len(txCbor)))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				tx, err := ledger.NewTransactionFromCbor(txType, txCbor)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchSink = tx
+			}
+		})
+	}
+}
+
+// BenchmarkTxHash benchmarks transaction hash calculation.
+func BenchmarkTxHash(b *testing.B) {
+	for _, era := range PostByronEraNames() {
+		fixture := MustLoadBlockFixture(era, "default")
+		txs := fixture.Block.Transactions()
+		if len(txs) == 0 {
+			continue
+		}
+		tx := txs[0]
+
+		b.Run("Era_"+era, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchSink = tx.Hash()
+			}
+		})
+	}
+}
+
+// BenchmarkTxInputs benchmarks transaction input iteration.
+func BenchmarkTxInputs(b *testing.B) {
+	for _, era := range PostByronEraNames() {
+		fixture := MustLoadBlockFixture(era, "default")
+		txs := fixture.Block.Transactions()
+		if len(txs) == 0 {
+			continue
+		}
+		tx := txs[0]
+
+		b.Run("Era_"+era, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchSink = tx.Inputs()
+			}
+		})
+	}
+}
+
+// BenchmarkTxOutputs benchmarks transaction output iteration.
+func BenchmarkTxOutputs(b *testing.B) {
+	for _, era := range PostByronEraNames() {
+		fixture := MustLoadBlockFixture(era, "default")
+		txs := fixture.Block.Transactions()
+		if len(txs) == 0 {
+			continue
+		}
+		tx := txs[0]
+
+		b.Run("Era_"+era, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchSink = tx.Outputs()
+			}
+		})
+	}
+}
+
+// BenchmarkTxFee benchmarks transaction fee retrieval.
+func BenchmarkTxFee(b *testing.B) {
+	for _, era := range PostByronEraNames() {
+		fixture := MustLoadBlockFixture(era, "default")
+		txs := fixture.Block.Transactions()
+		if len(txs) == 0 {
+			continue
+		}
+		tx := txs[0]
+
+		b.Run("Era_"+era, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchSink = tx.Fee()
+			}
+		})
+	}
+}
+
+// BenchmarkTxMetadata benchmarks transaction metadata retrieval.
+func BenchmarkTxMetadata(b *testing.B) {
+	for _, era := range PostByronEraNames() {
+		fixture := MustLoadBlockFixture(era, "default")
+		txs := fixture.Block.Transactions()
+		if len(txs) == 0 {
+			continue
+		}
+		tx := txs[0]
+
+		b.Run("Era_"+era, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchSink = tx.Metadata()
+			}
+		})
+	}
+}
+
+// BenchmarkTxCbor benchmarks getting transaction CBOR bytes.
+func BenchmarkTxCbor(b *testing.B) {
+	for _, era := range PostByronEraNames() {
+		fixture := MustLoadBlockFixture(era, "default")
+		txs := fixture.Block.Transactions()
+		if len(txs) == 0 {
+			continue
+		}
+		tx := txs[0]
+
+		b.Run("Era_"+era, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchSink = tx.Cbor()
+			}
+		})
+	}
+}
+
+// BenchmarkTxUtxorpc benchmarks transaction Utxorpc conversion.
+func BenchmarkTxUtxorpc(b *testing.B) {
+	for _, era := range PostByronEraNames() {
+		fixture := MustLoadBlockFixture(era, "default")
+		txs := fixture.Block.Transactions()
+		if len(txs) == 0 {
+			continue
+		}
+		tx := txs[0]
+
+		b.Run("Era_"+era, func(b *testing.B) {
+			// Pre-validate that Utxorpc conversion succeeds
+			result, err := tx.Utxorpc()
+			if err != nil {
+				b.Fatalf("Utxorpc failed for %s: %v", era, err)
+			}
+			benchSink = result
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				result, err := tx.Utxorpc()
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchSink = result
+			}
+		})
+	}
+}
+
+// BenchmarkTxProducedUtxos benchmarks produced UTXO enumeration.
+func BenchmarkTxProducedUtxos(b *testing.B) {
+	for _, era := range PostByronEraNames() {
+		fixture := MustLoadBlockFixture(era, "default")
+		txs := fixture.Block.Transactions()
+		if len(txs) == 0 {
+			continue
+		}
+		tx := txs[0]
+
+		b.Run("Era_"+era, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchSink = tx.Produced()
+			}
+		})
+	}
+}
+
+// BenchmarkTxConsumedUtxos benchmarks consumed UTXO enumeration.
+func BenchmarkTxConsumedUtxos(b *testing.B) {
+	for _, era := range PostByronEraNames() {
+		fixture := MustLoadBlockFixture(era, "default")
+		txs := fixture.Block.Transactions()
+		if len(txs) == 0 {
+			continue
+		}
+		tx := txs[0]
+
+		b.Run("Era_"+era, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchSink = tx.Consumed()
+			}
+		})
+	}
+}
+
+// BenchmarkTxBlockIteration benchmarks iterating through all transactions in a
+// block.
+func BenchmarkTxBlockIteration(b *testing.B) {
+	for _, era := range PostByronEraNames() {
+		fixture := MustLoadBlockFixture(era, "default")
+
+		b.Run("Era_"+era, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				txs := fixture.Block.Transactions()
+				for _, tx := range txs {
+					benchSink = tx.Hash()
+					benchSink = tx.Fee()
+					benchSink = tx.Inputs()
+					benchSink = tx.Outputs()
+				}
+			}
+		})
+	}
+}

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+# Copyright 2026 Blink Labs Software
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# profile.sh - Generate and analyze pprof profiles for gouroboros components
+#
+# Usage:
+#   ./scripts/profile.sh [component] [profile_type] [options]
+#
+# Components:
+#   block     - Block validation profiling (default)
+#   cbor      - CBOR decode profiling
+#   vrf       - VRF operations profiling
+#   consensus - Consensus operations profiling
+#   bodyhash  - Body hash validation profiling
+#   script    - Native script evaluation profiling
+#   all       - Run all profiling tests
+#
+# Profile types:
+#   cpu       - CPU profile only
+#   mem       - Memory profile only
+#   both      - Both CPU and memory (default)
+#
+# Options:
+#   --view    - Open profiles in pprof web UI after generation
+#   --help    - Show this help message
+#
+# Examples:
+#   ./scripts/profile.sh block cpu
+#   ./scripts/profile.sh cbor mem --view
+#   ./scripts/profile.sh all both
+#   ./scripts/profile.sh vrf both --view
+
+set -e
+
+# Default values
+COMPONENT="block"
+PROFILE_TYPE="both"
+VIEW_PROFILES=false
+OUTPUT_DIR="profiles"
+
+# Parse all arguments (options and positional) in a single pass
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --view)
+            VIEW_PROFILES=true
+            shift
+            ;;
+        --help|-h)
+            sed -n '16,43p' "$0" | sed 's/^# //' | sed 's/^#//'
+            exit 0
+            ;;
+        -*)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+        *)
+            POSITIONAL+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# Assign positional arguments
+if [[ ${#POSITIONAL[@]} -ge 1 ]]; then
+    COMPONENT="${POSITIONAL[0]}"
+fi
+if [[ ${#POSITIONAL[@]} -ge 2 ]]; then
+    PROFILE_TYPE="${POSITIONAL[1]}"
+fi
+
+# Create output directory
+mkdir -p "$OUTPUT_DIR"
+
+# Map component names to test names
+component_to_test() {
+    case "$1" in
+        block)     echo "TestProfileBlockValidation" ;;
+        cbor)      echo "TestProfileCBORDecode" ;;
+        vrf)       echo "TestProfileVRF" ;;
+        consensus) echo "TestProfileConsensus" ;;
+        bodyhash)  echo "TestProfileBodyHash" ;;
+        script)    echo "TestProfileNativeScript" ;;
+        *)         echo "" ;;
+    esac
+}
+
+# Run profiling for a single component
+run_profile() {
+    local component="$1"
+    local test_name
+    test_name=$(component_to_test "$component")
+
+    if [[ -z "$test_name" ]]; then
+        echo "Unknown component: $component"
+        return 1
+    fi
+
+    echo "=== Profiling $component ($test_name) ==="
+
+    local cpu_prof="$OUTPUT_DIR/cpu_${component}.prof"
+    local mem_prof="$OUTPUT_DIR/mem_${component}.prof"
+    local cmd_args=(-tags=profile "-run=$test_name" -timeout=10m)
+
+    case "$PROFILE_TYPE" in
+        cpu)
+            echo "Generating CPU profile: $cpu_prof"
+            go test "${cmd_args[@]}" -cpuprofile="$cpu_prof" ./internal/bench/...
+            ;;
+        mem)
+            echo "Generating memory profile: $mem_prof"
+            go test "${cmd_args[@]}" -memprofile="$mem_prof" ./internal/bench/...
+            ;;
+        both)
+            echo "Generating CPU profile: $cpu_prof"
+            echo "Generating memory profile: $mem_prof"
+            go test "${cmd_args[@]}" -cpuprofile="$cpu_prof" -memprofile="$mem_prof" ./internal/bench/...
+            ;;
+        *)
+            echo "Unknown profile type: $PROFILE_TYPE"
+            return 1
+            ;;
+    esac
+
+    echo "Profile(s) saved to $OUTPUT_DIR/"
+    echo ""
+}
+
+# View profiles in web UI
+view_profiles() {
+    local component="$1"
+    local cpu_prof="$OUTPUT_DIR/cpu_${component}.prof"
+    local mem_prof="$OUTPUT_DIR/mem_${component}.prof"
+    local port=8080
+
+    if [[ "$PROFILE_TYPE" == "cpu" || "$PROFILE_TYPE" == "both" ]] && [[ -f "$cpu_prof" ]]; then
+        echo "Opening CPU profile in browser at http://localhost:$port"
+        go tool pprof -http=localhost:$port "$cpu_prof" &
+        port=$((port + 1))
+    fi
+
+    if [[ "$PROFILE_TYPE" == "mem" || "$PROFILE_TYPE" == "both" ]] && [[ -f "$mem_prof" ]]; then
+        echo "Opening memory profile in browser at http://localhost:$port"
+        go tool pprof -http=localhost:$port "$mem_prof" &
+    fi
+
+    echo ""
+    echo "Press Ctrl+C to stop the pprof servers"
+    wait
+}
+
+# Main execution
+if [[ "$COMPONENT" == "all" ]]; then
+    COMPONENTS=(block cbor vrf consensus bodyhash script)
+    FAILURES=()
+    for comp in "${COMPONENTS[@]}"; do
+        if ! run_profile "$comp"; then
+            FAILURES+=("$comp")
+        fi
+    done
+
+    if [[ "$VIEW_PROFILES" == true ]]; then
+        echo "Note: --view with 'all' only opens the first component's profiles"
+        view_profiles "block"
+    fi
+else
+    run_profile "$COMPONENT"
+
+    if [[ "$VIEW_PROFILES" == true ]]; then
+        view_profiles "$COMPONENT"
+    fi
+fi
+
+echo "=== Profiling complete ==="
+echo ""
+if [[ "$COMPONENT" == "all" ]]; then
+    echo "To analyze profiles manually (example for 'block' component):"
+    if [[ "$PROFILE_TYPE" == "cpu" || "$PROFILE_TYPE" == "both" ]]; then
+        echo "  go tool pprof -http=localhost:8080 $OUTPUT_DIR/cpu_block.prof"
+    fi
+    if [[ "$PROFILE_TYPE" == "mem" || "$PROFILE_TYPE" == "both" ]]; then
+        echo "  go tool pprof -http=localhost:8081 $OUTPUT_DIR/mem_block.prof"
+    fi
+    echo ""
+    echo "Available components: block cbor vrf consensus bodyhash script"
+    echo "Replace 'block' with any component name above, e.g.:"
+    if [[ "$PROFILE_TYPE" == "cpu" || "$PROFILE_TYPE" == "both" ]]; then
+        echo "  go tool pprof -http=localhost:8080 $OUTPUT_DIR/cpu_cbor.prof"
+    fi
+    if [[ "$PROFILE_TYPE" == "mem" || "$PROFILE_TYPE" == "both" ]]; then
+        echo "  go tool pprof -http=localhost:8081 $OUTPUT_DIR/mem_cbor.prof"
+    fi
+else
+    echo "To analyze profiles manually:"
+    if [[ "$PROFILE_TYPE" == "cpu" || "$PROFILE_TYPE" == "both" ]]; then
+        echo "  go tool pprof -http=localhost:8080 $OUTPUT_DIR/cpu_${COMPONENT}.prof"
+    fi
+    if [[ "$PROFILE_TYPE" == "mem" || "$PROFILE_TYPE" == "both" ]]; then
+        echo "  go tool pprof -http=localhost:8081 $OUTPUT_DIR/mem_${COMPONENT}.prof"
+    fi
+fi
+echo ""
+if [[ "$COMPONENT" == "all" ]]; then
+    echo "For text-based analysis (example for 'block' component):"
+    if [[ "$PROFILE_TYPE" == "cpu" || "$PROFILE_TYPE" == "both" ]]; then
+        echo "  go tool pprof -top $OUTPUT_DIR/cpu_block.prof"
+    fi
+    if [[ "$PROFILE_TYPE" == "mem" || "$PROFILE_TYPE" == "both" ]]; then
+        echo "  go tool pprof -top $OUTPUT_DIR/mem_block.prof"
+    fi
+else
+    echo "For text-based analysis:"
+    if [[ "$PROFILE_TYPE" == "cpu" || "$PROFILE_TYPE" == "both" ]]; then
+        echo "  go tool pprof -top $OUTPUT_DIR/cpu_${COMPONENT}.prof"
+    fi
+    if [[ "$PROFILE_TYPE" == "mem" || "$PROFILE_TYPE" == "both" ]]; then
+        echo "  go tool pprof -top $OUTPUT_DIR/mem_${COMPONENT}.prof"
+    fi
+fi
+echo ""
+echo "Compare two profiles:"
+echo "  go tool pprof -base=old.prof new.prof"
+
+if [[ "$COMPONENT" == "all" && ${#FAILURES[@]} -gt 0 ]]; then
+    echo "WARNING: Profiling failed for: ${FAILURES[*]}"
+    exit 1
+fi


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a full memory profiling and benchmark suite across core validation paths to catch performance regressions early. Includes docs and CI to run, compare, and profile results.

- **New Features**
  - Benchmarks for blocks, transactions, CBOR, consensus (VRF/KES), and Plutus scripts using shared helpers and real fixtures.
  - Allocation regression tests with per-era baselines; fail on >20% alloc/time or >50% bytes (linux/amd64, Go 1.24+).
  - Profiling behind a "profile" build tag with scripts/profile.sh for CPU/heap pprof and benchstat diffs; guided by PROFILING.md.
  - GitHub Actions workflow (push to main + manual) runs vrf/kes/consensus/cbor/pipeline/ledger/internal/bench with benchmem and multiple runs; archives outputs. Docs include README, BASELINES.md, and fixture notes.

<sup>Written for commit 57b1c610fe3ee920a73aceea1458c4aed243a13a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive performance, profiling, and allocation-regression test suites covering block validation, CBOR, transactions, consensus, VRF/KES, native/Plutus scripts, and helpers.

* **Chores**
  * Added CI benchmark workflow to run and archive benchmark outputs, a profiling orchestration script, benchmark helpers, and realistic fixture data.

* **Documentation**
  * Added comprehensive benchmarking docs: README, profiling guide, baselines, and testdata usage notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->