### PR TITLE
feat(vrf): era-specific VRF

### DIFF
--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -76,7 +76,7 @@ func IsSlotLeader(
 //  5. Compare: eligible = leaderValue < T
 //
 // For TPraos (Shelley-Alonzo):
-//  1. Compute VRF input using MkInputVrf(slot, epochNonce)
+//  1. Compute VRF input using MkSeedTPraos(slot, epochNonce, SeedL())
 //  2. Generate VRF proof: proof, output = vrfSigner.Prove(input)
 //  3. Use raw 64-byte VRF output directly
 //  4. Compute threshold: T = 2^512 * (1 - (1-f)^σ)
@@ -116,12 +116,30 @@ func IsSlotLeaderWithMode(
 		}, nil
 	}
 
-	// Step 1: Compute VRF input
-	// Slot numbers in Cardano are far below int64 max (mainnet ~100M, max ~9.2 quintillion)
-	vrfInput := vrf.MkInputVrf(
-		int64(slot), //nolint:gosec
-		epochNonce,
-	)
+	// Step 1: Compute VRF input (era-specific)
+	// For leader election, TPraos uses seedL (mkNonceFromNumber 1)
+	if slot > math.MaxInt64 {
+		return nil, fmt.Errorf(
+			"slot %d exceeds maximum int64 value for VRF input",
+			slot,
+		)
+	}
+	var vrfInput []byte
+	switch mode {
+	case ConsensusModeTPraos:
+		vrfInput = vrf.MkSeedTPraos(
+			int64(slot), //nolint:gosec
+			epochNonce,
+			vrf.SeedL(),
+		)
+	case ConsensusModeCPraos:
+		vrfInput = vrf.MkInputVrf(
+			int64(slot), //nolint:gosec
+			epochNonce,
+		)
+	default:
+		return nil, fmt.Errorf("unknown consensus mode: %d", mode)
+	}
 
 	// Step 2: Generate VRF proof
 	proof, output, err := vrfSigner.Prove(vrfInput)

