### PR TITLE
fix(cbor): input validation

### DIFF
--- a/cbor/value.go
+++ b/cbor/value.go
@@ -17,6 +17,7 @@ package cbor
 import (
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -39,6 +40,9 @@ func (v *Value) MarshalCBOR() ([]byte, error) {
 }
 
 func (v *Value) UnmarshalCBOR(data []byte) error {
+	if len(data) == 0 {
+		return errors.New("empty CBOR data")
+	}
 	// Save the original CBOR
 	v.cborData = string(data[:])
 	cborType := data[0] & CborTypeMask
@@ -281,7 +285,7 @@ func (l *LazyValue) UnmarshalCBOR(data []byte) error {
 }
 
 func (l *LazyValue) MarshalJSON() ([]byte, error) {
-	if l.Value() == nil {
+	if l.Value() == nil && len(l.value.cborData) > 0 {
 		// Try to decode if we can, but don't blow up if we can't
 		_, _ = l.Decode()
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a strict CBOR decoder for untrusted inputs and tighten input validation to prevent OOM issues and bad payloads. Also align default decoder limits and avoid unnecessary decoding in JSON marshaling.

- **Bug Fixes**
  - Reject empty CBOR in Value.UnmarshalCBOR.
  - Avoid auto-decode in LazyValue.MarshalJSON unless CBOR data exists.
  - Set MaxArrayElements in default DecMode to 10,000,000 to match large snapshots.

- **New Features**
  - Add DecodeStrict with cached strict DecMode using smaller limits (MaxMapPairs/MaxArrayElements: 131,072) and ExtraDecErrorUnknownField for safer network decoding.

<sup>Written for commit 3aca3b9c04ba48bc03971e831a3cbd0256f235f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

