### PR TITLE
feat(cbor): LazyValue.MarshalJSON panics on empty CBOR data

### DIFF
--- a/cbor/value.go
+++ b/cbor/value.go
@@ -285,9 +285,19 @@ func (l *LazyValue) UnmarshalCBOR(data []byte) error {
 }
 
 func (l *LazyValue) MarshalJSON() ([]byte, error) {
+	if l.value == nil {
+		l.value = &Value{}
+	}
 	if l.Value() == nil && len(l.value.cborData) > 0 {
 		// Try to decode if we can, but don't blow up if we can't
-		_, _ = l.Decode()
+		if _, err := l.Decode(); err != nil {
+			tmpJsonObj := map[string]any{
+				"cbor":  hex.EncodeToString([]byte(l.value.cborData)),
+				"json":  nil,
+				"error": err.Error(),
+			}
+			return json.Marshal(tmpJsonObj)
+		}
 	}
 	return l.value.MarshalJSON()
 }

--- a/cbor/value_test.go
+++ b/cbor/value_test.go
@@ -293,3 +293,38 @@ func TestLazyValueMarshalJSON(t *testing.T) {
 		}
 	}
 }
+
+func TestLazyValueMarshalJSONEmptyCborData(t *testing.T) {
+	t.Run("zero value", func(t *testing.T) {
+		var tmpValue cbor.LazyValue
+		jsonData, err := json.Marshal(&tmpValue)
+		if err != nil {
+			t.Fatalf("failed to marshal LazyValue as JSON: %s", err)
+		}
+		if !test.JsonStringsEqual(jsonData, []byte(`{"cbor":""}`)) {
+			t.Fatalf(
+				"LazyValue did not marshal to expected JSON\n  got:    %s\n  wanted: %s",
+				jsonData,
+				`{"cbor":""}`,
+			)
+		}
+	})
+
+	t.Run("empty cbor after unmarshal", func(t *testing.T) {
+		var tmpValue cbor.LazyValue
+		if err := tmpValue.UnmarshalCBOR(nil); err != nil {
+			t.Fatalf("failed to unmarshal empty CBOR data: %s", err)
+		}
+		jsonData, err := json.Marshal(&tmpValue)
+		if err != nil {
+			t.Fatalf("failed to marshal LazyValue as JSON: %s", err)
+		}
+		if !test.JsonStringsEqual(jsonData, []byte(`{"cbor":""}`)) {
+			t.Fatalf(
+				"LazyValue did not marshal to expected JSON\n  got:    %s\n  wanted: %s",
+				jsonData,
+				`{"cbor":""}`,
+			)
+		}
+	})
+}


### PR DESCRIPTION
1. Made changes in LazyValue.MarshalJSON to prevent from panicking on zero-value or empty/nil CBOR input by safely initializing state and only decoding non-empty data.
2. Added a test with empty/nil CBOR data to ensure JSON output remains safe and stable for MarshalJSON.

Closes #1574 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LazyValue.MarshalJSON so zero-value and empty/nil CBOR no longer cause a panic. Empty input now returns stable JSON {"cbor":""}, and malformed data reports the decode error in the JSON.

- **Bug Fixes**
  - Initialize Value when nil and only decode when CBOR is non-empty; on decode failure, return JSON with hex cbor, json: null, and error.
  - Added tests for zero-value and empty CBOR to assert {"cbor":""} output.

<sup>Written for commit cbdca55f8ccc910ac045d8c5adde9c2045a7fd12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in CBOR-to-JSON conversion. Decoding errors now return diagnostic information including the original CBOR data and error messages, instead of being silently ignored. Improves visibility when debugging CBOR data issues.

* **Tests**
  * Added test coverage for JSON marshaling behavior with empty CBOR data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->