--- a/consensus/leader_test.go
+++ b/consensus/leader_test.go
@@ -15,6 +15,7 @@
 package consensus
 
 import (
+	"math"
 	"math/big"
 	"testing"
 
@@ -379,4 +380,44 @@ func TestFindNextSlotLeadershipNoEligibility(t *testing.T) {
 	if slot != 0 || proof != nil || output != nil {
 		t.Error("should not find eligibility with zero stake")
 	}
+}
+
+func TestIsSlotLeaderWithModeSlotOverflow(t *testing.T) {
+	signer, err := NewSimpleVRFSigner(testVRFSeed)
+	require.NoError(t, err)
+
+	epochNonce := make([]byte, 32)
+	activeSlotCoeff := big.NewRat(1, 20)
+
+	_, err = IsSlotLeaderWithMode(
+		math.MaxUint64, // overflows int64
+		epochNonce,
+		1000,
+		10000,
+		activeSlotCoeff,
+		signer,
+		ConsensusModeCPraos,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum int64 value")
+}
+
+func TestIsSlotLeaderWithModeUnknownMode(t *testing.T) {
+	signer, err := NewSimpleVRFSigner(testVRFSeed)
+	require.NoError(t, err)
+
+	epochNonce := make([]byte, 32)
+	activeSlotCoeff := big.NewRat(1, 20)
+
+	_, err = IsSlotLeaderWithMode(
+		1000,
+		epochNonce,
+		1000,
+		10000,
+		activeSlotCoeff,
+		signer,
+		ConsensusMode(99), // unknown mode
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown consensus mode")
 }

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -269,6 +269,7 @@ type BabbageBlockHeader struct {
 
 type BabbageBlockHeaderBody struct {
 	cbor.StructAsArray
+	cbor.DecodeStoreCbor
 	BlockNumber   uint64
 	Slot          uint64
 	PrevHash      common.Blake2b256
@@ -279,6 +280,17 @@ type BabbageBlockHeaderBody struct {
 	BlockBodyHash common.Blake2b256
 	OpCert        BabbageOpCert
 	ProtoVersion  BabbageProtoVersion
+}
+
+func (b *BabbageBlockHeaderBody) UnmarshalCBOR(cborData []byte) error {
+	type tBabbageBlockHeaderBody BabbageBlockHeaderBody
+	var tmp tBabbageBlockHeaderBody
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*b = BabbageBlockHeaderBody(tmp)
+	b.SetCbor(cborData)
+	return nil
 }
 
 type BabbageOpCert struct {

--- a/ledger/common/nonce.go
+++ b/ledger/common/nonce.go
@@ -87,9 +87,18 @@ func (n *Nonce) MarshalCBOR() ([]byte, error) {
 
 // CalculateRollingNonce calculates a rolling nonce (eta_v) value from the
 // previous block's eta_v value and the current block's VRF result.
-// This implements the Ouroboros Praos evolving nonce update:
+// This implements the Ouroboros Praos evolving nonce update using the
+// Haskell Nonce semigroup (⭒) operator:
 //
-//	eta_v' = eta_v XOR blake2b_256(vrfOutput)
+//	NeutralNonce ⭒ Nonce(x) = Nonce(x)
+//	Nonce(a) ⭒ Nonce(b) = Nonce(blake2b_256(a || b))
+//
+// Where the VRF contribution is hashToNonce(blake2b_256(vrfOutput)).
+//
+// NeutralNonce is represented as 32 zero bytes. When prevBlockNonce is
+// all zeros (identity element), the result is blake2b_256(vrfOutput).
+//
+// Ref: Cardano.Ledger.BaseTypes (⭒) operator
 func CalculateRollingNonce(
 	prevBlockNonce []byte,
 	blockVrf []byte,
@@ -107,19 +116,32 @@ func CalculateRollingNonce(
 		)
 	}
 	blockVrfHash := Blake2b256Hash(blockVrf)
-	var result Blake2b256
-	for i := 0; i < 32; i++ {
-		result[i] = prevBlockNonce[i] ^ blockVrfHash[i]
+	// NeutralNonce identity: if prevBlockNonce is all zeros,
+	// return blake2b_256(vrfOutput) directly (Nonce semigroup identity)
+	isNeutral := true
+	for _, b := range prevBlockNonce {
+		if b != 0 {
+			isNeutral = false
+			break
+		}
 	}
-	return result, nil
+	if isNeutral {
+		return blockVrfHash, nil
+	}
+	// Nonce(a) ⭒ Nonce(b) = Nonce(blake2b_256(a || b))
+	var buf [64]byte
+	copy(buf[:32], prevBlockNonce)
+	copy(buf[32:], blockVrfHash[:])
+	return Blake2b256Hash(buf[:]), nil
 }
 
-// CalculateEpochNonce calculates an epoch nonce using the TPraos method:
+// CalculateEpochNonce calculates an epoch nonce:
 //
-//	epochNonce = blake2b_256(candidateNonce || lastEpochBlockNonce)
+//	epochNonce = blake2b_256(candidateNonce || prevEpochFirstBlockHash)
 //
-// This is used for Shelley through Alonzo (TPraos). For Babbage+ (Praos),
-// use XOR-based nonce combination instead.
+// When extraEntropy is non-empty (must be exactly 32 bytes):
+//
+//	epochNonce = blake2b_256(epochNonce || extraEntropy)
 func CalculateEpochNonce(
 	stableBlockNonce []byte,
 	prevEpochFirstBlockHash []byte,
@@ -132,15 +154,20 @@ func CalculateEpochNonce(
 			len(prevEpochFirstBlockHash),
 		)
 	}
+	if len(extraEntropy) != 0 && len(extraEntropy) != 32 {
+		return Blake2b256{}, fmt.Errorf(
+			"invalid extraEntropy length: %d, expected 0 or 32",
+			len(extraEntropy),
+		)
+	}
 	var buf [64]byte
 	copy(buf[:32], stableBlockNonce)
 	copy(buf[32:], prevEpochFirstBlockHash)
 	tmpDataHash := Blake2b256Hash(buf[:])
-	if len(extraEntropy) > 0 {
-		buf2 := make([]byte, 32+len(extraEntropy))
-		copy(buf2[:32], tmpDataHash.Bytes())
-		copy(buf2[32:], extraEntropy)
-		tmpDataHash = Blake2b256Hash(buf2)
+	if len(extraEntropy) == 32 {
+		copy(buf[:32], tmpDataHash.Bytes())
+		copy(buf[32:], extraEntropy)
+		tmpDataHash = Blake2b256Hash(buf[:])
 	}
 	return tmpDataHash, nil
 }

--- a/ledger/common/nonce_test.go
+++ b/ledger/common/nonce_test.go
@@ -67,63 +67,63 @@ func TestCalculateRollingNonce(t *testing.T) {
 			// Shelley genesis hash (mainnet)
 			prevBlockNonce: "1a3be38bcbb7911969283716ad7aa550250226b76a61fc51cc9a9a35d9276d81",
 			blockVrf:       "36ec5378d1f5041a59eb8d96e61de96f0950fb41b49ff511f7bc7fd109d4383e1d24be7034e6749c6612700dd5ceb0c66577b88a19ae286b1321d15bce1ab736",
-			expectedNonce:  "5ef5b5a5e5f64b1e00134f57b14353d9bca39cbb2c94e81ed331d8bd47f80e90",
+			expectedNonce:  "2af15f57076a8ff225746624882a77c8d2736fe41d3db70154a22b50af851246",
 		},
 		{
 			blockVrf:      "e0bf34a6b73481302f22987cde4c12807cbc2c3fea3f7fcb77261385a50e8ccdda3226db3efff73e9fb15eecf841bbc85ce37550de0435ebcdcb205e0ed08467",
-			expectedNonce: "2b8b8ca6cdef26c99a4d8a4c7da024ae8142d77523ea3a587c8cc3d70c3b78d6",
+			expectedNonce: "a815ff978369b57df09b0072485c26920dc0ec8e924a852a42f0715981cf0042",
 		},
 		{
 			blockVrf:      "7107ef8c16058b09f4489715297e55d145a45fc0df75dfb419cab079cd28992854a034ad9dc4c764544fb70badd30a9611a942a03523c6f3d8967cf680c4ca6b",
-			expectedNonce: "3dd135661b482d5061eb104d37640aa531a57e6be0161e82a7cecf8599f2a258",
+			expectedNonce: "f112d91435b911b6b5acaf27198762905b1cdec8c5a7b712f925ce3c5c76bb5f",
 		},
 		{
 			blockVrf:      "6f561aad83884ee0d7b19fd3d757c6af096bfd085465d1290b13a9dfc817dfcdfb0b59ca06300206c64d1ba75fd222a88ea03c54fbbd5d320b4fbcf1c228ba4e",
-			expectedNonce: "c7c0d36543c97f7609e5cb620009d5311d04b97c55ddca91b38c92cf230d9ff8",
+			expectedNonce: "5450d95d9be4194a0ded40fbb4036b48d1f1d6da796e933fefd2c5c888794b4b",
 		},
 		{
 			blockVrf:      "3d3ba80724db0a028783afa56a85d684ee778ae45b9aa9af3120f5e1847be1983bd4868caf97fcfd82d5a3b0b7c1a6d53491d75440a75198014eb4e707785cad",
-			expectedNonce: "1fdec65e558b250291fb15c44e6a80dbc8335b7f10fefbf3329dc96e7402f911",
+			expectedNonce: "c5c0f406cb522ad3fead4ecc60bce9c31e80879bc17eb1bb9acaa9b998cdf8bf",
 		},
 		{
 			blockVrf:      "0b07976bc04321c2e7ba0f1acb3c61bd92b5fc780a855632e30e6746ab4ac4081490d816928762debd3e512d22ad512a558612adc569718df1784261f5c26aff",
-			expectedNonce: "c58e50b11c6394745307310e20a59b46159ab3cdec3cd76ea119f83c828328a8",
+			expectedNonce: "5857048c728580549de645e087ba20ef20bb7c51cc84b5bc89df6b8b0ed98c41",
 		},
 		{
 			blockVrf:      "5e9e001fb1e2ddb0dc7ff40af917ecf4ba9892491d4bcbf2c81db2efc57627d40d7aac509c9bcf5070d4966faaeb84fd76bb285af2e51af21a8c024089f598c1",
-			expectedNonce: "cc620555a316b8fa12780a84ccac3a8823b33b311c27785ce617b528724a6e88",
+			expectedNonce: "d6f40ef403687115db061b2cb9b1ab4ddeb98222075d5a3e03c8d217d4d7c40e",
 		},
 		{
 			blockVrf:      "182e83f8c67ad2e6bddead128e7108499ebcbc272b50c42783ef08f035aa688fecc7d15be15a90dbfe7fe5d7cd9926987b6ec12b05f2eadfe0eb6cad5130aca4",
-			expectedNonce: "f6433a150397c8306140347470f1c3149104c797b33f64d241fc6e38625bddcb",
+			expectedNonce: "5489d75a9f4971c1824462b5e2338609a91f121241f21fee09811bd5772ae0a8",
 		},
 		{
 			blockVrf:      "275e7404b2385a9d606d67d0e29f5516fb84c1c14aaaf91afa9a9b3dcdfe09075efdadbaf158cfa1e9f250cc7c691ed2db4a29288d2426bd74a371a2a4b91b57",
-			expectedNonce: "f94185828867bcebc0c3975be7c310cb626c08ac2b0779ea07029242a5c31465",
+			expectedNonce: "04716326833ecdb595153adac9566a4b39e5c16e8d02526cb4166e4099a00b1a",
 		},
 		{
 			blockVrf:      "0f35c7217792f8b0cbb721ae4ae5c9ae7f2869df49a3db256aacc10d23997a09e0273261b44ebbcecd6bf916f2c1cd79cf25b0c2851645d75dd0747a8f6f92f5",
-			expectedNonce: "0d2d0cab4c88bdac97b3cad5aa195b43deafce6ee056b04d15f00f3aefcc6a70",
+			expectedNonce: "39db709f50c8a279f0a94adcefb9360dbda6cdce168aed4288329a9cd53492b6",
 		},
 		{
 			blockVrf:      "14c28bf9b10421e9f90ffc9ab05df0dc8c8a07ffac1c51725fba7e2b7972d0769baea248f93ed0f2067d11d719c2858c62fc1d8d59927b41d4c0fbc68d805b32",
-			expectedNonce: "555524d10c6303e1d7de4fd5a1ccec74e97214571003dfcce24743c1bcaec8d2",
+			expectedNonce: "c784b8c8678e0a04748a3ad851dd7c34ed67141cd9dc0c50ceaff4df804699a7",
 		},
 		{
 			blockVrf:      "e4ce96fee9deb9378a107db48587438cddf8e20a69e21e5e4fbd35ef0c56530df77eba666cb152812111ba66bbd333ed44f627c727115f8f4f15b31726049a19",
-			expectedNonce: "b6878e849876154a954266a0c0cf39482de8ac233c6c030823a5fcadbf30ee70",
+			expectedNonce: "cc1a5861358c075de93a26a91c5a951d5e71190d569aa2dc786d4ca8fc80cc38",
 		},
 		{
 			blockVrf:      "b38f315e3ce369ea2551bf4f44e723dd15c7d67ba4b3763997909f65e46267d6540b9b00a7a65ae3d1f3a3316e57a821aeaac33e4e42ded415205073134cd185",
-			expectedNonce: "432556c6e3a30fe9b20d2887b485b30797c88b9f7692682c7bd355c9d2236bee",
+			expectedNonce: "514979c89313c49e8f59fb8445113fa7623e99375cc4917fe79df54f8d4bdfce",
 		},
 		{
 			blockVrf:      "4bcbf774af9c8ff24d4d96099001ec06a24802c88fea81680ea2411392d32dbd9b9828a690a462954b894708d511124a2db34ec4179841e07a897169f0f1ac0e",
-			expectedNonce: "ab39d6bf8ad7849f73bf58ce10312a290c76ab15cd4a0a167e84b9bb698bcb54",
+			expectedNonce: "6a783e04481b9e04e8f3498a3b74c90c06a1031fb663b6793ce592a6c26f56f4",
 		},
 		{
 			blockVrf:      "65247ace6355f978a12235265410c44f3ded02849ec8f8e6db2ac705c3f57d322ea073c13cf698e15d7e1d7f2bc95e7b3533be0dee26f58864f1664df0c1ebba",
-			expectedNonce: "434e8f5fde7880701021ed94a18a4184f442dfec727221661713a054bae91fda",
+			expectedNonce: "1190f5254599dcee4f3cf1afdf4181085c36a6db6c30f334bfe6e6f320a6ed91",
 		},
 	}
 	var rollingNonce []byte
@@ -153,6 +153,58 @@ func TestCalculateRollingNonce(t *testing.T) {
 			)
 		}
 		rollingNonce = nonce.Bytes()
+	}
+}
+
+func TestCalculateRollingNonceInvalidPrevBlockNonceLength(t *testing.T) {
+	validVrf := make([]byte, 64)
+	// Too short
+	_, err := common.CalculateRollingNonce(make([]byte, 16), validVrf)
+	if err == nil {
+		t.Fatal("expected error for invalid prevBlockNonce length, got nil")
+	}
+	// Too long
+	_, err = common.CalculateRollingNonce(make([]byte, 64), validVrf)
+	if err == nil {
+		t.Fatal("expected error for invalid prevBlockNonce length, got nil")
+	}
+}
+
+func TestCalculateRollingNonceInvalidBlockVrfLength(t *testing.T) {
+	validNonce := make([]byte, 32)
+	// Wrong length (not 32 or 64)
+	_, err := common.CalculateRollingNonce(validNonce, make([]byte, 48))
+	if err == nil {
+		t.Fatal("expected error for invalid blockVrf length, got nil")
+	}
+	_, err = common.CalculateRollingNonce(validNonce, make([]byte, 0))
+	if err == nil {
+		t.Fatal("expected error for empty blockVrf, got nil")
+	}
+}
+
+func TestCalculateRollingNonceNeutral(t *testing.T) {
+	// A neutral (all-zero) prevBlockNonce should follow the NeutralNonce
+	// identity path: NeutralNonce ⭒ Nonce(x) = Nonce(x), returning
+	// blake2b_256(blockVrf) directly without concatenation.
+	neutralNonce := make([]byte, 32) // all zeros
+	blockVrf, err := hex.DecodeString(
+		"36ec5378d1f5041a59eb8d96e61de96f0950fb41b49ff511f7bc7fd109d4383e1d24be7034e6749c6612700dd5ceb0c66577b88a19ae286b1321d15bce1ab736",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	result, err := common.CalculateRollingNonce(neutralNonce, blockVrf)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	// With neutral nonce, result should equal blake2b_256(blockVrf)
+	expected := common.Blake2b256Hash(blockVrf)
+	if result != expected {
+		t.Fatalf(
+			"neutral nonce should produce blake2b_256(blockVrf): got %x, want %x",
+			result, expected,
+		)
 	}
 }
 
@@ -210,5 +262,20 @@ func TestCalculateEpochNonce(t *testing.T) {
 				testDef.expectedNonce,
 			)
 		}
+	}
+}
+
+func TestCalculateEpochNonceInvalidExtraEntropyLength(t *testing.T) {
+	stable := make([]byte, 32)
+	prevHash := make([]byte, 32)
+	// 16 bytes: not 0 or 32
+	_, err := common.CalculateEpochNonce(stable, prevHash, make([]byte, 16))
+	if err == nil {
+		t.Fatal("expected error for 16-byte extraEntropy, got nil")
+	}
+	// 64 bytes: not 0 or 32
+	_, err = common.CalculateEpochNonce(stable, prevHash, make([]byte, 64))
+	if err == nil {
+		t.Fatal("expected error for 64-byte extraEntropy, got nil")
 	}
 }

--- a/ledger/leios/leios.go
+++ b/ledger/leios/leios.go
@@ -139,6 +139,7 @@ func (b *LeiosBlockHeaderBody) UnmarshalCBOR(cborData []byte) error {
 		}
 		b.CertifiedEb = &cert
 	}
