### PR TITLE
fix(ledger): block encoding nil lists

### DIFF
--- a/ledger/allegra/allegra.go
+++ b/ledger/allegra/allegra.go
@@ -76,6 +76,27 @@ func (b *AllegraBlock) UnmarshalCBOR(cborData []byte) error {
 	return nil
 }
 
+func (b *AllegraBlock) MarshalCBOR() ([]byte, error) {
+	if b.Cbor() != nil {
+		return b.Cbor(), nil
+	}
+	// Ensure nil slices encode as empty arrays, not CBOR null
+	txBodies := b.TransactionBodies
+	if txBodies == nil {
+		txBodies = []AllegraTransactionBody{}
+	}
+	txWitnesses := b.TransactionWitnessSets
+	if txWitnesses == nil {
+		txWitnesses = []shelley.ShelleyTransactionWitnessSet{}
+	}
+	return cbor.Encode([]any{
+		b.BlockHeader,
+		txBodies,
+		txWitnesses,
+		b.TransactionMetadataSet,
+	})
+}
+
 func (AllegraBlock) Type() int {
 	return BlockTypeAllegra
 }

--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -102,6 +102,16 @@ func (b *AlonzoBlock) MarshalCBOR() ([]byte, error) {
 		InvalidTransactions    cbor.IndefLengthList
 	}
 
+	// Ensure nil slices encode as empty arrays, not CBOR null
+	txBodies := b.TransactionBodies
+	if txBodies == nil {
+		txBodies = []AlonzoTransactionBody{}
+	}
+	txWitnesses := b.TransactionWitnessSets
+	if txWitnesses == nil {
+		txWitnesses = []AlonzoTransactionWitnessSet{}
+	}
+
 	// Convert InvalidTransactions to IndefLengthList
 	var invalidTx cbor.IndefLengthList
 	if b.InvalidTransactions != nil {
@@ -113,8 +123,8 @@ func (b *AlonzoBlock) MarshalCBOR() ([]byte, error) {
 
 	temp := tmpBlock{
 		BlockHeader:            b.BlockHeader,
-		TransactionBodies:      b.TransactionBodies,
-		TransactionWitnessSets: b.TransactionWitnessSets,
+		TransactionBodies:      txBodies,
+		TransactionWitnessSets: txWitnesses,
 		TransactionMetadataSet: b.TransactionMetadataSet,
 		InvalidTransactions:    invalidTx,
 	}

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -138,7 +138,18 @@ func (b *BabbageBlock) MarshalCBOR() ([]byte, error) {
 		return b.Cbor(), nil
 	}
 
-	// Ensure InvalidTransactions is encoded as empty array if nil
+	// Ensure nil slices are encoded as empty CBOR arrays (0x80)
+	// rather than CBOR null (0xF6). The Cardano CDDL requires
+	// arrays for transaction_bodies, transaction_witness_sets,
+	// and invalid_transactions.
+	txBodies := b.TransactionBodies
+	if txBodies == nil {
+		txBodies = []BabbageTransactionBody{}
+	}
+	txWitnesses := b.TransactionWitnessSets
+	if txWitnesses == nil {
+		txWitnesses = []BabbageTransactionWitnessSet{}
+	}
 	invalidTxs := b.InvalidTransactions
 	if invalidTxs == nil {
 		invalidTxs = []uint{}
@@ -146,8 +157,8 @@ func (b *BabbageBlock) MarshalCBOR() ([]byte, error) {
 
 	return cbor.Encode([]any{
 		b.BlockHeader,
-		b.TransactionBodies,
-		b.TransactionWitnessSets,
+		txBodies,
+		txWitnesses,
 		b.TransactionMetadataSet,
 		invalidTxs,
 	})

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -139,7 +139,18 @@ func (b *ConwayBlock) MarshalCBOR() ([]byte, error) {
 		return b.Cbor(), nil
 	}
 
-	// Ensure InvalidTransactions is encoded as empty array if nil
+	// Ensure nil slices are encoded as empty CBOR arrays (0x80)
+	// rather than CBOR null (0xF6). The Cardano CDDL requires
+	// arrays for transaction_bodies, transaction_witness_sets,
+	// and invalid_transactions.
+	txBodies := b.TransactionBodies
+	if txBodies == nil {
+		txBodies = []ConwayTransactionBody{}
+	}
+	txWitnesses := b.TransactionWitnessSets
+	if txWitnesses == nil {
+		txWitnesses = []ConwayTransactionWitnessSet{}
+	}
 	invalidTxs := b.InvalidTransactions
 	if invalidTxs == nil {
 		invalidTxs = []uint{}
@@ -147,8 +158,8 @@ func (b *ConwayBlock) MarshalCBOR() ([]byte, error) {
 
 	return cbor.Encode([]any{
 		b.BlockHeader,
-		b.TransactionBodies,
-		b.TransactionWitnessSets,
+		txBodies,
+		txWitnesses,
 		b.TransactionMetadataSet,
 		invalidTxs,
 	})

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -85,8 +85,21 @@ func (b *MaryBlock) MarshalCBOR() ([]byte, error) {
 	if b.Cbor() != nil {
 		return b.Cbor(), nil
 	}
-	// Otherwise, encode generically
-	return cbor.EncodeGeneric(b)
+	// Ensure nil slices encode as empty arrays, not CBOR null
+	txBodies := b.TransactionBodies
+	if txBodies == nil {
+		txBodies = []MaryTransactionBody{}
+	}
+	txWitnesses := b.TransactionWitnessSets
+	if txWitnesses == nil {
+		txWitnesses = []shelley.ShelleyTransactionWitnessSet{}
+	}
+	return cbor.Encode([]any{
+		b.BlockHeader,
+		txBodies,
+		txWitnesses,
+		b.TransactionMetadataSet,
+	})
 }
 
 func (MaryBlock) Type() int {

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -83,6 +83,27 @@ func (b *ShelleyBlock) UnmarshalCBOR(cborData []byte) error {
 	return nil
 }
 
+func (b *ShelleyBlock) MarshalCBOR() ([]byte, error) {
+	if b.Cbor() != nil {
+		return b.Cbor(), nil
+	}
+	// Ensure nil slices encode as empty arrays, not CBOR null
+	txBodies := b.TransactionBodies
+	if txBodies == nil {
+		txBodies = []ShelleyTransactionBody{}
+	}
+	txWitnesses := b.TransactionWitnessSets
+	if txWitnesses == nil {
+		txWitnesses = []ShelleyTransactionWitnessSet{}
+	}
+	return cbor.Encode([]any{
+		b.BlockHeader,
+		txBodies,
+		txWitnesses,
+		b.TransactionMetadataSet,
+	})
+}
+
 func (ShelleyBlock) Type() int {
 	return BlockTypeShelley
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix CBOR block encoding to emit empty arrays instead of CBOR null for nil list fields across eras. Aligns with Cardano CDDL and prevents downstream decode failures.

- **Bug Fixes**
  - Encode nil TransactionBodies and TransactionWitnessSets as empty arrays in Shelley, Allegra, Mary, Alonzo, Babbage, and Conway.
  - Default InvalidTransactions to empty array in Babbage and Conway.
  - Add explicit MarshalCBOR for Shelley, Allegra, and Mary to control array encoding; reuse cached CBOR when available.

<sup>Written for commit 5a99b5d2428dd73a65c13ab64cd765862564f2cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serialization of blockchain ledger data across multiple ledger versions (Allegra, Alonzo, Babbage, Conway, Mary, Shelley) to properly encode empty transaction collections as empty arrays rather than null values, ensuring consistent and correct data representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->