### PR TITLE
fix(protocol): nil committee is cbor nil

### DIFF
--- a/protocol/localstatequery/client_test.go
+++ b/protocol/localstatequery/client_test.go
@@ -571,6 +571,16 @@ func TestDecodeCommitteeEmptyWrapper(t *testing.T) {
 	assert.Nil(t, result, "expected nil for empty wrapper")
 }
 
+func TestDecodeCommitteeCborNull(t *testing.T) {
+	// CBOR null (0xf6) is what Cardano nodes send when no committee is present
+	govState := &localstatequery.GovStateResult{
+		Committee: cbor.RawMessage([]byte{0xf6}),
+	}
+	result, err := govState.DecodeCommittee()
+	require.NoError(t, err)
+	assert.Nil(t, result, "expected nil for CBOR null committee")
+}
+
 func TestGetGovStatePreConway(t *testing.T) {
 	// Test that GetGovState returns an error on pre-Conway eras
 	runTest(

--- a/protocol/localstatequery/queries.go
+++ b/protocol/localstatequery/queries.go
@@ -906,6 +906,10 @@ func (g *GovStateResult) DecodeCommittee() (*Committee, error) {
 	if len(g.Committee) == 0 {
 		return nil, nil
 	}
+	// CBOR null (0xf6) means no committee present
+	if len(g.Committee) == 1 && g.Committee[0] == 0xf6 {
+		return nil, nil
+	}
 	var wrapper []cbor.RawMessage
 	if _, err := cbor.Decode(g.Committee, &wrapper); err != nil {
 		return nil, err


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Handle CBOR null (0xf6) for the governance committee in local state queries by returning nil when no committee is present, avoiding decode errors. Adds a unit test to cover this case.

- **Bug Fixes**
  - Treat CBOR null (0xf6) in GovStateResult.Committee as nil in DecodeCommittee.
  - Added TestDecodeCommitteeCborNull to verify nil committee handling.

<sup>Written for commit d23c092cf5c0872c6dd33a34f138aa8c9a61821a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

