### PR TITLE
fix: queue state transitions for pipelined messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.1
 
 require (
 	filippo.io/edwards25519 v1.2.0
-	github.com/blinklabs-io/ouroboros-mock v0.9.0
+	github.com/blinklabs-io/ouroboros-mock v0.9.1
 	github.com/blinklabs-io/plutigo v0.0.25
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/fxamacker/cbor/v2 v2.9.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/bits-and-blooms/bitset v1.20.0 h1:2F+rfL86jE2d/bmw7OhqUg2Sj/1rURkBn3MdfoPyRVU=
 github.com/bits-and-blooms/bitset v1.20.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/ouroboros-mock v0.9.0 h1:O4FhgxKt43RcZGcxRQAOV9GMF6F06qtpU76eFeBKWeQ=
-github.com/blinklabs-io/ouroboros-mock v0.9.0/go.mod h1:piXZP3q8e/E3kkP8xkdc7tkD4mUjf5Ittzww6PCylDo=
+github.com/blinklabs-io/ouroboros-mock v0.9.1 h1:88LvCaivQ6j/JSb3j8t99lQvsgnWcjXGaMPdZngbxZo=
+github.com/blinklabs-io/ouroboros-mock v0.9.1/go.mod h1:wLZTHLwKdIC9axVzG7nyAynn2wfLp/ikvX9LjsDh8Xw=
 github.com/blinklabs-io/plutigo v0.0.25 h1:0FIsUPnuL9O/YLYC7ZhwHW3wpubLjPNwX/FZgj5b0Nw=
 github.com/blinklabs-io/plutigo v0.0.25/go.mod h1:a7U+TDtoyHrbNuGGQCWxkVqsfiuoc9CO889hlsur7mY=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=

--- a/protocol/chainsync/chainsync.go
+++ b/protocol/chainsync/chainsync.go
@@ -18,7 +18,6 @@ package chainsync
 import (
 	"fmt"
 	"math/rand/v2"
-	"sync"
 	"time"
 
 	"github.com/blinklabs-io/gouroboros/connection"
@@ -46,9 +45,8 @@ var (
 var (
 	idleTransitions = []protocol.StateTransition{
 		{
-			MsgType:   MessageTypeRequestNext,
-			NewState:  stateCanAwait,
-			MatchFunc: IncrementPipelineCount,
+			MsgType:  MessageTypeRequestNext,
+			NewState: stateCanAwait,
 		},
 		{
 			MsgType:  MessageTypeFindIntersect,
@@ -61,33 +59,16 @@ var (
 	}
 	canAwaitTransitions = []protocol.StateTransition{
 		{
-			MsgType:   MessageTypeRequestNext,
-			NewState:  stateCanAwait,
-			MatchFunc: IncrementPipelineCount,
-		},
-		{
 			MsgType:  MessageTypeAwaitReply,
 			NewState: stateMustReply,
 		},
 		{
-			MsgType:   MessageTypeRollForward,
-			NewState:  stateIdle,
-			MatchFunc: DecrementPipelineCountAndIsEmpty,
+			MsgType:  MessageTypeRollForward,
+			NewState: stateIdle,
 		},
 		{
-			MsgType:   MessageTypeRollForward,
-			NewState:  stateCanAwait,
-			MatchFunc: DecrementPipelineCountAndIsNotEmpty,
-		},
-		{
-			MsgType:   MessageTypeRollBackward,
-			NewState:  stateIdle,
-			MatchFunc: DecrementPipelineCountAndIsEmpty,
-		},
-		{
-			MsgType:   MessageTypeRollBackward,
-			NewState:  stateCanAwait,
-			MatchFunc: DecrementPipelineCountAndIsNotEmpty,
+			MsgType:  MessageTypeRollBackward,
+			NewState: stateIdle,
 		},
 	}
 	intersectTransitions = []protocol.StateTransition{
@@ -102,24 +83,12 @@ var (
 	}
 	mustReplyTransitions = []protocol.StateTransition{
 		{
-			MsgType:   MessageTypeRollForward,
-			NewState:  stateIdle,
-			MatchFunc: DecrementPipelineCountAndIsEmpty,
+			MsgType:  MessageTypeRollForward,
+			NewState: stateIdle,
 		},
 		{
-			MsgType:   MessageTypeRollForward,
-			NewState:  stateCanAwait,
-			MatchFunc: DecrementPipelineCountAndIsNotEmpty,
-		},
-		{
-			MsgType:   MessageTypeRollBackward,
-			NewState:  stateIdle,
-			MatchFunc: DecrementPipelineCountAndIsEmpty,
-		},
-		{
-			MsgType:   MessageTypeRollBackward,
-			NewState:  stateCanAwait,
-			MatchFunc: DecrementPipelineCountAndIsNotEmpty,
+			MsgType:  MessageTypeRollBackward,
+			NewState: stateIdle,
 		},
 	}
 )
@@ -193,60 +162,6 @@ var StateMapNtC = protocol.StateMap{
 
 // StateMap is a copy of StateMapNtN for backward compatibility.
 var StateMap = StateMapNtN.Copy()
-
-type StateContext struct {
-	mu            sync.Mutex
-	pipelineCount int
-}
-
-var IncrementPipelineCount = func(context any, msg protocol.Message) bool {
-	s := context.(*StateContext)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.pipelineCount++
-	return true
-}
-
-var DecrementPipelineCountAndIsEmpty = func(context any, msg protocol.Message) bool {
-	s := context.(*StateContext)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.pipelineCount == 1 {
-		s.pipelineCount--
-		return true
-	}
-	return false
-}
-
-var DecrementPipelineCountAndIsNotEmpty = func(context any, msg protocol.Message) bool {
-	s := context.(*StateContext)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.pipelineCount > 1 {
-		s.pipelineCount--
-		return true
-	}
-	return false
-}
-
-var PipelineIsEmtpy = func(context any, msg protocol.Message) bool {
-	s := context.(*StateContext)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	return s.pipelineCount == 0
-}
-
-var PipelineIsNotEmpty = func(context any, msg protocol.Message) bool {
-	s := context.(*StateContext)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	return s.pipelineCount > 0
-}
 
 // ChainSync is a wrapper object that holds the client and server instances
 type ChainSync struct {
@@ -322,14 +237,9 @@ type (
 
 // New returns a new ChainSync object
 func New(protoOptions protocol.ProtocolOptions, cfg *Config) *ChainSync {
-	// Each side gets its own StateContext so that client pipelining
-	// does not corrupt the server's pipeline count (and vice-versa).
-	clientStateContext := &StateContext{}
-	serverStateContext := &StateContext{}
-
 	c := &ChainSync{
-		Client: NewClient(clientStateContext, protoOptions, cfg),
-		Server: NewServer(serverStateContext, protoOptions, cfg),
+		Client: NewClient(protoOptions, cfg),
+		Server: NewServer(protoOptions, cfg),
 	}
 	return c
 }

--- a/protocol/chainsync/client.go
+++ b/protocol/chainsync/client.go
@@ -49,7 +49,6 @@ type Client struct {
 	readyForNextBlockChan    chan bool
 	syncPipelinedRequestNext int
 	protoOptions             protocol.ProtocolOptions
-	stateContext             any
 
 	// waitingForCurrentTipChan will process all the requests for the current tip until the channel
 	// is empty.
@@ -70,7 +69,6 @@ type clientPointResult struct {
 
 // NewClient returns a new ChainSync client object
 func NewClient(
-	stateContext any,
 	protoOptions protocol.ProtocolOptions,
 	cfg *Config,
 ) *Client {
@@ -89,7 +87,6 @@ func NewClient(
 	c := &Client{
 		config:                &config,
 		protoOptions:          protoOptions,
-		stateContext:          stateContext,
 		lifecycleState:        clientStateNew,
 		readyForNextBlockChan: nil,
 	}
@@ -165,7 +162,6 @@ func (c *Client) initProtocol() {
 		MessageHandlerFunc:  c.messageHandler,
 		MessageFromCborFunc: msgFromCborFunc,
 		StateMap:            stateMap,
-		StateContext:        c.stateContext,
 		InitialState:        stateIdle,
 	}
 	if c.config != nil {

--- a/protocol/chainsync/client_test.go
+++ b/protocol/chainsync/client_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -413,6 +414,201 @@ func TestUseCase_GetCurrentTip_Stop_Start_GetCurrentTip(t *testing.T) {
 		},
 		ouroboros.WithChainSyncConfig(
 			chainsync.Config{SkipBlockValidation: true},
+		),
+	)
+}
+
+func TestSyncPipelining(t *testing.T) {
+	const pipelineLimit = 5
+	// We need at least 3 blocks: 1 to trigger pipelining, then 2 more to verify
+	// the pipelined requests are being satisfied
+	const totalBlocks = 4
+
+	expectedIntersect := pcommon.NewPoint(
+		0,
+		test.DecodeHexString("0000000000000000"),
+	)
+
+	// Create test blocks
+	testBlocks := make([]ledger.BabbageBlock, totalBlocks)
+	blockCbors := make([][]byte, totalBlocks)
+	for i := 0; i < totalBlocks; i++ {
+		testBlocks[i] = ledger.BabbageBlock{
+			BlockHeader: &ledger.BabbageBlockHeader{},
+		}
+		testBlocks[i].BlockHeader.Body.Slot = uint64(1000 + i)
+		testBlocks[i].BlockHeader.Body.BlockNumber = uint64(100 + i)
+		var err error
+		blockCbors[i], err = cbor.Encode(testBlocks[i])
+		if err != nil {
+			t.Fatalf("failed to encode test block %d: %s", i, err)
+		}
+		if _, err := cbor.Decode(blockCbors[i], &testBlocks[i]); err != nil {
+			t.Fatalf("failed to decode test block %d: %s", i, err)
+		}
+	}
+
+	finalTip := chainsync.Tip{
+		BlockNumber: uint64(100 + totalBlocks - 1),
+		Point: pcommon.NewPoint(
+			uint64(1000+totalBlocks-1),
+			testBlocks[totalBlocks-1].Hash().Bytes(),
+		),
+	}
+
+	makeRollForward := func(idx int) protocol.Message {
+		msg, err := chainsync.NewMsgRollForwardNtC(
+			ledger.BlockTypeBabbage,
+			blockCbors[idx],
+			finalTip,
+		)
+		if err != nil {
+			t.Fatalf("failed to create RollForward message for block %d: %s", idx, err)
+		}
+		return msg
+	}
+
+	conversation := []ouroboros_mock.ConversationEntry{
+		// Handshake
+		ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+		ouroboros_mock.ConversationEntryHandshakeNtCResponse,
+		// FindIntersect -> IntersectFound
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  chainsync.ProtocolIdNtC,
+			MessageType: chainsync.MessageTypeFindIntersect,
+		},
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: chainsync.ProtocolIdNtC,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				chainsync.NewMsgIntersectFound(expectedIntersect, finalTip),
+			},
+		},
+		// Initial RequestNext from Sync()
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  chainsync.ProtocolIdNtC,
+			MessageType: chainsync.MessageTypeRequestNext,
+		},
+		// First block
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: chainsync.ProtocolIdNtC,
+			IsResponse: true,
+			Messages:   []protocol.Message{makeRollForward(0)},
+		},
+		// Second RequestNext, first of pipelined batch
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  chainsync.ProtocolIdNtC,
+			MessageType: chainsync.MessageTypeRequestNext,
+		},
+		// Second Block
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: chainsync.ProtocolIdNtC,
+			IsResponse: true,
+			Messages:   []protocol.Message{makeRollForward(1)},
+		},
+		// Third RequestNext, second of pipelined batch
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  chainsync.ProtocolIdNtC,
+			MessageType: chainsync.MessageTypeRequestNext,
+		},
+		// Third block
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: chainsync.ProtocolIdNtC,
+			IsResponse: true,
+			Messages:   []protocol.Message{makeRollForward(2)},
+		},
+		// Fourth RequestNext, third of pipelined batch
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  chainsync.ProtocolIdNtC,
+			MessageType: chainsync.MessageTypeRequestNext,
+		},
+		// Fourth block
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: chainsync.ProtocolIdNtC,
+			IsResponse: true,
+			Messages:   []protocol.Message{makeRollForward(3)},
+		},
+		// Fifth RequestNext, fourth of pipelined batch
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  chainsync.ProtocolIdNtC,
+			MessageType: chainsync.MessageTypeRequestNext,
+		},
+		// Signal that we're at tip
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: chainsync.ProtocolIdNtC,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				chainsync.NewMsgAwaitReply(),
+			},
+		},
+	}
+
+	receivedBlocks := make([]uint64, 0, totalBlocks)
+	var receivedMu sync.Mutex
+
+	runTest(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			doneChan := make(chan struct{})
+			// Wait until we've received enough blocks and end the test
+			go func() {
+				for {
+					receivedMu.Lock()
+					count := len(receivedBlocks)
+					receivedMu.Unlock()
+					if count >= totalBlocks {
+						// Signal to test that we've received all blocks
+						close(doneChan)
+						return
+					}
+					time.Sleep(10 * time.Millisecond)
+				}
+			}()
+
+			err := oConn.ChainSync().Client.Sync([]pcommon.Point{expectedIntersect})
+			if err != nil {
+				t.Fatalf("unexpected error starting sync: %s", err)
+			}
+
+			select {
+			case <-doneChan:
+				// Success
+			case <-time.After(5 * time.Second):
+				receivedMu.Lock()
+				defer receivedMu.Unlock()
+				t.Fatalf("timeout waiting for blocks, received %d of %d", len(receivedBlocks), totalBlocks)
+			}
+
+			// Verify blocks received in order
+			receivedMu.Lock()
+			defer receivedMu.Unlock()
+			if len(receivedBlocks) != totalBlocks {
+				t.Fatalf("expected %d blocks, received %d", totalBlocks, len(receivedBlocks))
+			}
+			for i := 0; i < totalBlocks; i++ {
+				expectedSlot := uint64(1000 + i)
+				if receivedBlocks[i] != expectedSlot {
+					t.Fatalf("block %d: expected slot %d, got %d", i, expectedSlot, receivedBlocks[i])
+				}
+			}
+		},
+		ouroboros.WithChainSyncConfig(
+			chainsync.Config{
+				PipelineLimit:       pipelineLimit,
+				SkipBlockValidation: true,
+				RollForwardFunc: func(ctx chainsync.CallbackContext, blockType uint, block any, tip chainsync.Tip) error {
+					b := block.(ledger.Block)
+					receivedMu.Lock()
+					receivedBlocks = append(receivedBlocks, b.SlotNumber())
+					count := len(receivedBlocks)
+					receivedMu.Unlock()
+					if count >= totalBlocks {
+						return chainsync.ErrStopSyncProcess
+					}
+					return nil
+				},
+			},
 		),
 	)
 }

