### PR TITLE
ci(benchmarks): support triggering by comment

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,43 +2,109 @@ name: Benchmarks
 
 on:
   push:
-    branches:
-      - main
-  workflow_dispatch:  # Allow manual triggering
-
-permissions:
-  contents: read
+    branches: [main]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
 
 jobs:
+  # Gate: verify the commenter has write access before running untrusted code
+  authorize:
+    name: authorize
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '/benchmark'))
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check commenter permission
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        with:
+          script: |
+            const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.payload.comment.user.login,
+            });
+            const allowed = ['admin', 'write'];
+            if (!allowed.includes(perm.permission)) {
+              core.setFailed(`User @${context.payload.comment.user.login} does not have write access`);
+              return;
+            }
+
+      - name: Add reaction to comment
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket'
+            });
+
+  # Run benchmarks with minimal permissions (untrusted PR code)
   benchmark:
     name: benchmark
+    needs: authorize
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      commit-sha: ${{ steps.checkout.outputs.commit }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
+        id: checkout
         with:
           fetch-depth: 0
           submodules: true
+          persist-credentials: false
+          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/merge', github.event.issue.number) || '' }}
 
-      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0 https://github.com/actions/setup-go/releases/tag/v6.2.0
+      - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0 https://github.com/actions/setup-go/releases/tag/v6.2.0
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Run benchmarks
-        run: |
-          set -o pipefail
-          go test -bench=. -benchmem -count=5 -timeout=30m -run='^$' \
-            ./vrf/... \
-            ./kes/... \
-            ./consensus/... \
-            ./cbor/... \
-            ./pipeline/... \
-            ./ledger/... \
-            ./internal/bench/... \
-            2>&1 | tee benchmark.txt
+        run: go test -run='^$' -bench=. -benchmem -count=3 -timeout=30m ./... 2>&1 | tee benchmark.txt
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0 https://github.com/actions/upload-artifact/releases/tag/v6.0.0
+        if: github.event_name == 'issue_comment'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
-          name: benchmark-${{ github.sha }}-${{ github.run_number }}
+          name: benchmark-results
           path: benchmark.txt
-          retention-days: 30
+
+  # Post results with write permissions (no untrusted code checkout)
+  post-results:
+    name: post-results
+    needs: benchmark
+    runs-on: ubuntu-latest
+    if: github.event_name == 'issue_comment'
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download benchmark results
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        with:
+          name: benchmark-results
+
+      - name: Post benchmark results
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const results = fs.readFileSync('benchmark.txt', 'utf8');
+            const truncated = results.length > 60000 ? results.substring(0, 60000) + '\n... (truncated)' : results;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: `## Benchmark Results\n\n<details>\n<summary>Click to expand</summary>\n\n\`\`\`\n${truncated}\n\`\`\`\n\n</details>\n\nCommit: ${{ needs.benchmark.outputs.commit-sha }}\nTriggered by: @${context.payload.comment.user.login}`
+            });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable secure, comment-triggered benchmark runs on PRs and post results back to the thread. Update Go to 1.25 and simplify the workflow.

- New Features
  - Trigger benchmarks with “/benchmark” in a PR comment; require write/admin on the commenter.
  - Add a rocket reaction and post results as an expandable PR comment (truncated at 60k).
  - Run against the PR’s merge ref.

- Refactors
  - Bump Go to 1.25.
  - Simplify command to ./... and reduce count to 3.
  - Split into authorize, benchmark (minimal perms), and post-results jobs.

<sup>Written for commit 46e2890c531ac1e7b3356df9e2ef3e3a701e1a79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manual benchmark triggering now available via workflow dispatch
  * Benchmarks can be triggered by commenting "/benchmark" on pull requests
  * Benchmark results are now posted as PR comments for easier review

* **Chores**
  * Updated to Go 1.25

<!-- end of auto-generated comment: release notes by coderabbit.ai -->