### PR TITLE
fix(consensus): require issuer vkey

### DIFF
--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -232,6 +232,13 @@ func (s *SimpleVRFSigner) PublicKey() []byte {
 	return s.publicKey
 }
 
+// Destroy zeroes the secret key material. Call when the signer is no longer needed.
+func (s *SimpleVRFSigner) Destroy() {
+	for i := range s.secretKey {
+		s.secretKey[i] = 0
+	}
+}
+
 // FindNextSlotLeadership finds the next slot where the pool is eligible to be leader.
 // This is useful for looking ahead to schedule block production.
 //

--- a/consensus/validate.go
+++ b/consensus/validate.go
@@ -395,9 +395,9 @@ func (v *HeaderValidator) validateKESSignature(
 func (v *HeaderValidator) validateOpCertSignature(
 	input *ValidateHeaderInput,
 ) error {
-	// Skip if no issuer key provided (validation may be done elsewhere)
+	// IssuerVkey is required for OpCert validation
 	if len(input.IssuerVkey) == 0 {
-		return nil
+		return errors.New("IssuerVkey is required for OpCert validation")
 	}
 
 	if len(input.IssuerVkey) != ed25519.PublicKeySize {

--- a/consensus/validate_test.go
+++ b/consensus/validate_test.go
@@ -628,11 +628,11 @@ func TestValidateOpCertSignature(t *testing.T) {
 		t.Error("expected error for wrong sequence number")
 	}
 
-	// Test with no issuer key (should skip validation)
+	// Test with no issuer key (should require IssuerVkey)
 	input.IssuerVkey = nil
 	err = validator.validateOpCertSignature(input)
-	if err != nil {
-		t.Errorf("expected nil error when IssuerVkey is empty, got: %v", err)
+	if err == nil {
+		t.Error("expected error when IssuerVkey is empty")
 	}
 
 	// Test with wrong issuer key size


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Require issuer verification key for OpCert validation and add a VRF signer cleanup method. This prevents skipped signature checks and improves key hygiene.

- **Bug Fixes**
  - validateOpCertSignature now returns an error when IssuerVkey is missing.
  - Updated tests to assert error on empty IssuerVkey.

- **New Features**
  - SimpleVRFSigner.Destroy() zeroes the secret key for secure disposal.

<sup>Written for commit 13f76150fc80a1c4e7e6dad70c866d2ca887187e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cryptographic key security with memory clearing functionality
  * Enforced required IssuerVkey validation for certificate verification

* **Tests**
  * Updated OpCert validation tests to reflect validation requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->