### PR TITLE
feat(messagesubmission): add V2 state machine (CIP-0137 update)

### DIFF
--- a/protocol/messagesubmission/client.go
+++ b/protocol/messagesubmission/client.go
@@ -28,6 +28,7 @@ type Client struct {
 	*protocol.Protocol
 	config          *Config
 	callbackContext CallbackContext
+	protoVersion    uint16
 
 	// Client-side state for message ID tracking
 	lock              sync.Mutex
@@ -48,14 +49,27 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 	c := &Client{
 		config:            cfg,
 		pendingMessageIDs: [][]byte{},
+		protoVersion:      protoOptions.Version,
 	}
 	c.callbackContext = CallbackContext{
 		Client:       c,
 		ConnectionId: protoOptions.ConnectionId,
 	}
 
+	// Select state map and initial state based on negotiated version
+	isV2 := protoOptions.Version >= MessageSubmissionV2MinVersion
+	var baseStateMap protocol.StateMap
+	var initialState protocol.State
+	if isV2 {
+		baseStateMap = stateMapV2
+		initialState = protocolStateIdle
+	} else {
+		baseStateMap = stateMapV1
+		initialState = protocolStateInit
+	}
+
 	// Update state map with configurable timeouts
-	stateMapCopy := stateMap.Copy()
+	stateMapCopy := baseStateMap.Copy()
 	if entry, ok := stateMapCopy[protocolStateInit]; ok {
 		entry.Timeout = c.config.InitTimeout
 		stateMapCopy[protocolStateInit] = entry
@@ -90,7 +104,7 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 		MessageHandlerFunc:  c.messageHandler,
 		MessageFromCborFunc: NewMsgFromCbor,
 		StateMap:            stateMapCopy,
-		InitialState:        protocolStateInit,
+		InitialState:        initialState,
 	}
 	c.Protocol = protocol.New(protoConfig)
 	return c
@@ -109,9 +123,21 @@ func (c *Client) Start() {
 	})
 }
 
