### PR TITLE
fix(muxer): unregister deadlock

### DIFF
--- a/muxer/muxer.go
+++ b/muxer/muxer.go
@@ -228,6 +228,7 @@ func (m *Muxer) UnregisterProtocol(
 	protocolRole ProtocolRole,
 ) {
 	m.protocolReceiversMutex.Lock()
+	defer m.protocolReceiversMutex.Unlock()
 	protocolRoles, ok := m.protocolReceivers[protocolId]
 	if !ok {
 		return
@@ -247,7 +248,6 @@ func (m *Muxer) UnregisterProtocol(
 
 	// Remove mapping
 	delete(protocolRoles, protocolRole)
-	m.protocolReceiversMutex.Unlock()
 }
 
 // Send takes a populated Segment and writes it to the connection. A mutex is used to prevent more than


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevented a deadlock in Muxer.UnregisterProtocol by deferring protocolReceiversMutex.Unlock immediately after Lock. This ensures the mutex is released on all return paths and avoids hangs when unregistering protocols.

<sup>Written for commit 2f59b77d3d54ee9840cce5b876602933fdcb35e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved protocol management reliability by enhancing mutex handling to ensure proper resource cleanup on all code paths, including early returns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->