### PR TITLE
fix(cbor): Rat JSON serialization panics for large or negative values

### DIFF
--- a/cbor/tags.go
+++ b/cbor/tags.go
@@ -113,6 +113,8 @@ func (r *Rat) UnmarshalCBOR(cborData []byte) error {
 		tmpNum.SetInt64(v)
 	case uint64:
 		tmpNum.SetUint64(v)
+	case big.Int:
+		tmpNum.Set(&v)
 	default:
 		return fmt.Errorf("unsupported numerator type for cbor.Rat: %T", v)
 	}
@@ -123,6 +125,8 @@ func (r *Rat) UnmarshalCBOR(cborData []byte) error {
 		tmpDenom.SetInt64(v)
 	case uint64:
 		tmpDenom.SetUint64(v)
+	case big.Int:
+		tmpDenom.Set(&v)
 	default:
 		return fmt.Errorf("unsupported denominator type for cbor.Rat: %T", v)
 	}

--- a/cbor/value.go
+++ b/cbor/value.go
@@ -203,8 +203,8 @@ func generateAstJson(obj any) ([]byte, error) {
 	case Rat:
 		return generateAstJson(
 			[]any{
-				v.Num().Uint64(),
-				v.Denom().Uint64(),
+				v.Num(),
+				v.Denom(),
 			},
 		)
 	case int, uint, uint64, int64:

--- a/cbor/value_test.go
+++ b/cbor/value_test.go
@@ -93,7 +93,7 @@ var testDefs = []struct {
 		},
 		expectedAstJson: `{"list":[{"int":3},{"int":1000}]}`,
 	},
-	// 30([-1, 2])
+	// 30([-1, 2]) -- negative rational
 	{
 		cborHex: "d81e822002",
 		expectedObject: cbor.Rat{
@@ -101,18 +101,18 @@ var testDefs = []struct {
 		},
 		expectedAstJson: `{"list":[{"int":-1},{"int":2}]}`,
 	},
-	// 30([18446744073709551616, 2])
+	// 30([18446744073709551617, 1]) -- numerator = 2^64+1 greater than MaxUint64
 	{
-		cborHex: "d81e82c24901000000000000000002",
+		cborHex: "d81e82c24901000000000000000101",
 		expectedObject: cbor.Rat{
 			Rat: new(big.Rat).SetFrac(
-				new(big.Int).SetBytes(test.DecodeHexString("010000000000000000")),
-				big.NewInt(2),
+				new(big.Int).SetBytes(test.DecodeHexString("010000000000000001")),
+				big.NewInt(1),
 			),
 		},
-		expectedAstJson: `{"list":[{"int":18446744073709551616},{"int":2}]}`,
+		expectedAstJson: `{"list":[{"int":18446744073709551617},{"int":1}]}`,
 	},
-	// 30([1, 0])
+	// 30([1, 0]) -- zero denominator
 	{
 		cborHex:             "d81e820100",
 		expectedObject:      nil,

--- a/cbor/value_test.go
+++ b/cbor/value_test.go
@@ -93,6 +93,31 @@ var testDefs = []struct {
 		},
 		expectedAstJson: `{"list":[{"int":3},{"int":1000}]}`,
 	},
+	// 30([-1, 2])
+	{
+		cborHex: "d81e822002",
+		expectedObject: cbor.Rat{
+			Rat: big.NewRat(-1, 2),
+		},
+		expectedAstJson: `{"list":[{"int":-1},{"int":2}]}`,
+	},
+	// 30([18446744073709551616, 2])
+	{
+		cborHex: "d81e82c24901000000000000000002",
+		expectedObject: cbor.Rat{
+			Rat: new(big.Rat).SetFrac(
+				new(big.Int).SetBytes(test.DecodeHexString("010000000000000000")),
+				big.NewInt(2),
+			),
+		},
+		expectedAstJson: `{"list":[{"int":18446744073709551616},{"int":2}]}`,
+	},
+	// 30([1, 0])
+	{
+		cborHex:             "d81e820100",
+		expectedObject:      nil,
+		expectedDecodeError: fmt.Errorf("invalid cbor.Rat: denominator cannot be zero"),
+	},
 	// 258([1, 2, 3])
 	{
 		cborHex: "d9010283010203",


### PR DESCRIPTION
1. Added failing regression tests first for negative rationals, oversized rational numerators, and zero denominators.
2. I have confirmed the tests reproduced the issue before making the code fix. (go test ./cbor/... -v.)
3. Added the fix and the fix replaces v.Num().Uint64() / v.Denom().Uint64() with v.Num() / v.Denom() so rationals use the existing *big.Int JSON path.
4. I have verified the fix by testing the negative tests with go test ./cbor/... -v.

Closes #1581 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix JSON serialization of `cbor.Rat` to handle negatives and numerators larger than `uint64` without panics and to preserve full precision (fixes #1581). Added regression tests and validation to reject zero denominators on decode.

- **Bug Fixes**
  - In `generateAstJson`, pass `v.Num()`/`v.Denom()` directly so JSON uses the `*big.Int` path instead of truncating to `uint64`.
  - In `Rat.UnmarshalCBOR`, accept `big.Int` for numerator and denominator; tests cover negative rationals, >MaxUint64 numerators, and zero-denominator errors.

<sup>Written for commit 8d813c7e90de3c5858529dc283691dead4265446. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended support for rational numbers with numerators/denominators larger than 64-bit integers
  * Added validation to reject rational numbers with zero denominators

* **Improvements**
  * Rational number JSON output now preserves full numeric precision instead of truncating to 64-bit values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->