### PR TITLE
fix(protocol): Ignored SendMessage errors in shutdown paths

### DIFF
--- a/ledger/common/protocol_version.go
+++ b/ledger/common/protocol_version.go
@@ -17,14 +17,14 @@ package common
 // Protocol version constants for Cardano hard forks.
 // These correspond to the major protocol version numbers.
 const (
-	ProtocolVersionShelley    uint = 2
-	ProtocolVersionAllegra    uint = 3
-	ProtocolVersionMary       uint = 4
-	ProtocolVersionAlonzo     uint = 6
-	ProtocolVersionBabbage    uint = 8
-	ProtocolVersionConway     uint = 9
-	ProtocolVersionPlomin     uint = 10 // PV10 intra-era hard fork; enabled full governance (incl. treasury withdrawals)
-	ProtocolVersionVanRossem  uint = 11 // PV11 intra-era hard fork
+	ProtocolVersionShelley   uint = 2
+	ProtocolVersionAllegra   uint = 3
+	ProtocolVersionMary      uint = 4
+	ProtocolVersionAlonzo    uint = 6
+	ProtocolVersionBabbage   uint = 8
+	ProtocolVersionConway    uint = 9
+	ProtocolVersionPlomin    uint = 10 // PV10 intra-era hard fork; enabled full governance (incl. treasury withdrawals)
+	ProtocolVersionVanRossem uint = 11 // PV11 intra-era hard fork
 )
 
 // IsProtocolVersionAtLeast checks if the given protocol version (major.minor)

--- a/protocol/handshake/client.go
+++ b/protocol/handshake/client.go
@@ -96,7 +96,7 @@ func (c *Client) Start() {
 					"error", err,
 				)
 			// Start cannot return this error, so log it and still clean up.
-			c.Protocol.Stop()
+			c.Stop()
 		}
 	})
 }

--- a/protocol/handshake/client.go
+++ b/protocol/handshake/client.go
@@ -87,7 +87,17 @@ func (c *Client) Start() {
 		c.Protocol.Start()
 		// Send our ProposeVersions message
 		msg := NewMsgProposeVersions(c.config.ProtocolVersionMap)
-		_ = c.SendMessage(msg)
+		if err := c.SendMessage(msg); err != nil {
+			c.Protocol.Logger().
+				Warn("failed to send handshake propose versions",
+					"component", "network",
+					"protocol", ProtocolName,
+					"connection_id", c.callbackContext.ConnectionId.String(),
+					"error", err,
+				)
+			// Start cannot return this error, so log it and still clean up.
+			c.Protocol.Stop()
+		}
 	})
 }
 

--- a/protocol/txsubmission/client.go
+++ b/protocol/txsubmission/client.go
@@ -243,7 +243,20 @@ func (c *Client) Init() {
 		)
 	// Send our Init message
 	msg := NewMsgInit()
-	_ = c.SendMessage(msg)
+	if err := c.SendMessage(msg); err != nil {
+		c.Protocol.Logger().
+			Warn("failed to send txsubmission init",
+				"component", "network",
+				"protocol", ProtocolName,
+				"role", "client",
+				"connection_id", c.callbackContext.ConnectionId.String(),
+				"error", err,
+			)
+		// Init cannot return this error, so log it and still clean up.
+		c.Protocol.Stop()
+		c.lifecycleState = clientStateStopped
+		return
+	}
 	c.initSent = true
 }
 


### PR DESCRIPTION
 1. Made changes to log previously discarded SendMessage errors in handshake and txsubmission clients.
2. Clean up the protocol instance when SendMessage fails and added comments explaining that the errors are logged instead of returned because the methods have no error return path.

Closes #1582 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in handshake and transaction submission protocols to properly detect and respond to message send failures.
  * Ensures protocol resources are cleaned up gracefully when communication errors occur, preventing silent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->