### PR TITLE
fix(protocol): correct max pending bytes, split n2n/n2c

### DIFF
--- a/protocol/PROTOCOL_LIMITS.md
+++ b/protocol/PROTOCOL_LIMITS.md
@@ -17,7 +17,7 @@ All limits are based on the [Ouroboros Network Specification](https://ouroboros-
 - `MaxRecvQueueSize = 100` - Maximum size of the receive message queue
 - `DefaultPipelineLimit = 50` - Conservative default for pipeline limit
 - `DefaultRecvQueueSize = 50` - Conservative default for receive queue size
-- `MaxPendingMessageBytes = 102400` - Maximum pending message bytes (100KB)
+- `MaxPendingMessageBytes = 462000` - NtN mux ingress buffer per spec Table 3.15 (462KB)
 
 **State timeout constants:**
 - `IdleTimeout = 60s` - Timeout for client to send next request

--- a/protocol/chainsync/chainsync.go
+++ b/protocol/chainsync/chainsync.go
@@ -132,31 +132,27 @@ var StateMapNtN = protocol.StateMap{
 	},
 }
 
-// StateMapNtC is the N2C ChainSync state machine with no timeouts per spec Table 3.9.
+// StateMapNtC is the N2C ChainSync state machine with no timeouts and no size
+// limits per spec Section 3.7.5: "There are no size-limits nor timeouts".
 var StateMapNtC = protocol.StateMap{
 	stateIdle: protocol.StateMapEntry{
-		Agency:                  protocol.AgencyClient,
-		PendingMessageByteLimit: MaxPendingMessageBytes,
-		Transitions:             idleTransitions,
+		Agency:      protocol.AgencyClient,
+		Transitions: idleTransitions,
 	},
 	stateCanAwait: protocol.StateMapEntry{
-		Agency:                  protocol.AgencyServer,
-		PendingMessageByteLimit: MaxPendingMessageBytes,
-		Transitions:             canAwaitTransitions,
+		Agency:      protocol.AgencyServer,
+		Transitions: canAwaitTransitions,
 	},
 	stateIntersect: protocol.StateMapEntry{
-		Agency:                  protocol.AgencyServer,
-		PendingMessageByteLimit: MaxPendingMessageBytes,
-		Transitions:             intersectTransitions,
+		Agency:      protocol.AgencyServer,
+		Transitions: intersectTransitions,
 	},
 	stateMustReply: protocol.StateMapEntry{
-		Agency:                  protocol.AgencyServer,
-		PendingMessageByteLimit: MaxPendingMessageBytes,
-		Transitions:             mustReplyTransitions,
+		Agency:      protocol.AgencyServer,
+		Transitions: mustReplyTransitions,
 	},
 	stateDone: protocol.StateMapEntry{
-		Agency:                  protocol.AgencyNone,
-		PendingMessageByteLimit: MaxPendingMessageBytes,
+		Agency: protocol.AgencyNone,
 	},
 }
 
@@ -202,7 +198,7 @@ const (
 	MaxRecvQueueSize            = 100    // Max receive queue size (messages)
 	DefaultPipelineLimit        = 75     // Default pipeline limit
 	DefaultRecvQueueSize        = 75     // Default queue size
-	MaxPendingMessageBytes      = 102400 // Max pending message bytes (100KB)
+	MaxPendingMessageBytes      = 462000 // NtN mux ingress buffer per spec Table 3.15 (462KB)
 	DefaultPipelineDrainTimeout = 30 * time.Second
 )
 

--- a/protocol/limits_test.go
+++ b/protocol/limits_test.go
@@ -87,7 +87,7 @@ func TestChainSyncLimitsAreDefined(t *testing.T) {
 			chainsync.MaxRecvQueueSize,
 		)
 	}
