### PR TITLE
fix: era mismatch handling

### DIFF
--- a/ledger/era_mismatch_test.go
+++ b/ledger/era_mismatch_test.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"encoding/hex"
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Golden CBOR bytes captured from
+// IntersectMBO/ouroboros-consensus/ouroboros-consensus-cardano/golden/cardano/QueryVersion3/CardanoNodeToClientVersion19/ApplyTxErr_WrongEra*
+// (exampleApplyTxErrWrongEraByron / Shelley in Test.Consensus.Cardano.Examples).
+//
+// Wire shape per encodeEitherMismatch + encodeNS in Haskell:
+//
+//	[2,                              -- listLen 2 (two NS entries)
+//	 [2, otherEraIndex, otherName],  -- NS: era position + name (offered era)
+//	 [2, ledgerEraIndex, ledgerName] -- NS: era position + name (ledger era)
+//	]
+//
+// Era indices are CardanoEras positions: 0=Byron, 1=Shelley, 2=Allegra,
+// 3=Mary, 4=Alonzo, 5=Babbage, 6=Conway. Era names match the strings the
+// Haskell node emits via singleEraName ("Byron", "Shelley", etc.).
+const (
+	// goldenWrongEraByron: applying a Shelley thing to a Byron ledger.
+	goldenWrongEraByron = "828201675368656c6c657982006542" +
+		"79726f6e"
+	// goldenWrongEraShelley: applying a Byron thing to a Shelley ledger.
+	goldenWrongEraShelley = "8282006542" +
+		"79726f6e82016753" +
+		"68656c6c6579"
+)
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	require.NoError(t, err)
+	return b
+}
+
+func TestEraMismatch_DecodesByronWire(t *testing.T) {
+	got := &EraMismatch{}
+	_, err := cbor.Decode(mustHex(t, goldenWrongEraByron), got)
+	require.NoError(t, err)
+	assert.Equal(t, uint8(1), got.OtherEra.Index, "other era index = Shelley(1)")
+	assert.Equal(t, "Shelley", got.OtherEra.Name)
+	assert.Equal(t, uint8(0), got.LedgerEra.Index, "ledger era index = Byron(0)")
+	assert.Equal(t, "Byron", got.LedgerEra.Name)
+}
+
+func TestEraMismatch_DecodesShelleyWire(t *testing.T) {
+	got := &EraMismatch{}
+	_, err := cbor.Decode(mustHex(t, goldenWrongEraShelley), got)
+	require.NoError(t, err)
+	assert.Equal(t, uint8(0), got.OtherEra.Index, "other era index = Byron(0)")
+	assert.Equal(t, "Byron", got.OtherEra.Name)
+	assert.Equal(t, uint8(1), got.LedgerEra.Index, "ledger era index = Shelley(1)")
+	assert.Equal(t, "Shelley", got.LedgerEra.Name)
+}
+
+func TestEraMismatch_EncodesByronWire(t *testing.T) {
+	em := &EraMismatch{
+		OtherEra:  EraInfo{Index: 1, Name: "Shelley"},
+		LedgerEra: EraInfo{Index: 0, Name: "Byron"},
+	}
+	got, err := cbor.Encode(em)
+	require.NoError(t, err)
+	assert.Equal(t, mustHex(t, goldenWrongEraByron), got,
+		"encoded bytes must match the Haskell golden ApplyTxErr_WrongEraByron")
+}
+
+func TestEraMismatch_EncodesShelleyWire(t *testing.T) {
+	em := &EraMismatch{
+		OtherEra:  EraInfo{Index: 0, Name: "Byron"},
+		LedgerEra: EraInfo{Index: 1, Name: "Shelley"},
+	}
+	got, err := cbor.Encode(em)
+	require.NoError(t, err)
+	assert.Equal(t, mustHex(t, goldenWrongEraShelley), got,
+		"encoded bytes must match the Haskell golden ApplyTxErr_WrongEraShelley")
+}
+
+func TestEraMismatch_RoundTrip(t *testing.T) {
+	original := &EraMismatch{
+		OtherEra:  EraInfo{Index: 6, Name: "Conway"},
+		LedgerEra: EraInfo{Index: 5, Name: "Babbage"},
+	}
+	encoded, err := cbor.Encode(original)
+	require.NoError(t, err)
+
+	decoded := &EraMismatch{}
+	_, err = cbor.Decode(encoded, decoded)
+	require.NoError(t, err)
+	assert.Equal(t, original.OtherEra, decoded.OtherEra)
+	assert.Equal(t, original.LedgerEra, decoded.LedgerEra)
+}
+
+// TestNewEraMismatchErrorFromCbor_RecognizesGoldenBytes verifies the
+// constructor returns *EraMismatch for canonical wire bytes (i.e. the
+// dispatch in NewTxSubmitErrorFromCbor will pick this branch instead of
+// falling through to GenericError).
+func TestNewEraMismatchErrorFromCbor_RecognizesGoldenBytes(t *testing.T) {
+	for name, hexBytes := range map[string]string{
+		"WrongEraByron":   goldenWrongEraByron,
+		"WrongEraShelley": goldenWrongEraShelley,
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := NewEraMismatchErrorFromCbor(mustHex(t, hexBytes))
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			var em *EraMismatch
+			require.True(t, errors.As(got, &em),
+				"constructor must return *EraMismatch")
+			assert.NotEmpty(t, em.OtherEra.Name)
+			assert.NotEmpty(t, em.LedgerEra.Name)
+		})
+	}
+}
+
+// TestNewTxSubmitErrorFromCbor_PrefersEraMismatch verifies the typed
+// dispatcher picks *EraMismatch (not GenericError) for canonical wire
+// bytes. This is the regression that gouroboros has carried since the
+// type was introduced — the prior decoder couldn't parse real
+// cardano-node responses, so this dispatch would always have fallen
+// through to the GenericError fallback.
+func TestNewTxSubmitErrorFromCbor_PrefersEraMismatch(t *testing.T) {
+	got, err := NewTxSubmitErrorFromCbor(mustHex(t, goldenWrongEraByron))
+	require.NoError(t, err)
+	var em *EraMismatch
+	require.True(t, errors.As(got, &em),
+		"NewTxSubmitErrorFromCbor must select *EraMismatch over GenericError fallback")
+	assert.Equal(t, "Shelley", em.OtherEra.Name)
+	assert.Equal(t, "Byron", em.LedgerEra.Name)
+}
+
+// TestEraMismatch_ErrorString verifies the Error() message names both
+// eras (it's user-facing in tx-submission rejection logs).
+func TestEraMismatch_ErrorString(t *testing.T) {
+	em := &EraMismatch{
+		OtherEra:  EraInfo{Index: 1, Name: "Shelley"},
+		LedgerEra: EraInfo{Index: 0, Name: "Byron"},
+	}
+	msg := em.Error()
+	assert.Contains(t, msg, "Shelley")
+	assert.Contains(t, msg, "Byron")
+}

