### PR TITLE
fix(ledger): aux data decode ignores unknown keys

### DIFF
--- a/ledger/common/metadata.go
+++ b/ledger/common/metadata.go
@@ -670,14 +670,12 @@ func DecodeAuxiliaryDataToMetadata(raw []byte) (TransactionMetadatum, error) {
 		if metadataRaw, ok := decodeAuxiliaryMetadataOnly(taggedContent); ok {
 			return DecodeMetadatumRaw(metadataRaw)
 		}
-		var auxMap struct {
-			Metadata cbor.RawMessage `cbor:"0,keyasint,omitempty"`
-		}
+		var auxMap map[uint]cbor.RawMessage
 		if _, err := cbor.Decode(taggedContent, &auxMap); err != nil {
 			return nil, err
 		}
-		if len(auxMap.Metadata) > 0 {
-			return DecodeMetadatumRaw(auxMap.Metadata)
+		if metadataRaw := auxMap[0]; len(metadataRaw) > 0 {
+			return DecodeMetadatumRaw(metadataRaw)
 		}
 		// If no metadata, return nil
 		return nil, nil
@@ -932,22 +930,14 @@ func (a *AlonzoAuxiliaryData) UnmarshalCBOR(data []byte) error {
 		return nil
 	}
 
-	// Decode the fixed-key map into a struct instead of a generic map to
-	// avoid per-entry hashing/allocation on the hot decode path.
-	var auxMap struct {
-		Metadata      cbor.RawMessage `cbor:"0,keyasint,omitempty"`
-		NativeScripts cbor.RawMessage `cbor:"1,keyasint,omitempty"`
-		PlutusV1      cbor.RawMessage `cbor:"2,keyasint,omitempty"`
-		PlutusV2      cbor.RawMessage `cbor:"3,keyasint,omitempty"`
-		PlutusV3      cbor.RawMessage `cbor:"4,keyasint,omitempty"`
-	}
+	var auxMap map[uint]cbor.RawMessage
 	if _, err := cbor.Decode(taggedContent, &auxMap); err != nil {
 		return fmt.Errorf("failed to decode auxiliary data map: %w", err)
 	}
 
 	// Key 0: metadata
-	if len(auxMap.Metadata) > 0 {
-		md, err := DecodeMetadatumRaw(auxMap.Metadata)
+	if metadataRaw := auxMap[0]; len(metadataRaw) > 0 {
+		md, err := DecodeMetadatumRaw(metadataRaw)
 		if err != nil {
 			return fmt.Errorf("failed to decode metadata: %w", err)
 		}
@@ -955,29 +945,29 @@ func (a *AlonzoAuxiliaryData) UnmarshalCBOR(data []byte) error {
 	}
 
 	// Key 1: native scripts
-	if len(auxMap.NativeScripts) > 0 {
-		if _, err := cbor.Decode(auxMap.NativeScripts, &a.nativeScripts); err != nil {
+	if nativeScriptsRaw := auxMap[1]; len(nativeScriptsRaw) > 0 {
+		if _, err := cbor.Decode(nativeScriptsRaw, &a.nativeScripts); err != nil {
 			return fmt.Errorf("failed to decode native scripts: %w", err)
 		}
 	}
 
 	// Key 2: Plutus V1 scripts
-	if len(auxMap.PlutusV1) > 0 {
-		if _, err := cbor.Decode(auxMap.PlutusV1, &a.plutusV1Scripts); err != nil {
+	if plutusV1Raw := auxMap[2]; len(plutusV1Raw) > 0 {
+		if _, err := cbor.Decode(plutusV1Raw, &a.plutusV1Scripts); err != nil {
 			return fmt.Errorf("failed to decode Plutus V1 scripts: %w", err)
 		}
 	}
 
 	// Key 3: Plutus V2 scripts
-	if len(auxMap.PlutusV2) > 0 {
-		if _, err := cbor.Decode(auxMap.PlutusV2, &a.plutusV2Scripts); err != nil {
+	if plutusV2Raw := auxMap[3]; len(plutusV2Raw) > 0 {
+		if _, err := cbor.Decode(plutusV2Raw, &a.plutusV2Scripts); err != nil {
 			return fmt.Errorf("failed to decode Plutus V2 scripts: %w", err)
 		}
 	}
 
 	// Key 4: Plutus V3 scripts
-	if len(auxMap.PlutusV3) > 0 {
-		if _, err := cbor.Decode(auxMap.PlutusV3, &a.plutusV3Scripts); err != nil {
+	if plutusV3Raw := auxMap[4]; len(plutusV3Raw) > 0 {
+		if _, err := cbor.Decode(plutusV3Raw, &a.plutusV3Scripts); err != nil {
 			return fmt.Errorf("failed to decode Plutus V3 scripts: %w", err)
 		}
 	}

--- a/ledger/common/metadata_test.go
+++ b/ledger/common/metadata_test.go
@@ -104,3 +104,68 @@ func TestCIP25_NFTMetadataDecode(t *testing.T) {
 		t.Fatalf("roundtrip metadata() failed: %v", err)
 	}
 }
+
+func TestMetadataSetIgnoresUnknownAuxiliaryDataKeys(t *testing.T) {
+	// {6: #6.259({0: {1: "ok"}, 6: [1]})}
+	// Key 6 inside the auxiliary-data map is a VanRossem-era extension.
+	const metadataSetHex = "a106d90103a200a101626f6b068101"
+	const auxiliaryDataHex = "d90103a200a101626f6b068101"
+
+	raw, err := hex.DecodeString(metadataSetHex)
+	if err != nil {
+		t.Fatalf("bad hex: %v", err)
+	}
+
+	var set TransactionMetadataSet
+	if _, err := cbor.Decode(raw, &set); err != nil {
+		t.Fatalf("decode metadata set: %v", err)
+	}
+
+	md, ok := set.GetMetadata(6)
+	if !ok {
+		t.Fatal("expected metadata for transaction index 6")
+	}
+	assertMetadataEntry(t, md)
+
+	rawMd, ok := set.GetRawMetadata(6)
+	if !ok {
+		t.Fatal("expected raw metadata for transaction index 6")
+	}
+	if got := hex.EncodeToString(rawMd); got != auxiliaryDataHex {
+		t.Fatalf("raw metadata mismatch: got %s, want %s", got, auxiliaryDataHex)
+	}
+
+	aux, err := DecodeAuxiliaryData(rawMd)
+	if err != nil {
+		t.Fatalf("decode auxiliary data: %v", err)
+	}
+	if got := hex.EncodeToString(aux.Cbor()); got != auxiliaryDataHex {
+		t.Fatalf("raw auxiliary data mismatch: got %s, want %s", got, auxiliaryDataHex)
+	}
+	md, err = aux.Metadata()
+	if err != nil {
+		t.Fatalf("get auxiliary data metadata: %v", err)
+	}
+	assertMetadataEntry(t, md)
+}
+
+func assertMetadataEntry(t *testing.T, md TransactionMetadatum) {
+	t.Helper()
+
+	mm, ok := md.(MetaMap)
+	if !ok {
+		t.Fatalf("expected metadata map, got %T", md)
+	}
+	if len(mm.Pairs) != 1 {
+		t.Fatalf("expected 1 metadata pair, got %d", len(mm.Pairs))
+	}
+
+	key, ok := mm.Pairs[0].Key.(MetaInt)
+	if !ok || key.Value == nil || key.Value.Uint64() != 1 {
+		t.Fatalf("expected metadata key 1, got %#v", mm.Pairs[0].Key)
+	}
+	value, ok := mm.Pairs[0].Value.(MetaText)
+	if !ok || value.Value != "ok" {
+		t.Fatalf("expected metadata value ok, got %#v", mm.Pairs[0].Value)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make auxiliary data decoding ignore unknown CBOR keys so metadata still loads even when extensions are present (e.g., key 6). This fixes failures when parsing future or vendor-extended auxiliary data.

- **Bug Fixes**
  - Decode auxiliary data maps into `map[uint]cbor.RawMessage` and read only known keys (0: metadata, 1: native scripts, 2–4: Plutus V1–V3).
  - Ignore unknown keys instead of failing; added `TestMetadataSetIgnoresUnknownAuxiliaryDataKeys` to verify round-trip and metadata extraction.

<sup>Written for commit 8826f18ee2a8186a85a7dbc27fb342a3043f9c96. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved auxiliary data decoding to handle unknown fields more robustly.

* **Tests**
  * Added test coverage for auxiliary data with unknown keys to ensure proper roundtrip encoding and decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->