### PR TITLE
feat: add min and max protocol versions to era packages

### DIFF
--- a/ledger/allegra/allegra.go
+++ b/ledger/allegra/allegra.go
@@ -29,6 +29,13 @@ const (
 	EraIdAllegra   = 2
 	EraNameAllegra = "Allegra"
 
+	// MinProtocolVersionAllegra is the lowest protocol major
+	// version that belongs to the Allegra era.
+	MinProtocolVersionAllegra = 3
+	// MaxProtocolVersionAllegra is the highest protocol major
+	// version that belongs to the Allegra era.
+	MaxProtocolVersionAllegra = 3
+
 	BlockTypeAllegra = 3
 
 	BlockHeaderTypeAllegra = 2

--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -34,6 +34,13 @@ const (
 	EraIdAlonzo   = 4
 	EraNameAlonzo = "Alonzo"
 
+	// MinProtocolVersionAlonzo is the lowest protocol major version
+	// that belongs to the Alonzo era.
+	MinProtocolVersionAlonzo = 5
+	// MaxProtocolVersionAlonzo is the highest protocol major
+	// version that belongs to the Alonzo era.
+	MaxProtocolVersionAlonzo = 6
+
 	BlockTypeAlonzo = 5
 
 	BlockHeaderTypeAlonzo = 4

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -33,6 +33,13 @@ const (
 	EraIdBabbage   = 5
 	EraNameBabbage = "Babbage"
 
+	// MinProtocolVersionBabbage is the lowest protocol major
+	// version that belongs to the Babbage era.
+	MinProtocolVersionBabbage = 7
+	// MaxProtocolVersionBabbage is the highest protocol major
+	// version that belongs to the Babbage era.
+	MaxProtocolVersionBabbage = 8
+
 	BlockTypeBabbage = 6
 
 	BlockHeaderTypeBabbage = 5

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -35,6 +35,13 @@ const (
 	EraIdConway   = 6
 	EraNameConway = "Conway"
 
+	// MinProtocolVersionConway is the lowest protocol major
+	// version that belongs to the Conway era.
+	MinProtocolVersionConway = 9
+	// MaxProtocolVersionConway is the highest protocol major
+	// version that belongs to the Conway era.
+	MaxProtocolVersionConway = 10
+
 	BlockTypeConway = 7
 
 	BlockHeaderTypeConway = 6

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -31,6 +31,13 @@ const (
 	EraIdMary   = 3
 	EraNameMary = "Mary"
 
+	// MinProtocolVersionMary is the lowest protocol major version
+	// that belongs to the Mary era.
+	MinProtocolVersionMary = 4
+	// MaxProtocolVersionMary is the highest protocol major
+	// version that belongs to the Mary era.
+	MaxProtocolVersionMary = 4
+
 	BlockTypeMary = 4
 
 	BlockHeaderTypeMary = 3

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -31,6 +31,13 @@ const (
 	EraIdShelley   = 1
 	EraNameShelley = "Shelley"
 
+	// MinProtocolVersionShelley is the lowest protocol major
+	// version that belongs to the Shelley era.
+	MinProtocolVersionShelley = 2
+	// MaxProtocolVersionShelley is the highest protocol major
+	// version that belongs to the Shelley era.
+	MaxProtocolVersionShelley = 2
+
 	BlockTypeShelley = 2
 
 	BlockHeaderTypeShelley = 1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add min/max protocol major version constants to each era package to enable reliable protocol-to-era lookup and validation.

- **New Features**
  - Added `MinProtocolVersion*` and `MaxProtocolVersion*` constants across era packages.
  - Protocol ranges: Shelley 2, Allegra 3, Mary 4, Alonzo 5–6, Babbage 7–8, Conway 9–10.

<sup>Written for commit c439d299e30b68dc23844601e6705bfcf7650dad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added protocol version range support for all ledger eras: Shelley, Allegra, Mary, Alonzo, Babbage, and Conway.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->