-// Stop transitions the protocol to the Done state
+// Stop transitions the protocol to the Done state.
+// In V1, the client sends MsgDone. In V2, only the server can send MsgDone;
+// the client-side Stop is a no-op.
 func (c *Client) Stop() error {
 	c.onceStop.Do(func() {
+		if c.protoVersion >= MessageSubmissionV2MinVersion {
+			// V2: client cannot send MsgDone; server controls termination
+			c.Protocol.Logger().
+				Debug("V2 client Stop() is a no-op; server sends MsgDone",
+					"component", "network",
+					"protocol", ProtocolName,
+					"connection_id", c.callbackContext.ConnectionId.String(),
+				)
+			return
+		}
 		c.Protocol.Logger().
 			Debug("stopping client protocol",
 				"component", "network",
@@ -124,8 +150,14 @@ func (c *Client) Stop() error {
 	return c.stopErr
 }
 
-// Init sends the initialization message to start the protocol
+// Init sends the initialization message to start the protocol.
+// This is only valid for V1; V2 starts directly in StIdle.
 func (c *Client) Init() error {
+	if c.protoVersion >= MessageSubmissionV2MinVersion {
+		return errors.New(
+			"Init is not supported in MessageSubmission V2; protocol starts in StIdle",
+		)
+	}
 	msg := NewMsgInit()
 	if err := c.SendMessage(msg); err != nil {
 		return err

--- a/protocol/messagesubmission/messagesubmission.go
+++ b/protocol/messagesubmission/messagesubmission.go
@@ -64,7 +64,15 @@ var (
 		"messages",
 	)
 	protocolStateDone = protocol.NewState(stateDoneId, "done")
-	stateMap          = protocol.StateMap{
+
+	// MessageSubmissionV2MinVersion is the minimum NtN protocol version
+	// that uses Message Submission V2 (no StInit, MsgDone only from StIdle).
+	MessageSubmissionV2MinVersion uint16 = 15
+
+	// stateMapV1 is the V1 state map (CIP-0137 original).
+	// Includes StInit; MsgDone can be sent by client from
+	// StMessageIdsBlocking / StMessageIdsNonBlocking, or by server from StIdle.
+	stateMapV1 = protocol.StateMap{
 		protocolStateInit: protocol.StateMapEntry{
 			Agency:                  protocol.AgencyClient,
 			PendingMessageByteLimit: 0,
@@ -134,6 +142,80 @@ var (
 				{
 					MsgType:  MessageTypeDone,
 					NewState: protocolStateDone,
+				},
+			},
+		},
+		protocolStateMessages: protocol.StateMapEntry{
+			Agency:                  protocol.AgencyClient,
+			PendingMessageByteLimit: 0,
+			Timeout:                 MessagesTimeout,
+			Transitions: []protocol.StateTransition{
+				{
+					MsgType:  MessageTypeReplyMessages,
+					NewState: protocolStateIdle,
+				},
+			},
+		},
+		protocolStateDone: protocol.StateMapEntry{
+			Agency:                  protocol.AgencyNone,
+			PendingMessageByteLimit: 0,
+		},
+	}
+
+	// stateMapV2 is the V2 state map (CIP-0137 V2).
+	// No StInit state; protocol starts directly in StIdle.
+	// MsgDone can only be sent by the server (inbound side) from StIdle.
+	stateMapV2 = protocol.StateMap{
+		protocolStateIdle: protocol.StateMapEntry{
+			Agency:                  protocol.AgencyServer,
+			PendingMessageByteLimit: 0,
+			Timeout:                 IdleTimeout,
+			Transitions: []protocol.StateTransition{
+				{
+					MsgType:  MessageTypeRequestMessageIds,
+					NewState: protocolStateMessageIdsBlock,
+					MatchFunc: func(_ any, msg protocol.Message) bool {
+						msgReq := msg.(*MsgRequestMessageIds)
+						return msgReq.IsBlocking
+					},
+				},
+				{
+					MsgType:  MessageTypeRequestMessageIds,
+					NewState: protocolStateMessageIdsNonBlk,
+					MatchFunc: func(_ any, msg protocol.Message) bool {
+						msgReq := msg.(*MsgRequestMessageIds)
+						return !msgReq.IsBlocking
+					},
+				},
+				{
+					MsgType:  MessageTypeRequestMessages,
+					NewState: protocolStateMessages,
+				},
+				{
+					MsgType:  MessageTypeDone,
+					NewState: protocolStateDone,
+				},
+			},
+		},
+		protocolStateMessageIdsBlock: protocol.StateMapEntry{
+			Agency:                  protocol.AgencyClient,
+			PendingMessageByteLimit: 0,
+			Timeout:                 MessageIdsBlockingTimeout,
+			Transitions: []protocol.StateTransition{
+				{
+					MsgType:  MessageTypeReplyMessageIds,
+					NewState: protocolStateIdle,
+				},
+			},
+		},
+		protocolStateMessageIdsNonBlk: protocol.StateMapEntry{
+			Agency:                  protocol.AgencyClient,
+			PendingMessageByteLimit: 0,
+			Timeout:                 MessageIdsNonblockingTimeout,
+			Transitions: []protocol.StateTransition{
+				{
+					MsgType:  MessageTypeReplyMessageIds,
+					NewState: protocolStateIdle,
 				},
 			},
 		},

--- a/protocol/messagesubmission/messagesubmission_v2_test.go
+++ b/protocol/messagesubmission/messagesubmission_v2_test.go
@@ -1,0 +1,211 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messagesubmission
+
+import (
+	"net"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- V2 state map structure tests ---
+
+func TestV2StateMapHasNoInitState(t *testing.T) {
+	_, hasInit := stateMapV2[protocolStateInit]
+	assert.False(t, hasInit, "V2 state map must not contain StInit")
+}
+
+func TestV2StateMapStartsInIdle(t *testing.T) {
+	_, hasIdle := stateMapV2[protocolStateIdle]
+	assert.True(t, hasIdle, "V2 state map must contain StIdle")
+
+	entry := stateMapV2[protocolStateIdle]
+	assert.Equal(
+		t,
+		protocol.AgencyServer,
+		entry.Agency,
+		"StIdle agency must be Server in V2",
+	)
+}
+
+func TestV2StateMapMsgDoneOnlyFromIdle(t *testing.T) {
+	// StIdle should have a MsgDone transition
+	idleEntry := stateMapV2[protocolStateIdle]
+	hasDoneFromIdle := false
+	for _, tr := range idleEntry.Transitions {
+		if tr.MsgType == MessageTypeDone {
+			hasDoneFromIdle = true
+			assert.Equal(
+				t,
+				protocolStateDone,
+				tr.NewState,
+				"MsgDone from StIdle must transition to StDone",
+			)
+		}
+	}
+	assert.True(t, hasDoneFromIdle, "StIdle must have a MsgDone transition in V2")
+
+	// StMessageIdsBlocking must NOT have MsgDone
+	blockEntry := stateMapV2[protocolStateMessageIdsBlock]
+	for _, tr := range blockEntry.Transitions {
+		assert.NotEqual(
+			t,
+			uint(MessageTypeDone),
+			tr.MsgType,
+			"StMessageIdsBlocking must not have MsgDone in V2",
+		)
+	}
+
+	// StMessageIdsNonBlocking must NOT have MsgDone
+	nonBlockEntry := stateMapV2[protocolStateMessageIdsNonBlk]
+	for _, tr := range nonBlockEntry.Transitions {
+		assert.NotEqual(
+			t,
+			uint(MessageTypeDone),
+			tr.MsgType,
+			"StMessageIdsNonBlocking must not have MsgDone in V2",
+		)
+	}
+}
+
+func TestV2StateMapDoneHasNoAgency(t *testing.T) {
+	doneEntry := stateMapV2[protocolStateDone]
+	assert.Equal(
+		t,
+		protocol.AgencyNone,
+		doneEntry.Agency,
+		"StDone must have AgencyNone in V2",
+	)
+}
+
+// --- V1 state map backward-compatibility tests ---
+
+func TestV1StateMapHasInitState(t *testing.T) {
+	entry, hasInit := stateMapV1[protocolStateInit]
+	assert.True(t, hasInit, "V1 state map must contain StInit")
+	assert.Equal(
+		t,
+		protocol.AgencyClient,
+		entry.Agency,
+		"StInit agency must be Client in V1",
+	)
+}
+
+func TestV1StateMapMsgDoneFromBlockingAndNonBlocking(t *testing.T) {
+	// StMessageIdsBlocking should have MsgDone
+	blockEntry := stateMapV1[protocolStateMessageIdsBlock]
+	hasDone := false
+	for _, tr := range blockEntry.Transitions {
+		if tr.MsgType == MessageTypeDone {
+			hasDone = true
+		}
+	}
+	assert.True(t, hasDone, "V1 StMessageIdsBlocking must have MsgDone transition")
+
+	// StMessageIdsNonBlocking should have MsgDone
+	nonBlockEntry := stateMapV1[protocolStateMessageIdsNonBlk]
+	hasDone = false
+	for _, tr := range nonBlockEntry.Transitions {
+		if tr.MsgType == MessageTypeDone {
+			hasDone = true
+		}
+	}
+	assert.True(t, hasDone, "V1 StMessageIdsNonBlocking must have MsgDone transition")
+}
+
+// --- V2 client behavior tests ---
+
+func newTestProtoOptions(version uint16) protocol.ProtocolOptions {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	return protocol.ProtocolOptions{
+		ConnectionId: connId,
+		Version:      version,
+	}
+}
+
+func TestV2ClientInitReturnsError(t *testing.T) {
+	cfg := NewConfig()
+	c := NewClient(newTestProtoOptions(MessageSubmissionV2MinVersion), &cfg)
+	err := c.Init()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported in MessageSubmission V2")
+}
+
+func TestV1ClientInitNoError(t *testing.T) {
+	cfg := NewConfig()
+	// Version 14 < V2 threshold → V1
+	c := NewClient(newTestProtoOptions(14), &cfg)
+	// Verify the V2 guard does NOT fire for V1 clients.
+	// We cannot call Init() end-to-end here because SendMessage requires
+	// a running muxer. Instead, confirm the version is below the V2 threshold.
+	assert.Less(
+		t,
+		c.protoVersion,
+		MessageSubmissionV2MinVersion,
+		"V1 client protoVersion must be below V2 threshold",
+	)
+}
+
+func TestV2ClientStopIsNoop(t *testing.T) {
+	cfg := NewConfig()
+	c := NewClient(newTestProtoOptions(MessageSubmissionV2MinVersion), &cfg)
+	// Stop should be a no-op in V2 (no MsgDone sent)
+	err := c.Stop()
+	assert.NoError(t, err, "V2 client Stop() must succeed as a no-op")
+	// Calling Stop again should also be fine
+	err = c.Stop()
+	assert.NoError(t, err)
+}
+
+// --- V2 version selection tests ---
+
+func TestV2VersionSelectsCorrectStateMap(t *testing.T) {
+	cfg := NewConfig()
+
+	// V1 client (version 14)
+	v1Client := NewClient(newTestProtoOptions(14), &cfg)
+	assert.Equal(t, uint16(14), v1Client.protoVersion)
+
+	// V2 client (version 15)
+	v2Client := NewClient(newTestProtoOptions(MessageSubmissionV2MinVersion), &cfg)
+	assert.Equal(t, MessageSubmissionV2MinVersion, v2Client.protoVersion)
+
+	// V1 server (version 14)
+	v1Server := NewServer(newTestProtoOptions(14), &cfg)
+	assert.Equal(t, uint16(14), v1Server.protoVersion)
+
+	// V2 server (version 15)
+	v2Server := NewServer(newTestProtoOptions(MessageSubmissionV2MinVersion), &cfg)
+	assert.Equal(t, MessageSubmissionV2MinVersion, v2Server.protoVersion)
+}
+
+func TestVersionZeroDefaultsToV1(t *testing.T) {
+	cfg := NewConfig()
+	c := NewClient(newTestProtoOptions(0), &cfg)
+	// Version 0 < 15 → should use V1 (Init guard should not fire)
+	assert.Less(
+		t,
+		c.protoVersion,
+		MessageSubmissionV2MinVersion,
+		"version 0 should default to V1",
+	)
+}

--- a/protocol/messagesubmission/server.go
+++ b/protocol/messagesubmission/server.go
@@ -29,6 +29,7 @@ type Server struct {
 	*protocol.Protocol
 	config          *Config
 	callbackContext CallbackContext
+	protoVersion    uint16
 
 	// Server-side state for message queue management
 	lock              sync.Mutex
@@ -47,11 +48,25 @@ func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 		config:            cfg,
 		messageQueue:      make([]*pcommon.DmqMessage, 0),
 		pendingMessageIDs: [][]byte{},
+		protoVersion:      protoOptions.Version,
 	}
 	s.callbackContext = CallbackContext{
 		Server:       s,
 		ConnectionId: protoOptions.ConnectionId,
 	}
+
+	// Select state map and initial state based on negotiated version
+	isV2 := protoOptions.Version >= MessageSubmissionV2MinVersion
+	var baseStateMap protocol.StateMap
+	var initialState protocol.State
+	if isV2 {
+		baseStateMap = stateMapV2
+		initialState = protocolStateIdle
+	} else {
+		baseStateMap = stateMapV1
+		initialState = protocolStateInit
+	}
+
 	protoConfig := protocol.ProtocolConfig{
 		Name:                ProtocolName,
 		ProtocolId:          ProtocolID,
@@ -62,8 +77,8 @@ func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 		Role:                protocol.ProtocolRoleServer,
 		MessageHandlerFunc:  s.messageHandler,
 		MessageFromCborFunc: NewMsgFromCbor,
-		StateMap:            stateMap,
-		InitialState:        protocolStateInit,
+		StateMap:            baseStateMap,
+		InitialState:        initialState,
 	}
 	s.Protocol = protocol.New(protoConfig)
 	return s
@@ -193,6 +208,14 @@ func (s *Server) RequestMessageIdsNonBlocking(
 // RequestMessages sends a request for specific messages by their IDs
 func (s *Server) RequestMessages(messageIDs [][]byte) error {
 	msg := NewMsgRequestMessages(messageIDs)
+	return s.SendMessage(msg)
+}
+
+// Done sends MsgDone to terminate the protocol from the server side.
+// In V1, this can be sent from StIdle. In V2, this is the only way
+// to end the protocol (the client cannot send MsgDone).
+func (s *Server) Done() error {
+	msg := NewMsgDone()
 	return s.SendMessage(msg)
 }
 


### PR DESCRIPTION
closes #1618 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Message Submission V2 (CIP-0137) with version-gated state machines and server-controlled termination, while preserving V1 behavior. V2 starts in Idle, removes Init, and only the server can send Done.

- **New Features**
  - Introduced `stateMapV1` and `stateMapV2`; V2 starts in `StIdle` (no `StInit`), and only the server can send `MsgDone` from `StIdle`.
  - Version-gated selection via `MessageSubmissionV2MinVersion` (15) on both client and server; version 0 defaults to V1.
  - Client: `Init()` errors and `Stop()` is a no-op in V2. Server: added `Done()` to send `MsgDone`.
  - Added `messagesubmission_v2_test.go` covering V2 structure, client/server version selection, and V1 compatibility.

- **Migration**
  - No changes for V1 peers.
  - For V2: do not call `Client.Init()`; terminate via `Server.Done()`.

<sup>Written for commit e54f796efaed52d1375109814733666c19a21438. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added protocol version support with V1 and V2 variants.
  * V2 protocol eliminates the initialization step and starts directly in an idle state.
  * Added server-side method for protocol termination.

* **Bug Fixes / Improvements**
  * V2 restricts message completion signals to server-side only, improving protocol efficiency.

* **Tests**
  * Added comprehensive test suite validating version-specific state behavior and backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->