### PR TITLE
fix(cbor): increase max map pairs

### DIFF
--- a/cbor/decode.go
+++ b/cbor/decode.go
@@ -41,6 +41,10 @@ func getDecMode() (_cbor.DecMode, error) {
 			ExtraReturnErrors: _cbor.ExtraDecErrorUnknownField,
 			// This defaults to 32, but there are blocks in the wild using >64 nested levels
 			MaxNestedLevels: 256,
+			// The fxamacker default is 131072, but Cardano ledger state
+			// snapshots contain stake distribution maps that can exceed
+			// 1M entries on mainnet.
+			MaxMapPairs: 10_000_000,
 		}
 		cachedDecMode, cachedDecModeErr = decOptions.DecModeWithTags(customTagSet)
 	})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase CBOR decoder MaxMapPairs to 10,000,000 to support very large stake distribution maps in Cardano ledger snapshots and prevent decode errors on mainnet data. This raises the fxamacker default (131,072) to handle maps exceeding 1M entries.

<sup>Written for commit ffdda4203cc69a572935927f1c9a7351da38236c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Expanded CBOR decoding capabilities to handle larger map data structures, with the maximum supported map size increased to 10 million entries, enabling processing of more complex encoded datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->