--- a/ledger/error.go
+++ b/ledger/error.go
@@ -267,18 +267,60 @@ func NewEraMismatchErrorFromCbor(cborData []byte) (error, error) {
 	return newErr, nil
 }
 
+// EraInfo identifies one era in a Cardano EraMismatch by its position in
+// the CardanoEras list and its canonical name. Wire-encoded as
+// [eraIndex_uint8, eraName_text] — the N-ary-sum encoding produced by
+// Haskell's encodeNS in
+// Ouroboros.Consensus.HardFork.Combinator.Serialisation.Common.
+//
+// Indices follow CardanoEras position: 0=Byron, 1=Shelley, 2=Allegra,
+// 3=Mary, 4=Alonzo, 5=Babbage, 6=Conway. Names match the strings emitted
+// by singleEraName in the Haskell node ("Byron", "Shelley", "Allegra",
+// "Mary", "Alonzo", "Babbage", "Conway").
+type EraInfo struct {
+	cbor.StructAsArray
+	Index uint8
+	Name  string
+}
+
+// EraMismatch is the canonical wire encoding of the Cardano HardFork
+// Combinator's era-mismatch error. Wire format:
+//
+//	[2,                                 -- listLen 2 (matches encodeListLen 2)
+//	 [2, otherEraIndex, "OtherEra"],    -- N-ary sum of the offered era
+//	 [2, ledgerEraIndex, "LedgerEra"]]  -- N-ary sum of the ledger era
+//
+// Produced by Haskell's encodeEitherMismatch (Left case) for
+// HardForkApplyTxErrWrongEra (in tx-submission MsgRejectTx Reason) and
+// for QueryResultEraMismatch (in local-state-query results). The Right
+// case (era-specific apply-tx-error or in-era query result) uses listLen
+// 1 with a different payload and is handled by the era-specific decoders
+// (e.g. ShelleyTxValidationError).
 type EraMismatch struct {
 	cbor.StructAsArray
-	LedgerEra uint8
-	OtherEra  uint8
+	OtherEra  EraInfo // era of the offered tx/query/header
+	LedgerEra EraInfo // era the ledger is currently in
 }
 
 func (e *EraMismatch) Error() string {
 	return fmt.Sprintf(
 		"The era of the node and the tx do not match. The node is running in the %s era, but the transaction is for the %s era.",
-		GetEraById(e.LedgerEra).Name,
-		GetEraById(e.OtherEra).Name,
+		e.LedgerEra.Name,
+		e.OtherEra.Name,
 	)
+}
+
+// MarshalCBOR encodes the EraMismatch as canonical wire bytes (see the
+// type doc for the format). Defining this method makes *EraMismatch
+// satisfy the localtxsubmission.CborRejectReason interface, so the
+// tx-submission server places the structured CBOR directly in
+// MsgRejectTx.Reason instead of falling back to encoding Error() as a
+// CBOR text string.
+//
+// EncodeGeneric is used to avoid infinite recursion: cbor.Encode would
+// otherwise re-enter MarshalCBOR.
+func (e *EraMismatch) MarshalCBOR() ([]byte, error) {
+	return cbor.EncodeGeneric(e)
 }
 
 // Helper function to try to parse CBOR as various error types

