### PR TITLE
fix(cbor): bounds checking on inputs

### DIFF
--- a/cbor/decode.go
+++ b/cbor/decode.go
@@ -64,6 +64,9 @@ func Decode(dataBytes []byte, dest any) (int, error) {
 // Extract the first item from a CBOR list. This will return the first item from the
 // provided list if it's numeric and an error otherwise
 func DecodeIdFromList(cborData []byte) (int, error) {
+	if len(cborData) < 2 {
+		return 0, errors.New("CBOR data too short for list with ID")
+	}
 	// If the list length is <= the max simple uint and the first list value
 	// is <= the max simple uint, then we can extract the value straight from
 	// the byte slice
@@ -108,6 +111,9 @@ func DecodeIdFromList(cborData []byte) (int, error) {
 
 // Determine the length of a CBOR list
 func ListLength(cborData []byte) (int, error) {
+	if len(cborData) == 0 {
+		return 0, errors.New("empty CBOR data")
+	}
 	// If the list length is <= the max simple uint, then we can extract the length
 	// value straight from the byte slice (with a little math)
 	if cborData[0] >= CborTypeArray &&

--- a/cbor/decode_test.go
+++ b/cbor/decode_test.go
@@ -380,3 +380,42 @@ func BenchmarkDecode(b *testing.B) {
 		}
 	}
 }
+
+// TestListLengthEmptyInput verifies that ListLength handles empty/nil input
+// gracefully without panicking (security fix for bounds checking).
+func TestListLengthEmptyInput(t *testing.T) {
+	t.Run("nil input", func(t *testing.T) {
+		_, err := cbor.ListLength(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty CBOR data")
+	})
+
+	t.Run("empty slice", func(t *testing.T) {
+		_, err := cbor.ListLength([]byte{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty CBOR data")
+	})
+}
+
+// TestDecodeIdFromListEmptyInput verifies that DecodeIdFromList handles
+// empty/nil and short input gracefully without panicking (security fix).
+func TestDecodeIdFromListEmptyInput(t *testing.T) {
+	t.Run("nil input", func(t *testing.T) {
+		_, err := cbor.DecodeIdFromList(nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "CBOR data too short")
+	})
+
+	t.Run("empty slice", func(t *testing.T) {
+		_, err := cbor.DecodeIdFromList([]byte{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "CBOR data too short")
+	})
+
+	t.Run("single byte input", func(t *testing.T) {
+		// 0x81 = array of length 1, but no second byte for the element
+		_, err := cbor.DecodeIdFromList([]byte{0x81})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "CBOR data too short")
+	})
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added bounds checks to CBOR ListLength and DecodeIdFromList to handle empty or too-short input safely, preventing panics and improving robustness.

- **Bug Fixes**
  - Validate input length and return errors for empty or short CBOR data.
  - Added tests covering nil, empty, and single-byte inputs.

<sup>Written for commit 615c1bcdd0735272a19210fc94d4c1d7312c5305. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced CBOR data input validation to properly handle empty, nil, and incomplete data inputs.

* **Tests**
  * Added comprehensive test coverage for input validation edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->