### PR TITLE
connection: make shutdown() idempotent with sync.Once

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -73,6 +73,7 @@ type Connection struct {
 	connClosedChan        chan struct{}
 	waitGroup             sync.WaitGroup
 	onceClose             sync.Once
+	onceShutdown          sync.Once
 	sendKeepAlives        bool
 	delayMuxerStart       bool
 	delayProtocolStart    bool
@@ -262,18 +263,27 @@ func (c *Connection) QueryReplyVersionMap() protocol.ProtocolVersionMap {
 	return c.queryReplyVersionMap
 }
 
-// shutdown performs cleanup operations when the connection is shutdown, either due to explicit Close() or an error
+// shutdown performs cleanup operations when the connection is shutdown, either due to explicit Close() or an error.
+// It is safe to call more than once; the cleanup steps run exactly once.
 func (c *Connection) shutdown() {
-	// Gracefully stop the muxer
-	if c.muxer != nil {
-		c.muxer.Stop()
-	}
-	// Close channel to let Close() know that it can return
-	close(c.connClosedChan)
-	// Wait for other goroutines to finish
-	c.waitGroup.Wait()
-	// Close consumer error channel to signify connection shutdown
-	close(c.errorChan)
+	// Races in setupConnection (e.g. a failure path that also trips the
+	// muxer-error goroutine, or a test that closes the underlying conn
+	// before Close() gets a chance to gate) have driven shutdown here
+	// more than once and panicked on `close of closed channel` at the
+	// connClosedChan/errorChan closes (txtop#287). Guard with sync.Once so
+	// the cleanup remains idempotent regardless of who races whom.
+	c.onceShutdown.Do(func() {
+		// Gracefully stop the muxer
+		if c.muxer != nil {
+			c.muxer.Stop()
+		}
+		// Close channel to let Close() know that it can return
+		close(c.connClosedChan)
+		// Wait for other goroutines to finish
+		c.waitGroup.Wait()
+		// Close consumer error channel to signify connection shutdown
+		close(c.errorChan)
+	})
 }
 
 // allProtocolsIdle returns true if every active protocol is in a terminal or


### PR DESCRIPTION
## Summary

`blinklabs-io/txtop#287` reports:

```
panic: close of closed channel

goroutine 6119927 [running]:
github.com/blinklabs-io/gouroboros.(*Connection).shutdown(...)
    gouroboros@v0.147.0/connection.go:266
github.com/blinklabs-io/gouroboros.(*Connection).setupConnection.func1()
    gouroboros@v0.147.0/connection.go:283
```

`shutdown` is invoked from exactly one goroutine spawned in `setupConnection`, but a partially-initialised connection (where the muxer-error goroutine calls `Close()` while the main setup path is also winding down) or a test that closes the underlying `net.Conn` out from under the library can drive the cleanup into `shutdown` a second time, which panics on the `close(c.connClosedChan)` / `close(c.errorChan)` calls.

## Fix

Add a symmetric `onceShutdown sync.Once` to `Connection` and wrap the cleanup in `c.onceShutdown.Do(...)`. `Close()` already uses `sync.Once` for the `doneChan` close; guarding the cleanup side keeps the contract simple: connection cleanup runs exactly once regardless of who triggers it.

## Test plan

- [x] `go build ./...`
- [x] `go test .` (package tests all pass)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a crash that could occur when the connection shutdown sequence was triggered multiple times concurrently, ensuring cleanup operations execute safely exactly once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make connection shutdown idempotent with `sync.Once` to prevent “close of closed channel” panics when shutdown is triggered more than once. Cleanup now runs exactly once, even with races or external `net.Conn` closes.

- **Bug Fixes**
  - Added `onceShutdown sync.Once` to `Connection`.
  - Wrapped shutdown cleanup in `c.onceShutdown.Do(...)`.
  - Prevents double-closing `connClosedChan` and `errorChan`, and duplicate muxer stops.

<sup>Written for commit b9770a3193dd24eebbc7d13d1aac624c2ab84875. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

