### PR TITLE
fix: transaction json serde

### DIFF
--- a/cbor/tags.go
+++ b/cbor/tags.go
@@ -243,3 +243,16 @@ func (t *SetType[T]) Items() []T {
 	copy(ret, t.items)
 	return ret
 }
+
+func (t SetType[T]) MarshalJSON() ([]byte, error) {
+	if t.items == nil {
+		return []byte("[]"), nil
+	}
+	return json.Marshal(t.items)
+}
+
+func (t *SetType[T]) UnmarshalJSON(data []byte) error {
+	t.useTag = false
+	t.SetCbor(nil)
+	return json.Unmarshal(data, &t.items)
+}

--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -551,16 +551,47 @@ func (o AlonzoTransactionOutput) String() string {
 
 type AlonzoRedeemer struct {
 	cbor.StructAsArray
-	Tag     common.RedeemerTag
-	Index   uint32
-	Data    common.Datum
-	ExUnits common.ExUnits
+	Tag     common.RedeemerTag `json:"tag"`
+	Index   uint32             `json:"index"`
+	Data    common.Datum       `json:"data"`
+	ExUnits common.ExUnits     `json:"exUnits"`
 }
 
 // AlonzoRedeemers wraps a slice of redeemers with CBOR preservation
 type AlonzoRedeemers struct {
 	cbor.DecodeStoreCbor
 	Redeemers []AlonzoRedeemer
+}
+
+func (r AlonzoRedeemers) MarshalJSON() ([]byte, error) {
+	if r.Redeemers == nil {
+		return []byte("[]"), nil
+	}
+	sorted := make([]AlonzoRedeemer, len(r.Redeemers))
+	copy(sorted, r.Redeemers)
+	slices.SortFunc(sorted, func(a, b AlonzoRedeemer) int {
+		return common.CompareRedeemerKeys(
+			common.RedeemerKey{Tag: a.Tag, Index: a.Index},
+			common.RedeemerKey{Tag: b.Tag, Index: b.Index},
+		)
+	})
+	return json.Marshal(sorted)
+}
+
+func (r *AlonzoRedeemers) UnmarshalJSON(raw []byte) error {
+	r.SetCbor(nil)
+	if err := json.Unmarshal(raw, &r.Redeemers); err != nil {
+		return err
+	}
+	seen := make(map[common.RedeemerKey]struct{}, len(r.Redeemers))
+	for _, entry := range r.Redeemers {
+		key := common.RedeemerKey{Tag: entry.Tag, Index: entry.Index}
+		if _, exists := seen[key]; exists {
+			return fmt.Errorf("duplicate redeemer key: tag=%d index=%d", entry.Tag, entry.Index)
+		}
+		seen[key] = struct{}{}
+	}
+	return nil
 }
 
 func (r *AlonzoRedeemers) UnmarshalCBOR(cborData []byte) error {
@@ -581,13 +612,10 @@ func (r AlonzoRedeemers) Iter() iter.Seq2[common.RedeemerKey, common.RedeemerVal
 		slices.SortFunc(
 			sorted,
 			func(a, b AlonzoRedeemer) int {
-				if a.Tag < b.Tag || (a.Tag == b.Tag && a.Index < b.Index) {
-					return -1
-				}
-				if a.Tag > b.Tag || (a.Tag == b.Tag && a.Index > b.Index) {
-					return 1
-				}
-				return 0
+				return common.CompareRedeemerKeys(
+					common.RedeemerKey{Tag: a.Tag, Index: a.Index},
+					common.RedeemerKey{Tag: b.Tag, Index: b.Index},
+				)
 			},
 		)
 		// Yield keys
@@ -647,6 +675,18 @@ func (p *PlutusDataList) UnmarshalCBOR(cborData []byte) error {
 
 func (p PlutusDataList) MarshalCBOR() ([]byte, error) {
 	return cbor.Encode(p.Items)
+}
+
+func (p PlutusDataList) MarshalJSON() ([]byte, error) {
+	if p.Items == nil {
+		return []byte("[]"), nil
+	}
+	return json.Marshal(p.Items)
+}
+
+func (p *PlutusDataList) UnmarshalJSON(raw []byte) error {
+	p.SetCbor(nil)
+	return json.Unmarshal(raw, &p.Items)
 }
 
 type AlonzoTransactionWitnessSet struct {

--- a/ledger/alonzo/redeemer_json_test.go
+++ b/ledger/alonzo/redeemer_json_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alonzo
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlonzoRedeemerMarshalJSON(t *testing.T) {
+	r := AlonzoRedeemer{
+		Tag:     common.RedeemerTagSpend,
+		Index:   0,
+		ExUnits: common.ExUnits{Memory: 1000, Steps: 2000},
+	}
+	data, err := json.Marshal(r)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"tag": "spend",
+		"index": 0,
+		"data": null,
+		"exUnits": {"memory": 1000, "steps": 2000}
+	}`, string(data))
+}
+
+func TestAlonzoRedeemerRoundTrip(t *testing.T) {
+	r := AlonzoRedeemer{
+		Tag:     common.RedeemerTagMint,
+		Index:   3,
+		ExUnits: common.ExUnits{Memory: 500000, Steps: 1000000},
+	}
+	data, err := json.Marshal(r)
+	require.NoError(t, err)
+
+	var decoded AlonzoRedeemer
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, r.Tag, decoded.Tag)
+	assert.Equal(t, r.Index, decoded.Index)
+	assert.Equal(t, r.ExUnits.Memory, decoded.ExUnits.Memory)
+	assert.Equal(t, r.ExUnits.Steps, decoded.ExUnits.Steps)
+}
+
+func TestAlonzoRedeemersMarshalJSON(t *testing.T) {
+	redeemers := AlonzoRedeemers{
+		Redeemers: []AlonzoRedeemer{
+			{
+				Tag:     common.RedeemerTagSpend,
+				Index:   0,
+				ExUnits: common.ExUnits{Memory: 100, Steps: 200},
+			},
+			{
+				Tag:     common.RedeemerTagMint,
+				Index:   1,
+				ExUnits: common.ExUnits{Memory: 300, Steps: 400},
+			},
+		},
+	}
+	data, err := json.Marshal(redeemers)
+	require.NoError(t, err)
+
+	// Should be a flat array, not {"Redeemers": [...]}
+	var arr []json.RawMessage
+	err = json.Unmarshal(data, &arr)
+	require.NoError(t, err)
+	assert.Len(t, arr, 2)
+}
+
+// Empty/nil AlonzoRedeemers serializes as "[]" for consistency with ConwayRedeemers.
+func TestAlonzoRedeemersEmptyMarshalJSON(t *testing.T) {
+	redeemers := AlonzoRedeemers{}
+	data, err := json.Marshal(redeemers)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(data))
+}
+
+func TestAlonzoRedeemersRoundTrip(t *testing.T) {
+	redeemers := AlonzoRedeemers{
+		Redeemers: []AlonzoRedeemer{
+			{
+				Tag:     common.RedeemerTagSpend,
+				Index:   0,
+				ExUnits: common.ExUnits{Memory: 100, Steps: 200},
+			},
+			{
+				Tag:     common.RedeemerTagCert,
+				Index:   2,
+				ExUnits: common.ExUnits{Memory: 500, Steps: 600},
+			},
+		},
+	}
+	data, err := json.Marshal(redeemers)
+	require.NoError(t, err)
+
+	var decoded AlonzoRedeemers
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+	require.Len(t, decoded.Redeemers, 2)
+	assert.Equal(t, common.RedeemerTagSpend, decoded.Redeemers[0].Tag)
+	assert.Equal(t, uint32(0), decoded.Redeemers[0].Index)
+	assert.Equal(t, common.RedeemerTagCert, decoded.Redeemers[1].Tag)
+	assert.Equal(t, uint32(2), decoded.Redeemers[1].Index)
+}
+
+func TestAlonzoTransactionWitnessSetMarshalJSON(t *testing.T) {
+	ws := AlonzoTransactionWitnessSet{
+		WsRedeemers: AlonzoRedeemers{
+			Redeemers: []AlonzoRedeemer{
+				{
+					Tag:     common.RedeemerTagSpend,
+					Index:   0,
+					ExUnits: common.ExUnits{Memory: 100, Steps: 200},
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(ws)
+	require.NoError(t, err)
+
+	var parsed map[string]json.RawMessage
+	err = json.Unmarshal(data, &parsed)
+	require.NoError(t, err)
+	assert.Contains(t, parsed, "WsRedeemers")
+}

--- a/ledger/common/address.go
+++ b/ledger/common/address.go
@@ -635,6 +635,19 @@ func (a Address) MarshalJSON() ([]byte, error) {
 	return []byte(`"` + a.String() + `"`), nil
 }
 
+func (a Address) MarshalText() ([]byte, error) {
+	return []byte(a.String()), nil
+}
+
+func (a *Address) UnmarshalText(text []byte) error {
+	parsed, err := NewAddress(string(text))
+	if err != nil {
+		return err
+	}
+	*a = parsed
+	return nil
+}
+
 type byronAddress struct {
 	cbor.StructAsArray
 	Payload  cbor.Tag

--- a/ledger/common/common.go
+++ b/ledger/common/common.go
@@ -64,6 +64,22 @@ func (b Blake2b256) MarshalJSON() ([]byte, error) {
 	return json.Marshal(b.String())
 }
 
+func (b Blake2b256) MarshalText() ([]byte, error) {
+	return []byte(b.String()), nil
+}
+
+func (b *Blake2b256) UnmarshalText(text []byte) error {
+	decoded, err := hex.DecodeString(string(text))
+	if err != nil {
+		return err
+	}
+	if len(decoded) != Blake2b256Size {
+		return fmt.Errorf("invalid blake2b-256 hash: expected %d bytes, got %d", Blake2b256Size, len(decoded))
+	}
+	copy(b[:], decoded)
+	return nil
+}
+
 func (b Blake2b256) MarshalCBOR() ([]byte, error) {
 	// Ensure we always encode a full-sized bytestring, even if the hash is zero-valued
 	hashBytes := make([]byte, Blake2b256Size)
@@ -123,6 +139,22 @@ func (b Blake2b224) ToPlutusData() data.PlutusData {
 
 func (b Blake2b224) MarshalJSON() ([]byte, error) {
 	return json.Marshal(b.String())
+}
+
+func (b Blake2b224) MarshalText() ([]byte, error) {
+	return []byte(b.String()), nil
+}
+
+func (b *Blake2b224) UnmarshalText(text []byte) error {
+	decoded, err := hex.DecodeString(string(text))
+	if err != nil {
+		return err
+	}
+	if len(decoded) != Blake2b224Size {
+		return fmt.Errorf("invalid blake2b-224 hash: expected %d bytes, got %d", Blake2b224Size, len(decoded))
+	}
+	copy(b[:], decoded)
+	return nil
 }
 
 func (b Blake2b224) MarshalCBOR() ([]byte, error) {
@@ -187,6 +219,22 @@ func (b Blake2b160) ToPlutusData() data.PlutusData {
 
 func (b Blake2b160) MarshalJSON() ([]byte, error) {
 	return json.Marshal(b.String())
+}
+
+func (b Blake2b160) MarshalText() ([]byte, error) {
+	return []byte(b.String()), nil
+}
+
+func (b *Blake2b160) UnmarshalText(text []byte) error {
+	decoded, err := hex.DecodeString(string(text))
+	if err != nil {
+		return err
+	}
+	if len(decoded) != Blake2b160Size {
+		return fmt.Errorf("invalid blake2b-160 hash: expected %d bytes, got %d", Blake2b160Size, len(decoded))
+	}
+	copy(b[:], decoded)
+	return nil
 }
 
 func (b Blake2b160) MarshalCBOR() ([]byte, error) {
@@ -702,8 +750,8 @@ func (i IssuerVkey) PoolId() string {
 // ExUnits represents the steps and memory usage for script execution
 type ExUnits struct {
 	cbor.StructAsArray
-	Memory int64
-	Steps  int64
+	Memory int64 `json:"memory"`
+	Steps  int64 `json:"steps"`
 }
 
 // GenesisRat is a convenience type for cbor.Rat

--- a/ledger/common/data.go
+++ b/ledger/common/data.go
@@ -15,6 +15,10 @@
 package common
 
 import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/plutigo/data"
 )
@@ -26,10 +30,46 @@ func DatumHashToBech32(d DatumHash) string {
 	return d.Bech32("datum")
 }
 
-// Datum represents a Plutus datum
+// Datum represents a Plutus datum.
+// JSON serialization encodes the datum as a plain CBOR hex string ("<hex>")
+// to preserve the interface type across round-trips.
 type Datum struct {
 	cbor.DecodeStoreCbor
-	Data data.PlutusData `json:"data"`
+	Data data.PlutusData
+}
+
+func (d Datum) MarshalJSON() ([]byte, error) {
+	if d.Data == nil {
+		return []byte("null"), nil
+	}
+	cborBytes, err := data.Encode(d.Data)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(hex.EncodeToString(cborBytes))
+}
+
+func (d *Datum) UnmarshalJSON(jsonData []byte) error {
+	var s *string
+	if err := json.Unmarshal(jsonData, &s); err != nil {
+		return fmt.Errorf("invalid datum JSON: expected hex string: %w", err)
+	}
+	if s == nil {
+		d.Data = nil
+		d.SetCbor(nil)
+		return nil
+	}
+	cborBytes, err := hex.DecodeString(*s)
+	if err != nil {
+		return fmt.Errorf("invalid datum hex: %w", err)
+	}
+	pd, err := data.Decode(cborBytes)
+	if err != nil {
+		return fmt.Errorf("invalid datum CBOR: %w", err)
+	}
+	d.Data = pd
+	d.SetCbor(cborBytes)
+	return nil
 }
 
 func (d *Datum) UnmarshalCBOR(cborData []byte) error {

--- a/ledger/common/data_test.go
+++ b/ledger/common/data_test.go
@@ -16,6 +16,7 @@ package common_test
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"math/big"
 	"reflect"
 	"testing"
@@ -24,6 +25,8 @@ import (
 	"github.com/blinklabs-io/gouroboros/internal/test"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/plutigo/data"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDatumHash(t *testing.T) {
@@ -206,6 +209,59 @@ func TestDatumHashBech32Specific(t *testing.T) {
 	// Verify prefix
 	if bech32Str[:6] != "datum1" {
 		t.Errorf("wrong prefix: got %s", bech32Str[:6])
+	}
+}
+
+func TestDatumJSONRoundTrip(t *testing.T) {
+	testCases := []struct {
+		name  string
+		datum common.Datum
+	}{
+		{
+			name:  "Nil",
+			datum: common.Datum{},
+		},
+		{
+			name:  "Integer",
+			datum: common.Datum{Data: data.NewInteger(big.NewInt(42))},
+		},
+		{
+			name:  "ByteString",
+			datum: common.Datum{Data: data.NewByteString([]byte("hello"))},
+		},
+		{
+			name: "Constr",
+			datum: common.Datum{Data: data.NewConstr(
+				0,
+				data.NewInteger(big.NewInt(1)),
+				data.NewByteString([]byte{0xde, 0xad}),
+			)},
+		},
+		{
+			name: "List",
+			datum: common.Datum{Data: data.NewList(
+				data.NewInteger(big.NewInt(1)),
+				data.NewInteger(big.NewInt(2)),
+			)},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			jsonBytes, err := json.Marshal(tc.datum)
+			require.NoError(t, err)
+
+			var decoded common.Datum
+			err = json.Unmarshal(jsonBytes, &decoded)
+			require.NoError(t, err)
+
+			if tc.datum.Data == nil {
+				assert.Nil(t, decoded.Data)
+			} else {
+				require.NotNil(t, decoded.Data)
+				assert.True(t, tc.datum.Data.Equal(decoded.Data),
+					"datum mismatch: got %s, want %s", decoded.Data, tc.datum.Data)
+			}
+		})
 	}
 }
 

--- a/ledger/common/gov.go
+++ b/ledger/common/gov.go
@@ -15,6 +15,7 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -149,6 +150,65 @@ func (v Voter) String() string {
 	}
 }
 
+func (v Voter) MarshalText() ([]byte, error) {
+	if v.Type > VoterTypeStakingPoolKeyHash {
+		return nil, fmt.Errorf("unsupported voter type: %d", v.Type)
+	}
+	return []byte(v.String()), nil
+}
+
+func (v *Voter) UnmarshalText(text []byte) error {
+	s := string(text)
+	prefix, rawData, err := bech32.DecodeNoLimit(s)
+	if err != nil {
+		return fmt.Errorf("invalid voter bech32: %w", err)
+	}
+	decoded, err := bech32.ConvertBits(rawData, 5, 8, false)
+	if err != nil {
+		return fmt.Errorf("invalid voter bech32 data: %w", err)
+	}
+	switch prefix {
+	case "pool":
+		if len(decoded) != 28 {
+			return fmt.Errorf("invalid pool voter hash length: %d", len(decoded))
+		}
+		v.Type = VoterTypeStakingPoolKeyHash
+		copy(v.Hash[:], decoded)
+	case "cc_hot", "drep":
+		if len(decoded) != 29 {
+			return fmt.Errorf("invalid %s voter data length: %d", prefix, len(decoded))
+		}
+		header := decoded[0]
+		v.Type = header >> 4
+		// Validate CIP-129 credential type nibble (0x2 = key hash, 0x3 = script hash)
+		credNibble := header & 0x0f
+		switch v.Type {
+		case VoterTypeConstitutionalCommitteeHotKeyHash, VoterTypeDRepKeyHash:
+			if credNibble != 0x2 {
+				return fmt.Errorf("invalid CIP-129 credential type nibble 0x%x for key hash voter type %d", credNibble, v.Type)
+			}
+		case VoterTypeConstitutionalCommitteeHotScriptHash, VoterTypeDRepScriptHash:
+			if credNibble != 0x3 {
+				return fmt.Errorf("invalid CIP-129 credential type nibble 0x%x for script hash voter type %d", credNibble, v.Type)
+			}
+		}
+		switch prefix {
+		case "cc_hot":
+			if v.Type != VoterTypeConstitutionalCommitteeHotKeyHash && v.Type != VoterTypeConstitutionalCommitteeHotScriptHash {
+				return fmt.Errorf("invalid voter type %d for prefix %s", v.Type, prefix)
+			}
+		case "drep":
+			if v.Type != VoterTypeDRepKeyHash && v.Type != VoterTypeDRepScriptHash {
+				return fmt.Errorf("invalid voter type %d for prefix %s", v.Type, prefix)
+			}
+		}
+		copy(v.Hash[:], decoded[1:])
+	default:
+		return fmt.Errorf("unknown voter bech32 prefix: %s", prefix)
+	}
+	return nil
+}
+
 func (v Voter) ToPlutusData() data.PlutusData {
 	switch v.Type {
 	case VoterTypeConstitutionalCommitteeHotScriptHash:
@@ -274,6 +334,43 @@ func (id *GovActionId) String() string {
 		)
 	}
 	return encoded
+}
+
+func (id *GovActionId) MarshalText() ([]byte, error) {
+	if id == nil {
+		return nil, errors.New("nil GovActionId")
+	}
+	if id.GovActionIdx > 255 {
+		return nil, fmt.Errorf(
+			"gov action index %d exceeds maximum value 255 allowed by CIP-0129",
+			id.GovActionIdx,
+		)
+	}
+	return []byte(id.String()), nil
+}
+
+func (id *GovActionId) UnmarshalText(text []byte) error {
+	s := string(text)
+	prefix, rawData, err := bech32.DecodeNoLimit(s)
+	if err != nil {
+		return fmt.Errorf("invalid gov action ID bech32: %w", err)
+	}
+	if prefix != "gov_action" {
+		return fmt.Errorf("invalid gov action ID prefix: %s", prefix)
+	}
+	decoded, err := bech32.ConvertBits(rawData, 5, 8, false)
+	if err != nil {
+		return fmt.Errorf("invalid gov action ID bech32 data: %w", err)
+	}
+	if len(decoded) != 33 {
+		return fmt.Errorf(
+			"invalid gov action ID data length: expected 33, got %d",
+			len(decoded),
+		)
+	}
+	copy(id.TransactionId[:], decoded[:32])
+	id.GovActionIdx = uint32(decoded[32])
+	return nil
 }
 
 type ProposalProcedure interface {

--- a/ledger/common/gov_test.go
+++ b/ledger/common/gov_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/plutigo/data"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Ttests the ToPlutusData method for Voter types
@@ -629,4 +630,143 @@ func TestGovActionIdString(t *testing.T) {
 			_ = govActionId.String()
 		})
 	})
+}
+
+func TestVoterTextRoundTrip(t *testing.T) {
+	var zeroHash [28]byte
+	var sequentialHash [28]byte
+	for i := range sequentialHash {
+		sequentialHash[i] = byte(i)
+	}
+	testCases := []struct {
+		name  string
+		voter Voter
+	}{
+		{
+			name:  "CcHotKeyHash",
+			voter: Voter{Type: VoterTypeConstitutionalCommitteeHotKeyHash, Hash: zeroHash},
+		},
+		{
+			name:  "CcHotScriptHash",
+			voter: Voter{Type: VoterTypeConstitutionalCommitteeHotScriptHash, Hash: zeroHash},
+		},
+		{
+			name:  "DRepKeyHash",
+			voter: Voter{Type: VoterTypeDRepKeyHash, Hash: sequentialHash},
+		},
+		{
+			name:  "DRepScriptHash",
+			voter: Voter{Type: VoterTypeDRepScriptHash, Hash: sequentialHash},
+		},
+		{
+			name:  "StakingPoolKeyHash",
+			voter: Voter{Type: VoterTypeStakingPoolKeyHash, Hash: sequentialHash},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			text, err := tc.voter.MarshalText()
+			require.NoError(t, err)
+			var decoded Voter
+			require.NoError(t, decoded.UnmarshalText(text))
+			assert.Equal(t, tc.voter.Type, decoded.Type)
+			assert.Equal(t, tc.voter.Hash, decoded.Hash)
+		})
+	}
+}
+
+func TestVoterMarshalTextUnknownType(t *testing.T) {
+	v := Voter{Type: 99}
+	_, err := v.MarshalText()
+	assert.Error(t, err)
+}
+
+func TestVoterUnmarshalTextErrors(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input string
+	}{
+		{"InvalidBech32", "not-valid-bech32!!!"},
+		{"UnknownPrefix", "unknown1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq2uwmrs"},
+		{"CcHotWithDRepType", "cc_hot1ygqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq7guj37"},
+		{"DRepWithCcHotType", "drep1qgqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqvuwczn"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var v Voter
+			assert.Error(t, v.UnmarshalText([]byte(tc.input)))
+		})
+	}
+}
+
+func TestGovActionIdTextRoundTrip(t *testing.T) {
+	testCases := []struct {
+		name        string
+		govActionId GovActionId
+	}{
+		{
+			name: "ZeroTxIdZeroIdx",
+			govActionId: GovActionId{
+				TransactionId: [32]byte{},
+				GovActionIdx:  0,
+			},
+		},
+		{
+			name: "NonZeroTxIdWithIdx",
+			govActionId: GovActionId{
+				TransactionId: [32]byte{
+					0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+					0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+					0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+					0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+				},
+				GovActionIdx: 42,
+			},
+		},
+		{
+			name: "MaxValidIdx",
+			govActionId: GovActionId{
+				TransactionId: [32]byte{0xff},
+				GovActionIdx:  255,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			text, err := tc.govActionId.MarshalText()
+			require.NoError(t, err)
+			var decoded GovActionId
+			require.NoError(t, decoded.UnmarshalText(text))
+			assert.Equal(t, tc.govActionId.TransactionId, decoded.TransactionId)
+			assert.Equal(t, tc.govActionId.GovActionIdx, decoded.GovActionIdx)
+		})
+	}
+}
+
+func TestGovActionIdMarshalTextNil(t *testing.T) {
+	var id *GovActionId
+	_, err := id.MarshalText()
+	assert.Error(t, err)
+}
+
+func TestGovActionIdMarshalTextOverflow(t *testing.T) {
+	id := &GovActionId{GovActionIdx: 256}
+	_, err := id.MarshalText()
+	assert.Error(t, err)
+}
+
+func TestGovActionIdUnmarshalTextErrors(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input string
+	}{
+		{"InvalidBech32", "not-valid!!!"},
+		{"WrongPrefix", "pool1qqqsyqcyq5rqwzqfpg9scrgwpugpzysnzs23v9ccrydpk35lkuk"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var id GovActionId
+			assert.Error(t, id.UnmarshalText([]byte(tc.input)))
+		})
+	}
 }

--- a/ledger/common/redeemer.go
+++ b/ledger/common/redeemer.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,10 @@
 package common
 
 import (
+	"cmp"
+	"encoding/json"
+	"fmt"
+
 	"github.com/blinklabs-io/gouroboros/cbor"
 )
 
@@ -29,14 +33,62 @@ const (
 	RedeemerTagProposing RedeemerTag = 5
 )
 
+var redeemerTagNames = map[RedeemerTag]string{
+	RedeemerTagSpend:     "spend",
+	RedeemerTagMint:      "mint",
+	RedeemerTagCert:      "cert",
+	RedeemerTagReward:    "reward",
+	RedeemerTagVoting:    "voting",
+	RedeemerTagProposing: "proposing",
+}
+
+var redeemerTagValues = map[string]RedeemerTag{
+	"spend":     RedeemerTagSpend,
+	"mint":      RedeemerTagMint,
+	"cert":      RedeemerTagCert,
+	"reward":    RedeemerTagReward,
+	"voting":    RedeemerTagVoting,
+	"proposing": RedeemerTagProposing,
+}
+
+func (t RedeemerTag) MarshalJSON() ([]byte, error) {
+	name, ok := redeemerTagNames[t]
+	if !ok {
+		return nil, fmt.Errorf("unknown redeemer tag: %d", t)
+	}
+	return json.Marshal(name)
+}
+
+func (t *RedeemerTag) UnmarshalJSON(data []byte) error {
+	var name string
+	if err := json.Unmarshal(data, &name); err != nil {
+		return err
+	}
+	val, ok := redeemerTagValues[name]
+	if !ok {
+		return fmt.Errorf("unknown redeemer tag name: %q", name)
+	}
+	*t = val
+	return nil
+}
+
 type RedeemerKey struct {
 	cbor.StructAsArray
-	Tag   RedeemerTag
-	Index uint32
+	Tag   RedeemerTag `json:"tag"`
+	Index uint32      `json:"index"`
 }
 
 type RedeemerValue struct {
 	cbor.StructAsArray
-	Data    Datum
-	ExUnits ExUnits
+	Data    Datum   `json:"data"`
+	ExUnits ExUnits `json:"exUnits"`
+}
+
+// CompareRedeemerKeys compares two RedeemerKey values by Tag then Index,
+// returning -1, 0, or 1. Suitable for use with slices.SortFunc.
+func CompareRedeemerKeys(a, b RedeemerKey) int {
+	if c := cmp.Compare(a.Tag, b.Tag); c != 0 {
+		return c
+	}
+	return cmp.Compare(a.Index, b.Index)
 }

--- a/ledger/common/redeemer_test.go
+++ b/ledger/common/redeemer_test.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedeemerTagMarshalJSON(t *testing.T) {
+	tests := []struct {
+		tag      RedeemerTag
+		expected string
+	}{
+		{RedeemerTagSpend, `"spend"`},
+		{RedeemerTagMint, `"mint"`},
+		{RedeemerTagCert, `"cert"`},
+		{RedeemerTagReward, `"reward"`},
+		{RedeemerTagVoting, `"voting"`},
+		{RedeemerTagProposing, `"proposing"`},
+	}
+	for _, tc := range tests {
+		data, err := json.Marshal(tc.tag)
+		require.NoError(t, err)
+		assert.Equal(t, tc.expected, string(data))
+	}
+}
+
+func TestRedeemerTagUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected RedeemerTag
+	}{
+		{`"spend"`, RedeemerTagSpend},
+		{`"mint"`, RedeemerTagMint},
+		{`"cert"`, RedeemerTagCert},
+		{`"reward"`, RedeemerTagReward},
+		{`"voting"`, RedeemerTagVoting},
+		{`"proposing"`, RedeemerTagProposing},
+	}
+	for _, tc := range tests {
+		var tag RedeemerTag
+		err := json.Unmarshal([]byte(tc.input), &tag)
+		require.NoError(t, err)
+		assert.Equal(t, tc.expected, tag)
+	}
+}
+
+func TestRedeemerTagMarshalJSONUnknown(t *testing.T) {
+	tag := RedeemerTag(99)
+	_, err := json.Marshal(tag)
+	assert.Error(t, err)
+}
+
+func TestRedeemerTagUnmarshalJSONUnknown(t *testing.T) {
+	var tag RedeemerTag
+	err := json.Unmarshal([]byte(`"unknown"`), &tag)
+	assert.Error(t, err)
+}
+
+func TestRedeemerTagRoundTrip(t *testing.T) {
+	for tag := RedeemerTagSpend; tag <= RedeemerTagProposing; tag++ {
+		data, err := json.Marshal(tag)
+		require.NoError(t, err)
+
+		var decoded RedeemerTag
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+		assert.Equal(t, tag, decoded)
+	}
+}
+
+func TestExUnitsMarshalJSON(t *testing.T) {
+	eu := ExUnits{Memory: 1000, Steps: 2000}
+	data, err := json.Marshal(eu)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"memory":1000,"steps":2000}`, string(data))
+}
+
+func TestExUnitsRoundTrip(t *testing.T) {
+	eu := ExUnits{Memory: 500000, Steps: 1000000}
+	data, err := json.Marshal(eu)
+	require.NoError(t, err)
+
+	var decoded ExUnits
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, eu.Memory, decoded.Memory)
+	assert.Equal(t, eu.Steps, decoded.Steps)
+}
+
+func TestRedeemerKeyMarshalJSON(t *testing.T) {
+	key := RedeemerKey{Tag: RedeemerTagSpend, Index: 0}
+	data, err := json.Marshal(key)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"tag":"spend","index":0}`, string(data))
+}
+
+func TestRedeemerKeyRoundTrip(t *testing.T) {
+	key := RedeemerKey{Tag: RedeemerTagMint, Index: 5}
+	data, err := json.Marshal(key)
+	require.NoError(t, err)
+
+	var decoded RedeemerKey
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, key.Tag, decoded.Tag)
+	assert.Equal(t, key.Index, decoded.Index)
+}
+
+func TestRedeemerValueMarshalJSON(t *testing.T) {
+	val := RedeemerValue{
+		ExUnits: ExUnits{Memory: 100, Steps: 200},
+	}
+	data, err := json.Marshal(val)
+	require.NoError(t, err)
+
+	var parsed map[string]json.RawMessage
+	err = json.Unmarshal(data, &parsed)
+	require.NoError(t, err)
+	assert.Contains(t, parsed, "data")
+	assert.Contains(t, parsed, "exUnits")
+}

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -15,6 +15,7 @@
 package conway
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"iter"
@@ -287,6 +288,59 @@ func (r *ConwayRedeemers) UnmarshalCBOR(cborData []byte) error {
 	return nil
 }
 
+// conwayRedeemerJSON is a helper type for JSON serialization of ConwayRedeemers
+type conwayRedeemerJSON struct {
+	Tag     common.RedeemerTag `json:"tag"`
+	Index   uint32             `json:"index"`
+	Data    common.Datum       `json:"data"`
+	ExUnits common.ExUnits     `json:"exUnits"`
+}
+
+func (r ConwayRedeemers) MarshalJSON() ([]byte, error) {
+	if r.legacy {
+		return json.Marshal(r.legacyRedeemers)
+	}
+	entries := make([]conwayRedeemerJSON, 0, len(r.Redeemers))
+	// Sort keys for deterministic output
+	sorted := slices.Collect(maps.Keys(r.Redeemers))
+	slices.SortFunc(sorted, common.CompareRedeemerKeys)
+	for _, key := range sorted {
+		val := r.Redeemers[key]
+		entries = append(entries, conwayRedeemerJSON{
+			Tag:     key.Tag,
+			Index:   key.Index,
+			Data:    val.Data,
+			ExUnits: val.ExUnits,
+		})
+	}
+	return json.Marshal(entries)
+}
+
+func (r *ConwayRedeemers) UnmarshalJSON(data []byte) error {
+	r.SetCbor(nil)
+	r.legacy = false
+	r.legacyRedeemers = alonzo.AlonzoRedeemers{}
+	var entries []conwayRedeemerJSON
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return err
+	}
+	r.Redeemers = make(map[common.RedeemerKey]common.RedeemerValue, len(entries))
+	for _, entry := range entries {
+		key := common.RedeemerKey{
+			Tag:   entry.Tag,
+			Index: entry.Index,
+		}
+		if _, exists := r.Redeemers[key]; exists {
+			return fmt.Errorf("duplicate redeemer key: tag=%d index=%d", entry.Tag, entry.Index)
+		}
+		r.Redeemers[key] = common.RedeemerValue{
+			Data:    entry.Data,
+			ExUnits: entry.ExUnits,
+		}
+	}
+	return nil
+}
+
 func (r *ConwayRedeemers) MarshalCBOR() ([]byte, error) {
 	if r.legacy {
 		return cbor.Encode(r.legacyRedeemers)
@@ -301,18 +355,7 @@ func (r ConwayRedeemers) Iter() iter.Seq2[common.RedeemerKey, common.RedeemerVal
 	return func(yield func(common.RedeemerKey, common.RedeemerValue) bool) {
 		// Sort redeemers
 		sorted := slices.Collect(maps.Keys(r.Redeemers))
-		slices.SortFunc(
-			sorted,
-			func(a, b common.RedeemerKey) int {
-				if a.Tag < b.Tag || (a.Tag == b.Tag && a.Index < b.Index) {
-					return -1
-				}
-				if a.Tag > b.Tag || (a.Tag == b.Tag && a.Index > b.Index) {
-					return 1
-				}
-				return 0
-			},
-		)
+		slices.SortFunc(sorted, common.CompareRedeemerKeys)
 		// Yield keys
 		for _, redeemerKey := range sorted {
 			tmpVal := r.Redeemers[redeemerKey]

--- a/ledger/conway/redeemer_json_test.go
+++ b/ledger/conway/redeemer_json_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conway
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConwayRedeemersMarshalJSON(t *testing.T) {
+	redeemers := ConwayRedeemers{
+		Redeemers: map[common.RedeemerKey]common.RedeemerValue{
+			{Tag: common.RedeemerTagSpend, Index: 0}: {
+				ExUnits: common.ExUnits{Memory: 100, Steps: 200},
+			},
+			{Tag: common.RedeemerTagMint, Index: 1}: {
+				ExUnits: common.ExUnits{Memory: 300, Steps: 400},
+			},
+		},
+	}
+	data, err := json.Marshal(redeemers)
+	require.NoError(t, err)
+
+	// Should be a flat array
+	var arr []json.RawMessage
+	err = json.Unmarshal(data, &arr)
+	require.NoError(t, err)
+	assert.Len(t, arr, 2)
+}
+
+func TestConwayRedeemersMarshalJSONSorted(t *testing.T) {
+	redeemers := ConwayRedeemers{
+		Redeemers: map[common.RedeemerKey]common.RedeemerValue{
+			{Tag: common.RedeemerTagMint, Index: 1}: {
+				ExUnits: common.ExUnits{Memory: 300, Steps: 400},
+			},
+			{Tag: common.RedeemerTagSpend, Index: 0}: {
+				ExUnits: common.ExUnits{Memory: 100, Steps: 200},
+			},
+		},
+	}
+	data, err := json.Marshal(redeemers)
+	require.NoError(t, err)
+
+	var entries []struct {
+		Tag   string `json:"tag"`
+		Index uint32 `json:"index"`
+	}
+	err = json.Unmarshal(data, &entries)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	// Spend (tag 0) should come before Mint (tag 1)
+	assert.Equal(t, "spend", entries[0].Tag)
+	assert.Equal(t, "mint", entries[1].Tag)
+}
+
+func TestConwayRedeemersEmptyMarshalJSON(t *testing.T) {
+	redeemers := ConwayRedeemers{}
+	data, err := json.Marshal(redeemers)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(data))
+}
+
+func TestConwayRedeemersRoundTrip(t *testing.T) {
+	redeemers := ConwayRedeemers{
+		Redeemers: map[common.RedeemerKey]common.RedeemerValue{
+			{Tag: common.RedeemerTagSpend, Index: 0}: {
+				ExUnits: common.ExUnits{Memory: 100, Steps: 200},
+			},
+			{Tag: common.RedeemerTagVoting, Index: 3}: {
+				ExUnits: common.ExUnits{Memory: 500, Steps: 600},
+			},
+		},
+	}
+	data, err := json.Marshal(redeemers)
+	require.NoError(t, err)
+
+	var decoded ConwayRedeemers
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+	require.Len(t, decoded.Redeemers, 2)
+
+	spendKey := common.RedeemerKey{Tag: common.RedeemerTagSpend, Index: 0}
+	votingKey := common.RedeemerKey{Tag: common.RedeemerTagVoting, Index: 3}
+
+	spendVal, ok := decoded.Redeemers[spendKey]
+	require.True(t, ok)
+	assert.Equal(t, common.Datum{}, spendVal.Data)
+	assert.Equal(t, int64(100), spendVal.ExUnits.Memory)
+	assert.Equal(t, int64(200), spendVal.ExUnits.Steps)
+
+	votingVal, ok := decoded.Redeemers[votingKey]
+	require.True(t, ok)
+	assert.Equal(t, common.Datum{}, votingVal.Data)
+	assert.Equal(t, int64(500), votingVal.ExUnits.Memory)
+	assert.Equal(t, int64(600), votingVal.ExUnits.Steps)
+}
+
+func TestConwayRedeemersUnmarshalJSONDuplicateKey(t *testing.T) {
+	jsonData := `[
+		{"tag":"spend","index":0,"data":null,"exUnits":{"memory":100,"steps":200}},
+		{"tag":"spend","index":0,"data":null,"exUnits":{"memory":300,"steps":400}}
+	]`
+	var r ConwayRedeemers
+	err := json.Unmarshal([]byte(jsonData), &r)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate redeemer key")
+}
+
+func TestConwayRedeemersLegacyMarshalJSON(t *testing.T) {
+	redeemers := ConwayRedeemers{
+		legacy: true,
+		legacyRedeemers: alonzo.AlonzoRedeemers{
+			Redeemers: []alonzo.AlonzoRedeemer{
+				{
+					Tag:     common.RedeemerTagSpend,
+					Index:   0,
+					ExUnits: common.ExUnits{Memory: 100, Steps: 200},
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(redeemers)
+	require.NoError(t, err)
+
+	var arr []json.RawMessage
+	err = json.Unmarshal(data, &arr)
+	require.NoError(t, err)
+	assert.Len(t, arr, 1)
+}
+
+// NOTE: These assertions use Go struct field names (e.g. "WsRedeemers")
+// since the structs have no json tags. They will break if fields are renamed
+// or json tags are added.
+func TestConwayTransactionWitnessSetMarshalJSON(t *testing.T) {
+	ws := ConwayTransactionWitnessSet{
+		VkeyWitnesses: cbor.NewSetType(
+			[]common.VkeyWitness{
+				{Vkey: []byte{0x01, 0x02}, Signature: []byte{0x03, 0x04}},
+			},
+			false,
+		),
+		WsRedeemers: ConwayRedeemers{
+			Redeemers: map[common.RedeemerKey]common.RedeemerValue{
+				{Tag: common.RedeemerTagSpend, Index: 0}: {
+					ExUnits: common.ExUnits{Memory: 100, Steps: 200},
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(ws)
+	require.NoError(t, err)
+
+	var parsed map[string]json.RawMessage
+	err = json.Unmarshal(data, &parsed)
+	require.NoError(t, err)
+	assert.Contains(t, parsed, "WsRedeemers")
+	assert.Contains(t, parsed, "VkeyWitnesses")
+}
+
+func TestConwayTransactionMarshalJSON(t *testing.T) {
+	tx := ConwayTransaction{
+		TxIsValid: true,
+		WitnessSet: ConwayTransactionWitnessSet{
+			WsRedeemers: ConwayRedeemers{
+				Redeemers: map[common.RedeemerKey]common.RedeemerValue{
+					{Tag: common.RedeemerTagSpend, Index: 0}: {
+						ExUnits: common.ExUnits{Memory: 100, Steps: 200},
+					},
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(tx)
+	require.NoError(t, err)
+
+	var parsed map[string]json.RawMessage
+	err = json.Unmarshal(data, &parsed)
+	require.NoError(t, err)
+	assert.Contains(t, parsed, "WitnessSet")
+	assert.Contains(t, parsed, "TxIsValid")
+}

--- a/ledger/tx_json_test.go
+++ b/ledger/tx_json_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger_test
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransactionMarshalJSON(t *testing.T) {
+	tests := []struct {
+		name      string
+		cborHex   string
+		txType    uint
+		checkKeys []string
+	}{
+		{
+			name:      "Byron",
+			cborHex:   byronTxCborHex,
+			txType:    ledger.TxTypeByron,
+			checkKeys: []string{"Body"},
+		},
+		{
+			name:      "Shelley",
+			cborHex:   shelleyTxCborHex,
+			txType:    ledger.TxTypeShelley,
+			checkKeys: []string{"Body", "WitnessSet"},
+		},
+		{
+			name:      "Allegra",
+			cborHex:   allegraTxCborHex,
+			txType:    ledger.TxTypeAllegra,
+			checkKeys: []string{"Body", "WitnessSet"},
+		},
+		{
+			name:      "Mary",
+			cborHex:   maryTxCborHex,
+			txType:    ledger.TxTypeMary,
+			checkKeys: []string{"Body", "WitnessSet"},
+		},
+		{
+			name:      "Alonzo",
+			cborHex:   alonzoTxCborHex,
+			txType:    ledger.TxTypeAlonzo,
+			checkKeys: []string{"Body", "WitnessSet", "TxIsValid"},
+		},
+		{
+			name:      "Babbage",
+			cborHex:   babbageTxCborHex,
+			txType:    ledger.TxTypeBabbage,
+			checkKeys: []string{"Body", "WitnessSet", "TxIsValid"},
+		},
+		{
+			name:      "Conway",
+			cborHex:   conwayTxCborHex,
+			txType:    ledger.TxTypeConway,
+			checkKeys: []string{"Body", "WitnessSet", "TxIsValid"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cborData, err := hex.DecodeString(tc.cborHex)
+			require.NoError(t, err)
+
+			tx, err := ledger.NewTransactionFromCbor(tc.txType, cborData)
+			require.NoError(t, err)
+
+			jsonData, err := json.Marshal(tx)
+			require.NoError(t, err, "json.Marshal should not fail for %s transaction", tc.name)
+			assert.NotEmpty(t, jsonData)
+
+			// Verify the JSON is valid and contains expected top-level keys
+			var parsed map[string]json.RawMessage
+			err = json.Unmarshal(jsonData, &parsed)
+			require.NoError(t, err, "JSON output should be valid for %s transaction", tc.name)
+
+			for _, key := range tc.checkKeys {
+				assert.Contains(t, parsed, key, "%s transaction JSON should contain %q key", tc.name, key)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1567 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes and stabilizes JSON (de)serialization for transactions and script-related types across all eras, with deterministic, human-readable, round-trippable output. Unifies field names and treats empty collections as [].

- **Bug Fixes**
  - Redeemers: Tag encodes/decodes as strings; fields are "tag", "index", "data", "exUnits.memory/steps"; shared comparator for deterministic sorting; Alonzo/Conway serialize to flat arrays, emit "[]", detect duplicate keys; Conway parses arrays into a map and supports legacy Alonzo array mode when flagged.
  - Datum/collections: Datum JSON is CBOR hex (null when absent); PlutusDataList and cbor.SetType serialize to arrays and emit "[]".
  - Text serde: Address and Blake2b160/224/256 add MarshalText/UnmarshalText; Voter and GovActionId add text serde with bech32/length validation, CIP-129 checks, and index bounds.
  - Transactions/tests: Fixed JSON output for Byron through Conway (stable Body/WitnessSet/TxIsValid keys); added round-trip and validation tests for redeemers, datums, witness sets, and full transactions.

<sup>Written for commit ddce9049e67b2eda646c403fa1ee2380bdcf0bb6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broad JSON/text (de)serialization added: redeemers (Alonzo/Conway) and collections with deterministic ordering and duplicate-key detection, generic sets, Datum as hex-encoded CBOR, Plutus data lists, addresses, Blake2b hashes, voters and gov action IDs (bech32), and ExUnits JSON field names.
* **Tests**
  * Extensive JSON/text marshal/unmarshal and round-trip tests for redeemers, datum, governance types, addresses, hashes, transactions, witness sets, and related collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->