### PR TITLE
fix: sanchonet bootstrap peer

### DIFF
--- a/networks.go
+++ b/networks.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -65,8 +65,8 @@ var (
 		NetworkMagic: 4,
 		BootstrapPeers: []NetworkBootstrapPeer{
 			{
-				Address: "sanchonet-node.play.dev.cardano.org",
-				Port:    3001,
+				Address: "sancho-testnet.able-pool.io",
+				Port:    6002,
 			},
 		},
 	}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes failed Sanchonet connections by updating the default bootstrap peer to sancho-testnet.able-pool.io:6002. Also updates the copyright year in the file header.

<sup>Written for commit c5c3ad00d707f8032214800d3dd1dfb06e70baab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

