### PR TITLE
fix(ledger): rename pv10 to plomin and bump max to 11

### DIFF
--- a/ledger/common/protocol_version.go
+++ b/ledger/common/protocol_version.go
@@ -23,7 +23,7 @@ const (
 	ProtocolVersionAlonzo     uint = 6
 	ProtocolVersionBabbage    uint = 8
 	ProtocolVersionConway     uint = 9
-	ProtocolVersionConwayPlus uint = 10
+	ProtocolVersionPlomin     uint = 10 // PV10 intra-era hard fork; enabled full governance (incl. treasury withdrawals)
 	ProtocolVersionVanRossem  uint = 11 // PV11 intra-era hard fork
 )
 

--- a/ledger/common/protocol_version_test.go
+++ b/ledger/common/protocol_version_test.go
@@ -28,7 +28,7 @@ func TestProtocolVersionConstants(t *testing.T) {
 	assert.Equal(t, uint(6), ProtocolVersionAlonzo)
 	assert.Equal(t, uint(8), ProtocolVersionBabbage)
 	assert.Equal(t, uint(9), ProtocolVersionConway)
-	assert.Equal(t, uint(10), ProtocolVersionConwayPlus)
+	assert.Equal(t, uint(10), ProtocolVersionPlomin)
 	assert.Equal(t, uint(11), ProtocolVersionVanRossem)
 }
 

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -40,7 +40,7 @@ const (
 	MinProtocolVersionConway = 9
 	// MaxProtocolVersionConway is the highest protocol major
 	// version that belongs to the Conway era.
-	MaxProtocolVersionConway = 10
+	MaxProtocolVersionConway = 11
 
 	BlockTypeConway = 7
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed PV10 to Plomin and raised the Conway era max protocol version to 11 to reflect intra-era hard forks; updated tests.

- **Migration**
  - Replace `ProtocolVersionConwayPlus` with `ProtocolVersionPlomin`.

<sup>Written for commit 1a361606333d002cfebe8e24d623a92bcdf5611f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated protocol version support configuration to maintain compatibility with the latest blockchain protocol specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->