### PR TITLE
fix(ledger): fill validation gaps

### DIFF
--- a/ledger/allegra/rules.go
+++ b/ledger/allegra/rules.go
@@ -27,6 +27,7 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateSignatures,
 	UtxoValidateOutsideValidityIntervalUtxo,
 	UtxoValidateInputSetEmptyUtxo,
+	UtxoValidateNoDuplicateInputs,
 	UtxoValidateFeeTooSmallUtxo,
 	UtxoValidateBadInputsUtxo,
 	UtxoValidateWrongNetwork,
@@ -73,6 +74,15 @@ func UtxoValidateInputSetEmptyUtxo(
 	pp common.ProtocolParameters,
 ) error {
 	return shelley.UtxoValidateInputSetEmptyUtxo(tx, slot, ls, pp)
+}
+
+func UtxoValidateNoDuplicateInputs(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return shelley.UtxoValidateNoDuplicateInputs(tx, slot, ls, pp)
 }
 
 func UtxoValidateFeeTooSmallUtxo(

--- a/ledger/alonzo/rules.go
+++ b/ledger/alonzo/rules.go
@@ -36,6 +36,7 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateScriptDataHash,
 	UtxoValidateOutsideValidityIntervalUtxo,
 	UtxoValidateInputSetEmptyUtxo,
+	UtxoValidateNoDuplicateInputs,
 	UtxoValidateFeeTooSmallUtxo,
 	UtxoValidateInsufficientCollateral,
 	UtxoValidateCollateralContainsNonAda,
@@ -106,8 +107,28 @@ func UtxoValidateExUnitsTooBigUtxo(
 	}
 	var totalSteps, totalMemory int64
 	for _, redeemer := range tmpTx.WitnessSet.WsRedeemers.Redeemers {
-		totalSteps += redeemer.ExUnits.Steps
-		totalMemory += redeemer.ExUnits.Memory
+		newSteps, ok := common.AddInt64Checked(totalSteps, redeemer.ExUnits.Steps)
+		if !ok {
+			return ExUnitsTooBigUtxoError{
+				TotalExUnits: common.ExUnits{
+					Memory: totalMemory,
+					Steps:  totalSteps,
+				},
+				MaxTxExUnits: tmpPparams.MaxTxExUnits,
+			}
+		}
+		totalSteps = newSteps
+		newMemory, ok := common.AddInt64Checked(totalMemory, redeemer.ExUnits.Memory)
+		if !ok {
+			return ExUnitsTooBigUtxoError{
+				TotalExUnits: common.ExUnits{
+					Memory: totalMemory,
+					Steps:  totalSteps,
+				},
+				MaxTxExUnits: tmpPparams.MaxTxExUnits,
+			}
+		}
+		totalMemory = newMemory
 	}
 	if totalSteps <= tmpPparams.MaxTxExUnits.Steps &&
 		totalMemory <= tmpPparams.MaxTxExUnits.Memory {
@@ -229,6 +250,15 @@ func UtxoValidateInputSetEmptyUtxo(
 	pp common.ProtocolParameters,
 ) error {
 	return shelley.UtxoValidateInputSetEmptyUtxo(tx, slot, ls, pp)
+}
+
+func UtxoValidateNoDuplicateInputs(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return shelley.UtxoValidateNoDuplicateInputs(tx, slot, ls, pp)
 }
 
 // UtxoValidateSignatures verifies vkey and bootstrap signatures present in the transaction.
@@ -732,12 +762,17 @@ func UtxoValidateNativeScripts(
 }
 
 // UtxoValidateWithdrawals validates withdrawals against ledger state.
+// For phase-2 invalid transactions (IsValid=false), withdrawal validation is
+// skipped since their effects are reverted and only collateral rules apply.
 func UtxoValidateWithdrawals(
 	tx common.Transaction,
 	slot uint64,
 	ls common.LedgerState,
 	pp common.ProtocolParameters,
 ) error {
+	if !tx.IsValid() {
+		return nil
+	}
 	return shelley.UtxoValidateWithdrawals(tx, slot, ls, pp)
 }
 

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -40,6 +40,7 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateDisjointRefInputs,
 	UtxoValidateOutsideValidityIntervalUtxo,
 	UtxoValidateInputSetEmptyUtxo,
+	UtxoValidateNoDuplicateInputs,
 	UtxoValidateFeeTooSmallUtxo,
 	UtxoValidateInsufficientCollateral,
 	UtxoValidateCollateralContainsNonAda,
@@ -310,6 +311,15 @@ func UtxoValidateInputSetEmptyUtxo(
 	pp common.ProtocolParameters,
 ) error {
 	return shelley.UtxoValidateInputSetEmptyUtxo(tx, slot, ls, pp)
+}
+
+func UtxoValidateNoDuplicateInputs(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return shelley.UtxoValidateNoDuplicateInputs(tx, slot, ls, pp)
 }
 
 func UtxoValidateFeeTooSmallUtxo(
@@ -842,8 +852,28 @@ func UtxoValidateExUnitsTooBigUtxo(
 	}
 	var totalSteps, totalMemory int64
 	for _, redeemer := range tmpTx.WitnessSet.WsRedeemers.Redeemers {
-		totalSteps += redeemer.ExUnits.Steps
-		totalMemory += redeemer.ExUnits.Memory
+		newSteps, ok := common.AddInt64Checked(totalSteps, redeemer.ExUnits.Steps)
+		if !ok {
+			return alonzo.ExUnitsTooBigUtxoError{
+				TotalExUnits: common.ExUnits{
+					Memory: totalMemory,
+					Steps:  totalSteps,
+				},
+				MaxTxExUnits: tmpPparams.MaxTxExUnits,
+			}
+		}
+		totalSteps = newSteps
+		newMemory, ok := common.AddInt64Checked(totalMemory, redeemer.ExUnits.Memory)
+		if !ok {
+			return alonzo.ExUnitsTooBigUtxoError{
+				TotalExUnits: common.ExUnits{
+					Memory: totalMemory,
+					Steps:  totalSteps,
+				},
+				MaxTxExUnits: tmpPparams.MaxTxExUnits,
+			}
+		}
+		totalMemory = newMemory
 	}
 	if totalSteps <= tmpPparams.MaxTxExUnits.Steps &&
 		totalMemory <= tmpPparams.MaxTxExUnits.Memory {
@@ -1010,12 +1040,17 @@ func UtxoValidateNativeScripts(
 }
 
 // UtxoValidateWithdrawals validates withdrawals against ledger state.
+// For phase-2 invalid transactions (IsValid=false), withdrawal validation is
+// skipped since their effects are reverted and only collateral rules apply.
 func UtxoValidateWithdrawals(
 	tx common.Transaction,
 	slot uint64,
 	ls common.LedgerState,
 	pp common.ProtocolParameters,
 ) error {
+	if !tx.IsValid() {
+		return nil
+	}
 	return shelley.UtxoValidateWithdrawals(tx, slot, ls, pp)
 }
 

--- a/ledger/common/common.go
+++ b/ledger/common/common.go
@@ -1634,6 +1634,16 @@ func cborArrayHeaderSize(length int) uint32 {
 	return 5 // 0x9a + 4-byte length (covers up to 2^32 elements)
 }
 
+// AddInt64Checked adds two int64 values and returns the result with an overflow flag.
+// Returns (sum, true) on success, or (0, false) if the addition would overflow.
+func AddInt64Checked(a, b int64) (int64, bool) {
+	sum := a + b
+	if (b > 0 && sum < a) || (b < 0 && sum > a) {
+		return 0, false
+	}
+	return sum, true
+}
+
 type MissingTransactionMetadataError struct {
 	Hash Blake2b256
 }

--- a/ledger/common/common_test.go
+++ b/ledger/common/common_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"math"
 	"math/big"
 	"reflect"
 	"testing"
@@ -25,6 +26,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/internal/test"
 	"github.com/blinklabs-io/plutigo/data"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBlake2b256_MarshalCBOR_ZeroHash(t *testing.T) {
@@ -1378,6 +1380,34 @@ func TestPoolIdBech32RoundTrip(t *testing.T) {
 					decoded,
 					tc.poolId,
 				)
+			}
+		})
+	}
+}
+
+func TestAddInt64Checked(t *testing.T) {
+	tests := []struct {
+		name    string
+		a, b    int64
+		wantSum int64
+		wantOk  bool
+	}{
+		{"zero plus zero", 0, 0, 0, true},
+		{"normal addition", 100, 200, 300, true},
+		{"negative addition", -100, -200, -300, true},
+		{"max int64 no overflow", math.MaxInt64, 0, math.MaxInt64, true},
+		{"max int64 overflow", math.MaxInt64, 1, 0, false},
+		{"min int64 no overflow", math.MinInt64, 0, math.MinInt64, true},
+		{"min int64 overflow", math.MinInt64, -1, 0, false},
+		{"large values no overflow", math.MaxInt64 / 2, math.MaxInt64 / 2, math.MaxInt64 - 1, true},
+		{"large values overflow", math.MaxInt64/2 + 1, math.MaxInt64/2 + 1, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sum, ok := AddInt64Checked(tt.a, tt.b)
+			assert.Equal(t, tt.wantOk, ok)
+			if ok {
+				assert.Equal(t, tt.wantSum, sum)
 			}
 		})
 	}

