### PR TITLE
fix(ledger): script refs are inert unless triggered

### DIFF
--- a/ledger/alonzo/rules.go
+++ b/ledger/alonzo/rules.go
@@ -804,22 +804,19 @@ func UtxoValidateScriptDataHash(
 		usedVersions[0] = struct{}{}
 	}
 
-	hasPlutusScripts := len(usedVersions) > 0
 	declaredHash := tx.ScriptDataHash()
 
-	// If no Plutus scripts and no redeemers/datums, ScriptDataHash should be absent
-	if !hasPlutusScripts && !hasRedeemers && !hasDatums {
+	// ScriptDataHash is required only when the transaction has redeemers or
+	// witness datums, indicating actual script execution.
+	if !hasRedeemers && !hasDatums {
 		if declaredHash != nil {
 			return common.ExtraneousScriptDataHashError{Provided: *declaredHash}
 		}
 		return nil
 	}
 
-	// If there are Plutus scripts/redeemers/datums, ScriptDataHash is required
-	if hasPlutusScripts || hasRedeemers || hasDatums {
-		if declaredHash == nil {
-			return common.MissingScriptDataHashError{}
-		}
+	if declaredHash == nil {
+		return common.MissingScriptDataHashError{}
 	}
 
 	// Verify cost models are present for all used Plutus versions

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -1109,7 +1109,8 @@ func UtxoValidateScriptDataHash(
 		}
 	}
 
-	// Check scripts in regular inputs
+	// Check reference scripts on regular inputs.
+	// These may provide reference scripts for minting, spending, etc.
 	for _, input := range tmpTx.Inputs() {
 		utxo, err := ls.UtxoById(input)
 		if err != nil {
@@ -1130,22 +1131,21 @@ func UtxoValidateScriptDataHash(
 		}
 	}
 
-	hasPlutusScripts := len(usedVersions) > 0
 	declaredHash := tx.ScriptDataHash()
 
-	// If no Plutus scripts and no redeemers/datums, ScriptDataHash should be absent
-	if !hasPlutusScripts && !hasRedeemers && !hasDatums {
+	// ScriptDataHash is required only when the transaction has redeemers or
+	// witness datums, indicating actual script execution. The mere presence
+	// of ScriptRefs in consumed/referenced UTxOs does NOT require a hash —
+	// they are inert data unless matched by a redeemer.
+	if !hasRedeemers && !hasDatums {
 		if declaredHash != nil {
 			return common.ExtraneousScriptDataHashError{Provided: *declaredHash}
 		}
 		return nil
 	}
 
-	// If there are Plutus scripts/redeemers/datums, ScriptDataHash is required
-	if hasPlutusScripts || hasRedeemers || hasDatums {
-		if declaredHash == nil {
-			return common.MissingScriptDataHashError{}
-		}
+	if declaredHash == nil {
+		return common.MissingScriptDataHashError{}
 	}
 
 	// Verify cost models are present for all used Plutus versions

--- a/ledger/common/errors.go
+++ b/ledger/common/errors.go
@@ -35,6 +35,31 @@ func (e MissingCostModelError) Error() string {
 	return fmt.Sprintf("missing cost model for Plutus v%d", e.Version+1)
 }
 
+// InputResolutionError indicates a failure to resolve a regular input UTxO
+type InputResolutionError struct {
+	Input TransactionInput
+	Err   error
+}
+
+func (e InputResolutionError) Error() string {
+	return fmt.Sprintf(
+		"failed to resolve input %s: %v",
+		e.Input.String(),
+		e.Err,
+	)
+}
+
+func (e InputResolutionError) Unwrap() error { return e.Err }
+
+// Sentinel error for input resolution failures so callers can use errors.Is
+var ErrInputResolution = errors.New(
+	"input resolution failed",
+)
+
+func (InputResolutionError) Is(target error) bool {
+	return target == ErrInputResolution
+}
+
 // ReferenceInputResolutionError indicates a failure to resolve a reference input UTxO
 type ReferenceInputResolutionError struct {
 	Input TransactionInput

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -722,7 +722,8 @@ func UtxoValidateScriptDataHash(
 		}
 	}
 
-	// Check scripts in regular inputs
+	// Check reference scripts on regular inputs.
+	// These may provide reference scripts for minting, spending, etc.
 	for _, input := range tmpTx.Inputs() {
 		utxo, err := ls.UtxoById(input)
 		if err != nil {
@@ -745,22 +746,21 @@ func UtxoValidateScriptDataHash(
 		}
 	}
 
-	hasPlutusScripts := len(usedVersions) > 0
 	declaredHash := tx.ScriptDataHash()
 
-	// If no Plutus scripts and no redeemers/datums, ScriptDataHash should be absent
-	if !hasPlutusScripts && !hasRedeemers && !hasDatums {
+	// ScriptDataHash is required only when the transaction has redeemers or
+	// witness datums, indicating actual script execution. The mere presence
+	// of ScriptRefs in consumed/referenced UTxOs does NOT require a hash —
+	// they are inert data unless matched by a redeemer.
+	if !hasRedeemers && !hasDatums {
 		if declaredHash != nil {
 			return common.ExtraneousScriptDataHashError{Provided: *declaredHash}
 		}
 		return nil
 	}
 
-	// If there are Plutus scripts/redeemers/datums, ScriptDataHash is required
-	if hasPlutusScripts || hasRedeemers || hasDatums {
-		if declaredHash == nil {
-			return common.MissingScriptDataHashError{}
-		}
+	if declaredHash == nil {
+		return common.MissingScriptDataHashError{}
 	}
 
 	// Verify cost models are present for all used Plutus versions
@@ -1903,7 +1903,10 @@ func UtxoValidatePlutusScripts(
 	for _, input := range tx.Inputs() {
 		utxo, err := ls.UtxoById(input)
 		if err != nil {
-			continue
+			return common.InputResolutionError{
+				Input: input,
+				Err:   err,
+			}
 		}
 		resolvedInputs = append(resolvedInputs, utxo)
 		resolvedInputsMap[input.String()] = utxo


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes ScriptDataHash validation: it’s now required only when a transaction has redeemers or witness datums; reference scripts alone no longer trigger it. Also adds a typed input resolution error to fail fast when inputs can’t be resolved.

- **Bug Fixes**
  - Alonzo/Babbage/Conway: treat ScriptRefs as inert; require ScriptDataHash only with redeemers or witness datums, return ExtraneousScriptDataHash when provided without them, and MissingScriptDataHash only when needed.
  - Introduced InputResolutionError (with ErrInputResolution) and used it in Conway UtxoValidatePlutusScripts to surface unresolved inputs instead of silently continuing.

<sup>Written for commit 274218776ed01e41b4e6a00d4b90f9225ae8e39e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and explicit reporting for input resolution failures during transaction validation.
  * Enhanced error propagation in Plutus script validation for phase-2 validation failures.

* **Improvements**
  * Simplified and clarified ScriptDataHash validation logic to require the hash only when redeemers or datums are present.
  * Refined validation requirements across multiple ledger eras for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->