### PR TITLE
fix: update Leios protocol message shapes

### DIFF
--- a/protocol/leiosfetch/client.go
+++ b/protocol/leiosfetch/client.go
@@ -121,12 +121,11 @@ func (c *Client) Stop() error {
 	return err
 }
 
-// BlockRequest fetches the requested EB identified by the slot and Leios hash
+// BlockRequest fetches the requested EB identified by the specified point
 func (c *Client) BlockRequest(
-	slot uint64,
-	hash []byte,
+	point pcommon.Point,
 ) (protocol.Message, error) {
-	msg := NewMsgBlockRequest(slot, hash)
+	msg := NewMsgBlockRequest(point)
 	if err := c.SendMessage(msg); err != nil {
 		return nil, err
 	}
@@ -137,13 +136,12 @@ func (c *Client) BlockRequest(
 	return resp, nil
 }
 
-// BlockTxsRequest fetches the requested TXs identified by the slot, Leios hash, and TX bitmaps
+// BlockTxsRequest fetches the requested TXs identified by the specified point and TX bitmaps
 func (c *Client) BlockTxsRequest(
-	slot uint64,
-	hash []byte,
-	bitmaps map[uint16][8]byte,
+	point pcommon.Point,
+	bitmaps map[uint16]uint64,
 ) (protocol.Message, error) {
-	msg := NewMsgBlockTxsRequest(slot, hash, bitmaps)
+	msg := NewMsgBlockTxsRequest(point, bitmaps)
 	if err := c.SendMessage(msg); err != nil {
 		return nil, err
 	}

--- a/protocol/leiosfetch/client_test.go
+++ b/protocol/leiosfetch/client_test.go
@@ -150,7 +150,7 @@ func TestClientMessageHandlerUnexpectedType(t *testing.T) {
 	client := NewClient(protoOptions, nil)
 
 	// Create a message with an unexpected type
-	msg := NewMsgBlockRequest(123, []byte{0x01, 0x02})
+	msg := NewMsgBlockRequest(pcommon.NewPoint(123, []byte{0x01, 0x02}))
 
 	err := client.messageHandler(msg)
 
@@ -231,11 +231,11 @@ func TestConfig(t *testing.T) {
 
 	cfg = NewConfig(
 		WithTimeout(30*time.Second),
-		WithBlockRequestFunc(func(ctx CallbackContext, slot uint64, hash []byte) (protocol.Message, error) {
+		WithBlockRequestFunc(func(ctx CallbackContext, point pcommon.Point) (protocol.Message, error) {
 			blockRequestCalled = true
 			return nil, nil
 		}),
-		WithBlockTxsRequestFunc(func(ctx CallbackContext, slot uint64, hash []byte, bitmaps map[uint16][8]byte) (protocol.Message, error) {
+		WithBlockTxsRequestFunc(func(ctx CallbackContext, point pcommon.Point, bitmaps map[uint16]uint64) (protocol.Message, error) {
 			blockTxsRequestCalled = true
 			return nil, nil
 		}),
@@ -256,10 +256,10 @@ func TestConfig(t *testing.T) {
 	assert.NotNil(t, cfg.BlockRangeRequestFunc)
 
 	// Test that callbacks can be invoked
-	_, _ = cfg.BlockRequestFunc(CallbackContext{}, 0, nil)
+	_, _ = cfg.BlockRequestFunc(CallbackContext{}, pcommon.NewPoint(0, nil))
 	assert.True(t, blockRequestCalled)
 
-	_, _ = cfg.BlockTxsRequestFunc(CallbackContext{}, 0, nil, nil)
+	_, _ = cfg.BlockTxsRequestFunc(CallbackContext{}, pcommon.NewPoint(0, nil), nil)
 	assert.True(t, blockTxsRequestCalled)
 
 	_, _ = cfg.VotesRequestFunc(CallbackContext{}, nil)

--- a/protocol/leiosfetch/leiosfetch.go
+++ b/protocol/leiosfetch/leiosfetch.go
@@ -129,8 +129,8 @@ type CallbackContext struct {
 
 // Callback function types
 type (
-	BlockRequestFunc      func(CallbackContext, uint64, []byte) (protocol.Message, error)
-	BlockTxsRequestFunc   func(CallbackContext, uint64, []byte, map[uint16][8]byte) (protocol.Message, error)
+	BlockRequestFunc      func(CallbackContext, pcommon.Point) (protocol.Message, error)
+	BlockTxsRequestFunc   func(CallbackContext, pcommon.Point, map[uint16]uint64) (protocol.Message, error)
 	VotesRequestFunc      func(CallbackContext, []MsgVotesRequestVoteId) (protocol.Message, error)
 	BlockRangeRequestFunc func(CallbackContext, pcommon.Point, pcommon.Point) error
 )

--- a/protocol/leiosfetch/messages.go
+++ b/protocol/leiosfetch/messages.go
@@ -15,7 +15,6 @@
 package leiosfetch
 
 import (
-	"bytes"
 	"fmt"
 	"maps"
 	"slices"
@@ -75,17 +74,15 @@ func NewMsgFromCbor(msgType uint, data []byte) (protocol.Message, error) {
 
 type MsgBlockRequest struct {
 	protocol.MessageBase
-	Slot uint64
-	Hash []byte
+	Point pcommon.Point
 }
 
-func NewMsgBlockRequest(slot uint64, hash []byte) *MsgBlockRequest {
+func NewMsgBlockRequest(point pcommon.Point) *MsgBlockRequest {
 	m := &MsgBlockRequest{
 		MessageBase: protocol.MessageBase{
 			MessageType: MessageTypeBlockRequest,
 		},
-		Slot: slot,
-		Hash: bytes.Clone(hash),
+		Point: point,
 	}
 	return m
 }
@@ -107,25 +104,22 @@ func NewMsgBlock(block cbor.RawMessage) *MsgBlock {
 
 type MsgBlockTxsRequest struct {
 	protocol.MessageBase
-	Slot uint64
-	Hash []byte
+	Point pcommon.Point
 	// Bitmaps identifies which transactions to fetch using a map
 	// from 16-bit index to a 64-bit bitmap (8 bytes) per CIP-0164.
 	// The offset of the first transaction bit is 64*index.
-	Bitmaps map[uint16][8]byte
+	Bitmaps map[uint16]uint64
 }
 
 func NewMsgBlockTxsRequest(
-	slot uint64,
-	hash []byte,
-	bitmaps map[uint16][8]byte,
+	point pcommon.Point,
+	bitmaps map[uint16]uint64,
 ) *MsgBlockTxsRequest {
 	m := &MsgBlockTxsRequest{
 		MessageBase: protocol.MessageBase{
 			MessageType: MessageTypeBlockTxsRequest,
 		},
-		Slot:    slot,
-		Hash:    bytes.Clone(hash),
+		Point:   point,
 		Bitmaps: maps.Clone(bitmaps),
 	}
 	return m

--- a/protocol/leiosfetch/server.go
+++ b/protocol/leiosfetch/server.go
@@ -98,8 +98,7 @@ func (s *Server) handleBlockRequest(msg protocol.Message) error {
 	msgBlockRequest := msg.(*MsgBlockRequest)
 	resp, err := s.config.BlockRequestFunc(
 		s.callbackContext,
-		msgBlockRequest.Slot,
-		msgBlockRequest.Hash,
+		msgBlockRequest.Point,
 	)
 	if err != nil {
 		return err
@@ -131,8 +130,7 @@ func (s *Server) handleBlockTxsRequest(msg protocol.Message) error {
 	msgBlockTxsRequest := msg.(*MsgBlockTxsRequest)
 	resp, err := s.config.BlockTxsRequestFunc(
 		s.callbackContext,
-		msgBlockTxsRequest.Slot,
-		msgBlockTxsRequest.Hash,
+		msgBlockTxsRequest.Point,
 		msgBlockTxsRequest.Bitmaps,
 	)
 	if err != nil {

--- a/protocol/leiosnotify/client_test.go
+++ b/protocol/leiosnotify/client_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -81,12 +82,12 @@ func TestClientMessageHandler(t *testing.T) {
 		},
 		{
 			name:        "BlockOffer message",
-			msg:         NewMsgBlockOffer(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+			msg:         NewMsgBlockOffer(pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}), 12345),
 			expectError: false,
 		},
 		{
 			name:        "BlockTxsOffer message",
-			msg:         NewMsgBlockTxsOffer(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+			msg:         NewMsgBlockTxsOffer(pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04})),
 			expectError: false,
 		},
 		{
@@ -262,7 +263,7 @@ func TestClientHandleBlockOffer(t *testing.T) {
 	}
 	client := NewClient(protoOptions, nil)
 
-	msg := NewMsgBlockOffer(12345, []byte{0x01, 0x02, 0x03, 0x04})
+	msg := NewMsgBlockOffer(pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}), 12345)
 
 	// Start a goroutine to receive the message
 	received := make(chan protocol.Message, 1)
@@ -290,7 +291,7 @@ func TestClientHandleBlockTxsOffer(t *testing.T) {
 	}
 	client := NewClient(protoOptions, nil)
 
-	msg := NewMsgBlockTxsOffer(12345, []byte{0x01, 0x02, 0x03, 0x04})
+	msg := NewMsgBlockTxsOffer(pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}))
 
 	// Start a goroutine to receive the message
 	received := make(chan protocol.Message, 1)

--- a/protocol/leiosnotify/messages.go
+++ b/protocol/leiosnotify/messages.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
 // NOTE: these are dummy message IDs and will probably need to be changed
@@ -89,34 +90,32 @@ func NewMsgBlockAnnouncement(
 
 type MsgBlockOffer struct {
 	protocol.MessageBase
-	Slot uint64
-	Hash []byte
+	Point pcommon.Point
+	Size  uint64
 }
 
-func NewMsgBlockOffer(slot uint64, hash []byte) *MsgBlockOffer {
+func NewMsgBlockOffer(point pcommon.Point, size uint64) *MsgBlockOffer {
 	m := &MsgBlockOffer{
 		MessageBase: protocol.MessageBase{
 			MessageType: MessageTypeBlockOffer,
 		},
-		Slot: slot,
-		Hash: hash,
+		Point: point,
+		Size:  size,
 	}
 	return m
 }
 
 type MsgBlockTxsOffer struct {
 	protocol.MessageBase
-	Slot uint64
-	Hash []byte
+	Point pcommon.Point
 }
 
-func NewMsgBlockTxsOffer(slot uint64, hash []byte) *MsgBlockTxsOffer {
+func NewMsgBlockTxsOffer(point pcommon.Point) *MsgBlockTxsOffer {
 	m := &MsgBlockTxsOffer{
 		MessageBase: protocol.MessageBase{
 			MessageType: MessageTypeBlockTxsOffer,
 		},
-		Slot: slot,
-		Hash: hash,
+		Point: point,
 	}
 	return m
 }

--- a/protocol/leiosnotify/messages_test.go
+++ b/protocol/leiosnotify/messages_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -47,16 +48,21 @@ func getTestDefinitions() []testDefinition {
 		{
 			Name: "MsgBlockOffer",
 			Message: NewMsgBlockOffer(
+				pcommon.NewPoint(
+					12345,
+					[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+				),
 				12345,
-				[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
 			),
 			MessageType: MessageTypeBlockOffer,
 		},
 		{
 			Name: "MsgBlockTxsOffer",
 			Message: NewMsgBlockTxsOffer(
-				67890,
-				[]byte{0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+				pcommon.NewPoint(
+					67890,
+					[]byte{0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+				),
 			),
 			MessageType: MessageTypeBlockTxsOffer,
 		},
@@ -155,22 +161,22 @@ func TestMsgBlockOffer(t *testing.T) {
 	slot := uint64(123456)
 	hash := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
 
-	msg := NewMsgBlockOffer(slot, hash)
+	msg := NewMsgBlockOffer(pcommon.NewPoint(slot, hash), 12345)
 
 	assert.Equal(t, uint8(MessageTypeBlockOffer), msg.Type())
-	assert.Equal(t, slot, msg.Slot)
-	assert.Equal(t, hash, msg.Hash)
+	assert.Equal(t, slot, msg.Point.Slot)
+	assert.Equal(t, hash, msg.Point.Hash)
 }
 
 func TestMsgBlockTxsOffer(t *testing.T) {
 	slot := uint64(123456)
 	hash := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
 
-	msg := NewMsgBlockTxsOffer(slot, hash)
+	msg := NewMsgBlockTxsOffer(pcommon.NewPoint(slot, hash))
 
 	assert.Equal(t, uint8(MessageTypeBlockTxsOffer), msg.Type())
-	assert.Equal(t, slot, msg.Slot)
-	assert.Equal(t, hash, msg.Hash)
+	assert.Equal(t, slot, msg.Point.Slot)
+	assert.Equal(t, hash, msg.Point.Hash)
 }
 
 func TestMsgVotesOffer(t *testing.T) {

--- a/protocol/leiosnotify/server_test.go
+++ b/protocol/leiosnotify/server_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -171,7 +172,7 @@ func TestServerMessageHandler_UnexpectedType(t *testing.T) {
 	server := NewServer(protoOptions, &cfg)
 
 	// Create a message with an unexpected type for the server
-	msg := NewMsgBlockOffer(12345, []byte{0x01, 0x02})
+	msg := NewMsgBlockOffer(pcommon.NewPoint(12345, []byte{0x01, 0x02}), 12345)
 
 	err := server.messageHandler(msg)
 
@@ -255,11 +256,11 @@ func TestCallbackResponseTypes(t *testing.T) {
 		},
 		{
 			name:     "BlockOffer response",
-			response: NewMsgBlockOffer(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+			response: NewMsgBlockOffer(pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}), 12345),
 		},
 		{
 			name:     "BlockTxsOffer response",
-			response: NewMsgBlockTxsOffer(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+			response: NewMsgBlockTxsOffer(pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04})),
 		},
 		{
 			name: "VotesOffer response",


### PR DESCRIPTION
Fixes #1541

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Leios fetch/notify message shapes with the spec: blocks use pcommon.Point, TX bitmaps use map[uint16]uint64, and BlockOffer includes Size. Updates client/server APIs and tests; fixes #1541.

- **Refactors**
  - MsgBlockRequest and MsgBlockTxsRequest now carry pcommon.Point instead of slot/hash.
  - TX bitmaps use map[uint16]uint64 (was [8]byte) per CIP-0164.
  - MsgBlockOffer and MsgBlockTxsOffer now use pcommon.Point; BlockOffer adds Size.
  - Client/server methods and callbacks updated to use Point and new bitmap type.

- **Migration**
  - Build requests with NewMsgBlockRequest(pcommon.NewPoint(slot, hash)) and NewMsgBlockTxsRequest(point, bitmaps).
  - Update callbacks to BlockRequestFunc(ctx, pcommon.Point) and BlockTxsRequestFunc(ctx, pcommon.Point, map[uint16]uint64).
  - For notify, use NewMsgBlockOffer(point, size) and NewMsgBlockTxsOffer(point).

<sup>Written for commit 3ffe95a6d303d535e98db5b469003ba2449640b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified block identification: slot+hash replaced by a single point-based identifier across fetch and notify protocols.
  * Callbacks and public constructors updated to use the point identifier for block requests, offers and ranges.
  * Block transactions bitmap representation simplified to a numeric map for clearer, consistent handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->