### PR TITLE
fix(ledger): iterate legacy redeemers also

### DIFF
--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -284,6 +284,9 @@ func (r *ConwayRedeemers) MarshalCBOR() ([]byte, error) {
 }
 
 func (r ConwayRedeemers) Iter() iter.Seq2[common.RedeemerKey, common.RedeemerValue] {
+	if r.legacy {
+		return r.legacyRedeemers.Iter()
+	}
 	return func(yield func(common.RedeemerKey, common.RedeemerValue) bool) {
 		// Sort redeemers
 		sorted := slices.Collect(maps.Keys(r.Redeemers))


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes iteration for legacy redeemers in ConwayRedeemers by delegating to r.legacyRedeemers.Iter() when legacy mode is enabled. Prevents missing redeemers when processing legacy transactions.

- **Bug Fixes**
  - Add early return in Iter() for legacy mode to use legacyRedeemers iterator.
  - Non-legacy behavior unchanged with sorted iteration.

<sup>Written for commit fb239e27f672035ddceec20fe8c3b5c8a22ffee1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