-	expectedMaxBytes := 102400
+	expectedMaxBytes := 462000
 	if chainsync.MaxPendingMessageBytes != expectedMaxBytes {
 		t.Errorf(
 			"MaxPendingMessageBytes should be %d, got %d",
@@ -821,6 +821,17 @@ func TestStateMapTimeouts(t *testing.T) {
 					state,
 				)
 			}
+		}
+	})
+
+	t.Run("ChainSync N2C StateMap has no byte limits", func(t *testing.T) {
+		for state, entry := range chainsync.StateMapNtC {
+			assert.Zero(
+				t,
+				entry.PendingMessageByteLimit,
+				"N2C state %s should have no byte limit (spec Section 3.7.5)",
+				state,
+			)
 		}
 	})
 

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -593,31 +593,58 @@ func (p *Protocol) readLoop() {
 		}
 		// Calculate message size
 		msgLen := len(msgData)
-		// Check pending recv bytes limit for current state
+		// Wait for pending recv bytes to drop below limit before accepting.
+		// This applies TCP backpressure to the remote peer instead of
+		// disconnecting with a protocol violation during rapid catch-up sync.
 		currentState := p.getCurrentState()
 		limit := 0
 		if entry, ok := p.config.StateMap[currentState]; ok {
 			limit = entry.PendingMessageByteLimit
 		}
-		p.pendingBytesMu.Lock()
-		if limit > 0 && p.pendingRecvBytes+msgLen > limit {
+		if limit > 0 {
+			// Fail fast if a single message exceeds the limit to prevent
+			// a livelock where the backpressure loop can never make progress.
+			if msgLen > limit {
+				p.SendError(
+					fmt.Errorf(
+						"%s: received oversized message (%d bytes) exceeding limit (%d bytes)",
+						p.config.Name,
+						msgLen,
+						limit,
+					),
+				)
+				return
+			}
+			for {
+				p.pendingBytesMu.Lock()
+				if p.pendingRecvBytes+msgLen <= limit {
+					p.pendingRecvBytes += msgLen
+					p.pendingRecvSizes = append(p.pendingRecvSizes, msgLen)
+					p.pendingBytesMu.Unlock()
+					break
+				}
+				p.pendingBytesMu.Unlock()
+				// Wait briefly for recvLoop to drain pending bytes
+				select {
+				case <-p.stopChan:
+					return
+				case <-p.muxerDoneChan:
+					return
+				case <-time.After(time.Millisecond):
+				}
+			}
+		} else {
+			p.pendingBytesMu.Lock()
+			p.pendingRecvBytes += msgLen
+			p.pendingRecvSizes = append(p.pendingRecvSizes, msgLen)
 			p.pendingBytesMu.Unlock()
-			p.SendError(ErrProtocolViolationQueueExceeded)
-			return
 		}
-		p.pendingRecvBytes += msgLen
-		p.pendingRecvSizes = append(p.pendingRecvSizes, msgLen)
-		p.pendingBytesMu.Unlock()
-		// Add message to receive queue
+		// Add message to receive queue (blocking with shutdown checks)
 		select {
 		case p.recvQueueChan <- msg:
-		default:
-			p.SendError(
-				fmt.Errorf(
-					"%s: received message queue limit exceeded",
-					p.config.Name,
-				),
-			)
+		case <-p.stopChan:
+			return
+		case <-p.muxerDoneChan:
 			return
 		}
 		if numBytesRead < readBuffer.Len() {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned protocol limits with the spec: set NtN pending message byte limit to 462KB and removed size/time limits for N2C. The reader now applies backpressure and blocks instead of disconnecting when the limit is reached.

- **Bug Fixes**
  - Set MaxPendingMessageBytes to 462000 for NtN (spec Table 3.15); updated docs and tests.
  - Split ChainSync state maps: NtN keeps limits/timeouts; NtC has none (spec §3.7.5).
  - readLoop now waits for pending bytes to drain, rejects single messages over the limit, and blocks queue writes with shutdown checks.
  - Added test to ensure N2C states have no byte limits.

<sup>Written for commit ab14d9200d79ae000e29ccc1fec823d6034098db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced message backpressure handling to gracefully delay acceptance during high load instead of immediate protocol violations.

* **Chores**
  * Increased per-connection message buffer capacity to 462 KB, aligning with specification requirements.
  * Simplified protocol behavior by removing per-state message byte limits for client connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->