--- a/protocol/chainsync/messages_test.go
+++ b/protocol/chainsync/messages_test.go
@@ -411,7 +411,6 @@ func TestMsgDone(t *testing.T) {
 // using NewConfig(), the Client and Server apply default values for zero fields.
 // This fixes issue #1299 where PipelineLimit=0 caused sync to stall.
 func TestConfigDefaults(t *testing.T) {
-	stateContext := &StateContext{}
 	protoOptions := protocol.ProtocolOptions{
 		Mode: protocol.ProtocolModeNodeToClient,
 	}
@@ -419,14 +418,14 @@ func TestConfigDefaults(t *testing.T) {
 	t.Run("Client applies defaults for zero PipelineLimit", func(t *testing.T) {
 		// Create config directly without NewConfig() - PipelineLimit will be 0
 		cfg := &Config{SkipBlockValidation: true}
-		client := NewClient(stateContext, protoOptions, cfg)
+		client := NewClient(protoOptions, cfg)
 
 		require.Equal(t, DefaultPipelineLimit, client.config.PipelineLimit)
 	})
 
 	t.Run("Client applies defaults for zero RecvQueueSize", func(t *testing.T) {
 		cfg := &Config{SkipBlockValidation: true}
-		client := NewClient(stateContext, protoOptions, cfg)
+		client := NewClient(protoOptions, cfg)
 
 		require.Equal(t, DefaultRecvQueueSize, client.config.RecvQueueSize)
 	})
@@ -436,7 +435,7 @@ func TestConfigDefaults(t *testing.T) {
 			PipelineLimit: 10,
 			RecvQueueSize: 20,
 		}
-		client := NewClient(stateContext, protoOptions, cfg)
+		client := NewClient(protoOptions, cfg)
 
 		require.Equal(t, 10, client.config.PipelineLimit)
 		require.Equal(t, 20, client.config.RecvQueueSize)
@@ -444,13 +443,13 @@ func TestConfigDefaults(t *testing.T) {
 
 	t.Run("Server applies defaults for zero RecvQueueSize", func(t *testing.T) {
 		cfg := &Config{SkipBlockValidation: true}
-		server := NewServer(stateContext, protoOptions, cfg)
+		server := NewServer(protoOptions, cfg)
 
 		require.Equal(t, DefaultRecvQueueSize, server.config.RecvQueueSize)
 	})
 
 	t.Run("Client with nil config uses NewConfig defaults", func(t *testing.T) {
-		client := NewClient(stateContext, protoOptions, nil)
+		client := NewClient(protoOptions, nil)
 
 		require.Equal(t, DefaultPipelineLimit, client.config.PipelineLimit)
 	})

--- a/protocol/chainsync/server.go
+++ b/protocol/chainsync/server.go
@@ -29,12 +29,10 @@ type Server struct {
 	config          *Config
 	callbackContext CallbackContext
 	protoOptions    protocol.ProtocolOptions
-	stateContext    any
 }
 
 // NewServer returns a new ChainSync server object
 func NewServer(
-	stateContext any,
 	protoOptions protocol.ProtocolOptions,
 	cfg *Config,
 ) *Server {
@@ -51,7 +49,6 @@ func NewServer(
 		config: config,
 		// Save these for re-use later
 		protoOptions: protoOptions,
-		stateContext: stateContext,
 	}
 	s.callbackContext = CallbackContext{
 		Server:       s,
@@ -102,7 +99,6 @@ func (s *Server) initProtocol() {
 		MessageHandlerFunc:  s.messageHandler,
 		MessageFromCborFunc: msgFromCborFunc,
 		StateMap:            stateMap,
-		StateContext:        s.stateContext,
 		InitialState:        stateIdle,
 	}
 	if s.config != nil {

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"slices"
 	"sync"
 	"time"
 
@@ -344,6 +345,8 @@ func (p *Protocol) sendLoop() {
 		close(p.sendDoneChan)
 	}()
 
+	var queuedStateTransitions []Message
+waitSendReadyChan:
 	for {
 		select {
 		case <-p.stopChan:
@@ -355,10 +358,33 @@ func (p *Protocol) sendLoop() {
 			// We are ready to send based on state map
 		}
 
+		// Check for queued state transitions
+		if len(queuedStateTransitions) > 0 {
+			if err := p.transitionState(queuedStateTransitions[0]); err != nil {
+				if errors.Is(err, ErrProtocolShuttingDown) {
+					// Graceful shutdown in progress
+					return
+				}
+				p.SendError(
+					fmt.Errorf(
+						"%s: error sending message: %w",
+						p.config.Name,
+						err,
+					),
+				)
+				return
+			}
+			queuedStateTransitions = slices.Delete(queuedStateTransitions, 0, 1)
+			// Don't read more messages from the send queue until all state transitions from
+			// previously sent pipelined messages have been completed
+			continue waitSendReadyChan
+		}
+
 		// Read queued messages and write into buffer
 		payloadBuf := bytes.NewBuffer(nil)
 		msgCount := 0
-	outer:
+		queueTransition := false
+	readSendQueueLoop:
 		for {
 			// Get next message from send queue
 			select {
@@ -399,32 +425,38 @@ func (p *Protocol) sendLoop() {
 				}
 				p.pendingBytesMu.Unlock()
 
-				if err := p.transitionState(msg); err != nil {
-					if errors.Is(err, ErrProtocolShuttingDown) {
-						// Graceful shutdown in progress
+				if queueTransition {
+					queuedStateTransitions = append(queuedStateTransitions, msg)
+				} else {
+					if err := p.transitionState(msg); err != nil {
+						if errors.Is(err, ErrProtocolShuttingDown) {
+							// Graceful shutdown in progress
+							return
+						}
+						p.SendError(
+							fmt.Errorf(
+								"%s: error sending message: %w",
+								p.config.Name,
+								err,
+							),
+						)
 						return
 					}
-					p.SendError(
-						fmt.Errorf(
-							"%s: error sending message: %w",
-							p.config.Name,
-							err,
-						),
-					)
-					return
+					// Queue any state transitions after the initial one for this message batch
+					queueTransition = true
 				}
 
 				// We don't want more than maxMessagesPerSegment messages in a segment
 				if msgCount >= maxMessagesPerSegment {
-					break outer
+					break readSendQueueLoop
 				}
 				// We don't want to add more messages once we spill over into a second segment
 				if payloadBuf.Len() > muxer.SegmentMaxPayloadLength {
-					break outer
+					break readSendQueueLoop
 				}
 				// Check if there are any more queued messages
 				if len(p.sendQueueChan) == 0 {
-					break outer
+					break readSendQueueLoop
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #1565

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Queues protocol state transitions for pipelined ChainSync messages so batched RequestNext calls don’t break the state machine. Prevents stalls and keeps blocks in order during pipelined sync.

- **Bug Fixes**
  - Queue transitions in the send loop: apply the first immediately, then queue the rest and pause reading new messages until queued transitions complete.
  - Simplify ChainSync transitions: remove pipeline counters/state context; RollForward/RollBackward now always transition to idle, fixing canAwait/mustReply with pipelining.
  - Add a pipelining test to validate in-order blocks and tip-await behavior.

- **Dependencies**
  - Update github.com/blinklabs-io/ouroboros-mock to v0.9.1.

<sup>Written for commit b2cd52c28f28bcb27ef348ed64e3f5be2ed3feb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated ouroboros-mock dependency from v0.9.0 to v0.9.1

* **Tests**
  * Added a comprehensive chain synchronization pipelining test validating block ordering and timeout handling

* **Refactor**
  * Simplified chain sync state handling by removing pipeline counter side effects
  * Introduced queued state-transition behavior in the protocol send loop for more robust message processing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->