### PR TITLE
feat(connection): add DMQ N2C support (CIP-0137)

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -41,6 +41,8 @@ import (
 	"github.com/blinklabs-io/gouroboros/protocol/keepalive"
 	"github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
 	"github.com/blinklabs-io/gouroboros/protocol/leiosnotify"
+	"github.com/blinklabs-io/gouroboros/protocol/localmessagenotification"
+	"github.com/blinklabs-io/gouroboros/protocol/localmessagesubmission"
 	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
 	"github.com/blinklabs-io/gouroboros/protocol/localtxmonitor"
 	"github.com/blinklabs-io/gouroboros/protocol/localtxsubmission"
@@ -62,6 +64,7 @@ type Connection struct {
 	networkMagic          uint32
 	server                bool
 	useNodeToNodeProto    bool
+	useDMQProtocol        bool
 	logger                *slog.Logger
 	muxer                 *muxer.Muxer
 	errorChan             chan error
@@ -105,6 +108,11 @@ type Connection struct {
 	peerSharingConfig       *peersharing.Config
 	txSubmission            *txsubmission.TxSubmission
 	txSubmissionConfig      *txsubmission.Config
+	// DMQ N2C mini-protocols (CIP-0137); only constructed when WithDMQ is set
+	localMessageSubmission         *localmessagesubmission.LocalMessageSubmission
+	localMessageSubmissionConfig   *localmessagesubmission.Config
+	localMessageNotification       *localmessagenotification.LocalMessageNotification
+	localMessageNotificationConfig *localmessagenotification.Config
 }
 
 // NewConnection returns a new Connection object with the specified options. If a connection is provided, the
@@ -252,6 +260,19 @@ func (c *Connection) TxSubmission() *txsubmission.TxSubmission {
 	return c.txSubmission
 }
 
+// LocalMessageSubmission returns the DMQ local-message-submission protocol
+// handler. Only non-nil on a Connection constructed with WithDMQ(true).
+func (c *Connection) LocalMessageSubmission() *localmessagesubmission.LocalMessageSubmission {
+	return c.localMessageSubmission
+}
+
+// LocalMessageNotification returns the DMQ local-message-notification
+// protocol handler. Only non-nil on a Connection constructed with
+// WithDMQ(true).
+func (c *Connection) LocalMessageNotification() *localmessagenotification.LocalMessageNotification {
+	return c.localMessageNotification
+}
+
 // ProtocolVersion returns the negotiated protocol version and the version data from the remote peer
 func (c *Connection) ProtocolVersion() (uint16, protocol.VersionData) {
 	return c.handshakeVersion, c.handshakeVersionData
@@ -380,6 +401,22 @@ func (c *Connection) allProtocolsIdle() bool {
 			protocols = append(protocols, c.leiosFetch.Server.ProtocolInstance())
 		}
 	}
+	if c.localMessageSubmission != nil {
+		if c.localMessageSubmission.Client != nil {
+			protocols = append(protocols, c.localMessageSubmission.Client.Protocol)
+		}
+		if c.localMessageSubmission.Server != nil {
+			protocols = append(protocols, c.localMessageSubmission.Server.Protocol)
+		}
+	}
+	if c.localMessageNotification != nil {
+		if c.localMessageNotification.Client != nil {
+			protocols = append(protocols, c.localMessageNotification.Client.Protocol)
+		}
+		if c.localMessageNotification.Server != nil {
+			protocols = append(protocols, c.localMessageNotification.Server.Protocol)
+		}
+	}
 	for _, p := range protocols {
 		if p != nil && !p.IsInTerminalOrIdleState() {
 			return false
@@ -397,6 +434,11 @@ func (c *Connection) setupConnection() error {
 			"invalid network magic value provided: %d",
 			c.networkMagic,
 		)
+	}
+	// DMQ mode is a node-to-client variant; it cannot be combined with
+	// node-to-node mode on the same connection.
+	if c.useDMQProtocol && c.useNodeToNodeProto {
+		return errors.New("WithDMQ and WithNodeToNode are mutually exclusive")
 	}
 	// Start Goroutine to shutdown when doneChan is closed
 	c.doneChan = make(chan any)
@@ -466,13 +508,23 @@ func (c *Connection) setupConnection() error {
 	if c.fullDuplex {
 		handshakeDiffusionMode = protocol.DiffusionModeInitiatorAndResponder
 	}
-	protoVersions := protocol.GetProtocolVersionMap(
-		protoOptions.Mode,
-		c.networkMagic,
-		handshakeDiffusionMode,
-		c.peerSharingEnabled,
-		c.queryMode,
-	)
+	var protoVersions protocol.ProtocolVersionMap
+	if c.useDMQProtocol {
+		// DMQ uses a separate version-encoding namespace (bit 12) and a
+		// topic-specific network magic distinct from any Cardano network.
+		protoVersions = protocol.GetProtocolVersionMapDMQNtC(
+			c.networkMagic,
+			c.queryMode,
+		)
+	} else {
+		protoVersions = protocol.GetProtocolVersionMap(
+			protoOptions.Mode,
+			c.networkMagic,
+			handshakeDiffusionMode,
+			c.peerSharingEnabled,
+			c.queryMode,
+		)
+	}
 	// Perform handshake
 	var handshakeFullDuplex bool
 	handshakeConfig := handshake.NewConfig(
@@ -600,6 +652,38 @@ func (c *Connection) setupConnection() error {
 				}
 				c.leiosNotify.Server.Start()
 				c.leiosFetch.Server.Start()
+			}
+		}
+	} else if c.useDMQProtocol {
+		// DMQ N2C: only LocalMessageSubmission (proto 14) and
+		// LocalMessageNotification (proto 15) are valid on this
+		// connection. No chain-sync, no localTxSubmission, etc.
+		protoOptions.Mode = protocol.ProtocolModeNodeToClient
+		c.protocolMu.Lock()
+		c.localMessageSubmission = localmessagesubmission.New(
+			protoOptions,
+			c.localMessageSubmissionConfig,
+		)
+		c.localMessageNotification = localmessagenotification.New(
+			protoOptions,
+			c.localMessageNotificationConfig,
+		)
+		c.protocolsReady = true
+		c.protocolMu.Unlock()
+		// Register server protocols early to avoid race conditions
+		if (c.fullDuplex && handshakeFullDuplex) || c.server {
+			c.localMessageSubmission.Server.EnsureRegistered()
+			c.localMessageNotification.Server.EnsureRegistered()
+		}
+		// Start protocols
+		if !c.delayProtocolStart {
+			if (c.fullDuplex && handshakeFullDuplex) || !c.server {
+				c.localMessageSubmission.Client.Start()
+				c.localMessageNotification.Client.Start()
+			}
+			if (c.fullDuplex && handshakeFullDuplex) || c.server {
+				c.localMessageSubmission.Server.Start()
+				c.localMessageNotification.Server.Start()
 			}
 		}
 	} else {

--- a/connection_options.go
+++ b/connection_options.go
@@ -23,6 +23,8 @@ import (
 	"github.com/blinklabs-io/gouroboros/protocol/keepalive"
 	"github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
 	"github.com/blinklabs-io/gouroboros/protocol/leiosnotify"
+	"github.com/blinklabs-io/gouroboros/protocol/localmessagenotification"
+	"github.com/blinklabs-io/gouroboros/protocol/localmessagesubmission"
 	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
 	"github.com/blinklabs-io/gouroboros/protocol/localtxmonitor"
 	"github.com/blinklabs-io/gouroboros/protocol/localtxsubmission"
@@ -80,6 +82,17 @@ func WithLogger(logger *slog.Logger) ConnectionOptionFunc {
 func WithNodeToNode(nodeToNode bool) ConnectionOptionFunc {
 	return func(c *Connection) {
 		c.useNodeToNodeProto = nodeToNode
+	}
+}
+
+// WithDMQ enables CIP-0137 DMQ node-to-client mode. The connection
+// negotiates the DMQ N2C handshake (NodeToClientV_1, bit-12 encoded) using
+// the configured network magic as the DMQ topic identifier, and exposes
+// only the LocalMessageSubmission and LocalMessageNotification mini-
+// protocols. Mutually exclusive with WithNodeToNode.
+func WithDMQ(useDMQ bool) ConnectionOptionFunc {
+	return func(c *Connection) {
+		c.useDMQProtocol = useDMQ
 	}
 }
 
@@ -205,5 +218,27 @@ func WithPeerSharingConfig(cfg peersharing.Config) ConnectionOptionFunc {
 func WithTxSubmissionConfig(cfg txsubmission.Config) ConnectionOptionFunc {
 	return func(c *Connection) {
 		c.txSubmissionConfig = &cfg
+	}
+}
+
+// WithLocalMessageSubmissionConfig specifies LocalMessageSubmission
+// protocol config (CIP-0137 DMQ N2C). Only effective when WithDMQ(true)
+// is also set.
+func WithLocalMessageSubmissionConfig(
+	cfg localmessagesubmission.Config,
+) ConnectionOptionFunc {
+	return func(c *Connection) {
+		c.localMessageSubmissionConfig = &cfg
+	}
+}
+
+// WithLocalMessageNotificationConfig specifies LocalMessageNotification
+// protocol config (CIP-0137 DMQ N2C). Only effective when WithDMQ(true)
+// is also set.
+func WithLocalMessageNotificationConfig(
+	cfg localmessagenotification.Config,
+) ConnectionOptionFunc {
+	return func(c *Connection) {
+		c.localMessageNotificationConfig = &cfg
 	}
 }

--- a/connection_test.go
+++ b/connection_test.go
@@ -40,6 +40,21 @@ import (
 	"go.uber.org/goleak"
 )
 
+// TestWithDMQ verifies that constructing a Connection with WithDMQ does
+// not panic and exposes the DMQ N2C accessors. Full handshake exercise
+// against a real DMQ peer is covered by integration tests in downstream
+// consumers (e.g. raven, dingo); here we just validate the option plumbing.
+func TestWithDMQ(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	oConn, err := ouroboros.New(ouroboros.WithDMQ(true))
+	require.NoError(t, err)
+	defer oConn.Close()
+	// Before setupConnection runs (no underlying conn supplied yet) the
+	// DMQ protocol handles are nil. The accessors must still be callable.
+	assert.Nil(t, oConn.LocalMessageSubmission(), "LocalMessageSubmission should be nil before handshake")
+	assert.Nil(t, oConn.LocalMessageNotification(), "LocalMessageNotification should be nil before handshake")
+}
+
 // Ensure that we don't panic when closing the Connection object after a failed Dial() call
 func TestDialFailClose(t *testing.T) {
 	defer goleak.VerifyNone(t)

--- a/ledger/common/address.go
+++ b/ledger/common/address.go
@@ -15,6 +15,7 @@
 package common
 
 import (
+	"crypto/sha3"
 	"errors"
 	"fmt"
 	"hash/crc32"
@@ -25,7 +26,6 @@ import (
 	"github.com/blinklabs-io/plutigo/data"
 	"github.com/btcsuite/btcd/btcutil/base58"
 	"github.com/btcsuite/btcd/btcutil/bech32"
-	"golang.org/x/crypto/sha3"
 )
 
 const (

--- a/ledger/common/verify.go
+++ b/ledger/common/verify.go
@@ -16,10 +16,9 @@ package common
 
 import (
 	"crypto/ed25519"
+	"crypto/sha3"
 	"errors"
 	"fmt"
-
-	"golang.org/x/crypto/sha3"
 )
 
 // VerifyVKeySignature verifies an ed25519 signature against the provided public key and message.

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -15,11 +15,11 @@ This directory contains implementations of the Ouroboros mini-protocols used for
 | [KeepAlive](keepalive/) | 8 | NtN | Connection liveness |
 | [LocalTxMonitor](localtxmonitor/) | 9 | NtC | Mempool monitoring |
 | [PeerSharing](peersharing/) | 10 | NtN | Peer discovery |
-| [MessageSubmission](messagesubmission/) | 17 | NtN | DMQ message propagation |
+| [MessageSubmission](messagesubmission/) | 11 | NtN | DMQ message propagation (sig-submission-v2) |
+| [LocalMessageSubmission](localmessagesubmission/) | 14 | NtC | Local DMQ submission |
+| [LocalMessageNotification](localmessagenotification/) | 15 | NtC | Local DMQ notifications |
 | [LeiosNotify](leiosnotify/) | 18 | NtN | Leios notifications |
-| [LocalMessageSubmission](localmessagesubmission/) | 18 | NtC | Local DMQ submission |
 | [LeiosFetch](leiosfetch/) | 19 | NtN | Leios data retrieval |
-| [LocalMessageNotification](localmessagenotification/) | 19 | NtC | Local DMQ notifications |
 
 **Mode Key:**
 - **NtN**: Node-to-Node (between full nodes)

--- a/protocol/localmessagenotification/README.md
+++ b/protocol/localmessagenotification/README.md
@@ -7,7 +7,7 @@ The LocalMessageNotification protocol receives notifications about new messages 
 | Property | Value |
 |----------|-------|
 | Protocol Name | `LocalMessageNotification` |
-| Protocol ID | `19` |
+| Protocol ID | `15` |
 | Mode | Node-to-Client |
 
 ## State Machine

--- a/protocol/localmessagenotification/localmessagenotification.go
+++ b/protocol/localmessagenotification/localmessagenotification.go
@@ -25,7 +25,11 @@ import (
 
 const (
 	ProtocolName = "LocalMessageNotification"
-	ProtocolID   = 19
+	// ProtocolID is the DMQ N2C mini-protocol number. dmq-node reference
+	// (DMQ.NodeToClient: localMsgNotification miniProtocolNum =
+	// MiniProtocolNum 15) and Pallas (PROTOCOL_N2C_MSG_NOTIFICATION = 15)
+	// both use 15.
+	ProtocolID = 15
 )
 
 // State timeouts for Local Message Notification protocol

--- a/protocol/localmessagesubmission/README.md
+++ b/protocol/localmessagesubmission/README.md
@@ -7,7 +7,7 @@ The LocalMessageSubmission protocol submits authenticated messages to the local 
 | Property | Value |
 |----------|-------|
 | Protocol Name | `LocalMessageSubmission` |
-| Protocol ID | `18` |
+| Protocol ID | `14` |
 | Mode | Node-to-Client |
 
 ## State Machine

--- a/protocol/localmessagesubmission/localmessagesubmission.go
+++ b/protocol/localmessagesubmission/localmessagesubmission.go
@@ -25,7 +25,11 @@ import (
 
 const (
 	ProtocolName = "LocalMessageSubmission"
-	ProtocolID   = 18
+	// ProtocolID is the DMQ N2C mini-protocol number. dmq-node reference
+	// (DMQ.NodeToClient: localMsgSubmission miniProtocolNum =
+	// MiniProtocolNum 14) and Pallas (PROTOCOL_N2C_MSG_SUBMISSION = 14)
+	// both use 14.
+	ProtocolID = 14
 )
 
 // State timeouts for Local Message Submission protocol

--- a/protocol/messagesubmission/README.md
+++ b/protocol/messagesubmission/README.md
@@ -7,7 +7,7 @@ The MessageSubmission protocol propagates authenticated messages between nodes. 
 | Property | Value |
 |----------|-------|
 | Protocol Name | `MessageSubmission` |
-| Protocol ID | `17` |
+| Protocol ID | `11` |
 | Mode | Node-to-Node |
 
 ## State Machine

--- a/protocol/messagesubmission/messagesubmission.go
+++ b/protocol/messagesubmission/messagesubmission.go
@@ -25,7 +25,10 @@ import (
 
 const (
 	ProtocolName = "MessageSubmission"
-	ProtocolID   = 17
+	// ProtocolID is the DMQ N2N mini-protocol number. dmq-node reference
+	// (DMQ.NodeToNode: sigSubmissionMiniProtocolNum = MiniProtocolNum 11)
+	// and Pallas (PROTOCOL_N2N_DMQ_SIG_SUBMISSION = 11) both use 11.
+	ProtocolID = 11
 )
 
 // State timeouts for Message Submission protocol

--- a/protocol/versions.go
+++ b/protocol/versions.go
@@ -19,6 +19,13 @@ import "slices"
 // The NtC protocol versions have the 15th bit set in the handshake
 const ProtocolVersionNtCOffset = 0x8000
 
+// The DMQ N2C protocol versions have the 12th bit set in the handshake.
+// Note that this is a different bit than Cardano's NtC offset (15th bit);
+// dmq-node uses the 12th bit deliberately to keep the DMQ namespace
+// distinct from the Cardano N2N/N2C version space (see
+// dmq-node/src/DMQ/NodeToClient/Version.hs).
+const ProtocolVersionDMQNtCOffset = 0x1000
+
 type NewVersionDataFromCborFunc func([]byte) (VersionData, error)
 
 type ProtocolVersionMap map[uint16]VersionData
@@ -339,6 +346,48 @@ func GetProtocolVersionMap(
 	return ret
 }
 
+// dmqProtocolVersions maps supported DMQ N2C protocol versions to their
+// version metadata. dmq-node currently advertises only NodeToClientV_1
+// (encoded with the 12th bit set: 1 | 0x1000 = 0x1001).
+//
+// VersionData is structurally [uint32 networkMagic, bool query] — identical
+// to Cardano's VersionDataNtC15andUp — so the same CBOR decoder is reused.
+var dmqProtocolVersions = map[uint16]ProtocolVersion{
+	(1 + ProtocolVersionDMQNtCOffset): {
+		NewVersionDataFromCborFunc: NewVersionDataNtC15andUpFromCbor,
+	},
+}
+
+// GetProtocolVersionMapDMQNtC returns a ProtocolVersionMap suitable for
+// handshaking against a DMQ node's node-to-client listener (CIP-0137).
+// The networkMagic argument is the DMQ-specific topic magic (e.g. Mithril
+// mainnet = 2912307721, dmq-node default = 3141592), distinct from any
+// Cardano network magic.
+func GetProtocolVersionMapDMQNtC(
+	networkMagic uint32,
+	queryMode bool,
+) ProtocolVersionMap {
+	ret := ProtocolVersionMap{}
+	for version := range dmqProtocolVersions {
+		ret[version] = VersionDataNtC15andUp{
+			CborNetworkMagic: networkMagic,
+			CborQuery:        queryMode,
+		}
+	}
+	return ret
+}
+
+// GetProtocolVersionsDMQNtC returns a list of supported DMQ N2C protocol
+// versions in ascending order.
+func GetProtocolVersionsDMQNtC() []uint16 {
+	versions := make([]uint16, 0, len(dmqProtocolVersions))
+	for key := range dmqProtocolVersions {
+		versions = append(versions, key)
+	}
+	slices.Sort(versions)
+	return versions
+}
+
 // GetProtocolVersionsNtC returns a list of supported NtC protocol versions
 func GetProtocolVersionsNtC() []uint16 {
 	versions := []uint16{}
@@ -369,7 +418,12 @@ func GetProtocolVersionsNtN() []uint16 {
 	return versions
 }
 
-// GetProtocolVersion returns the protocol version config for the specified protocol version
+// GetProtocolVersion returns the protocol version config for the specified protocol version.
+// It searches both the Cardano NtN/NtC map and the DMQ N2C map, whose key spaces
+// are disjoint (DMQ uses the 0x1000 offset, Cardano NtC uses 0x8000, NtN uses 7-15).
 func GetProtocolVersion(version uint16) ProtocolVersion {
-	return protocolVersions[version]
+	if v, ok := protocolVersions[version]; ok {
+		return v
+	}
+	return dmqProtocolVersions[version]
 }

--- a/protocol/versions_test.go
+++ b/protocol/versions_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDMQVersionEncoding verifies the DMQ N2C version offset matches the
+// upstream encoding: dmq-node uses bit 12 (= 0x1000) to mark DMQ N2C
+// versions in the handshake, distinct from Cardano's NtC offset 0x8000
+// (bit 15). NodeToClientV_1 is therefore wire-encoded as
+// 1 | 0x1000 = 0x1001 = 4097.
+func TestDMQVersionEncoding(t *testing.T) {
+	require.Equal(t, uint16(0x1000), uint16(ProtocolVersionDMQNtCOffset))
+	versions := GetProtocolVersionsDMQNtC()
+	require.Len(t, versions, 1)
+	assert.Equal(t, uint16(0x1001), versions[0])
+	assert.NotEqual(
+		t,
+		uint16(ProtocolVersionNtCOffset+1),
+		versions[0],
+		"DMQ version must not collide with Cardano NtC version space",
+	)
+}
+
+// TestGetProtocolVersionMapDMQNtC verifies the version map produced for a
+// DMQ N2C handshake. The VersionData carries the supplied network magic
+// and query flag, encoded with the same shape as Cardano's
+// VersionDataNtC15andUp.
+func TestGetProtocolVersionMapDMQNtC(t *testing.T) {
+	const dmqDefaultMagic uint32 = 3_141_592 // dmq-node default
+	m := GetProtocolVersionMapDMQNtC(dmqDefaultMagic, false)
+	require.Len(t, m, 1, "DMQ currently advertises only V1")
+	v, ok := m[0x1001]
+	require.True(t, ok, "DMQ N2C v1 (0x1001) missing from version map")
+	assert.Equal(t, dmqDefaultMagic, v.NetworkMagic())
+	assert.False(t, v.Query())
+
+	// Query flag passes through.
+	mq := GetProtocolVersionMapDMQNtC(dmqDefaultMagic, true)
+	vq, ok := mq[0x1001]
+	require.True(t, ok, "DMQ N2C v1 (0x1001) missing from query-mode version map")
+	assert.True(t, vq.Query(), "Query flag did not propagate from caller to VersionData")
+}
+
+// TestGetProtocolVersionDMQResolvable verifies that GetProtocolVersion can
+// resolve DMQ N2C versions. Without this, handshake.Client.handleAcceptVersion
+// and handshake.Server.handleProposeVersions would panic when calling
+// NewVersionDataFromCborFunc on a zero-value ProtocolVersion returned for
+// any DMQ version.
+func TestGetProtocolVersionDMQResolvable(t *testing.T) {
+	require.NotNil(
+		t,
+		GetProtocolVersion(0x1001).NewVersionDataFromCborFunc,
+		"DMQ versions are not reachable via GetProtocolVersion",
+	)
+}
+
+// TestGetProtocolVersionMapDMQNtCMithril verifies the well-known Mithril
+// magics round-trip through the DMQ version map. These values are
+// documented in CIP-0137 and used by Mithril's published deployments;
+// breaking them would silently misroute DMQ traffic.
+func TestGetProtocolVersionMapDMQNtCMithril(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		magic uint32
+	}{
+		{"mainnet", 2_912_307_721},
+		{"preprod", 2_147_483_649},
+		{"preview", 2_147_483_650},
+		{"devnet", 2_147_483_690},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := GetProtocolVersionMapDMQNtC(tc.magic, false)
+			v, ok := m[0x1001]
+			require.True(t, ok, "DMQ N2C v1 (0x1001) missing from version map")
+			assert.Equal(t, tc.magic, v.NetworkMagic())
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CIP‑0137 DMQ node‑to‑client support behind `WithDMQ(true)`, negotiating v1 `0x1001` (bit‑12 offset) and exposing only `LocalMessageSubmission` (14) and `LocalMessageNotification` (15).

- **New Features**
  - `WithDMQ(true)` enables DMQ N2C using the configured network magic as the topic ID; cannot be combined with `WithNodeToNode`.
  - `LocalMessageSubmission()` and `LocalMessageNotification()` accessors; DMQ mini‑protocols included in idle checks.
  - Config hooks: `WithLocalMessageSubmissionConfig` and `WithLocalMessageNotificationConfig`; client/server start respects mode.
  - DMQ version helpers `GetProtocolVersionMapDMQNtC`/`GetProtocolVersionsDMQNtC`; `GetProtocolVersion()` resolves DMQ versions; handshake advertises v1 `0x1001`.
  - Corrects protocol IDs: `MessageSubmission`=11, `LocalMessageSubmission`=14, `LocalMessageNotification`=15; docs updated; tests cover DMQ version encoding/resolution and Mithril topic magics.

- **Migration**
  - Opt in with `WithDMQ(true)` and pass the DMQ topic magic via your network‑magic option (e.g., Mithril mainnet `2912307721`); do not combine with `WithNodeToNode`.
  - Use `LocalMessageSubmission()`/`LocalMessageNotification()`; other mini‑protocols are unavailable in DMQ mode.

<sup>Written for commit d69eeaa4a6b4f7938fc2b189ebd2010bef42a300. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DMQ (Direct Message Queue) node-to-client protocol support with new connection configuration options

* **Documentation**
  * Updated protocol identifier specifications for message submission and notification protocols

* **Tests**
  * Added comprehensive test coverage for DMQ protocol version encoding and resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->