### PR TITLE
fix(protocol): split chainsync n2n/n2c state map, update timeouts

### DIFF
--- a/cbor/constructor.go
+++ b/cbor/constructor.go
@@ -134,7 +134,7 @@ func (cd ConstructorDecoder) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf(`{"constructor":%d,"fields":[`, cd.tag))
+	fmt.Fprintf(&sb, `{"constructor":%d,"fields":[`, cd.tag)
 	for idx, val := range fields {
 		tmpVal, err := generateAstJson(val)
 		if err != nil {

--- a/cbor/debug.go
+++ b/cbor/debug.go
@@ -70,7 +70,7 @@ func DumpCborStructure(data any, prefix string) string {
 		// Add 2 more spaces to the new prefix
 		newPrefix = "  " + newPrefix
 		for key, val := range v {
-			ret.WriteString(fmt.Sprintf("%s%#v => %#v,\n", newPrefix, key, val))
+			fmt.Fprintf(&ret, "%s%#v => %#v,\n", newPrefix, key, val)
 		}
 		ret.WriteString(prefix + "}\n")
 	default:

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -94,12 +94,12 @@ func (b *BabbageBlock) UnmarshalCBOR(cborData []byte) error {
 			if val < 0 || val > maxReasonableIndex {
 				continue // Skip negative or unreasonably large indices
 			}
-			result = append(result, uint(val))
+			result = append(result, uint(val)) //nolint:gosec // bounds checked above
 		case int64:
 			if val < 0 || val > maxReasonableIndex {
 				continue // Skip negative or unreasonably large indices
 			}
-			result = append(result, uint(val))
+			result = append(result, uint(val)) //nolint:gosec // bounds checked above
 		default:
 			// Skip invalid types (strings, floats, etc.)
 			continue

--- a/ledger/common/address.go
+++ b/ledger/common/address.go
@@ -751,7 +751,7 @@ func (a *AddressPayloadPointer) encode() ([]byte, error) {
 		for val > 0 {
 			data = append(
 				data,
-				byte((val&0x7F)|0x80),
+				byte((val&0x7F)|0x80), //nolint:gosec // masked to 7 bits, always fits byte
 			)
 			val /= 128
 		}

--- a/ledger/common/rules.go
+++ b/ledger/common/rules.go
@@ -573,9 +573,9 @@ func EncodeLangViews(
 	result := make([]byte, 0, 128)
 	// Encode map length (definite-length map)
 	if len(views) < 24 {
-		result = append(result, 0xa0+byte(len(views)))
+		result = append(result, 0xa0+byte(len(views))) //nolint:gosec // len < 24
 	} else {
-		result = append(result, 0xb8, byte(len(views)))
+		result = append(result, 0xb8, byte(len(views))) //nolint:gosec // len < 256
 	}
 
 	// Append key-value pairs in sorted order

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -95,12 +95,12 @@ func (b *ConwayBlock) UnmarshalCBOR(cborData []byte) error {
 			if val < 0 || val > maxReasonableIndex {
 				continue // Skip negative or unreasonably large indices
 			}
-			result = append(result, uint(val))
+			result = append(result, uint(val)) //nolint:gosec // bounds checked above
 		case int64:
 			if val < 0 || val > maxReasonableIndex {
 				continue // Skip negative or unreasonably large indices
 			}
-			result = append(result, uint(val))
+			result = append(result, uint(val)) //nolint:gosec // bounds checked above
 		default:
 			// Skip invalid types (strings, floats, etc.)
 			continue

--- a/ledger/error.go
+++ b/ledger/error.go
@@ -1265,8 +1265,8 @@ func (e *BabbageOutputTooSmallUTxO) Error() string {
 	var sb strings.Builder
 	sb.WriteString("BabbageOutputTooSmallUTxO ([")
 	for idx, entry := range e.Outputs {
-		sb.WriteString(fmt.Sprintf("(Output %s, MinRequired %d)",
-			entry.Output.String(), entry.MinRequired))
+		fmt.Fprintf(&sb, "(Output %s, MinRequired %d)",
+			entry.Output.String(), entry.MinRequired)
 		if idx < len(e.Outputs)-1 {
 			sb.WriteString(", ")
 		}
@@ -1319,8 +1319,8 @@ func (e *MissingRedeemers) Error() string {
 	var sb strings.Builder
 	sb.WriteString("MissingRedeemers ([")
 	for idx, entry := range e.Missing {
-		sb.WriteString(fmt.Sprintf("(Purpose %v, ScriptHash %s)",
-			entry.Purpose.Value(), entry.ScriptHash.String()))
+		fmt.Fprintf(&sb, "(Purpose %v, ScriptHash %s)",
+			entry.Purpose.Value(), entry.ScriptHash.String())
 		if idx < len(e.Missing)-1 {
 			sb.WriteString(", ")
 		}
@@ -1425,7 +1425,7 @@ func (e *ExtraRedeemers) Error() string {
 		if int(entry.Tag) < len(tagNames) {
 			tagName = tagNames[entry.Tag]
 		}
-		sb.WriteString(fmt.Sprintf("(%s, Index %d)", tagName, entry.Index))
+		fmt.Fprintf(&sb, "(%s, Index %d)", tagName, entry.Index)
 		if idx < len(e.Redeemers)-1 {
 			sb.WriteString(", ")
 		}

--- a/ledger/leios/leios.go
+++ b/ledger/leios/leios.go
@@ -22,6 +22,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
@@ -205,16 +206,18 @@ func (b *LeiosEndorserBlock) MarshalCBOR() ([]byte, error) {
 	} else if mapLen < 256 {
 		mapBytes = []byte{0xb8, byte(mapLen)} // map with 1-byte length
 	} else if mapLen < 65536 {
-		mapBytes = []byte{0xb9, byte(mapLen >> 8), byte(mapLen)} // map with 2-byte length
-	} else {
+		mapBytes = []byte{0xb9, byte(mapLen >> 8), byte(mapLen)} //nolint:gosec // mapLen < 65536
+	} else if mapLen <= math.MaxUint32 {
 		// map with 4-byte length (0xba + 4 bytes)
 		mapBytes = []byte{
 			0xba,
-			byte(mapLen >> 24),
-			byte(mapLen >> 16),
-			byte(mapLen >> 8),
-			byte(mapLen),
+			byte(mapLen >> 24), //nolint:gosec // CBOR 4-byte length encoding
+			byte(mapLen >> 16), //nolint:gosec // CBOR 4-byte length encoding
+			byte(mapLen >> 8),  //nolint:gosec // CBOR 4-byte length encoding
+			byte(mapLen),       //nolint:gosec // CBOR 4-byte length encoding
 		}
+	} else {
+		return nil, fmt.Errorf("map length %d exceeds maximum for 4-byte CBOR encoding", mapLen)
 	}
 	for _, ref := range b.Body.TxReferences {
 		// Encode key: 32-byte bytestring (0x58 0x20 prefix)
@@ -222,11 +225,11 @@ func (b *LeiosEndorserBlock) MarshalCBOR() ([]byte, error) {
 		mapBytes = append(mapBytes, ref.TxHash[:]...)
 		// Encode value: uint16
 		if ref.TxSize < 24 {
-			mapBytes = append(mapBytes, byte(ref.TxSize))
+			mapBytes = append(mapBytes, byte(ref.TxSize)) //nolint:gosec // TxSize < 24
 		} else if ref.TxSize < 256 {
-			mapBytes = append(mapBytes, 0x18, byte(ref.TxSize))
+			mapBytes = append(mapBytes, 0x18, byte(ref.TxSize)) //nolint:gosec // TxSize < 256
 		} else {
-			mapBytes = append(mapBytes, 0x19, byte(ref.TxSize>>8), byte(ref.TxSize))
+			mapBytes = append(mapBytes, 0x19, byte(ref.TxSize>>8), byte(ref.TxSize)) //nolint:gosec // uint16 fits in 2 bytes
 		}
 	}
 	// Encode as single-element array: [ map ]

--- a/protocol/chainsync/README.md
+++ b/protocol/chainsync/README.md
@@ -101,14 +101,16 @@ The ChainSync protocol synchronizes blockchain state between nodes by streaming 
 | `IntersectFound` | Idle |
 | `IntersectNotFound` | Idle |
 
-## Timeouts
+## Timeouts (NtN only, per spec Table 3.8)
+
+NtC mode has no timeouts per Ouroboros spec Table 3.9.
 
 | State | Timeout | Description |
 |-------|---------|-------------|
-| Idle | 60 seconds | Client must send next request |
-| CanAwait | 300 seconds | Server must provide block or await |
-| Intersect | 5 seconds | Server must respond to intersect |
-| MustReply | 300 seconds | Server must provide block |
+| Idle | 3673 seconds | Client must send next request |
+| CanAwait | 10 seconds | Server must provide block or await |
+| Intersect | 10 seconds | Server must respond to intersect |
+| MustReply | random(135-269 seconds) | Server must provide block |
 
 ## Limits
 
@@ -133,8 +135,8 @@ chainsync.NewConfig(
     chainsync.WithRollForwardRawFunc(rollForwardRawCallback),
     chainsync.WithFindIntersectFunc(findIntersectCallback),
     chainsync.WithRequestNextFunc(requestNextCallback),
-    chainsync.WithIntersectTimeout(5 * time.Second),
-    chainsync.WithBlockTimeout(300 * time.Second),
+    chainsync.WithIntersectTimeout(10 * time.Second),
+    chainsync.WithBlockTimeout(269 * time.Second),
     chainsync.WithPipelineLimit(75),
     chainsync.WithRecvQueueSize(75),
 )

--- a/protocol/chainsync/chainsync.go
+++ b/protocol/chainsync/chainsync.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package chainsync
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -41,111 +42,157 @@ var (
 	stateDone      = protocol.NewState(5, "Done")
 )
 
-// ChainSync protocol state machine
-var StateMap = protocol.StateMap{
+// Shared transitions used by both N2N and N2C state maps.
+var (
+	idleTransitions = []protocol.StateTransition{
+		{
+			MsgType:   MessageTypeRequestNext,
+			NewState:  stateCanAwait,
+			MatchFunc: IncrementPipelineCount,
+		},
+		{
+			MsgType:  MessageTypeFindIntersect,
+			NewState: stateIntersect,
+		},
+		{
+			MsgType:  MessageTypeDone,
+			NewState: stateDone,
+		},
+	}
+	canAwaitTransitions = []protocol.StateTransition{
+		{
+			MsgType:   MessageTypeRequestNext,
+			NewState:  stateCanAwait,
+			MatchFunc: IncrementPipelineCount,
+		},
+		{
+			MsgType:  MessageTypeAwaitReply,
+			NewState: stateMustReply,
+		},
+		{
+			MsgType:   MessageTypeRollForward,
+			NewState:  stateIdle,
+			MatchFunc: DecrementPipelineCountAndIsEmpty,
+		},
+		{
+			MsgType:   MessageTypeRollForward,
+			NewState:  stateCanAwait,
+			MatchFunc: DecrementPipelineCountAndIsNotEmpty,
+		},
+		{
+			MsgType:   MessageTypeRollBackward,
+			NewState:  stateIdle,
+			MatchFunc: DecrementPipelineCountAndIsEmpty,
+		},
+		{
+			MsgType:   MessageTypeRollBackward,
+			NewState:  stateCanAwait,
+			MatchFunc: DecrementPipelineCountAndIsNotEmpty,
+		},
+	}
+	intersectTransitions = []protocol.StateTransition{
+		{
+			MsgType:  MessageTypeIntersectFound,
+			NewState: stateIdle,
+		},
+		{
+			MsgType:  MessageTypeIntersectNotFound,
+			NewState: stateIdle,
+		},
+	}
+	mustReplyTransitions = []protocol.StateTransition{
+		{
+			MsgType:   MessageTypeRollForward,
+			NewState:  stateIdle,
+			MatchFunc: DecrementPipelineCountAndIsEmpty,
+		},
+		{
+			MsgType:   MessageTypeRollForward,
+			NewState:  stateCanAwait,
+			MatchFunc: DecrementPipelineCountAndIsNotEmpty,
+		},
+		{
+			MsgType:   MessageTypeRollBackward,
+			NewState:  stateIdle,
+			MatchFunc: DecrementPipelineCountAndIsEmpty,
+		},
+		{
+			MsgType:   MessageTypeRollBackward,
+			NewState:  stateCanAwait,
+			MatchFunc: DecrementPipelineCountAndIsNotEmpty,
+		},
+	}
+)
+
+// MustReplyTimeoutFunc returns a random timeout in [MustReplyTimeoutMin, MustReplyTimeoutMax)
+// per Ouroboros Network Specification Table 3.8.
+func MustReplyTimeoutFunc() time.Duration {
+	rangeMs := MustReplyTimeoutMax.Milliseconds() - MustReplyTimeoutMin.Milliseconds()
+	return MustReplyTimeoutMin + time.Duration(rand.Int64N(rangeMs))*time.Millisecond //nolint:gosec
+}
+
+// StateMapNtN is the N2N ChainSync state machine with timeouts per spec Table 3.8.
+var StateMapNtN = protocol.StateMap{
 	stateIdle: protocol.StateMapEntry{
 		Agency:                  protocol.AgencyClient,
 		PendingMessageByteLimit: MaxPendingMessageBytes,
-		Timeout:                 IdleTimeout, // Timeout for client to send next request
-		Transitions: []protocol.StateTransition{
-			{
-				MsgType:   MessageTypeRequestNext,
-				NewState:  stateCanAwait,
-				MatchFunc: IncrementPipelineCount,
-			},
-			{
-				MsgType:  MessageTypeFindIntersect,
-				NewState: stateIntersect,
-			},
-			{
-				MsgType:  MessageTypeDone,
-				NewState: stateDone,
-			},
-		},
+		Timeout:                 IdleTimeout,
+		Transitions:             idleTransitions,
 	},
 	stateCanAwait: protocol.StateMapEntry{
 		Agency:                  protocol.AgencyServer,
 		PendingMessageByteLimit: MaxPendingMessageBytes,
-		Timeout:                 CanAwaitTimeout, // Timeout for server to provide next block or await
-		Transitions: []protocol.StateTransition{
-			{
-				MsgType:   MessageTypeRequestNext,
-				NewState:  stateCanAwait,
-				MatchFunc: IncrementPipelineCount,
-			},
-			{
-				MsgType:  MessageTypeAwaitReply,
-				NewState: stateMustReply,
-			},
-			{
-				MsgType:   MessageTypeRollForward,
-				NewState:  stateIdle,
-				MatchFunc: DecrementPipelineCountAndIsEmpty,
-			},
-			{
-				MsgType:   MessageTypeRollForward,
-				NewState:  stateCanAwait,
-				MatchFunc: DecrementPipelineCountAndIsNotEmpty,
-			},
-			{
-				MsgType:   MessageTypeRollBackward,
-				NewState:  stateIdle,
-				MatchFunc: DecrementPipelineCountAndIsEmpty,
-			},
-			{
-				MsgType:   MessageTypeRollBackward,
-				NewState:  stateCanAwait,
-				MatchFunc: DecrementPipelineCountAndIsNotEmpty,
-			},
-		},
+		Timeout:                 CanAwaitTimeout,
+		Transitions:             canAwaitTransitions,
 	},
 	stateIntersect: protocol.StateMapEntry{
 		Agency:                  protocol.AgencyServer,
 		PendingMessageByteLimit: MaxPendingMessageBytes,
-		Timeout:                 IntersectTimeout, // Timeout for server to respond to intersect request
-		Transitions: []protocol.StateTransition{
-			{
-				MsgType:  MessageTypeIntersectFound,
-				NewState: stateIdle,
-			},
-			{
-				MsgType:  MessageTypeIntersectNotFound,
-				NewState: stateIdle,
-			},
-		},
+		Timeout:                 IntersectTimeout,
+		Transitions:             intersectTransitions,
 	},
 	stateMustReply: protocol.StateMapEntry{
 		Agency:                  protocol.AgencyServer,
 		PendingMessageByteLimit: MaxPendingMessageBytes,
-		Timeout:                 MustReplyTimeout, // Timeout for server to provide next block
-		Transitions: []protocol.StateTransition{
-			{
-				MsgType:   MessageTypeRollForward,
-				NewState:  stateIdle,
-				MatchFunc: DecrementPipelineCountAndIsEmpty,
-			},
-			{
-				MsgType:   MessageTypeRollForward,
-				NewState:  stateCanAwait,
-				MatchFunc: DecrementPipelineCountAndIsNotEmpty,
-			},
-			{
-				MsgType:   MessageTypeRollBackward,
-				NewState:  stateIdle,
-				MatchFunc: DecrementPipelineCountAndIsEmpty,
-			},
-			{
-				MsgType:   MessageTypeRollBackward,
-				NewState:  stateCanAwait,
-				MatchFunc: DecrementPipelineCountAndIsNotEmpty,
-			},
-		},
+		TimeoutFunc:             MustReplyTimeoutFunc,
+		Transitions:             mustReplyTransitions,
 	},
 	stateDone: protocol.StateMapEntry{
 		Agency:                  protocol.AgencyNone,
 		PendingMessageByteLimit: MaxPendingMessageBytes,
 	},
 }
+
+// StateMapNtC is the N2C ChainSync state machine with no timeouts per spec Table 3.9.
+var StateMapNtC = protocol.StateMap{
+	stateIdle: protocol.StateMapEntry{
+		Agency:                  protocol.AgencyClient,
+		PendingMessageByteLimit: MaxPendingMessageBytes,
+		Transitions:             idleTransitions,
+	},
+	stateCanAwait: protocol.StateMapEntry{
+		Agency:                  protocol.AgencyServer,
+		PendingMessageByteLimit: MaxPendingMessageBytes,
+		Transitions:             canAwaitTransitions,
+	},
+	stateIntersect: protocol.StateMapEntry{
+		Agency:                  protocol.AgencyServer,
+		PendingMessageByteLimit: MaxPendingMessageBytes,
+		Transitions:             intersectTransitions,
+	},
+	stateMustReply: protocol.StateMapEntry{
+		Agency:                  protocol.AgencyServer,
+		PendingMessageByteLimit: MaxPendingMessageBytes,
+		Transitions:             mustReplyTransitions,
+	},
+	stateDone: protocol.StateMapEntry{
+		Agency:                  protocol.AgencyNone,
+		PendingMessageByteLimit: MaxPendingMessageBytes,
+	},
+}
+
+// StateMap is a copy of StateMapNtN for backward compatibility.
+var StateMap = StateMapNtN.Copy()
 
 type StateContext struct {
 	mu            sync.Mutex
@@ -243,12 +290,14 @@ const (
 	DefaultPipelineDrainTimeout = 30 * time.Second
 )
 
-// Protocol state timeout constants per network specification
+// Protocol state timeout constants per Ouroboros Network Specification (Table 3.8).
 const (
-	IdleTimeout      = 60 * time.Second  // Timeout for client to send next request
-	CanAwaitTimeout  = 300 * time.Second // Timeout for server to provide next block or await
-	IntersectTimeout = 5 * time.Second   // Timeout for server to respond to intersect request
-	MustReplyTimeout = 300 * time.Second // Timeout for server to provide next block
+	IdleTimeout         = 3673 * time.Second  // Timeout for client to send next request
+	CanAwaitTimeout     = 10 * time.Second    // Timeout for server to provide next block or await
+	IntersectTimeout    = 10 * time.Second    // Timeout for server to respond to intersect request
+	MustReplyTimeoutMin = 135 * time.Second   // Minimum random timeout for MustReply state
+	MustReplyTimeoutMax = 269 * time.Second   // Maximum random timeout for MustReply state
+	MustReplyTimeout    = MustReplyTimeoutMax // Fixed timeout for backward compatibility
 )
 
 // Callback context
@@ -292,12 +341,11 @@ func NewConfig(options ...ChainSyncOptionFunc) Config {
 	c := Config{
 		PipelineLimit:    DefaultPipelineLimit,
 		RecvQueueSize:    DefaultRecvQueueSize,
-		IntersectTimeout: 5 * time.Second,
-		// We should really use something more useful like 30-60s, but we've seen 55s between blocks
-		// in the preview network and almost 240s in preprod
-		// https://preview.cexplorer.io/block/cb08a386363a946d2606e912fcd81ffed2bf326cdbc4058297b14471af4f67e9
-		// https://preview.cexplorer.io/block/86806dca4ba735b233cbeee6da713bdece36fd41fb5c568f9ef5a3f5cbf572a3
-		BlockTimeout: 300 * time.Second,
+		IntersectTimeout: IntersectTimeout,
+		// MustReply spec timeout is random(135s, 269s). We use the max
+		// as the application-level default since preview/preprod can
+		// have gaps up to ~240s between blocks.
+		BlockTimeout: MustReplyTimeoutMax,
 	}
 	// Apply provided options functions
 	for _, option := range options {

--- a/protocol/chainsync/client.go
+++ b/protocol/chainsync/client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -123,16 +123,30 @@ func (c *Client) initProtocol() {
 	c.wantFirstBlockChan = make(chan chan<- clientPointResult, 1)
 	c.wantIntersectFoundChan = make(chan chan<- clientPointResult, 1)
 
-	// Update state map with timeouts
-	stateMap := StateMap.Copy()
-	if entry, ok := stateMap[stateIntersect]; ok {
-		entry.Timeout = c.config.IntersectTimeout
-		stateMap[stateIntersect] = entry
+	// Select base state map based on protocol mode.
+	// Default to NtC (matching ProtocolId/CBOR defaults above) so that
+	// callers who omit Mode get consistent NtC behaviour throughout.
+	baseStateMap := StateMapNtC
+	if c.protoOptions.Mode == protocol.ProtocolModeNodeToNode {
+		baseStateMap = StateMapNtN
 	}
-	for _, state := range []protocol.State{stateCanAwait, stateMustReply} {
-		if entry, ok := stateMap[state]; ok {
-			entry.Timeout = c.config.BlockTimeout
-			stateMap[state] = entry
+	stateMap := baseStateMap.Copy()
+	// Override timeouts from config only for NtN mode.
+	// NtC mode intentionally has no timeouts per Ouroboros spec (Table 3.9).
+	if c.protoOptions.Mode == protocol.ProtocolModeNodeToNode {
+		if entry, ok := stateMap[stateIntersect]; ok {
+			entry.Timeout = c.config.IntersectTimeout
+			stateMap[stateIntersect] = entry
+		}
+		for _, state := range []protocol.State{stateCanAwait, stateMustReply} {
+			if entry, ok := stateMap[state]; ok {
+				if entry.TimeoutFunc != nil {
+					// Dynamic timeout (e.g. MustReplyTimeoutFunc) takes precedence; skip override.
+					continue
+				}
+				entry.Timeout = c.config.BlockTimeout
+				stateMap[state] = entry
+			}
 		}
 	}
 	// Configure underlying Protocol

--- a/protocol/chainsync/messages_test.go
+++ b/protocol/chainsync/messages_test.go
@@ -212,6 +212,7 @@ func TestMsgRollForwardNodeToNode_CorruptedCBOR(t *testing.T) {
 		)
 	}
 }
+
 func TestMsgRollForwardNodeToClient(t *testing.T) {
 	createMsg := func(t *testing.T, blockType uint, filePath string, tip Tip) *MsgRollForwardNtC {
 		blockData := hexDecode(string(readFile(filePath)))
@@ -232,7 +233,7 @@ func TestMsgRollForwardNodeToClient(t *testing.T) {
 			),
 			Message: createMsg(
 				t,
-				0,
+				ledger.BlockTypeByronEbb,
 				"testdata/byron_ebb_testnet_8f8602837f7c6f8b8867dd1cbc1842cf51a27eaed2c70ef48325d00f8efb320f.hex",
 				Tip{
 					Point: pcommon.Point{
@@ -256,7 +257,7 @@ func TestMsgRollForwardNodeToClient(t *testing.T) {
 			),
 			Message: createMsg(
 				t,
-				1,
+				ledger.BlockTypeByronMain,
 				"testdata/byron_main_block_testnet_f38aa5e8cf0b47d1ffa8b2385aa2d43882282db2ffd5ac0e3dadec1a6f2ecf08.hex",
 				Tip{
 					Point: pcommon.Point{
@@ -280,7 +281,7 @@ func TestMsgRollForwardNodeToClient(t *testing.T) {
 			),
 			Message: createMsg(
 				t,
-				2,
+				ledger.BlockTypeShelley,
 				"testdata/shelley_block_testnet_02b1c561715da9e540411123a6135ee319b02f60b9a11a603d3305556c04329f.hex",
 				Tip{
 					Point: pcommon.Point{

--- a/protocol/chainsync/server.go
+++ b/protocol/chainsync/server.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -70,6 +70,13 @@ func (s *Server) initProtocol() {
 		ProtocolId = ProtocolIdNtN
 		msgFromCborFunc = NewMsgFromCborNtN
 	}
+	// Select state map based on protocol mode.
+	// Default to NtC (matching ProtocolId/CBOR defaults above) so that
+	// callers who omit Mode get consistent NtC behaviour throughout.
+	stateMap := StateMapNtC.Copy()
+	if s.protoOptions.Mode == protocol.ProtocolModeNodeToNode {
+		stateMap = StateMapNtN.Copy()
+	}
 	protoConfig := protocol.ProtocolConfig{
 		Name:                ProtocolName,
 		ProtocolId:          ProtocolId,
@@ -80,7 +87,7 @@ func (s *Server) initProtocol() {
 		Role:                protocol.ProtocolRoleServer,
 		MessageHandlerFunc:  s.messageHandler,
 		MessageFromCborFunc: msgFromCborFunc,
-		StateMap:            StateMap,
+		StateMap:            stateMap,
 		StateContext:        s.stateContext,
 		InitialState:        stateIdle,
 	}

--- a/protocol/handshake/client.go
+++ b/protocol/handshake/client.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,11 +43,19 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 		Client:       c,
 		ConnectionId: protoOptions.ConnectionId,
 	}
-	// Update state map with timeout
-	stateMap := StateMap.Copy()
-	if entry, ok := stateMap[stateConfirm]; ok {
-		entry.Timeout = c.config.Timeout
-		stateMap[stateConfirm] = entry
+	// Select state map based on protocol mode
+	baseStateMap := StateMapNtN
+	if protoOptions.Mode == protocol.ProtocolModeNodeToClient {
+		baseStateMap = StateMapNtC
+	}
+	stateMap := baseStateMap.Copy()
+	// Override confirm timeout from config for NtN only (client waits for server response).
+	// NtC has no timeouts per spec Table 3.5.
+	if protoOptions.Mode == protocol.ProtocolModeNodeToNode {
+		if entry, ok := stateMap[stateConfirm]; ok {
+			entry.Timeout = c.config.Timeout
+			stateMap[stateConfirm] = entry
+		}
 	}
 	// Configure underlying Protocol
 	protoConfig := protocol.ProtocolConfig{

--- a/protocol/handshake/handshake.go
+++ b/protocol/handshake/handshake.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,10 +28,11 @@ const (
 	ProtocolId   = 0
 )
 
-// Protocol state timeout constants per network specification
+// Protocol state timeout constants per Ouroboros Network Specification (Table 3.4).
+// N2N handshake has timeouts; N2C handshake has none.
 const (
-	ProposeTimeout = 5 * time.Second // Timeout for client to propose versions
-	ConfirmTimeout = 5 * time.Second // Timeout for server to accept or refuse versions
+	ProposeTimeout = 10 * time.Second // N2N: timeout for client to propose versions
+	ConfirmTimeout = 10 * time.Second // N2N: timeout for server to accept or refuse versions
 )
 
 var (
@@ -40,40 +41,64 @@ var (
 	stateDone    = protocol.NewState(3, "Done")
 )
 
-// Handshake protocol state machine
-var StateMap = protocol.StateMap{
+// confirmTransitions are shared between N2N and N2C state maps.
+var confirmTransitions = []protocol.StateTransition{
+	{
+		MsgType:  MessageTypeAcceptVersion,
+		NewState: stateDone,
+	},
+	{
+		MsgType:  MessageTypeRefuse,
+		NewState: stateDone,
+	},
+	{
+		MsgType:  MessageTypeQueryReply,
+		NewState: stateDone,
+	},
+}
+
+// proposeTransitions are shared between N2N and N2C state maps.
+var proposeTransitions = []protocol.StateTransition{
+	{
+		MsgType:  MessageTypeProposeVersions,
+		NewState: stateConfirm,
+	},
+}
+
+// StateMapNtN is the N2N handshake state machine with timeouts per spec Table 3.4.
+var StateMapNtN = protocol.StateMap{
 	statePropose: protocol.StateMapEntry{
-		Agency:  protocol.AgencyClient,
-		Timeout: ProposeTimeout, // Timeout for client to propose versions
-		Transitions: []protocol.StateTransition{
-			{
-				MsgType:  MessageTypeProposeVersions,
-				NewState: stateConfirm,
-			},
-		},
+		Agency:      protocol.AgencyClient,
+		Timeout:     ProposeTimeout,
+		Transitions: proposeTransitions,
 	},
 	stateConfirm: protocol.StateMapEntry{
-		Agency:  protocol.AgencyServer,
-		Timeout: ConfirmTimeout, // Timeout for server to accept or refuse versions
-		Transitions: []protocol.StateTransition{
-			{
-				MsgType:  MessageTypeAcceptVersion,
-				NewState: stateDone,
-			},
-			{
-				MsgType:  MessageTypeRefuse,
-				NewState: stateDone,
-			},
-			{
-				MsgType:  MessageTypeQueryReply,
-				NewState: stateDone,
-			},
-		},
+		Agency:      protocol.AgencyServer,
+		Timeout:     ConfirmTimeout,
+		Transitions: confirmTransitions,
 	},
 	stateDone: protocol.StateMapEntry{
 		Agency: protocol.AgencyNone,
 	},
 }
+
+// StateMapNtC is the N2C handshake state machine with no timeouts per spec Table 3.5.
+var StateMapNtC = protocol.StateMap{
+	statePropose: protocol.StateMapEntry{
+		Agency:      protocol.AgencyClient,
+		Transitions: proposeTransitions,
+	},
+	stateConfirm: protocol.StateMapEntry{
+		Agency:      protocol.AgencyServer,
+		Transitions: confirmTransitions,
+	},
+	stateDone: protocol.StateMapEntry{
+		Agency: protocol.AgencyNone,
+	},
+}
+
+// StateMap is a copy of StateMapNtN for backward compatibility.
+var StateMap = StateMapNtN.Copy()
 
 // Handshake is a wrapper object that holds the client and server instances
 type Handshake struct {
@@ -116,7 +141,7 @@ type HandshakeOptionFunc func(*Config)
 // NewConfig returns a new Handshake config object with the provided options
 func NewConfig(options ...HandshakeOptionFunc) Config {
 	c := Config{
-		Timeout: 5 * time.Second,
+		Timeout: 10 * time.Second,
 	}
 	// Apply provided options functions
 	for _, option := range options {

--- a/protocol/handshake/server.go
+++ b/protocol/handshake/server.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,11 +38,19 @@ func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 		Server:       s,
 		ConnectionId: protoOptions.ConnectionId,
 	}
-	// Update state map with timeout
-	stateMap := StateMap.Copy()
-	if entry, ok := stateMap[statePropose]; ok {
-		entry.Timeout = s.config.Timeout
-		stateMap[statePropose] = entry
+	// Select state map based on protocol mode
+	baseStateMap := StateMapNtN
+	if protoOptions.Mode == protocol.ProtocolModeNodeToClient {
+		baseStateMap = StateMapNtC
+	}
+	stateMap := baseStateMap.Copy()
+	// Override propose timeout from config for NtN only (server waits for client proposal).
+	// NtC has no timeouts per spec Table 3.5.
+	if protoOptions.Mode == protocol.ProtocolModeNodeToNode {
+		if entry, ok := stateMap[statePropose]; ok {
+			entry.Timeout = s.config.Timeout
+			stateMap[statePropose] = entry
+		}
 	}
 	protoConfig := protocol.ProtocolConfig{
 		Name:                ProtocolName,

--- a/protocol/keepalive/keepalive.go
+++ b/protocol/keepalive/keepalive.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,12 +33,12 @@ const (
 	DefaultKeepAliveTimeout = 10
 )
 
-// Protocol state timeout constants as specified by the network protocol.
+// Protocol state timeout constants per Ouroboros Network Specification (Table 3.13).
 const (
 	// ClientTimeout is the maximum time the server waits to receive the next keep-alive ping from the client (while in the "Client" protocol state).
-	ClientTimeout = 60 * time.Second
+	ClientTimeout = 97 * time.Second
 	// ServerTimeout is the maximum time the client waits for a keep-alive pong from the server (while in the "Server" protocol state).
-	ServerTimeout = 10 * time.Second
+	ServerTimeout = 60 * time.Second
 )
 
 var (

--- a/protocol/limits_test.go
+++ b/protocol/limits_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/protocol/localtxsubmission"
 	"github.com/blinklabs-io/gouroboros/protocol/peersharing"
 	"github.com/blinklabs-io/gouroboros/protocol/txsubmission"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestChainSyncLimitsAreDefined validates that ChainSync limits are properly defined and positive
@@ -331,22 +332,22 @@ func TestTxSubmissionLimitsAreDefined(t *testing.T) {
 		)
 	}
 
-	// Test timeout constants
-	if txsubmission.InitTimeout <= 0 {
+	// Test timeout constants: per spec, Init/Idle/TxIdsBlocking have no timeout (0)
+	if txsubmission.InitTimeout != 0 {
 		t.Errorf(
-			"InitTimeout must be positive, got %v",
+			"InitTimeout must be 0 per spec, got %v",
 			txsubmission.InitTimeout,
 		)
 	}
-	if txsubmission.IdleTimeout <= 0 {
+	if txsubmission.IdleTimeout != 0 {
 		t.Errorf(
-			"IdleTimeout must be positive, got %v",
+			"IdleTimeout must be 0 per spec, got %v",
 			txsubmission.IdleTimeout,
 		)
 	}
-	if txsubmission.TxIdsBlockingTimeout <= 0 {
+	if txsubmission.TxIdsBlockingTimeout != 0 {
 		t.Errorf(
-			"TxIdsBlockingTimeout must be positive, got %v",
+			"TxIdsBlockingTimeout must be 0 per spec, got %v",
 			txsubmission.TxIdsBlockingTimeout,
 		)
 	}
@@ -537,20 +538,22 @@ func TestProtocolStateTimeouts(t *testing.T) {
 		}
 
 		// Test that timeout values are reasonable (between 1 second and 1 hour)
-		timeouts := map[string]time.Duration{
-			"IdleTimeout":      chainsync.IdleTimeout,
-			"CanAwaitTimeout":  chainsync.CanAwaitTimeout,
-			"IntersectTimeout": chainsync.IntersectTimeout,
-			"MustReplyTimeout": chainsync.MustReplyTimeout,
+		// Per spec, IdleTimeout is 3673s (~61 min) which exceeds 1 hour.
+		// Validate each timeout individually against spec values.
+		if chainsync.IdleTimeout != 3673*time.Second {
+			t.Errorf("IdleTimeout should be 3673s per spec, got %v", chainsync.IdleTimeout)
 		}
-		for name, timeout := range timeouts {
-			if timeout < time.Second || timeout > time.Hour {
-				t.Errorf(
-					"%s should be between 1 second and 1 hour, got %v",
-					name,
-					timeout,
-				)
-			}
+		if chainsync.CanAwaitTimeout != 10*time.Second {
+			t.Errorf("CanAwaitTimeout should be 10s per spec, got %v", chainsync.CanAwaitTimeout)
+		}
+		if chainsync.IntersectTimeout != 10*time.Second {
+			t.Errorf("IntersectTimeout should be 10s per spec, got %v", chainsync.IntersectTimeout)
+		}
+		if chainsync.MustReplyTimeoutMin != 135*time.Second {
+			t.Errorf("MustReplyTimeoutMin should be 135s per spec, got %v", chainsync.MustReplyTimeoutMin)
+		}
+		if chainsync.MustReplyTimeoutMax != 269*time.Second {
+			t.Errorf("MustReplyTimeoutMax should be 269s per spec, got %v", chainsync.MustReplyTimeoutMax)
 		}
 	})
 
@@ -586,55 +589,13 @@ func TestProtocolStateTimeouts(t *testing.T) {
 	})
 
 	t.Run("TxSubmission timeouts", func(t *testing.T) {
-		// Test that all timeout constants are positive
-		if txsubmission.InitTimeout <= 0 {
-			t.Errorf(
-				"InitTimeout must be positive, got %v",
-				txsubmission.InitTimeout,
-			)
-		}
-		if txsubmission.IdleTimeout <= 0 {
-			t.Errorf(
-				"IdleTimeout must be positive, got %v",
-				txsubmission.IdleTimeout,
-			)
-		}
-		if txsubmission.TxIdsBlockingTimeout <= 0 {
-			t.Errorf(
-				"TxIdsBlockingTimeout must be positive, got %v",
-				txsubmission.TxIdsBlockingTimeout,
-			)
-		}
-		if txsubmission.TxIdsNonblockingTimeout <= 0 {
-			t.Errorf(
-				"TxIdsNonblockingTimeout must be positive, got %v",
-				txsubmission.TxIdsNonblockingTimeout,
-			)
-		}
-		if txsubmission.TxsTimeout <= 0 {
-			t.Errorf(
-				"TxsTimeout must be positive, got %v",
-				txsubmission.TxsTimeout,
-			)
-		}
-
-		// Test that timeout values are reasonable
-		timeouts := map[string]time.Duration{
-			"InitTimeout":             txsubmission.InitTimeout,
-			"IdleTimeout":             txsubmission.IdleTimeout,
-			"TxIdsBlockingTimeout":    txsubmission.TxIdsBlockingTimeout,
-			"TxIdsNonblockingTimeout": txsubmission.TxIdsNonblockingTimeout,
-			"TxsTimeout":              txsubmission.TxsTimeout,
-		}
-		for name, timeout := range timeouts {
-			if timeout < time.Second || timeout > time.Hour {
-				t.Errorf(
-					"%s should be between 1 second and 1 hour, got %v",
-					name,
-					timeout,
-				)
-			}
-		}
+		// Per spec: Init, Idle, and TxIdsBlocking have no timeout (0)
+		assert.Equal(t, time.Duration(0), txsubmission.InitTimeout, "InitTimeout must be 0 per spec")
+		assert.Equal(t, time.Duration(0), txsubmission.IdleTimeout, "IdleTimeout must be 0 per spec")
+		assert.Equal(t, time.Duration(0), txsubmission.TxIdsBlockingTimeout, "TxIdsBlockingTimeout must be 0 per spec")
+		// NonBlocking and Txs have 10s timeouts per spec
+		assert.Equal(t, 10*time.Second, txsubmission.TxIdsNonblockingTimeout, "TxIdsNonblockingTimeout should be 10s per spec")
+		assert.Equal(t, 10*time.Second, txsubmission.TxsTimeout, "TxsTimeout should be 10s per spec")
 	})
 
 	t.Run("Handshake timeouts", func(t *testing.T) {
@@ -794,13 +755,13 @@ func TestProtocolStateTimeouts(t *testing.T) {
 
 // TestStateMapTimeouts verifies that StateMap entries use the correct timeout constants
 func TestStateMapTimeouts(t *testing.T) {
-	t.Run("ChainSync StateMap timeouts", func(t *testing.T) {
+	t.Run("ChainSync N2N StateMap timeouts", func(t *testing.T) {
 		stateIdle := protocol.NewState(1, "Idle")
 		stateCanAwait := protocol.NewState(2, "CanAwait")
 		stateIntersect := protocol.NewState(4, "Intersect")
 		stateMustReply := protocol.NewState(3, "MustReply")
 
-		if entry, exists := chainsync.StateMap[stateIdle]; exists {
+		if entry, exists := chainsync.StateMapNtN[stateIdle]; exists {
 			if entry.Timeout != chainsync.IdleTimeout {
 				t.Errorf(
 					"stateIdle timeout should be %v, got %v",
@@ -809,7 +770,7 @@ func TestStateMapTimeouts(t *testing.T) {
 				)
 			}
 		}
-		if entry, exists := chainsync.StateMap[stateCanAwait]; exists {
+		if entry, exists := chainsync.StateMapNtN[stateCanAwait]; exists {
 			if entry.Timeout != chainsync.CanAwaitTimeout {
 				t.Errorf(
 					"stateCanAwait timeout should be %v, got %v",
@@ -818,7 +779,7 @@ func TestStateMapTimeouts(t *testing.T) {
 				)
 			}
 		}
-		if entry, exists := chainsync.StateMap[stateIntersect]; exists {
+		if entry, exists := chainsync.StateMapNtN[stateIntersect]; exists {
 			if entry.Timeout != chainsync.IntersectTimeout {
 				t.Errorf(
 					"stateIntersect timeout should be %v, got %v",
@@ -827,12 +788,37 @@ func TestStateMapTimeouts(t *testing.T) {
 				)
 			}
 		}
-		if entry, exists := chainsync.StateMap[stateMustReply]; exists {
-			if entry.Timeout != chainsync.MustReplyTimeout {
+		if entry, exists := chainsync.StateMapNtN[stateMustReply]; exists {
+			if entry.TimeoutFunc == nil {
+				t.Error("stateMustReply should have TimeoutFunc set")
+			} else {
+				// Verify the random timeout is within spec range
+				timeout := entry.TimeoutFunc()
+				if timeout < chainsync.MustReplyTimeoutMin ||
+					timeout >= chainsync.MustReplyTimeoutMax {
+					t.Errorf(
+						"stateMustReply timeout %v outside spec range [%v, %v)",
+						timeout,
+						chainsync.MustReplyTimeoutMin,
+						chainsync.MustReplyTimeoutMax,
+					)
+				}
+			}
+		}
+	})
+
+	t.Run("ChainSync N2C StateMap has no timeouts", func(t *testing.T) {
+		for state, entry := range chainsync.StateMapNtC {
+			if entry.Timeout != 0 {
 				t.Errorf(
-					"stateMustReply timeout should be %v, got %v",
-					chainsync.MustReplyTimeout,
-					entry.Timeout,
+					"N2C state %s should have no timeout, got %v",
+					state, entry.Timeout,
+				)
+			}
+			if entry.TimeoutFunc != nil {
+				t.Errorf(
+					"N2C state %s should have no TimeoutFunc",
+					state,
 				)
 			}
 		}

--- a/protocol/localstatequery/client_test.go
+++ b/protocol/localstatequery/client_test.go
@@ -980,7 +980,7 @@ func TestGetRatifyState(t *testing.T) {
 	// RatifyState with empty enacted, empty expired, not delayed
 	expectedResult := localstatequery.RatifyStateResult{
 		EnactState: localstatequery.EnactState{
-			Committee:    cbor.RawMessage([]byte{0xf6}), // null
+			Committee: cbor.RawMessage([]byte{0xf6}), // null
 			Constitution: localstatequery.ConstitutionResult{
 				Anchor: lcommon.GovAnchor{
 					Url:      "https://constitution.cardano.org",
@@ -1075,7 +1075,7 @@ func TestGetProposalsSingleProposal(t *testing.T) {
 	// Encode a minimal proposal procedure as RawMessage
 	// (empty array is simplest valid CBOR for testing)
 	proposalCbor, err := cbor.Encode([]any{
-		uint64(500000000),   // deposit
+		uint64(500000000),  // deposit
 		[]byte{0xe0, 0x01}, // reward account (minimal)
 		[]any{uint(6)},     // info gov action
 		[]any{"https://example.com", [32]byte{0xab}}, // anchor
@@ -1363,7 +1363,7 @@ func TestGenesisConfigJSON(t *testing.T) {
 		t.Fatalf("Failed to unmarshal JSON: %v", err)
 	}
 
-	//Compare everything after unmarshalling
+	// Compare everything after unmarshalling
 
 	if !reflect.DeepEqual(genesisConfig, result) {
 		t.Errorf(
@@ -1375,4 +1375,3 @@ func TestGenesisConfigJSON(t *testing.T) {
 		t.Logf("Successfully validated the GenesisConfigResult after JSON marshalling and unmarshalling.")
 	}
 }
-

--- a/protocol/localstatequery/messages_test.go
+++ b/protocol/localstatequery/messages_test.go
@@ -160,12 +160,12 @@ func TestDecode(t *testing.T) {
 		}
 		// cast msg to MsgResult and further try to decode cbor
 		if m, ok := msg.(*MsgResult); ok && test.Result != nil {
-			var decoded = reflect.New(reflect.TypeOf(test.Result))
+			decoded := reflect.New(reflect.TypeOf(test.Result))
 			_, err := cbor.Decode(m.Result, decoded.Interface())
 			if err != nil {
 				t.Fatalf("failed to decode result: %s", err)
 			}
-			var actual = reflect.Indirect(decoded).Interface()
+			actual := reflect.Indirect(decoded).Interface()
 			if !reflect.DeepEqual(actual, test.Result) {
 				t.Fatalf(
 					"MsgResult content did not decode to expected Result object\n  got:    %#v\n  wanted: %#v",

--- a/protocol/peersharing/peersharing.go
+++ b/protocol/peersharing/peersharing.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,11 @@ const (
 	ProtocolId   = 10
 )
 
+// Protocol state timeout constants per Ouroboros Network Specification (Table 3.15).
+const (
+	BusyTimeout = 60 * time.Second // Timeout for server to respond with peers
+)
+
 var (
 	stateIdle = protocol.NewState(1, "Idle")
 	stateBusy = protocol.NewState(2, "Busy")
@@ -50,7 +55,8 @@ var StateMap = protocol.StateMap{
 		},
 	},
 	stateBusy: protocol.StateMapEntry{
-		Agency: protocol.AgencyServer,
+		Agency:  protocol.AgencyServer,
+		Timeout: BusyTimeout,
 		Transitions: []protocol.StateTransition{
 			{
 				MsgType:  MessageTypeSharePeers,
@@ -100,7 +106,7 @@ type PeerSharingOptionFunc func(*Config)
 // NewConfig returns a new PeerSharing config object with the provided options
 func NewConfig(options ...PeerSharingOptionFunc) Config {
 	c := Config{
-		Timeout: 5 * time.Second,
+		Timeout: BusyTimeout,
 	}
 	// Apply provided options functions
 	for _, option := range options {

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -709,10 +709,13 @@ func (p *Protocol) stateLoop(ch <-chan protocolStateTransition) {
 		}
 
 		// Set timeout for state transition
-		if p.config.StateMap[s].Timeout > 0 {
-			transitionTimer = time.NewTimer(
-				p.config.StateMap[s].Timeout,
-			)
+		entry := p.config.StateMap[s]
+		timeout := entry.Timeout
+		if entry.TimeoutFunc != nil {
+			timeout = entry.TimeoutFunc()
+		}
+		if timeout > 0 {
+			transitionTimer = time.NewTimer(timeout)
 		}
 	}
 	getTimerChan := func() <-chan time.Time {

--- a/protocol/state.go
+++ b/protocol/state.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -62,8 +62,9 @@ type StateTransitionMatchFunc func(any, Message) bool
 type StateMapEntry struct {
 	Agency                  ProtocolStateAgency
 	Transitions             []StateTransition
-	Timeout                 time.Duration
-	PendingMessageByteLimit int // Maximum pending message bytes allowed in this state (0 = no limit)
+	Timeout                 time.Duration        // Fixed timeout for this state (0 = no timeout)
+	TimeoutFunc             func() time.Duration // Dynamic timeout; if set, overrides Timeout
+	PendingMessageByteLimit int                  // Maximum pending message bytes allowed in this state (0 = no limit)
 }
 
 // StateMap represents the state machine definition for a mini-protocol

--- a/protocol/txsubmission/README.md
+++ b/protocol/txsubmission/README.md
@@ -96,15 +96,15 @@ The TxSubmission protocol propagates transactions between nodes. It uses a pull-
 |---------|-----------|
 | `ReplyTxs` | Idle |
 
-## Timeouts
+## Timeouts (per spec Table 3.11)
 
 | State | Timeout | Description |
 |-------|---------|-------------|
-| Init | 30 seconds | Client must send Init message |
-| Idle | 300 seconds | Server must send tx request |
-| TxIdsBlocking | 60 seconds | Client must reply with tx IDs |
-| TxIdsNonblocking | 30 seconds | Client must reply with tx IDs |
-| Txs | 120 seconds | Client must reply with transactions |
+| Init | none | No timeout per spec |
+| Idle | none | No timeout per spec |
+| TxIdsBlocking | none | No timeout per spec (blocking waits indefinitely) |
+| TxIdsNonblocking | 10 seconds | Client must reply with tx IDs |
+| Txs | 10 seconds | Client must reply with transactions |
 
 ## Limits
 
@@ -130,7 +130,7 @@ txsubmission.NewConfig(
     txsubmission.WithRequestTxsFunc(requestTxsCallback),
     txsubmission.WithInitFunc(initCallback),
     txsubmission.WithDoneFunc(doneCallback),
-    txsubmission.WithIdleTimeout(300 * time.Second),
+    txsubmission.WithIdleTimeout(0), // no timeout per spec
 )
 ```
 

--- a/protocol/txsubmission/txsubmission.go
+++ b/protocol/txsubmission/txsubmission.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ var StateMap = protocol.StateMap{
 	stateTxIdsBlocking: protocol.StateMapEntry{
 		Agency:                  protocol.AgencyClient,
 		PendingMessageByteLimit: 0,
-		Timeout:                 TxIdsBlockingTimeout, // Timeout for client to reply with tx IDs (blocking)
+		Timeout:                 TxIdsBlockingTimeout, // No timeout per spec: client blocks until tx available
 		Transitions: []protocol.StateTransition{
 			{
 				MsgType:  MessageTypeReplyTxIds,
@@ -145,13 +145,13 @@ const (
 	DefaultAckLimit     = 1000  // Default ack limit
 )
 
-// Protocol state timeout constants per network specification
+// Protocol state timeout constants per Ouroboros Network Specification (Table 3.11).
 const (
-	InitTimeout             = 30 * time.Second  // Timeout for client to send init message
-	IdleTimeout             = 300 * time.Second // Timeout for server to send tx request when idle
-	TxIdsBlockingTimeout    = 60 * time.Second  // Timeout for client to reply with tx IDs (blocking)
-	TxIdsNonblockingTimeout = 30 * time.Second  // Timeout for client to reply with tx IDs (non-blocking)
-	TxsTimeout              = 120 * time.Second // Timeout for client to reply with full transactions
+	InitTimeout             = time.Duration(0) // No timeout per spec
+	IdleTimeout             = time.Duration(0) // No timeout per spec
+	TxIdsBlockingTimeout    = time.Duration(0) // No timeout per spec (blocking waits indefinitely)
+	TxIdsNonblockingTimeout = 10 * time.Second // Timeout for client to reply with tx IDs (non-blocking)
+	TxsTimeout              = 10 * time.Second // Timeout for client to reply with full transactions
 )
 
 // Callback context
@@ -185,7 +185,7 @@ type TxSubmissionOptionFunc func(*Config)
 // NewConfig returns a new TxSubmission config object with the provided options
 func NewConfig(options ...TxSubmissionOptionFunc) Config {
 	c := Config{
-		IdleTimeout: 300 * time.Second,
+		IdleTimeout: 0, // No timeout per spec
 	}
 	// Apply provided options functions
 	for _, option := range options {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split ChainSync and Handshake into separate Node-to-Node and Node-to-Client state maps, and aligned timeouts with the Ouroboros spec. ChainSync MustReply is now randomized; TxSubmission blocking timeouts are removed to prevent premature disconnects.

- **Refactors**
  - Added NtN/NtC state maps for ChainSync and Handshake; default to NtC (no timeouts) unless Mode=NtN.
  - Added TimeoutFunc support; ChainSync MustReply randomized (135–269s).
  - ChainSync NtN timeouts per spec: Idle 3673s, CanAwait 10s, Intersect 10s; app defaults Intersect 10s, BlockTimeout 269s.
  - Handshake NtN Propose/Confirm 10s; KeepAlive Client 97s, Server 60s; PeerSharing Busy 60s.

- **Bug Fixes**
  - TxSubmission timeouts per spec: Init/Idle/TxIdsBlocking=0; Nonblocking/Txs=10s to avoid premature disconnects.
  - Respected dynamic timeouts and applied overrides only in NtN mode.

<sup>Written for commit 97ebb07c4e33818c2456429617ece1c6551e077b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Protocol Changes**
  * Timeouts aligned with the spec across Handshake, ChainSync, KeepAlive and TxSubmission; distinct N2N vs N2C behaviors introduced.
  * ChainSync MustReply now uses a randomized timeout range; new Busy timeout added for peer sharing.

* **Bug Fixes**
  * Timeout application corrected to preserve dynamic timeouts and apply overrides conditionally.

* **Tests**
  * Expanded coverage for N2N vs N2C behaviors and randomized timeout ranges.

* **Documentation**
  * ChainSync timeouts and N2N/N2C behavior clarified in docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->