### PR TITLE
feat(protocol): filtered vote delegatees query

### DIFF
--- a/protocol/localstatequery/queries.go
+++ b/protocol/localstatequery/queries.go
@@ -911,8 +911,8 @@ type CommitteeMembersStateResult struct {
 
 // FilteredVoteDelegateesResult represents the vote delegatees
 // for stake credentials.
-// The result is raw CBOR that maps credentials to DRep delegations
-type FilteredVoteDelegateesResult cbor.RawMessage
+// The result maps stake credentials to their DRep delegations
+type FilteredVoteDelegateesResult map[StakeCredential]lcommon.Drep
 
 // SPOStakeDistrResult represents the SPO stake distribution for governance
 // Maps pool IDs to their governance voting power


### PR DESCRIPTION
Closes #1507 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds filtered vote delegatees and proposals queries for Conway governance, with typed results and strict era checks. Closes #1507.

- **New Features**
  - Client.GetFilteredVoteDelegatees returns map[StakeCredential]Drep (typed, not raw CBOR); clear error on pre-Conway; round-trip decode and query tests added.
  - Client.GetProposals returns all active proposals with IDs, votes (committee/DRep/SPO), procedure, and active epochs; clear error on pre-Conway; tests for empty and single proposal cases.

<sup>Written for commit 8d6e075bba7422bd5319fe7c97df7f126c5879f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for governance proposals queries with detailed action states and voting information.
  * Enhanced vote delegatee data representation with improved type safety.

* **Tests**
  * Added comprehensive tests for governance proposals query functionality, result decoding, and era compatibility validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->