### PR TITLE
feat(protocol): get ratify state

### DIFF
--- a/protocol/localstatequery/client.go
+++ b/protocol/localstatequery/client.go
@@ -1219,6 +1219,39 @@ func (c *Client) GetProposals() (*ProposalsResult, error) {
 	return &result, nil
 }
 
+// GetRatifyState returns the current ratification state (Conway era)
+// This includes the enact state, enacted proposals, expired proposal IDs, and delayed flag
+func (c *Client) GetRatifyState() (*RatifyStateResult, error) {
+	c.Protocol.Logger().
+		Debug("calling GetRatifyState()",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "client",
+			"connection_id", c.callbackContext.ConnectionId.String(),
+		)
+	c.busyMutex.Lock()
+	defer c.busyMutex.Unlock()
+	currentEra, err := c.getCurrentEra()
+	if err != nil {
+		return nil, err
+	}
+	if currentEra < ledger.EraIdConway {
+		return nil, fmt.Errorf(
+			"GetRatifyState requires Conway era or later (current era: %d)",
+			currentEra,
+		)
+	}
+	query := buildShelleyQuery(
+		currentEra,
+		QueryTypeShelleyGetRatifyState,
+	)
+	var result RatifyStateResult
+	if err := c.runQuery(query, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 func (c *Client) messageHandler(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {

--- a/protocol/localstatequery/client_test.go
+++ b/protocol/localstatequery/client_test.go
@@ -966,6 +966,86 @@ func TestGetProposalsEmpty(t *testing.T) {
 	)
 }
 
+func TestGetRatifyState(t *testing.T) {
+	// RatifyState with empty enacted, empty expired, not delayed
+	expectedResult := localstatequery.RatifyStateResult{
+		EnactState: localstatequery.EnactState{
+			Committee:    cbor.RawMessage([]byte{0xf6}), // null
+			Constitution: localstatequery.ConstitutionResult{
+				Anchor: lcommon.GovAnchor{
+					Url:      "https://constitution.cardano.org",
+					DataHash: [32]byte{0xde, 0xad, 0xbe, 0xef},
+				},
+				ScriptHash: nil,
+			},
+			CurPParams:    cbor.RawMessage([]byte{0xa0}), // Empty map
+			PrevPParams:   cbor.RawMessage([]byte{0xa0}),
+			Treasury:      500000000,
+			Withdrawals:   map[localstatequery.StakeCredential]uint64{},
+			PrevActionIds: cbor.RawMessage([]byte{0xa0}),
+		},
+		Enacted: []localstatequery.GovActionState{},
+		Expired: []lcommon.GovActionId{},
+		Delayed: false,
+	}
+	cborData, err := cbor.Encode(expectedResult)
+	if err != nil {
+		t.Fatalf("unexpected error encoding: %s", err)
+	}
+	conversation := append(
+		conversationConwayEra,
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  localstatequery.ProtocolId,
+			MessageType: localstatequery.MessageTypeQuery,
+		},
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: localstatequery.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				localstatequery.NewMsgResult(cborData),
+			},
+		},
+	)
+	runTest(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			ratifyState, err := oConn.LocalStateQuery().Client.GetRatifyState()
+			if err != nil {
+				t.Fatalf("received unexpected error: %s", err)
+			}
+			// Check enact state constitution anchor
+			if ratifyState.EnactState.Constitution.Anchor.Url != expectedResult.EnactState.Constitution.Anchor.Url {
+				t.Fatalf(
+					"constitution URL mismatch: got %s, wanted %s",
+					ratifyState.EnactState.Constitution.Anchor.Url,
+					expectedResult.EnactState.Constitution.Anchor.Url,
+				)
+			}
+			// Check treasury
+			if ratifyState.EnactState.Treasury != expectedResult.EnactState.Treasury {
+				t.Fatalf(
+					"treasury mismatch: got %d, wanted %d",
+					ratifyState.EnactState.Treasury,
+					expectedResult.EnactState.Treasury,
+				)
+			}
+			// Check enacted is empty
+			if len(ratifyState.Enacted) != 0 {
+				t.Fatalf("expected 0 enacted, got %d", len(ratifyState.Enacted))
+			}
+			// Check expired is empty
+			if len(ratifyState.Expired) != 0 {
+				t.Fatalf("expected 0 expired, got %d", len(ratifyState.Expired))
+			}
+			// Check delayed is false
+			if ratifyState.Delayed {
+				t.Fatal("expected delayed to be false")
+			}
+		},
+	)
+}
+
 func TestGetProposalsSingleProposal(t *testing.T) {
 	// Build a single proposal with votes
 	govActionId := lcommon.GovActionId{
@@ -1200,6 +1280,19 @@ func TestGetFilteredVoteDelegateesPreConway(t *testing.T) {
 		conversationCurrentEra, // Era 5 (Babbage)
 		func(t *testing.T, oConn *ouroboros.Connection) {
 			_, err := oConn.LocalStateQuery().Client.GetFilteredVoteDelegatees(nil)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "Conway era or later")
+		},
+	)
+}
+
+func TestGetRatifyStatePreConway(t *testing.T) {
+	// Test that GetRatifyState returns an error on pre-Conway eras
+	runTest(
+		t,
+		conversationCurrentEra, // Era 5 (Babbage)
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			_, err := oConn.LocalStateQuery().Client.GetRatifyState()
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "Conway era or later")
 		},

