### PR TITLE
fix(protocol): 16mb buffer

### DIFF
--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -32,6 +32,12 @@ import (
 // This is completely arbitrary, but the line had to be drawn somewhere
 const maxMessagesPerSegment = 20
 
+// maxReadBufferSize is the upper bound on the read buffer in readLoop.
+// This prevents a malicious peer from sending incomplete CBOR indefinitely
+// to cause unbounded memory growth (OOM). 16MB accommodates large legitimate
+// messages such as ledger state query responses.
+const maxReadBufferSize = 16 * 1024 * 1024 // 16MB
+
 // DefaultRecvQueueSize is the default capacity for the recv queue channel
 const DefaultRecvQueueSize = 55
 
@@ -503,6 +509,16 @@ func (p *Protocol) readLoop() {
 			if errors.Is(err, io.ErrUnexpectedEOF) && readBuffer.Len() > 0 {
 				// This is probably a multi-part message, so we wait until we get more of the message
 				// before trying to process it
+				if readBuffer.Len() > maxReadBufferSize {
+					p.SendError(
+						fmt.Errorf(
+							"%s: read buffer exceeded maximum size (%d bytes)",
+							p.config.Name,
+							readBuffer.Len(),
+						),
+					)
+					return
+				}
 				continue
 			}
 			p.SendError(fmt.Errorf("%s: decode error: %w", p.config.Name, err))


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 16MB cap to the protocol read buffer to prevent unbounded memory growth from partial CBOR messages. This avoids OOMs while still allowing large responses like ledger state queries.

- **Bug Fixes**
  - Define maxReadBufferSize (16MB) and enforce it in readLoop; if a partial read exceeds the limit, send an error and stop processing.

<sup>Written for commit 4a5c655dbf05af5b8b402741d5cd3c6d0b52605f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents unbounded memory growth by enforcing an upper limit on incoming message buffering; oversized inputs now produce a protocol error, improving stability during message processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->