### PR TITLE
feat: increase taylor series term count

### DIFF
--- a/consensus/threshold.go
+++ b/consensus/threshold.go
@@ -57,11 +57,6 @@ var twoTo256 = new(big.Int).Exp(big.NewInt(2), big.NewInt(vrfOutputBitsCPraos), 
 // it as a read-only constant. Create new big.Int instances for calculations.
 var twoTo512 = new(big.Int).Exp(big.NewInt(2), big.NewInt(vrfOutputBitsTPraos), nil)
 
-// oneRat is the constant 1/1 for reuse in calculations.
-// WARNING: This package-level big.Rat value must not be mutated. Always use
-// it as a read-only constant. Create new big.Rat instances for calculations.
-var oneRat = big.NewRat(1, 1)
-
 // CertifiedNatThreshold computes the leadership threshold for a pool using CPRAOS.
 // For TPraos compatibility, use CertifiedNatThresholdWithMode.
 //
@@ -214,26 +209,6 @@ func expFloat(x *big.Float) *big.Float {
 	}
 
 	return result
-}
-
-// lnOneMinus computes ln(1-x) for 0 < x < 1 using Taylor series.
-// This is a convenience wrapper around lnOneMinusFloat that accepts
-// and returns big.Rat for backward compatibility with tests.
-func lnOneMinus(x *big.Rat) *big.Rat {
-	xf := new(big.Float).SetPrec(thresholdPrecision).SetRat(x)
-	result := lnOneMinusFloat(xf)
-	rat, _ := result.Rat(nil)
-	return rat
-}
-
-// expRational computes exp(x) for a rational x using Taylor series.
-// This is a convenience wrapper around expFloat that accepts and
-// returns big.Rat for backward compatibility with tests.
-func expRational(x *big.Rat) *big.Rat {
-	xf := new(big.Float).SetPrec(thresholdPrecision).SetRat(x)
-	result := expFloat(xf)
-	rat, _ := result.Rat(nil)
-	return rat
 }
 
 // VrfLeaderValue computes the CPRAOS leader value from a VRF output.