--- a/protocol/localstatequery/queries.go
+++ b/protocol/localstatequery/queries.go
@@ -73,6 +73,7 @@ const (
 	QueryTypeShelleyFilteredVoteDelegatees = 28
 	QueryTypeShelleySPOStakeDistr          = 30
 	QueryTypeShelleyGetProposals           = 31
+	QueryTypeShelleyGetRatifyState         = 32
 )
 
 // simpleQueryBase is a helper type used for various query types
@@ -217,6 +218,7 @@ func (q *ShelleyQuery) UnmarshalCBOR(data []byte) error {
 			QueryTypeShelleyFilteredVoteDelegatees: &ShelleyFilteredVoteDelegateesQuery{},
 			QueryTypeShelleySPOStakeDistr:          &ShelleySPOStakeDistrQuery{},
 			QueryTypeShelleyGetProposals:           &ShelleyGetProposalsQuery{},
+			QueryTypeShelleyGetRatifyState:         &ShelleyGetRatifyStateQuery{},
 		},
 	)
 	if err != nil {
@@ -849,6 +851,10 @@ type ShelleyGetProposalsQuery struct {
 	simpleQueryBase
 }
 
+type ShelleyGetRatifyStateQuery struct {
+	simpleQueryBase
+}
+
 // Conway governance result types
 
 // ConstitutionResult represents the constitution query result.
@@ -1143,3 +1149,28 @@ type SPOStakeDistrResult struct {
 // ProposalsResult represents the result of a GetProposals query.
 // It contains a list of governance action states for all active proposals.
 type ProposalsResult []GovActionState
+
+// EnactState represents the enactment state within a ratify state result.
+// It contains the current committee, constitution, protocol parameters,
+// treasury, withdrawals, and previous governance action IDs.
+type EnactState struct {
+	cbor.StructAsArray
+	Committee     cbor.RawMessage // Complex committee structure, keep as RawMessage
+	Constitution  ConstitutionResult
+	CurPParams    cbor.RawMessage // Era-specific protocol params
+	PrevPParams   cbor.RawMessage
+	Treasury      uint64
+	Withdrawals   map[StakeCredential]uint64
+	PrevActionIds cbor.RawMessage // Complex map of gov action types to optional action IDs
+}
+
+// RatifyStateResult represents the result of the GetRatifyState query (query ID 32).
+// It contains the enact state, a list of enacted governance actions,
+// a set of expired governance action IDs, and a delayed flag.
+type RatifyStateResult struct {
+	cbor.StructAsArray
+	EnactState EnactState
+	Enacted    []GovActionState
+	Expired    []lcommon.GovActionId
+	Delayed    bool
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add GetRatifyState to the LocalStateQuery client to fetch Conway-era ratification state, including enactment details, enacted/expired actions, and delay status. Returns an error on pre-Conway eras.

- **New Features**
  - Added QueryTypeShelleyGetRatifyState (32) and ShelleyGetRatifyStateQuery.
  - Implemented Client.GetRatifyState with Conway-era check.
  - Added EnactState and RatifyStateResult types (committee, constitution anchor, protocol params, treasury, withdrawals, prev action IDs; enacted actions; expired IDs; delayed).
  - Added tests for success and pre-Conway error.

<sup>Written for commit 43490fe2b472201898fdb97f293fb8ca326b0b7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new ratification state query capability for Conway era or later, enabling retrieval of current governance enactment state, enacted proposals, expired action tracking, and delayed status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->