--- a/ledger/conway/errors.go
+++ b/ledger/conway/errors.go
@@ -296,22 +296,6 @@ func (e DelegateVoteToUnregisteredDRepError) Error() string {
 // WithdrawalFromUnregisteredRewardAccountError indicates withdrawal from an unregistered reward account
 type WithdrawalFromUnregisteredRewardAccountError = shelley.WithdrawalFromUnregisteredRewardAccountError
 
-// WithdrawalWrongAmountError indicates withdrawal of wrong amount from reward account
-type WithdrawalWrongAmountError struct {
-	RewardAddress   common.Address
-	RequestedAmount uint64
-	ActualBalance   uint64
-}
-
-func (e WithdrawalWrongAmountError) Error() string {
-	return fmt.Sprintf(
-		"withdrawal wrong amount from %s: requested %d, actual balance %d",
-		e.RewardAddress.String(),
-		e.RequestedAmount,
-		e.ActualBalance,
-	)
-}
-
 // StakeCredentialAlreadyRegisteredError indicates attempting to register an already registered stake credential
 type StakeCredentialAlreadyRegisteredError struct {
 	Credential common.Credential

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -50,6 +50,7 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateDisjointRefInputs,
 	UtxoValidateOutsideValidityIntervalUtxo,
 	UtxoValidateInputSetEmptyUtxo,
+	UtxoValidateNoDuplicateInputs,
 	UtxoValidateFeeTooSmallUtxo,
 	UtxoValidateInsufficientCollateral,
 	UtxoValidateCollateralContainsNonAda,
@@ -865,6 +866,15 @@ func UtxoValidateInputSetEmptyUtxo(
 	return shelley.UtxoValidateInputSetEmptyUtxo(tx, slot, ls, pp)
 }
 
+func UtxoValidateNoDuplicateInputs(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return shelley.UtxoValidateNoDuplicateInputs(tx, slot, ls, pp)
+}
+
 func UtxoValidateFeeTooSmallUtxo(
 	tx common.Transaction,
 	slot uint64,
@@ -1642,8 +1652,28 @@ func UtxoValidateExUnitsTooBigUtxo(
 	}
 	var totalSteps, totalMemory int64
 	for _, redeemer := range tmpTx.WitnessSet.WsRedeemers.Redeemers {
-		totalSteps += redeemer.ExUnits.Steps
-		totalMemory += redeemer.ExUnits.Memory
+		newSteps, ok := common.AddInt64Checked(totalSteps, redeemer.ExUnits.Steps)
+		if !ok {
+			return alonzo.ExUnitsTooBigUtxoError{
+				TotalExUnits: common.ExUnits{
+					Memory: totalMemory,
+					Steps:  totalSteps,
+				},
+				MaxTxExUnits: tmpPparams.MaxTxExUnits,
+			}
+		}
+		totalSteps = newSteps
+		newMemory, ok := common.AddInt64Checked(totalMemory, redeemer.ExUnits.Memory)
+		if !ok {
+			return alonzo.ExUnitsTooBigUtxoError{
+				TotalExUnits: common.ExUnits{
+					Memory: totalMemory,
+					Steps:  totalSteps,
+				},
+				MaxTxExUnits: tmpPparams.MaxTxExUnits,
+			}
+		}
+		totalMemory = newMemory
 	}
 	if totalSteps <= tmpPparams.MaxTxExUnits.Steps &&
 		totalMemory <= tmpPparams.MaxTxExUnits.Memory {
@@ -2354,56 +2384,18 @@ func UtxoValidateDelegation(
 }
 
 // UtxoValidateWithdrawals validates withdrawals against ledger state.
-// It checks that reward accounts are registered and that withdrawal amounts
-// match the account balance (when balance tracking is available).
+// For phase-2 invalid transactions (IsValid=false), withdrawal validation is
+// skipped since their effects are reverted and only collateral rules apply.
 func UtxoValidateWithdrawals(
 	tx common.Transaction,
 	slot uint64,
 	ls common.LedgerState,
 	pp common.ProtocolParameters,
 ) error {
-	withdrawals := tx.Withdrawals()
-	if withdrawals == nil {
+	if !tx.IsValid() {
 		return nil
 	}
-
-	for addr, amount := range withdrawals {
-		// Extract credential from reward address staking payload
-		stakingPayload := addr.StakingPayload()
-		if stakingPayload == nil {
-			continue
-		}
-
-		var cred common.Credential
-		switch p := stakingPayload.(type) {
-		case common.AddressPayloadKeyHash:
-			cred = common.Credential{
-				CredType:   common.CredentialTypeAddrKeyHash,
-				Credential: common.NewBlake2b224(p.Hash.Bytes()),
-			}
-		case common.AddressPayloadScriptHash:
-			cred = common.Credential{
-				CredType:   common.CredentialTypeScriptHash,
-				Credential: common.NewBlake2b224(p.Hash.Bytes()),
-			}
-		default:
-			continue // Pointer addresses not supported
-		}
-
-		// Check if reward account is registered
-		if !ls.IsRewardAccountRegistered(cred) {
-			return WithdrawalFromUnregisteredRewardAccountError{
-				RewardAddress: *addr,
-			}
-		}
-
-		// NOTE: Withdrawal amount validation (checking amount == balance) is disabled.
-		// Accurate validation requires tracking balance changes through each transaction
-		// which is complex for multi-TX test scenarios. The registration check above
-		// catches the most important case (unregistered reward account).
-		_ = amount // Prevent unused variable warning
-	}
-	return nil
+	return shelley.UtxoValidateWithdrawals(tx, slot, ls, pp)
 }
 
 func UtxoValidateCommitteeCertificates(

--- a/ledger/mary/rules.go
+++ b/ledger/mary/rules.go
@@ -34,6 +34,7 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateSignatures,
 	UtxoValidateOutsideValidityIntervalUtxo,
 	UtxoValidateInputSetEmptyUtxo,
+	UtxoValidateNoDuplicateInputs,
 	UtxoValidateFeeTooSmallUtxo,
 	UtxoValidateBadInputsUtxo,
 	UtxoValidateWrongNetwork,
@@ -103,6 +104,15 @@ func UtxoValidateInputSetEmptyUtxo(
 	pp common.ProtocolParameters,
 ) error {
 	return shelley.UtxoValidateInputSetEmptyUtxo(tx, slot, ls, pp)
+}
+
+func UtxoValidateNoDuplicateInputs(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return shelley.UtxoValidateNoDuplicateInputs(tx, slot, ls, pp)
 }
 
 func UtxoValidateFeeTooSmallUtxo(

--- a/ledger/shelley/errors.go
+++ b/ledger/shelley/errors.go
@@ -46,6 +46,16 @@ func (InputSetEmptyUtxoError) Error() string {
 	return "input set empty"
 }
 
+// DuplicateInputError indicates a duplicate input was found in the transaction
+type DuplicateInputError struct {
+	Input     common.TransactionInput
+	InputType string // "regular", "collateral", or "reference"
+}
+
+func (e DuplicateInputError) Error() string {
+	return fmt.Sprintf("duplicate %s input: %s", e.InputType, e.Input.String())
+}
+
 type FeeTooSmallUtxoError struct {
 	Provided *big.Int
 	Min      *big.Int

--- a/ledger/shelley/rules.go
+++ b/ledger/shelley/rules.go
@@ -37,6 +37,7 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateSignatures,
 	UtxoValidateTimeToLive,
 	UtxoValidateInputSetEmptyUtxo,
+	UtxoValidateNoDuplicateInputs,
 	UtxoValidateFeeTooSmallUtxo,
 	UtxoValidateBadInputsUtxo,
 	UtxoValidateWrongNetwork,
@@ -77,6 +78,43 @@ func UtxoValidateInputSetEmptyUtxo(
 		return nil
 	}
 	return InputSetEmptyUtxoError{}
+}
+
+// UtxoValidateNoDuplicateInputs ensures that there are no duplicate inputs in any input set
+func UtxoValidateNoDuplicateInputs(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	// Check regular inputs
+	seen := make(map[string]bool)
+	for _, input := range tx.Inputs() {
+		key := input.String()
+		if seen[key] {
+			return DuplicateInputError{Input: input, InputType: "regular"}
+		}
+		seen[key] = true
+	}
+	// Check collateral inputs
+	seen = make(map[string]bool)
+	for _, input := range tx.Collateral() {
+		key := input.String()
+		if seen[key] {
+			return DuplicateInputError{Input: input, InputType: "collateral"}
+		}
+		seen[key] = true
+	}
+	// Check reference inputs
+	seen = make(map[string]bool)
+	for _, input := range tx.ReferenceInputs() {
+		key := input.String()
+		if seen[key] {
+			return DuplicateInputError{Input: input, InputType: "reference"}
+		}
+		seen[key] = true
+	}
+	return nil
 }
 
 // UtxoValidateFeeTooSmallUtxo ensures that the fee is at least the calculated minimum

--- a/ledger/shelley/rules_test.go
+++ b/ledger/shelley/rules_test.go
@@ -15,6 +15,7 @@
 package shelley_test
 
 import (
+	"bytes"
 	"crypto/rand"
 	"encoding/hex"
 	"testing"
@@ -23,6 +24,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // shelleyTxWithRequired embeds a ShelleyTransaction but overrides RequiredSigners
@@ -848,6 +850,85 @@ func TestUtxoValidateOutputBootAddrAttrsTooBig(t *testing.T) {
 	)
 }
 
+func TestUtxoValidateNoDuplicateInputs(t *testing.T) {
+	input1, err := mockledger.NewSimpleTransactionInput(
+		bytes.Repeat([]byte{0x01}, 32),
+		0,
+	)
+	require.NoError(t, err)
+	input2, err := mockledger.NewSimpleTransactionInput(
+		bytes.Repeat([]byte{0x02}, 32),
+		1,
+	)
+	require.NoError(t, err)
+
+	t.Run("unique inputs pass", func(t *testing.T) {
+		tx := mockledger.NewTransactionBuilder()
+		tx.WithInputs(input1, input2)
+		err := shelley.UtxoValidateNoDuplicateInputs(tx, 0, nil, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("duplicate regular inputs fail", func(t *testing.T) {
+		tx := mockledger.NewTransactionBuilder()
+		tx.WithInputs(input1, input1)
+		err := shelley.UtxoValidateNoDuplicateInputs(tx, 0, nil, nil)
+		assert.Error(t, err)
+		assert.IsType(t, shelley.DuplicateInputError{}, err)
+	})
+
+	t.Run("empty inputs pass", func(t *testing.T) {
+		tx := mockledger.NewTransactionBuilder()
+		err := shelley.UtxoValidateNoDuplicateInputs(tx, 0, nil, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("single input passes", func(t *testing.T) {
+		tx := mockledger.NewTransactionBuilder()
+		tx.WithInputs(input1)
+		err := shelley.UtxoValidateNoDuplicateInputs(tx, 0, nil, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("duplicate collateral inputs fail", func(t *testing.T) {
+		tx := mockledger.NewTransactionBuilder()
+		tx.WithCollateral(input1, input1)
+		err := shelley.UtxoValidateNoDuplicateInputs(tx, 0, nil, nil)
+		assert.Error(t, err)
+		assert.IsType(t, shelley.DuplicateInputError{}, err)
+	})
+
+	t.Run("unique collateral inputs pass", func(t *testing.T) {
+		tx := mockledger.NewTransactionBuilder()
+		tx.WithCollateral(input1, input2)
+		err := shelley.UtxoValidateNoDuplicateInputs(tx, 0, nil, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("duplicate reference inputs fail", func(t *testing.T) {
+		tx := mockledger.NewTransactionBuilder()
+		tx.WithReferenceInputs(input1, input1)
+		err := shelley.UtxoValidateNoDuplicateInputs(tx, 0, nil, nil)
+		assert.Error(t, err)
+		assert.IsType(t, shelley.DuplicateInputError{}, err)
+	})
+
+	t.Run("unique reference inputs pass", func(t *testing.T) {
+		tx := mockledger.NewTransactionBuilder()
+		tx.WithReferenceInputs(input1, input2)
+		err := shelley.UtxoValidateNoDuplicateInputs(tx, 0, nil, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("same input in regular and collateral passes", func(t *testing.T) {
+		tx := mockledger.NewTransactionBuilder()
+		tx.WithInputs(input1)
+		tx.WithCollateral(input1)
+		err := shelley.UtxoValidateNoDuplicateInputs(tx, 0, nil, nil)
+		assert.NoError(t, err)
+	})
+}
+
 func TestUtxoValidateMaxTxSizeUtxo(t *testing.T) {
 	var testMaxTxSizeSmall uint = 2
 	var testMaxTxSizeLarge uint = 64 * 1024
@@ -902,4 +983,59 @@ func TestUtxoValidateMaxTxSizeUtxo(t *testing.T) {
 			)
 		},
 	)
+}
+
+// makeRewardAddress builds a reward address (type 14 / NoneKey) from a 28-byte key hash
+func makeRewardAddress(t *testing.T, keyHash common.Blake2b224) common.Address {
+	t.Helper()
+	// Reward address: header = (AddressTypeNoneKey << 4) | networkId
+	// AddressTypeNoneKey = 0b1110 = 14, mainnet networkId = 1
+	addrBytes := make([]byte, 0, 29)
+	addrBytes = append(addrBytes, 0xE1) // (14 << 4) | 1
+	addrBytes = append(addrBytes, keyHash.Bytes()...)
+	addr, err := common.NewAddressFromBytes(addrBytes)
+	require.NoError(t, err)
+	return addr
+}
+
+func TestUtxoValidateWithdrawals(t *testing.T) {
+	t.Run("no withdrawals passes", func(t *testing.T) {
+		tx := mockledger.NewTransactionBuilder()
+		ls := mockledger.NewLedgerStateBuilder().Build()
+		err := shelley.UtxoValidateWithdrawals(tx, 0, ls, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("registered reward account passes", func(t *testing.T) {
+		keyHash := common.Blake2b224Hash([]byte("test-stake-key"))
+		rewardAddr := makeRewardAddress(t, keyHash)
+
+		tx := mockledger.NewTransactionBuilder().
+			WithWithdrawals(map[*common.Address]uint64{
+				&rewardAddr: 5_000_000,
+			})
+
+		ls := mockledger.NewLedgerStateBuilder().
+			WithStakeCredentialRegistered(keyHash, true).
+			Build()
+
+		err := shelley.UtxoValidateWithdrawals(tx, 0, ls, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("unregistered reward account fails", func(t *testing.T) {
+		keyHash := common.Blake2b224Hash([]byte("test-stake-key"))
+		rewardAddr := makeRewardAddress(t, keyHash)
+
+		tx := mockledger.NewTransactionBuilder().
+			WithWithdrawals(map[*common.Address]uint64{
+				&rewardAddr: 1_000_000,
+			})
+
+		ls := mockledger.NewLedgerStateBuilder().Build()
+
+		err := shelley.UtxoValidateWithdrawals(tx, 0, ls, nil)
+		require.Error(t, err)
+		assert.IsType(t, shelley.WithdrawalFromUnregisteredRewardAccountError{}, err)
+	})
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filled validation gaps across Shelley–Conway eras to block invalid transactions. Adds per-set duplicate input checks, overflow-safe ExUnits sums, and skips withdrawal checks for phase-2 invalid txs, addressing SEC-14/15/16.

- **Bug Fixes**
  - Use AddInt64Checked when summing redeemer ExUnits in Alonzo, Babbage, and Conway.
  - Skip withdrawal validation for IsValid=false transactions in Alonzo, Babbage, and Conway.
  - Remove Conway-specific WithdrawalWrongAmountError; use shared Shelley errors.

- **New Features**
  - Enforce no duplicate inputs within regular, collateral, and reference sets across all eras (wired into Shelley, Allegra, Mary, Alonzo, Babbage, Conway).
  - Unit tests for AddInt64Checked, duplicate-input validation, and withdrawal registration.

<sup>Written for commit cec78f17aefee87af7914b93b92070882af0ee44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global validation to detect and reject duplicate transaction inputs across input categories, with clearer duplicate-input error reporting.

* **Behavior Changes**
  * Withdrawal validation: some eras now skip checks for phase‑2 invalid transactions and later eras simplified withdrawal handling.
  * Safer resource accounting: overflow-checked arithmetic to prevent overflow-related errors when summing execution units.

* **Tests**
  * Added tests for duplicate-input validation and withdrawal scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->