### PR TITLE
feat(protocol): drep state query

### DIFF
--- a/protocol/localstatequery/queries.go
+++ b/protocol/localstatequery/queries.go
@@ -877,9 +877,8 @@ type DRepStateEntry struct {
 }
 
 // DRepStateResult represents the DRep state query result.
-// The result is raw CBOR that maps credentials to DRep state.
-// Consumers must decode the CBOR themselves based on the expected format.
-type DRepStateResult cbor.RawMessage
+// The result is a map of stake credentials to DRep state entries.
+type DRepStateResult map[StakeCredential]DRepStateEntry
 
 // DRepStakeDistrResult represents the DRep stake distribution
 // The result is returned as raw CBOR that maps DReps to stake amounts


### PR DESCRIPTION
Closes #1505 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DRep state query to LocalStateQuery. The result is now a typed map of stake credentials to DRepStateEntry, with Conway-era gating and tests.

- **New Features**
  - Added Client.GetDRepState() for Conway era and later.
  - Switched DRepStateResult from raw CBOR to map[StakeCredential]DRepStateEntry.
  - Added tests for populated, empty, and pre-Conway error cases.

- **Migration**
  - Remove manual CBOR decoding and use the returned map directly.
  - Handle empty results and the era error: “GetDRepState requires Conway era or later.”

<sup>Written for commit 1ebe13e8906af94be0c6d8eadb282ee9dd8c38e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

