### PR TITLE
fix(protocol): state map per connection on servers

### DIFF
--- a/protocol/chainsync/chainsync.go
+++ b/protocol/chainsync/chainsync.go
@@ -262,6 +262,7 @@ type Config struct {
 	FindIntersectFunc   FindIntersectFunc
 	RequestNextFunc     RequestNextFunc
 	IntersectTimeout    time.Duration
+	IdleTimeout         time.Duration
 	BlockTimeout        time.Duration
 	PipelineLimit       int
 	RecvQueueSize       int
@@ -448,6 +449,16 @@ func WithRequestNextFunc(requestNextFunc RequestNextFunc) ChainSyncOptionFunc {
 func WithIntersectTimeout(timeout time.Duration) ChainSyncOptionFunc {
 	return func(c *Config) {
 		c.IntersectTimeout = timeout
+	}
+}
+
+// WithIdleTimeout specifies the timeout for the Idle state (client agency).
+// A non-zero value overrides the protocol default. This is primarily useful
+// for the server side where the client may take a long time to send the next
+// request.
+func WithIdleTimeout(timeout time.Duration) ChainSyncOptionFunc {
+	return func(c *Config) {
+		c.IdleTimeout = timeout
 	}
 }
 

--- a/protocol/chainsync/client.go
+++ b/protocol/chainsync/client.go
@@ -138,6 +138,10 @@ func (c *Client) initProtocol() {
 			entry.Timeout = c.config.IntersectTimeout
 			stateMap[stateIntersect] = entry
 		}
+		if entry, ok := stateMap[stateIdle]; ok && c.config.IdleTimeout != 0 {
+			entry.Timeout = c.config.IdleTimeout
+			stateMap[stateIdle] = entry
+		}
 		for _, state := range []protocol.State{stateCanAwait, stateMustReply} {
 			if entry, ok := stateMap[state]; ok {
 				if entry.TimeoutFunc != nil {

--- a/protocol/chainsync/server.go
+++ b/protocol/chainsync/server.go
@@ -77,6 +77,20 @@ func (s *Server) initProtocol() {
 	if s.protoOptions.Mode == protocol.ProtocolModeNodeToNode {
 		stateMap = StateMapNtN.Copy()
 	}
+	// Apply per-connection config overrides to the copied state map.
+	// Only override when the state already has a timeout defined —
+	// NtC mode has no timeouts per spec (Table 3.9) and must not
+	// have timeouts injected.
+	if s.config != nil {
+		if entry, ok := stateMap[stateIntersect]; ok && entry.Timeout != 0 && s.config.IntersectTimeout != 0 {
+			entry.Timeout = s.config.IntersectTimeout
+			stateMap[stateIntersect] = entry
+		}
+		if entry, ok := stateMap[stateIdle]; ok && entry.Timeout != 0 && s.config.IdleTimeout != 0 {
+			entry.Timeout = s.config.IdleTimeout
+			stateMap[stateIdle] = entry
+		}
+	}
 	protoConfig := protocol.ProtocolConfig{
 		Name:                ProtocolName,
 		ProtocolId:          ProtocolId,

--- a/protocol/txsubmission/client.go
+++ b/protocol/txsubmission/client.go
@@ -64,12 +64,8 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 }
 
 func (c *Client) initProtocol() {
-	// Update state map with timeout
+	// Copy the global StateMap to avoid mutating shared state.
 	stateMap := StateMap.Copy()
-	if entry, ok := stateMap[stateIdle]; ok {
-		entry.Timeout = c.config.IdleTimeout
-		stateMap[stateIdle] = entry
-	}
 	// Configure underlying Protocol
 	protoConfig := protocol.ProtocolConfig{
 		Name:                ProtocolName,

--- a/protocol/txsubmission/server.go
+++ b/protocol/txsubmission/server.go
@@ -56,6 +56,8 @@ func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 }
 
 func (s *Server) initProtocol() {
+	// Copy the global StateMap to avoid mutating shared state.
+	stateMap := StateMap.Copy()
 	protoConfig := protocol.ProtocolConfig{
 		Name:                ProtocolName,
 		ProtocolId:          ProtocolId,
@@ -66,7 +68,7 @@ func (s *Server) initProtocol() {
 		Role:                protocol.ProtocolRoleServer,
 		MessageHandlerFunc:  s.messageHandler,
 		MessageFromCborFunc: NewMsgFromCbor,
-		StateMap:            StateMap,
+		StateMap:            stateMap,
 		InitialState:        stateInit,
 	}
 	s.Protocol = protocol.New(protoConfig)

--- a/protocol/txsubmission/txsubmission.go
+++ b/protocol/txsubmission/txsubmission.go
@@ -134,7 +134,6 @@ type Config struct {
 	RequestTxsFunc   RequestTxsFunc
 	InitFunc         InitFunc
 	DoneFunc         DoneFunc
-	IdleTimeout      time.Duration
 }
 
 // Protocol limits per Ouroboros Network Specification
@@ -184,9 +183,7 @@ type TxSubmissionOptionFunc func(*Config)
 
 // NewConfig returns a new TxSubmission config object with the provided options
 func NewConfig(options ...TxSubmissionOptionFunc) Config {
-	c := Config{
-		IdleTimeout: 0, // No timeout per spec
-	}
+	c := Config{}
 	// Apply provided options functions
 	for _, option := range options {
 		option(&c)
@@ -221,12 +218,5 @@ func WithInitFunc(initFunc InitFunc) TxSubmissionOptionFunc {
 func WithDoneFunc(doneFunc DoneFunc) TxSubmissionOptionFunc {
 	return func(c *Config) {
 		c.DoneFunc = doneFunc
-	}
-}
-
-// WithIdleTimeout specifies the timeout for waiting for new transactions from the remote node's mempool
-func WithIdleTimeout(timeout time.Duration) TxSubmissionOptionFunc {
-	return func(c *Config) {
-		c.IdleTimeout = timeout
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a per-connection state map to stop shared state mutations and scope timeouts to each connection. Adds a ChainSync IdleTimeout override and removes the non-spec IdleTimeout from TxSubmission.

- **New Features**
  - ChainSync: added IdleTimeout config and option; applied to the idle state on client and server. Server only overrides when the state has a timeout (keeps NtC without timeouts).
  - Servers: apply per-connection overrides to copied ChainSync state maps (IntersectTimeout, IdleTimeout). TxSubmission client and server now copy their state maps to avoid shared mutations.

- **Migration**
  - Remove any use of TxSubmission.WithIdleTimeout. TxSubmission no longer supports an idle timeout per spec.

<sup>Written for commit 6ad1cdfd914d02ee25510636c3c1d028e75b0989. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chain-sync gains a configurable idle timeout per connection.

* **Refactor**
  * Per-connection timeout overrides added for protocol initialization.
  * Protocol state handling improved to avoid mutating shared global state during setup.

* **Behavior Change**
  * Idle timeout setting was removed from the transaction-submission component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->