### PR TITLE
docs: inform agents of new mock ledger state requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,14 +235,19 @@ func TestSomething(t *testing.T) {
 }
 ```
 
-Use `MockLedgerState` for validation tests (`internal/test/ledger/ledger.go`):
+Use `ouroboros-mock` builders for validation tests (`github.com/blinklabs-io/ouroboros-mock/ledger`):
 ```go
-ls := &MockLedgerState{
-    NetworkIdVal: 0,
-    UtxoByIdFunc: func(id TransactionInput) (Utxo, error) {
-        return testUtxo, nil
-    },
-}
+import mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+
+ls := mockledger.NewLedgerStateBuilder().
+    WithNetworkId(0).
+    WithUtxos([]lcommon.Utxo{testUtxo}).
+    Build()
+
+tx := mockledger.NewTransactionBuilder().
+    WithInputs(input1, input2).
+    WithOutputs(output1).
+    WithFee(200000)
 ```
 
 ### Conformance Tests


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update AGENTS.md to direct agents to use github.com/blinklabs-io/ouroboros-mock/ledger builders for validation tests instead of the in-repo MockLedgerState. Adds simple examples for building ledger state and transactions to match the new mock ledger state requirements.

<sup>Written for commit d5683c52d7cc783f7e739f85bc4911d5f725db5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

