### PR TITLE
fix(protocol): split chainsync client/server states

### DIFF
--- a/protocol/chainsync/chainsync.go
+++ b/protocol/chainsync/chainsync.go
@@ -272,11 +272,14 @@ type (
 
 // New returns a new ChainSync object
 func New(protoOptions protocol.ProtocolOptions, cfg *Config) *ChainSync {
-	stateContext := &StateContext{}
+	// Each side gets its own StateContext so that client pipelining
+	// does not corrupt the server's pipeline count (and vice-versa).
+	clientStateContext := &StateContext{}
+	serverStateContext := &StateContext{}
 
 	c := &ChainSync{
-		Client: NewClient(stateContext, protoOptions, cfg),
-		Server: NewServer(stateContext, protoOptions, cfg),
+		Client: NewClient(clientStateContext, protoOptions, cfg),
+		Server: NewServer(serverStateContext, protoOptions, cfg),
 	}
 	return c
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Split the ChainSync client and server StateContext objects so pipelining on one side can’t affect the other. This fixes incorrect pipeline counts and stabilizes concurrent client/server sync.

<sup>Written for commit 17d86494107b960bfaec45cc3a465b669b980c59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