+	b.SetCbor(cborData)
 	return nil
 }
 

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -203,6 +203,7 @@ type ShelleyBlockHeader struct {
 }
 type ShelleyBlockHeaderBody struct {
 	cbor.StructAsArray
+	cbor.DecodeStoreCbor
 	BlockNumber          uint64
 	Slot                 uint64
 	PrevHash             common.Blake2b256
@@ -218,6 +219,17 @@ type ShelleyBlockHeaderBody struct {
 	OpCertSignature      []byte
 	ProtoMajorVersion    uint64
 	ProtoMinorVersion    uint64
+}
+
+func (b *ShelleyBlockHeaderBody) UnmarshalCBOR(cborData []byte) error {
+	type tShelleyBlockHeaderBody ShelleyBlockHeaderBody
+	var tmp tShelleyBlockHeaderBody
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	*b = ShelleyBlockHeaderBody(tmp)
+	b.SetCbor(cborData)
+	return nil
 }
 
 func (h *ShelleyBlockHeader) UnmarshalCBOR(cborData []byte) error {

--- a/ledger/verify_block.go
+++ b/ledger/verify_block.go
@@ -31,6 +31,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/leios"
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/blinklabs-io/gouroboros/vrf"
@@ -119,6 +120,35 @@ func DetermineBlockType(headerCbor []byte) (uint, error) {
 	}
 }
 
+// extractOriginalBodyCbor returns the original CBOR bytes for the block
+// header body. Each body type stores its raw CBOR at decode time via
+// DecodeStoreCbor, so we just retrieve it here. This is critical for KES
+// signature verification because the signature is computed over the original
+// CBOR encoding, not a re-encoded version.
+func extractOriginalBodyCbor(header BlockHeader) ([]byte, error) {
+	switch h := header.(type) {
+	case *shelley.ShelleyBlockHeader:
+		return h.Body.Cbor(), nil
+	case *allegra.AllegraBlockHeader:
+		return h.Body.Cbor(), nil
+	case *mary.MaryBlockHeader:
+		return h.Body.Cbor(), nil
+	case *alonzo.AlonzoBlockHeader:
+		return h.Body.Cbor(), nil
+	case *babbage.BabbageBlockHeader:
+		return h.Body.Cbor(), nil
+	case *conway.ConwayBlockHeader:
+		return h.Body.Cbor(), nil
+	case *leios.LeiosBlockHeader:
+		return h.Body.Cbor(), nil
+	default:
+		return nil, fmt.Errorf(
+			"unsupported header type for body CBOR extraction: %T",
+			header,
+		)
+	}
+}
+
 func extractHeaderFields(
 	header BlockHeader,
 ) (issuerVkey, vrfKey []byte, err error) {
@@ -155,7 +185,6 @@ func VerifyBlock(
 	slotsPerKesPeriod uint64,
 	config common.VerifyConfig,
 ) (bool, string, uint64, uint64, error) {
-	isValid := false
 	vrfHex := ""
 
 	// Decode eta0
@@ -184,19 +213,24 @@ func VerifyBlock(
 	var kesValid bool
 	var vrfResult common.VrfResult
 	var vrfKey []byte
+	var isTPraos bool
 	switch h := block.Header().(type) {
 	case *shelley.ShelleyBlockHeader:
 		vrfResult = h.Body.LeaderVrf
 		vrfKey = h.Body.VrfKey
+		isTPraos = true
 	case *allegra.AllegraBlockHeader:
 		vrfResult = h.Body.LeaderVrf
 		vrfKey = h.Body.VrfKey
+		isTPraos = true
 	case *mary.MaryBlockHeader:
 		vrfResult = h.Body.LeaderVrf
 		vrfKey = h.Body.VrfKey
+		isTPraos = true
 	case *alonzo.AlonzoBlockHeader:
 		vrfResult = h.Body.LeaderVrf
 		vrfKey = h.Body.VrfKey
+		isTPraos = true
 	case *babbage.BabbageBlockHeader:
 		vrfResult = h.Body.VrfResult
 		vrfKey = h.Body.VrfKey
@@ -231,7 +265,35 @@ func VerifyBlock(
 			nil,
 		)
 	}
-	vrfMsg := vrf.MkInputVrf(int64(slot), eta0)
+	// TPraos (Shelley-Alonzo) and CPraos (Babbage+) use different VRF
+	// input constructions. TPraos applies an additional XOR with a seed
+	// constant derived from mkNonceFromNumber. CPraos uses the raw
+	// blake2b-256(slot || nonce) without any XOR step.
+	//
+	// For verifying the LeaderVrf (bheaderL), use seedL = mkNonceFromNumber(1).
+	// For verifying the NonceVrf (bheaderEta), use seedEta = mkNonceFromNumber(0).
+	// We verify the LeaderVrf here (the one that proves leader election).
+	//
+	// Ref: Cardano.Protocol.TPraos.Rules.Overlay.vrfChecks (TPraos)
+	// Ref: Ouroboros.Consensus.Protocol.Praos.VRF.mkInputVRF (CPraos)
+	if len(eta0) != 32 {
+		return false, "", 0, 0, common.NewValidationError(
+			common.ValidationErrorTypeConfiguration,
+			"eta0 must be exactly 32 bytes",
+			map[string]any{
+				"eta0_hex":     eta0Hex,
+				"actual_len":   len(eta0),
+				"expected_len": 32,
+			},
+			nil,
+		)
+	}
+	var vrfMsg []byte
+	if isTPraos {
+		vrfMsg = vrf.MkSeedTPraos(int64(slot), eta0, vrf.SeedL())
+	} else {
+		vrfMsg = vrf.MkInputVrf(int64(slot), eta0)
+	}
 	vrfValid, err = vrf.Verify(
 		vrfKey,
 		vrfResult.Proof,
@@ -254,134 +316,56 @@ func VerifyBlock(
 		)
 	}
 
+	if !vrfValid {
+		return false, "", 0, 0, common.NewValidationError(
+			common.ValidationErrorTypeVRF,
+			"VRF output mismatch",
+			map[string]any{
+				"slot":           slot,
+				"block_number":   blockNo,
+				"era":            era,
+				"vrf_output_len": len(vrfResult.Output),
+				"vrf_proof_len":  len(vrfResult.Proof),
+			},
+			nil,
+		)
+	}
+
 	vrfHex = hex.EncodeToString(vrfResult.Output)
 
 	// KES verification
-	var bodyCbor []byte
-	var signature []byte
-	var hotVkey []byte
-	var kesPeriod uint64
-	switch h := block.Header().(type) {
-	case *shelley.ShelleyBlockHeader:
-		bodyCbor, err = cbor.Encode(h.Body)
-		if err != nil {
-			return false, "", 0, 0, common.NewValidationError(
-				common.ValidationErrorTypeProtocol,
-				"failed to encode Shelley header body for KES verification",
-				map[string]any{
-					"slot":         slot,
-					"block_number": blockNo,
-					"era":          era,
-					"block_type":   "Shelley",
-				},
-				err,
-			)
-		}
-		signature = h.Signature
-		hotVkey = h.Body.OpCertHotVkey
-		kesPeriod = uint64(h.Body.OpCertKesPeriod)
-	case *allegra.AllegraBlockHeader:
-		bodyCbor, err = cbor.Encode(h.Body)
-		if err != nil {
-			return false, "", 0, 0, common.NewValidationError(
-				common.ValidationErrorTypeProtocol,
-				"failed to encode Allegra header body for KES verification",
-				map[string]any{
-					"slot":         slot,
-					"block_number": blockNo,
-					"era":          era,
-					"block_type":   "Allegra",
-				},
-				err,
-			)
-		}
-		signature = h.Signature
-		hotVkey = h.Body.OpCertHotVkey
-		kesPeriod = uint64(h.Body.OpCertKesPeriod)
-	case *mary.MaryBlockHeader:
-		bodyCbor, err = cbor.Encode(h.Body)
-		if err != nil {
-			return false, "", 0, 0, common.NewValidationError(
-				common.ValidationErrorTypeProtocol,
-				"failed to encode Mary header body for KES verification",
-				map[string]any{
-					"slot":         slot,
-					"block_number": blockNo,
-					"era":          era,
-					"block_type":   "Mary",
-				},
-				err,
-			)
-		}
-		signature = h.Signature
-		hotVkey = h.Body.OpCertHotVkey
-		kesPeriod = uint64(h.Body.OpCertKesPeriod)
-	case *alonzo.AlonzoBlockHeader:
-		bodyCbor, err = cbor.Encode(h.Body)
-		if err != nil {
-			return false, "", 0, 0, common.NewValidationError(
-				common.ValidationErrorTypeProtocol,
-				"failed to encode Alonzo header body for KES verification",
-				map[string]any{
-					"slot":         slot,
-					"block_number": blockNo,
-					"era":          era,
-					"block_type":   "Alonzo",
-				},
-				err,
-			)
-		}
-		signature = h.Signature
-		hotVkey = h.Body.OpCertHotVkey
-		kesPeriod = uint64(h.Body.OpCertKesPeriod)
-	case *babbage.BabbageBlockHeader:
-		bodyCbor, err = cbor.Encode(h.Body)
-		if err != nil {
-			return false, "", 0, 0, common.NewValidationError(
-				common.ValidationErrorTypeProtocol,
-				"failed to encode Babbage header body for KES verification",
-				map[string]any{
-					"slot":         slot,
-					"block_number": blockNo,
-					"era":          era,
-					"block_type":   "Babbage",
-				},
-				err,
-			)
-		}
-		signature = h.Signature
-		hotVkey = h.Body.OpCert.HotVkey
-		kesPeriod = uint64(h.Body.OpCert.KesPeriod)
-	case *conway.ConwayBlockHeader:
-		bodyCbor, err = cbor.Encode(h.Body)
-		if err != nil {
-			return false, "", 0, 0, common.NewValidationError(
-				common.ValidationErrorTypeProtocol,
-				"failed to encode Conway header body for KES verification",
-				map[string]any{
-					"slot":         slot,
-					"block_number": blockNo,
-					"era":          era,
-					"block_type":   "Conway",
-				},
-				err,
-			)
-		}
-		signature = h.Signature
-		hotVkey = h.Body.OpCert.HotVkey
-		kesPeriod = uint64(h.Body.OpCert.KesPeriod)
-	default:
+	// Extract the original body CBOR from the stored header CBOR.
+	// The header is encoded as [body, signature] in CBOR. We must use
+	// the original body bytes (not re-encoded) because the KES signature
+	// is computed over the exact original CBOR encoding.
+	bodyCbor, err := extractOriginalBodyCbor(block.Header())
+	if err != nil {
 		return false, "", 0, 0, common.NewValidationError(
 			common.ValidationErrorTypeProtocol,
-			"unsupported block type for KES verification",
+			"failed to extract header body CBOR for KES verification",
 			map[string]any{
-				"block_type":   fmt.Sprintf("%T", block.Header()),
+				"slot":         slot,
+				"block_number": blockNo,
+				"era":          era,
+			},
+			err,
+		)
+	}
+	if len(bodyCbor) == 0 {
+		return false, "", 0, 0, common.NewValidationError(
+			common.ValidationErrorTypeProtocol,
+			"empty body CBOR from extractOriginalBodyCbor",
+			map[string]any{
 				"slot":         slot,
 				"block_number": blockNo,
 				"era":          era,
 			},
 			nil,
 		)
+	}
+	signature, hotVkey, kesPeriod, err := ExtractKesFields(block.Header())
+	if err != nil {
+		return false, "", 0, 0, err
 	}
 
 	kesValid, err = VerifyKesComponents(
@@ -409,13 +393,24 @@ func VerifyBlock(
 			err,
 		)
 	}
+	if !kesValid {
+		return false, "", 0, 0, common.NewValidationError(
+			common.ValidationErrorTypeKES,
+			"KES signature invalid",
+			map[string]any{
+				"slot":         slot,
+				"block_number": blockNo,
+				"era":          era,
+			},
+			nil,
+		)
+	}
 
 	// Verify block body hash (can be skipped via config)
 	// Intended usage: production should keep this enabled for security.
 	// Tests or environments lacking full block CBOR may set
 	// VerifyConfig{SkipBodyHashValidation:true} to bypass this check.
 	expectedBodyHash := block.BlockBodyHash()
-	isBodyValid := true
 	if block.Era() != byron.EraByron && !config.SkipBodyHashValidation {
 		rawCbor := block.Cbor()
 		if len(rawCbor) == 0 {
@@ -562,9 +557,7 @@ func VerifyBlock(
 		}
 	}
 
-	isValid = isBodyValid && vrfValid && kesValid
-	slotNo := slot
-	return isValid, vrfHex, blockNo, slotNo, nil
+	return true, vrfHex, blockNo, slot, nil
 }
 
 type BlockHexCbor struct {

--- a/ledger/verify_kes.go
+++ b/ledger/verify_kes.go
@@ -37,63 +37,38 @@ import (
 // This module inspired by https://github.com/input-output-hk/kes,
 // special thanks to https://github.com/iquerejeta, who helped me a lot on this journey
 
-func extractKesFieldsShelleyAlonzo(
-	header any,
-) (bodyCbor []byte, sig []byte, hotVkey []byte, kesPeriod uint64, slot uint64, err error) {
+// ExtractKesFields extracts KES signature, hot verification key, and KES period
+// from a block header of any supported era. Returns a ValidationError for
+// unsupported header types.
+func ExtractKesFields(
+	header common.BlockHeader,
+) (signature []byte, hotVkey []byte, kesPeriod uint64, err error) {
 	switch h := header.(type) {
 	case *shelley.ShelleyBlockHeader:
-		bodyCbor, err = cbor.Encode(h.Body)
-		if err != nil {
-			return nil, nil, nil, 0, 0, err
-		}
-		return bodyCbor, h.Signature, h.Body.OpCertHotVkey, uint64(h.Body.OpCertKesPeriod), h.Body.Slot, nil
+		return h.Signature, h.Body.OpCertHotVkey, uint64(h.Body.OpCertKesPeriod), nil
 	case *allegra.AllegraBlockHeader:
-		bodyCbor, err = cbor.Encode(h.Body)
-		if err != nil {
-			return nil, nil, nil, 0, 0, err
-		}
-		return bodyCbor, h.Signature, h.Body.OpCertHotVkey, uint64(h.Body.OpCertKesPeriod), h.Body.Slot, nil
+		return h.Signature, h.Body.OpCertHotVkey, uint64(h.Body.OpCertKesPeriod), nil
 	case *mary.MaryBlockHeader:
-		bodyCbor, err = cbor.Encode(h.Body)
-		if err != nil {
-			return nil, nil, nil, 0, 0, err
-		}
-		return bodyCbor, h.Signature, h.Body.OpCertHotVkey, uint64(h.Body.OpCertKesPeriod), h.Body.Slot, nil
+		return h.Signature, h.Body.OpCertHotVkey, uint64(h.Body.OpCertKesPeriod), nil
 	case *alonzo.AlonzoBlockHeader:
-		bodyCbor, err = cbor.Encode(h.Body)
-		if err != nil {
-			return nil, nil, nil, 0, 0, err
-		}
-		return bodyCbor, h.Signature, h.Body.OpCertHotVkey, uint64(h.Body.OpCertKesPeriod), h.Body.Slot, nil
-	default:
-		return nil, nil, nil, 0, 0, fmt.Errorf("unsupported header type: %T", header)
-	}
-}
-
-func extractKesFieldsBabbagePlus(
-	header any,
-) (bodyCbor []byte, sig []byte, hotVkey []byte, kesPeriod uint64, slot uint64, err error) {
-	switch h := header.(type) {
+		return h.Signature, h.Body.OpCertHotVkey, uint64(h.Body.OpCertKesPeriod), nil
 	case *babbage.BabbageBlockHeader:
-		bodyCbor, err = cbor.Encode(h.Body)
-		if err != nil {
-			return nil, nil, nil, 0, 0, err
-		}
-		return bodyCbor, h.Signature, h.Body.OpCert.HotVkey, uint64(h.Body.OpCert.KesPeriod), h.Body.Slot, nil
+		return h.Signature, h.Body.OpCert.HotVkey, uint64(h.Body.OpCert.KesPeriod), nil
 	case *conway.ConwayBlockHeader:
-		bodyCbor, err = cbor.Encode(h.Body)
-		if err != nil {
-			return nil, nil, nil, 0, 0, err
-		}
-		return bodyCbor, h.Signature, h.Body.OpCert.HotVkey, uint64(h.Body.OpCert.KesPeriod), h.Body.Slot, nil
+		return h.Signature, h.Body.OpCert.HotVkey, uint64(h.Body.OpCert.KesPeriod), nil
 	case *leios.LeiosBlockHeader:
-		bodyCbor, err = cbor.Encode(h.Body)
-		if err != nil {
-			return nil, nil, nil, 0, 0, err
-		}
-		return bodyCbor, h.Signature, h.Body.OpCert.HotVkey, uint64(h.Body.OpCert.KesPeriod), h.Body.Slot, nil
+		return h.Signature, h.Body.OpCert.HotVkey, uint64(h.Body.OpCert.KesPeriod), nil
 	default:
-		return nil, nil, nil, 0, 0, fmt.Errorf("unsupported header type: %T", header)
+		return nil, nil, 0, common.NewValidationError(
+			common.ValidationErrorTypeProtocol,
+			"unsupported block type for KES verification",
+			map[string]any{
+				"block_type":   fmt.Sprintf("%T", header),
+				"slot":         header.SlotNumber(),
+				"block_number": header.BlockNumber(),
+			},
+			nil,
+		)
 	}
 }
 
@@ -104,34 +79,32 @@ func VerifyKes(
 ) (bool, error) {
 	// Ref: https://github.com/IntersectMBO/ouroboros-consensus/blob/de74882102236fdc4dd25aaa2552e8b3e208448c/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Protocol/Praos.hs#L125
 	// Ref: https://github.com/IntersectMBO/cardano-ledger/blob/master/libs/cardano-protocol-tpraos/src/Cardano/Protocol/TPraos/BHeader.hs#L189
-	var msgBytes []byte
-	var signature []byte
-	var hotVkey []byte
-	var kesPeriod uint64
-	var slot uint64
-	var err error
 
-	switch h := header.(type) {
-	case *shelley.ShelleyBlockHeader, *allegra.AllegraBlockHeader, *mary.MaryBlockHeader, *alonzo.AlonzoBlockHeader:
-		msgBytes, signature, hotVkey, kesPeriod, slot, err = extractKesFieldsShelleyAlonzo(h)
-		if err != nil {
-			return false, fmt.Errorf("VerifyKes: %w", err)
-		}
-	case *babbage.BabbageBlockHeader, *conway.ConwayBlockHeader, *leios.LeiosBlockHeader:
-		msgBytes, signature, hotVkey, kesPeriod, slot, err = extractKesFieldsBabbagePlus(h)
-		if err != nil {
-			return false, fmt.Errorf("VerifyKes: %w", err)
-		}
-	default:
-		return false, fmt.Errorf("VerifyKes: unsupported block header type %T", header)
+	// Extract the original body CBOR stored at decode time.
+	// The KES signature is over the exact original CBOR encoding,
+	// so we must NOT re-encode via cbor.Encode.
+	bodyCbor, err := extractOriginalBodyCbor(header)
+	if err != nil {
+		return false, fmt.Errorf("VerifyKes: %w", err)
+	}
+	if len(bodyCbor) == 0 {
+		return false, fmt.Errorf(
+			"VerifyKes: no stored body CBOR for header type %T",
+			header,
+		)
+	}
+
+	signature, hotVkey, kesPeriod, err := ExtractKesFields(header)
+	if err != nil {
+		return false, fmt.Errorf("VerifyKes: %w", err)
 	}
 
 	return VerifyKesComponents(
-		msgBytes,
+		bodyCbor,
 		signature,
 		hotVkey,
 		kesPeriod,
-		slot,
+		header.SlotNumber(),
 		slotsPerKesPeriod,
 	)
 }
@@ -165,7 +138,10 @@ func VerifyKesComponents(
 	return kes.VerifySignedKES(hotVkey, t, bodyCbor, signature), nil
 }
 
-// GetHeaderBodyCbor returns the CBOR-encoded bytes of the block header body.
+// GetHeaderBodyCbor returns re-encoded CBOR bytes of the block header body.
+// WARNING: This re-encodes via cbor.Encode, which may produce different bytes
+// than the original on-wire encoding. Do NOT use for KES signature verification;
+// use extractOriginalBodyCbor (which returns the stored original CBOR) instead.
 func GetHeaderBodyCbor(header common.BlockHeader) ([]byte, error) {
 	switch h := header.(type) {
 	case *shelley.ShelleyBlockHeader:

--- a/vrf/vrf.go
+++ b/vrf/vrf.go
@@ -274,6 +274,79 @@ func MkInputVrf(slot int64, eta0 []byte) []byte {
 	return result
 }
 
+// mkNonceFromNumber computes blake2b-256 of a uint64 in big-endian encoding.
+// This matches Haskell's mkNonceFromNumber from Cardano.Ledger.BaseTypes.
+func mkNonceFromNumber(n uint64) []byte {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, n)
+	h, err := blake2b.New(32, nil)
+	if err != nil {
+		panic(fmt.Sprintf(
+			"unexpected error creating empty blake2b hash: %s", err,
+		))
+	}
+	h.Write(buf)
+	result := h.Sum(nil)
+	if result == nil {
+		panic("blake2b.Sum returned nil")
+	}
+	return result
+}
+
+// seedEta is the TPraos nonce VRF seed constant: blake2b-256(uint64be(0)).
+// Used with NonceVrf (bheaderEta) for epoch nonce contribution.
+// Matches Haskell: seedEta = mkNonceFromNumber 0
+var seedEta = mkNonceFromNumber(0)
+
+// seedL is the TPraos leader VRF seed constant: blake2b-256(uint64be(1)).
+// Used with LeaderVrf (bheaderL) for leader eligibility checks.
+// Matches Haskell: seedL = mkNonceFromNumber 1
+var seedL = mkNonceFromNumber(1)
+
+// SeedEta returns a copy of the TPraos nonce VRF seed constant.
+func SeedEta() []byte {
+	out := make([]byte, len(seedEta))
+	copy(out, seedEta)
+	return out
+}
+
+// SeedL returns a copy of the TPraos leader VRF seed constant.
+func SeedL() []byte {
+	out := make([]byte, len(seedL))
+	copy(out, seedL)
+	return out
+}
+
+// MkSeedTPraos constructs the TPraos VRF input used in Shelley through
+// Alonzo eras. The TPraos construction computes the same base hash as
+// MkInputVrf, then XORs it with a seed constant:
+//
+//	result = blake2b-256(slot_be64 || eta0) XOR seedConstant
+//
+// For the leader VRF check, pass SeedL() as seedConstant.
+// For the nonce VRF contribution, pass SeedEta() as seedConstant.
+//
+// This matches Haskell's mkSeed from Cardano.Protocol.TPraos.BHeader:
+//
+//	mkSeed ucNonce slot eNonce =
+//	    Hash.xor(ucNonce) . Hash.hashWith id $ slot <> eNonce
+//
+// IMPORTANT: eta0 must be exactly 32 bytes and seedConstant must be
+// exactly 32 bytes. This function will panic if either length is wrong.
+func MkSeedTPraos(slot int64, eta0 []byte, seedConstant []byte) []byte {
+	if len(seedConstant) != 32 {
+		panic(fmt.Sprintf(
+			"seedConstant must be 32 bytes, got %d", len(seedConstant),
+		))
+	}
+	base := MkInputVrf(slot, eta0)
+	result := make([]byte, 32)
+	for i := range result {
+		result[i] = base[i] ^ seedConstant[i]
+	}
+	return result
+}
+
 // ProofToHash extracts the hash output from a VRF proof.
 func ProofToHash(pi []byte) ([]byte, error) {
 	var hashInput [34]byte

--- a/vrf/vrf_test.go
+++ b/vrf/vrf_test.go
@@ -17,8 +17,12 @@ package vrf
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/blake2b"
 )
 
 // Test seed (exactly 32 bytes)
@@ -160,6 +164,47 @@ func TestMkInputVrf(t *testing.T) {
 	if bytes.Equal(input, input3) {
 		t.Error("expected different outputs for different slots")
 	}
+}
+
+func TestMkSeedTPraos(t *testing.T) {
+	slot := int64(12345)
+	eta0 := make([]byte, 32)
+	for i := range eta0 {
+		eta0[i] = byte(i)
+	}
+
+	// MkSeedTPraos with zero seed constant should equal MkInputVrf
+	// (XOR with zero is identity)
+	zeroSeed := make([]byte, 32)
+	tpraosWithZero := MkSeedTPraos(slot, eta0, zeroSeed)
+	praos := MkInputVrf(slot, eta0)
+	assert.Equal(t, praos, tpraosWithZero, "MkSeedTPraos with zero seed should equal MkInputVrf")
+
+	// MkSeedTPraos with SeedEta should differ from MkInputVrf
+	tpraosSeed := MkSeedTPraos(slot, eta0, SeedEta())
+	assert.NotEqual(t, praos, tpraosSeed, "TPraos seed should differ from CPraos input")
+
+	// MkSeedTPraos should be deterministic
+	tpraosSeed2 := MkSeedTPraos(slot, eta0, SeedEta())
+	assert.Equal(t, tpraosSeed, tpraosSeed2, "MkSeedTPraos not deterministic")
+
+	// Different seed constants should produce different results
+	tpraosL := MkSeedTPraos(slot, eta0, SeedL())
+	assert.NotEqual(t, tpraosSeed, tpraosL, "SeedEta and SeedL should produce different results")
+
+	// Verify SeedEta is blake2b-256 of uint64be(0)
+	seedEtaVal := SeedEta()
+	var uint64beBytes [8]byte
+	binary.BigEndian.PutUint64(uint64beBytes[:], 0)
+	expected := blake2b.Sum256(uint64beBytes[:])
+	assert.Equal(t, expected[:], seedEtaVal, "SeedEta should be blake2b-256(uint64be(0))")
+
+	// Verify XOR property: base XOR seed XOR seed = base
+	recovered := make([]byte, len(tpraosSeed))
+	for i := range tpraosSeed {
+		recovered[i] = tpraosSeed[i] ^ seedEtaVal[i]
+	}
+	assert.Equal(t, praos, recovered, "XOR inverse should recover base")
 }
 
 func TestProofToHash(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make VRF inputs era-aware and verify KES against the original header body CBOR to fix leader selection and block validation across TPraos (Shelley–Alonzo) and CPraos (Babbage+).

- **New Features**
  - Era-specific VRF: TPraos uses MkSeedTPraos with SeedL; CPraos keeps MkInputVrf. Exposes SeedEta/SeedL.
  - KES verification uses the stored original body CBOR; added extractOriginalBodyCbor and unified ExtractKesFields across Shelley–Conway and Leios.

- **Bug Fixes**
  - Rolling nonce now follows the Cardano Nonce semigroup: blake2b256(a||b) with NeutralNonce as identity.
  - Stricter validation and clearer errors: require 32-byte eta0; reject slot overflows; error on unknown consensus mode; explicit VRF/KES failure messages.

<sup>Written for commit abf097809fa8809d35b4e6cdabbc355bfa238866. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Era-aware VRF/KES validation with clearer, component-specific error reporting and KES verification against original header CBOR; explicit errors for slot overflow and unknown consensus mode.

* **New Features**
  * Preservation of original header CBOR for more header types.
  * TPraos-specific VRF seed utilities exposed.

* **Behavioral Changes**
  * Rolling nonce now uses semigroup composition with identity handling and stricter input validation.

* **Tests**
  * Added TPraos seed tests, rolling-nonce validation & error tests, and leader-check edge-case tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->