--- a/consensus/threshold.go
+++ b/consensus/threshold.go
@@ -150,8 +150,9 @@ func CertifiedNatThresholdWithMode(
 // active slot coefficient range (typically 0.05).
 func lnOneMinus(x *big.Rat) *big.Rat {
 	// Number of terms to compute (more terms = more precision)
-	// 20 terms provides sufficient precision for Cardano's f=0.05
-	const terms = 20
+	// 100 terms provides sufficient precision for active slot coefficients
+	// up to f=0.5 and beyond, where 20 terms would not converge.
+	const terms = 100
 
 	result := new(big.Rat)
 	xPower := new(big.Rat).Set(x) // x^n starting with x^1
@@ -175,8 +176,9 @@ func lnOneMinus(x *big.Rat) *big.Rat {
 // exp(x) = 1 + x + x²/2! + x³/3! + x⁴/4! + ...
 func expRational(x *big.Rat) *big.Rat {
 	// Number of terms to compute
-	// 20 terms provides sufficient precision for Cardano's typical values
-	const terms = 20
+	// 100 terms provides sufficient precision for active slot coefficients
+	// up to f=0.5 and beyond, where 20 terms would not converge.
+	const terms = 100
 
 	result := new(big.Rat).Set(oneRat) // Start with 1
 	term := new(big.Rat).Set(oneRat)   // Current term (x^n / n!)

--- a/consensus/threshold.go
+++ b/consensus/threshold.go
@@ -41,6 +41,12 @@ const (
 	vrfOutputBitsTPraos = 512
 )
 
+// thresholdPrecision is the number of mantissa bits used for big.Float
+// arithmetic in the Taylor series computation. 1024 bits provides ~308
+// decimal digits of precision, far exceeding the ~77 digits needed for
+// a 256-bit threshold result.
+const thresholdPrecision = 1024
+
 // twoTo256 is 2^256, the upper bound for CPRAOS leader value comparison.
 // WARNING: These package-level big.Int values must not be mutated. Always use
 // them as read-only constants. Create new big.Int instances for calculations.
@@ -110,23 +116,30 @@ func CertifiedNatThresholdWithMode(
 		poolStake = totalStake
 	}
 
-	// Calculate σ = poolStake / totalStake as a rational
-	sigma := new(big.Rat).SetFrac(
-		new(big.Int).SetUint64(poolStake),
-		new(big.Int).SetUint64(totalStake),
+	const prec = thresholdPrecision
+
+	// Calculate σ = poolStake / totalStake as a big.Float
+	sigma := new(big.Float).SetPrec(prec).Quo(
+		new(big.Float).SetPrec(prec).SetUint64(poolStake),
+		new(big.Float).SetPrec(prec).SetUint64(totalStake),
 	)
 
 	// Calculate (1-f)^σ using the approximation:
 	// (1-f)^σ ≈ exp(σ * ln(1-f))
 	//
-	// For the Cardano implementation, we use a Taylor series expansion
-	// of ln(1-f) and exp to achieve sufficient precision.
-	oneMinusFPowerSigma := expRational(
-		new(big.Rat).Mul(sigma, lnOneMinus(activeSlotCoeff)),
-	)
+	// We use big.Float internally to avoid the O(n²) GCD normalization
+	// cost of big.Rat arithmetic over 100 Taylor series terms.
+	f := new(big.Float).SetPrec(prec).SetRat(activeSlotCoeff)
+	lnVal := lnOneMinusFloat(f)
+	product := new(big.Float).SetPrec(prec).Mul(sigma, lnVal)
+	oneMinusFPowerSigma := expFloat(product)
 
 	// Calculate 1 - (1-f)^σ
-	probability := new(big.Rat).Sub(oneRat, oneMinusFPowerSigma)
+	one := new(big.Float).SetPrec(prec).SetInt64(1)
+	probability := new(big.Float).SetPrec(prec).Sub(
+		one,
+		oneMinusFPowerSigma,
+	)
 
 	// Select the appropriate upper bound based on consensus mode
 	var upperBound *big.Int
@@ -137,64 +150,90 @@ func CertifiedNatThresholdWithMode(
 	}
 
 	// threshold = floor(probability * upperBound)
-	threshold := new(big.Int).Mul(probability.Num(), upperBound)
-	threshold.Div(threshold, probability.Denom())
+	upperBoundFloat := new(big.Float).SetPrec(prec).SetInt(upperBound)
+	thresholdFloat := new(big.Float).SetPrec(prec).Mul(
+		probability,
+		upperBoundFloat,
+	)
+	threshold, _ := thresholdFloat.Int(nil)
 
 	return threshold
 }
 
-// lnOneMinus computes ln(1-x) for 0 < x < 1 using Taylor series:
+// lnOneMinusFloat computes ln(1-x) for 0 < x < 1 using Taylor series:
 // ln(1-x) = -x - x²/2 - x³/3 - x⁴/4 - ...
 //
-// We use enough terms to achieve the required precision for Cardano's
-// active slot coefficient range (typically 0.05).
-func lnOneMinus(x *big.Rat) *big.Rat {
-	// Number of terms to compute (more terms = more precision)
-	// 100 terms provides sufficient precision for active slot coefficients
-	// up to f=0.5 and beyond, where 20 terms would not converge.
+// Uses big.Float arithmetic with fixed precision to avoid the expensive
+// GCD normalization that big.Rat incurs on every operation.
+// 100 terms provides sufficient precision for active slot coefficients
+// up to f=0.5 and beyond.
+func lnOneMinusFloat(x *big.Float) *big.Float {
 	const terms = 100
 
-	result := new(big.Rat)
-	xPower := new(big.Rat).Set(x) // x^n starting with x^1
-	term := new(big.Rat)
-	denom := new(big.Rat)
+	prec := x.Prec()
+	result := new(big.Float).SetPrec(prec)
+	xPower := new(big.Float).SetPrec(prec).Set(x) // x^n, starts at x^1
+	term := new(big.Float).SetPrec(prec)
+	nFloat := new(big.Float).SetPrec(prec)
 
 	for n := 1; n <= terms; n++ {
-		// Add -x^n / n to result
-		denom.SetFrac64(int64(n), 1)
-		term.Quo(xPower, denom)
+		// term = xPower / n
+		nFloat.SetInt64(int64(n))
+		term.Quo(xPower, nFloat)
+		// result -= term
 		result.Sub(result, term)
-
-		// xPower = xPower * x for next iteration
+		// xPower *= x for next iteration
 		xPower.Mul(xPower, x)
 	}
 
 	return result
 }
 
-// expRational computes exp(x) for a rational x using Taylor series:
+// expFloat computes exp(x) for a big.Float x using Taylor series:
 // exp(x) = 1 + x + x²/2! + x³/3! + x⁴/4! + ...
-func expRational(x *big.Rat) *big.Rat {
-	// Number of terms to compute
-	// 100 terms provides sufficient precision for active slot coefficients
-	// up to f=0.5 and beyond, where 20 terms would not converge.
+//
+// Uses big.Float arithmetic with fixed precision for efficiency.
+// 100 terms provides sufficient precision for active slot coefficients
+// up to f=0.5 and beyond.
+func expFloat(x *big.Float) *big.Float {
 	const terms = 100
 
-	result := new(big.Rat).Set(oneRat) // Start with 1
-	term := new(big.Rat).Set(oneRat)   // Current term (x^n / n!)
-	denom := new(big.Rat)
+	prec := x.Prec()
+	one := new(big.Float).SetPrec(prec).SetInt64(1)
+	result := new(big.Float).SetPrec(prec).Set(one) // Start with 1
+	term := new(big.Float).SetPrec(prec).Set(one)   // x^n / n!
+	nFloat := new(big.Float).SetPrec(prec)
 
 	for n := 1; n <= terms; n++ {
 		// term = term * x / n
 		term.Mul(term, x)
-		denom.SetFrac64(int64(n), 1)
-		term.Quo(term, denom)
-
-		// Add term to result
+		nFloat.SetInt64(int64(n))
+		term.Quo(term, nFloat)
+		// result += term
 		result.Add(result, term)
 	}
 
 	return result
+}
+
+// lnOneMinus computes ln(1-x) for 0 < x < 1 using Taylor series.
+// This is a convenience wrapper around lnOneMinusFloat that accepts
+// and returns big.Rat for backward compatibility with tests.
+func lnOneMinus(x *big.Rat) *big.Rat {
+	xf := new(big.Float).SetPrec(thresholdPrecision).SetRat(x)
+	result := lnOneMinusFloat(xf)
+	rat, _ := result.Rat(nil)
+	return rat
+}
+
+// expRational computes exp(x) for a rational x using Taylor series.
+// This is a convenience wrapper around expFloat that accepts and
+// returns big.Rat for backward compatibility with tests.
+func expRational(x *big.Rat) *big.Rat {
+	xf := new(big.Float).SetPrec(thresholdPrecision).SetRat(x)
+	result := expFloat(xf)
+	rat, _ := result.Rat(nil)
+	return rat
 }
 
 // VrfLeaderValue computes the CPRAOS leader value from a VRF output.

--- a/consensus/threshold_test.go
+++ b/consensus/threshold_test.go
@@ -964,9 +964,7 @@ func TestLnOneMinusConvergence(t *testing.T) {
 	result := lnOneMinus(x)
 
 	// Convert to float64 for approximate comparison
-	numF, _ := result.Num().Float64()
-	denF, _ := result.Denom().Float64()
-	approx := numF / denF
+	approx, _ := result.Float64()
 
 	// ln(0.5) ≈ -0.693147180559945...
 	// With 100 terms the relative error should be negligible

--- a/consensus/threshold_test.go
+++ b/consensus/threshold_test.go
@@ -842,3 +842,134 @@ func TestCPRAOSHighStakeIncreasesEligibility(t *testing.T) {
 			highStakeEligible, lowStakeEligible)
 	}
 }
+
+// TestThresholdAccuracyFullStake verifies the threshold computation against
+// known exact values for various active slot coefficients.
+func TestThresholdAccuracyFullStake(t *testing.T) {
+	testCases := []struct {
+		name string
+		f    *big.Rat
+	}{
+		{"f=0.05", big.NewRat(1, 20)},
+		{"f=0.1", big.NewRat(1, 10)},
+		{"f=0.25", big.NewRat(1, 4)},
+		{"f=0.5", big.NewRat(1, 2)},
+	}
+
+	totalStake := uint64(1_000_000_000)
+	poolStake := totalStake // σ = 1
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			threshold := CertifiedNatThreshold(
+				poolStake,
+				totalStake,
+				tc.f,
+			)
+
+			// Exact expected value: floor(2^256 * f)
+			expected := new(big.Int).Mul(twoTo256, tc.f.Num())
+			expected.Div(expected, tc.f.Denom())
+
+			require.True(t, threshold.Sign() > 0,
+				"threshold must be positive")
+			require.True(t, threshold.Cmp(twoTo256) < 0,
+				"threshold must be less than 2^256")
+
+			// Compute absolute difference
+			diff := new(big.Int).Sub(threshold, expected)
+			diff.Abs(diff)
+
+			// Relative error must be < 10^-20
+			// Equivalently: diff * 10^20 < expected
+			scale := new(big.Int).Exp(
+				big.NewInt(10),
+				big.NewInt(20),
+				nil,
+			)
+			scaledDiff := new(big.Int).Mul(diff, scale)
+
+			require.True(t, scaledDiff.Cmp(expected) < 0,
+				"relative error too large for %s: diff=%s, expected=%s",
+				tc.name, diff.String(), expected.String())
+		})
+	}
+}
+
+// TestThresholdAccuracyPartialStake verifies the threshold computation for
+// partial stake with higher active slot coefficients, which stress the
+// Taylor series convergence.
+//
+// For σ=0.5 and f=0.5:
+//
+//	T = 2^256 * (1 - (1-0.5)^0.5) = 2^256 * (1 - 1/√2) ≈ 2^256 * 0.29289...
+//
+// We verify the result is in the correct range and that increasing f
+// increases the threshold monotonically.
+func TestThresholdAccuracyPartialStake(t *testing.T) {
+	totalStake := uint64(1_000_000_000)
+	poolStake := uint64(500_000_000) // σ = 0.5
+
+	fValues := []*big.Rat{
+		big.NewRat(1, 20), // f=0.05
+		big.NewRat(1, 10), // f=0.1
+		big.NewRat(1, 4),  // f=0.25
+		big.NewRat(1, 2),  // f=0.5
+	}
+
+	var prevThreshold *big.Int
+	for _, f := range fValues {
+		threshold := CertifiedNatThreshold(poolStake, totalStake, f)
+
+		require.True(t, threshold.Sign() > 0,
+			"threshold must be positive for f=%s", f.RatString())
+		require.True(t, threshold.Cmp(twoTo256) < 0,
+			"threshold must be < 2^256 for f=%s", f.RatString())
+
+		if prevThreshold != nil {
+			require.True(t, threshold.Cmp(prevThreshold) > 0,
+				"threshold should increase with f: f=%s",
+				f.RatString())
+		}
+		prevThreshold = new(big.Int).Set(threshold)
+	}
+
+	// Verify f=0.5 with σ=0.5 produces a threshold approximately
+	// equal to 2^256 * (1 - 1/√2) ≈ 2^256 * 0.29289...
+	//
+	// We check: 0.29 * 2^256 < threshold < 0.30 * 2^256
+	thresholdF05 := CertifiedNatThreshold(
+		poolStake,
+		totalStake,
+		big.NewRat(1, 2),
+	)
+	lowerBound := new(big.Int).Mul(twoTo256, big.NewInt(29))
+	lowerBound.Div(lowerBound, big.NewInt(100))
+	upperBound := new(big.Int).Mul(twoTo256, big.NewInt(30))
+	upperBound.Div(upperBound, big.NewInt(100))
+
+	require.True(t, thresholdF05.Cmp(lowerBound) > 0,
+		"f=0.5, σ=0.5 threshold too low: got %s, want > %s",
+		thresholdF05.String(), lowerBound.String())
+	require.True(t, thresholdF05.Cmp(upperBound) < 0,
+		"f=0.5, σ=0.5 threshold too high: got %s, want < %s",
+		thresholdF05.String(), upperBound.String())
+}
+
+// TestLnOneMinusConvergence verifies that lnOneMinus converges for x=0.5,
+// which is the boundary case that required increasing the term count.
+func TestLnOneMinusConvergence(t *testing.T) {
+	// ln(1-0.5) = ln(0.5) = -0.693147...
+	x := big.NewRat(1, 2)
+	result := lnOneMinus(x)
+
+	// Convert to float64 for approximate comparison
+	numF, _ := result.Num().Float64()
+	denF, _ := result.Denom().Float64()
+	approx := numF / denF
+
+	// ln(0.5) ≈ -0.693147180559945...
+	// With 100 terms the relative error should be negligible
+	require.InDelta(t, -0.693147180559945, approx, 1e-10,
+		"lnOneMinus(0.5) should be approximately ln(0.5)")
+}

--- a/consensus/threshold_test.go
+++ b/consensus/threshold_test.go
@@ -23,6 +23,24 @@ import (
 	"golang.org/x/crypto/blake2b"
 )
 
+// lnOneMinus computes ln(1-x) for 0 < x < 1 using Taylor series.
+// Test helper wrapping lnOneMinusFloat with big.Rat conversion.
+func lnOneMinus(x *big.Rat) *big.Rat {
+	xf := new(big.Float).SetPrec(thresholdPrecision).SetRat(x)
+	result := lnOneMinusFloat(xf)
+	rat, _ := result.Rat(nil)
+	return rat
+}
+
+// expRational computes exp(x) for a rational x using Taylor series.
+// Test helper wrapping expFloat with big.Rat conversion.
+func expRational(x *big.Rat) *big.Rat {
+	xf := new(big.Float).SetPrec(thresholdPrecision).SetRat(x)
+	result := expFloat(xf)
+	rat, _ := result.Rat(nil)
+	return rat
+}
+
 func TestCertifiedNatThresholdZeroStake(t *testing.T) {
 	activeSlotCoeff := big.NewRat(1, 20) // 0.05
 


### PR DESCRIPTION
closes #1578 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase Taylor series terms to 100 and switch internal math to `big.Float` with 1024-bit precision to ensure convergence and accurate CPRAOS/TPraos thresholds up to f≈0.5+. Also speeds up threshold computation by avoiding `big.Rat` GCDs and using float multiply/floor.

- **Refactors**
  - Use `big.Float` (via `thresholdPrecision`=1024 bits) for σ, ln(1−f), and exp; raise series terms to 100 and remove production `big.Rat` helpers (tests keep thin wrappers).
  - Compute threshold as floor(probability × upperBound) with `big.Float`; faster by avoiding `big.Rat` normalization.

- **Bug Fixes**
  - Accurate thresholds for σ=1 across f={0.05, 0.1, 0.25, 0.5} with <1e-20 relative error.
  - Monotonic thresholds for σ=0.5 and correct range at f=0.5; verified ln(1−0.5) convergence.

<sup>Written for commit 7c1caa0bde41c9bcc24dcf5d0575753bf5ccdd88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved numerical precision in consensus threshold calculations by optimizing internal mathematical computations.

* **Tests**
  * Added comprehensive accuracy tests for threshold computation with full and partial stake scenarios, including convergence validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->