### PR TITLE
ci(go-test): add go 1.26.x to the matrix

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
     name: go-test
     strategy:
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version: [1.24.x, 1.25.x, 1.26.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Go 1.26.x to the GitHub Actions test matrix alongside 1.24.x and 1.25.x. This ensures our tests run on the latest Go version and catch compatibility issues early.

<sup>Written for commit f7dc3dec55258072343391e4eff463a9375ab02c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD test matrix to include Go 1.26.x support alongside existing versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->