--- a/protocol/localtxsubmission/reject_reason.go
+++ b/protocol/localtxsubmission/reject_reason.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localtxsubmission
+
+import (
+	"errors"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+)
+
+// CborRejectReason marks errors whose canonical wire form is a
+// structured CBOR value rather than the error's text representation.
+//
+// SubmitTxFunc callbacks may return values implementing this interface
+// when the rejection reason has a well-defined wire format on a real
+// cardano-node (e.g. *ledger.EraMismatch for HardForkApplyTxErrWrongEra).
+// The server places MarshalCBOR's output verbatim in MsgRejectTx.Reason;
+// errors that do not implement this interface are encoded as a CBOR
+// text string of err.Error(), preserving the pre-typed behaviour for
+// callers that haven't migrated to typed reject reasons yet.
+//
+// Implementations must produce the exact wire bytes a Haskell node
+// would emit for the same condition — see the ledger package's
+// EraMismatch for the reference implementation.
+type CborRejectReason interface {
+	error
+	MarshalCBOR() ([]byte, error)
+}
+
+// encodeRejectReason returns the bytes to place in MsgRejectTx.Reason
+// for the given submit-tx error. errors.As walks the wrapping chain so
+// callers can fmt.Errorf("...: %w", typedErr) without losing the typed
+// encoding.
+func encodeRejectReason(err error) ([]byte, error) {
+	var typed CborRejectReason
+	if errors.As(err, &typed) {
+		return typed.MarshalCBOR()
+	}
+	return cbor.Encode(err.Error())
+}

--- a/protocol/localtxsubmission/reject_reason_test.go
+++ b/protocol/localtxsubmission/reject_reason_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localtxsubmission
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// goldenWrongEraByron mirrors the golden bytes captured from
+// IntersectMBO/ouroboros-consensus golden test corpus
+// (ApplyTxErr_WrongEraByron) — applying a Shelley tx to a Byron ledger.
+const goldenWrongEraByron = "828201675368656c6c657982006542" +
+	"79726f6e"
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	require.NoError(t, err)
+	return b
+}
+
+// TestEncodeRejectReason_TypedEraMismatch verifies that an *EraMismatch
+// returned from a SubmitTxFunc is wire-encoded as canonical CBOR (matching
+// the Haskell golden bytes) rather than its Error() string.
+func TestEncodeRejectReason_TypedEraMismatch(t *testing.T) {
+	em := &ledger.EraMismatch{
+		OtherEra:  ledger.EraInfo{Index: 1, Name: "Shelley"},
+		LedgerEra: ledger.EraInfo{Index: 0, Name: "Byron"},
+	}
+	got, err := encodeRejectReason(em)
+	require.NoError(t, err)
+	assert.Equal(t, mustHex(t, goldenWrongEraByron), got,
+		"typed *EraMismatch must be encoded as canonical Haskell wire bytes")
+}
+
+// TestEncodeRejectReason_StringFallback verifies that a plain error is
+// CBOR-encoded as a text string — preserving the existing pre-typed
+// behaviour so untyped callbacks remain wire-compatible.
+func TestEncodeRejectReason_StringFallback(t *testing.T) {
+	plainErr := errors.New("something went wrong")
+	got, err := encodeRejectReason(plainErr)
+	require.NoError(t, err)
+
+	// Decode and check it's a CBOR text string equal to err.Error().
+	var decoded string
+	_, err = cbor.Decode(got, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, "something went wrong", decoded)
+}
+
+// TestEncodeRejectReason_WrappedTypedError verifies that errors wrapped
+// via fmt.Errorf("%w", ...) still get the typed CBOR encoding via
+// errors.As. Without this, callers would have to be careful never to
+// wrap typed reject reasons.
+func TestEncodeRejectReason_WrappedTypedError(t *testing.T) {
+	em := &ledger.EraMismatch{
+		OtherEra:  ledger.EraInfo{Index: 1, Name: "Shelley"},
+		LedgerEra: ledger.EraInfo{Index: 0, Name: "Byron"},
+	}
+	wrapped := fmt.Errorf("submission failed: %w", em)
+	got, err := encodeRejectReason(wrapped)
+	require.NoError(t, err)
+	assert.Equal(t, mustHex(t, goldenWrongEraByron), got,
+		"wrapped *EraMismatch must still be encoded as canonical CBOR")
+}
+
+// TestEncodeRejectReason_RoundTripThroughClientDecoder verifies that the
+// bytes produced by encodeRejectReason can be parsed by the client-side
+// ledger.NewTxSubmitErrorFromCbor dispatcher, closing the wire-protocol
+// loop. Today that loop is broken: the server emits string CBOR for
+// every error, so the client always falls through to GenericError.
+func TestEncodeRejectReason_RoundTripThroughClientDecoder(t *testing.T) {
+	original := &ledger.EraMismatch{
+		OtherEra:  ledger.EraInfo{Index: 6, Name: "Conway"},
+		LedgerEra: ledger.EraInfo{Index: 5, Name: "Babbage"},
+	}
+	wireBytes, err := encodeRejectReason(original)
+	require.NoError(t, err)
+
+	clientErr, err := ledger.NewTxSubmitErrorFromCbor(wireBytes)
+	require.NoError(t, err)
+	var em *ledger.EraMismatch
+	require.True(t, errors.As(clientErr, &em),
+		"client-side decoder must recognise typed reject reason")
+	assert.Equal(t, "Conway", em.OtherEra.Name)
+	assert.Equal(t, "Babbage", em.LedgerEra.Name)
+}

--- a/protocol/localtxsubmission/server.go
+++ b/protocol/localtxsubmission/server.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/protocol"
 )
 
@@ -94,9 +93,9 @@ func (s *Server) handleSubmitTx(msg protocol.Message) error {
 			return err
 		}
 	} else {
-		errCbor, err := cbor.Encode(err.Error())
-		if err != nil {
-			return err
+		errCbor, encErr := encodeRejectReason(err)
+		if encErr != nil {
+			return encErr
 		}
 		newMsg := NewMsgRejectTx(errCbor)
 		if err := s.SendMessage(newMsg); err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Era mismatch errors now include blockchain era names for improved clarity.
  * Transaction rejection information is now properly structured and formatted consistently.
* **Tests**
  * Added comprehensive test coverage for era mismatch validation and rejection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds canonical era-mismatch handling and structured reject reasons. The tx-submission server now emits typed CBOR for `ledger.EraMismatch`, so clients receive clear era names and can decode the exact error type.

- **New Features**
  - Added `protocol/localtxsubmission` `CborRejectReason` and `encodeRejectReason`; `ledger.EraMismatch` implements `MarshalCBOR` to produce cardano-node–compatible CBOR.

- **Bug Fixes**
  - Client decoders now select typed `ledger.EraMismatch` (not `GenericError`) on era mismatch, and the error message names both eras.

<sup>Written for commit 599c1e90d785b70d35920444dc5e1e422e6aa0af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

