### PR TITLE
feat(ledger): Conway PV9 gating

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Companion to `AGENTS.md`; read that first. This file: Claude-specific facts and 
 
 | Metric | Value |
 |--------|-------|
-| Test functions | 2531 (100% passing) |
+| Test functions | 2537 (100% passing) |
 | Ledger rule vectors | 314/314 (via Amaru) |
 | VRF | 29 vectors + 15 unit tests |
 | KES | 14 (input-output-hk/kes) |

--- a/ledger/conway/errors.go
+++ b/ledger/conway/errors.go
@@ -257,6 +257,34 @@ func (e ZeroTreasuryWithdrawalAmountError) Error() string {
 	return "treasury withdrawal governance action has zero withdrawal amount"
 }
 
+// BootstrapDisallowedGovActionError indicates a governance action type that is
+// not permitted during the Conway bootstrap phase (PV9, before the Plomin hard fork).
+type BootstrapDisallowedGovActionError struct {
+	ActionType common.GovActionType
+}
+
+func (e BootstrapDisallowedGovActionError) Error() string {
+	return fmt.Sprintf(
+		"governance action type %d is not allowed during the Conway bootstrap phase (PV9); requires PV10 (Plomin) or later",
+		e.ActionType,
+	)
+}
+
+// BootstrapDisallowedParameterChangeError indicates a ParameterChange proposal
+// that updates one or more bootstrap-restricted fields, which is not permitted
+// during the Conway bootstrap phase (PV9). The Plomin hard fork (PV10) lifts
+// the restriction.
+type BootstrapDisallowedParameterChangeError struct {
+	Fields []string
+}
+
+func (e BootstrapDisallowedParameterChangeError) Error() string {
+	return fmt.Sprintf(
+		"ParameterChange proposal updates bootstrap-restricted fields %v which are not allowed during the Conway bootstrap phase (PV9); requires PV10 (Plomin) or later",
+		e.Fields,
+	)
+}
+
 // WrongNetworkProposalAddressError indicates that a proposal address has wrong network ID
 type WrongNetworkProposalAddressError struct {
 	NetId uint

--- a/ledger/conway/errors_test.go
+++ b/ledger/conway/errors_test.go
@@ -467,3 +467,21 @@ func TestConway_Rule7_ScriptDataHashWithWitnessDatumsNoRedeemers(
 		)
 	}
 }
+
+func TestBootstrapDisallowedGovActionError_String(t *testing.T) {
+	err := conway.BootstrapDisallowedGovActionError{ActionType: common.GovActionTypeTreasuryWithdrawal}
+	got := err.Error()
+	want := "governance action type 2 is not allowed during the Conway bootstrap phase (PV9); requires PV10 (Plomin) or later"
+	if got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestBootstrapDisallowedParameterChangeError_String(t *testing.T) {
+	err := conway.BootstrapDisallowedParameterChangeError{Fields: []string{"DRepDeposit", "MinCommitteeSize"}}
+	got := err.Error()
+	want := "ParameterChange proposal updates bootstrap-restricted fields [DRepDeposit MinCommitteeSize] which are not allowed during the Conway bootstrap phase (PV9); requires PV10 (Plomin) or later"
+	if got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+}

--- a/ledger/conway/pparams.go
+++ b/ledger/conway/pparams.go
@@ -427,6 +427,48 @@ type ConwayProtocolParameterUpdate struct {
 	MinFeeRefScriptCostPerByte *cbor.Rat                                 `cbor:"33,keyasint"`
 }
 
+// BootstrapRestrictedFields returns the names of parameter fields that this
+// update mutates and that are restricted during the Conway bootstrap phase.
+// Order is stable to make error messages deterministic.
+//
+// These fields span the governance, security, and economic groups per
+// CIP-1694; the unifying property is that they were not on-chain governable
+// during PV9 (bootstrap) and only became governable at PV10 (Plomin). The
+// name avoids claiming a single CIP-1694 group taxonomy because the set
+// crosses groups (e.g., MinFeeRefScriptCostPerByte is economic/security,
+// not governance).
+func (u *ConwayProtocolParameterUpdate) BootstrapRestrictedFields() []string {
+	var fields []string
+	if u.PoolVotingThresholds != nil {
+		fields = append(fields, "PoolVotingThresholds")
+	}
+	if u.DRepVotingThresholds != nil {
+		fields = append(fields, "DRepVotingThresholds")
+	}
+	if u.MinCommitteeSize != nil {
+		fields = append(fields, "MinCommitteeSize")
+	}
+	if u.CommitteeTermLimit != nil {
+		fields = append(fields, "CommitteeTermLimit")
+	}
+	if u.GovActionValidityPeriod != nil {
+		fields = append(fields, "GovActionValidityPeriod")
+	}
+	if u.GovActionDeposit != nil {
+		fields = append(fields, "GovActionDeposit")
+	}
+	if u.DRepDeposit != nil {
+		fields = append(fields, "DRepDeposit")
+	}
+	if u.DRepInactivityPeriod != nil {
+		fields = append(fields, "DRepInactivityPeriod")
+	}
+	if u.MinFeeRefScriptCostPerByte != nil {
+		fields = append(fields, "MinFeeRefScriptCostPerByte")
+	}
+	return fields
+}
+
 func (u *ConwayProtocolParameterUpdate) UnmarshalCBOR(cborData []byte) error {
 	type tConwayProtocolParameterUpdate ConwayProtocolParameterUpdate
 	var tmp tConwayProtocolParameterUpdate

--- a/ledger/conway/pparams_test.go
+++ b/ledger/conway/pparams_test.go
@@ -1023,3 +1023,36 @@ func TestConwayProtocolParameters_CborRoundTrip(t *testing.T) {
 		decoded.MinFeeRefScriptCostPerByte.Rat.RatString(),
 	)
 }
+
+func TestConwayProtocolParameterUpdate_BootstrapRestrictedFields(t *testing.T) {
+	t.Run("empty update has no restricted fields", func(t *testing.T) {
+		u := &conway.ConwayProtocolParameterUpdate{}
+		fields := u.BootstrapRestrictedFields()
+		if len(fields) != 0 {
+			t.Fatalf("want empty, got %v", fields)
+		}
+	})
+
+	t.Run("DRepDeposit and MinCommitteeSize are restricted", func(t *testing.T) {
+		dep := uint64(500_000_000)
+		size := uint(7)
+		u := &conway.ConwayProtocolParameterUpdate{
+			DRepDeposit:      &dep,
+			MinCommitteeSize: &size,
+		}
+		fields := u.BootstrapRestrictedFields()
+		want := []string{"MinCommitteeSize", "DRepDeposit"}
+		if !reflect.DeepEqual(fields, want) {
+			t.Fatalf("want %v, got %v", want, fields)
+		}
+	})
+
+	t.Run("non-restricted fields are ignored", func(t *testing.T) {
+		fee := uint(44)
+		u := &conway.ConwayProtocolParameterUpdate{MinFeeA: &fee}
+		fields := u.BootstrapRestrictedFields()
+		if len(fields) != 0 {
+			t.Fatalf("want empty for MinFeeA-only update, got %v", fields)
+		}
+	})
+}

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -38,6 +38,8 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateProposalProcedures,
 	UtxoValidateProposalNetworkIds,
 	UtxoValidateEmptyTreasuryWithdrawals,
+	UtxoValidateBootstrapAllowedGovActions,
+	UtxoValidateBootstrapParameterGroups,
 	UtxoValidateIsValidFlag,
 	UtxoValidateRequiredVKeyWitnesses,
 	UtxoValidateCollateralVKeyWitnesses,
@@ -78,6 +80,26 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateCommitteeCertificates,
 	UtxoValidateCCVotingRestrictions,
 	UtxoValidateMalformedReferenceScripts,
+}
+
+// isInConwayBootstrapPhase reports whether the given protocol parameters
+// are in the Conway bootstrap phase: protocol major version in the range
+// [PV9, PV10). The Plomin hard fork at PV10 lifts the bootstrap restrictions
+// on governance actions.
+//
+// The predicate is bounded on both sides: a sub-PV9 major (e.g., a Babbage
+// pp accidentally wrapped in *ConwayProtocolParameters) returns false, and
+// PV10+ returns false. Returns false for non-Conway parameter types as a
+// defensive fallback; callers in this package always pass
+// *ConwayProtocolParameters.
+func isInConwayBootstrapPhase(pp common.ProtocolParameters) bool {
+	conwayPp, ok := pp.(*ConwayProtocolParameters)
+	if !ok {
+		return false
+	}
+	major := conwayPp.ProtocolVersion.Major
+	return major >= common.ProtocolVersionConway &&
+		major < common.ProtocolVersionPlomin
 }
 
 // UtxoValidateDisjointRefInputs ensures reference inputs don't overlap with regular inputs.
@@ -220,6 +242,97 @@ func UtxoValidateEmptyTreasuryWithdrawals(
 			if !hasNonZero {
 				return ZeroTreasuryWithdrawalAmountError{}
 			}
+		}
+	}
+	return nil
+}
+
+// UtxoValidateBootstrapAllowedGovActions enforces the Conway bootstrap-phase
+// restriction on which governance action types may be proposed.
+//
+// Pre-Plomin (PV9), only InfoAction, HardForkInitiation, and ParameterChange
+// are permitted (ParameterChange's restricted parameter groups are enforced
+// separately by UtxoValidateBootstrapParameterGroups). TreasuryWithdrawal,
+// NoConfidence, UpdateCommittee, and NewConstitution are rejected.
+//
+// At PV10 (Plomin) and later, all governance action types are allowed.
+func UtxoValidateBootstrapAllowedGovActions(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	if !isInConwayBootstrapPhase(pp) {
+		return nil
+	}
+	for _, proposal := range tx.ProposalProcedures() {
+		govAction := proposal.GovAction()
+		if govAction == nil {
+			continue
+		}
+		// NOTE: closed-set type-switch over the 7 GovActionType constants in
+		// ledger/common/gov.go. Permissive default is intentional — matches
+		// cardano-ledger's deny-list semantics. New GovAction types added to
+		// common will fall into the default arm and be allowed at PV9; an
+		// explicit case must be added here to gate them.
+		switch govAction.(type) {
+		case *common.InfoGovAction:
+			// always allowed
+		case *common.HardForkInitiationGovAction:
+			// allowed because it is the path out of bootstrap
+		case *ConwayParameterChangeGovAction:
+			// allowed shape; group restriction enforced separately
+		case *common.TreasuryWithdrawalGovAction:
+			return BootstrapDisallowedGovActionError{
+				ActionType: common.GovActionTypeTreasuryWithdrawal,
+			}
+		case *common.NoConfidenceGovAction:
+			return BootstrapDisallowedGovActionError{
+				ActionType: common.GovActionTypeNoConfidence,
+			}
+		case *common.UpdateCommitteeGovAction:
+			return BootstrapDisallowedGovActionError{
+				ActionType: common.GovActionTypeUpdateCommittee,
+			}
+		case *common.NewConstitutionGovAction:
+			return BootstrapDisallowedGovActionError{
+				ActionType: common.GovActionTypeNewConstitution,
+			}
+		default:
+			// Any new GovAction type added to ledger/common is implicitly
+			// allowed here; this branch exists so the assumption is visible
+			// at the call site rather than only in the NOTE above.
+		}
+	}
+	return nil
+}
+
+// UtxoValidateBootstrapParameterGroups enforces the Conway bootstrap-phase
+// restriction that ParameterChange proposals may not touch fields restricted
+// during bootstrap. The Plomin hard fork (PV10) lifts this restriction.
+//
+// See UtxoValidateBootstrapAllowedGovActions for the action-type-level
+// restriction enforced first.
+func UtxoValidateBootstrapParameterGroups(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	if !isInConwayBootstrapPhase(pp) {
+		return nil
+	}
+	for _, proposal := range tx.ProposalProcedures() {
+		govAction := proposal.GovAction()
+		if govAction == nil {
+			continue
+		}
+		paramChange, ok := govAction.(*ConwayParameterChangeGovAction)
+		if !ok {
+			continue
+		}
+		if fields := paramChange.ParamUpdate.BootstrapRestrictedFields(); len(fields) > 0 {
+			return BootstrapDisallowedParameterChangeError{Fields: fields}
 		}
 	}
 	return nil

--- a/ledger/conway/rules_internal_test.go
+++ b/ledger/conway/rules_internal_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conway
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+func TestIsInConwayBootstrapPhase(t *testing.T) {
+	tests := []struct {
+		name string
+		pp   common.ProtocolParameters
+		want bool
+	}{
+		{
+			name: "PV8 (Babbage) wrapped in Conway pparams returns false",
+			pp:   &ConwayProtocolParameters{ProtocolVersion: common.ProtocolParametersProtocolVersion{Major: 8}},
+			want: false,
+		},
+		{
+			name: "PV9 (bootstrap) returns true",
+			pp:   &ConwayProtocolParameters{ProtocolVersion: common.ProtocolParametersProtocolVersion{Major: 9}},
+			want: true,
+		},
+		{
+			name: "PV10 (Plomin) returns false",
+			pp:   &ConwayProtocolParameters{ProtocolVersion: common.ProtocolParametersProtocolVersion{Major: 10}},
+			want: false,
+		},
+		{
+			name: "PV11 (VanRossem) returns false",
+			pp:   &ConwayProtocolParameters{ProtocolVersion: common.ProtocolParametersProtocolVersion{Major: 11}},
+			want: false,
+		},
+		{
+			name: "non-Conway pparams returns false (defensive)",
+			pp:   &babbage.BabbageProtocolParameters{},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isInConwayBootstrapPhase(tt.pp); got != tt.want {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"reflect"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -2687,5 +2688,238 @@ func TestUtxoValidateDelegation_InTxVrfKeyDuplicates(t *testing.T) {
 		// PV10 doesn't enforce VRF key uniqueness
 		err := conway.UtxoValidateDelegation(tx, 0, ls, pv10Params)
 		assert.NoError(t, err)
+	})
+}
+
+func TestUtxoValidateBootstrapAllowedGovActions(t *testing.T) {
+	mkPp := func(major uint) *conway.ConwayProtocolParameters {
+		return &conway.ConwayProtocolParameters{
+			ProtocolVersion: common.ProtocolParametersProtocolVersion{
+				Major: major,
+			},
+		}
+	}
+	mkTx := func(actions ...common.GovAction) *conway.ConwayTransaction {
+		tx := &conway.ConwayTransaction{}
+		for _, a := range actions {
+			tx.Body.TxProposalProcedures = append(
+				tx.Body.TxProposalProcedures,
+				conway.ConwayProposalProcedure{
+					PPGovAction: conway.ConwayGovAction{Action: a},
+				},
+			)
+		}
+		return tx
+	}
+
+	tests := []struct {
+		name        string
+		pvMajor     uint
+		actions     []common.GovAction
+		wantErrType any
+	}{
+		{
+			name:    "PV9 InfoAction allowed",
+			pvMajor: 9,
+			actions: []common.GovAction{&common.InfoGovAction{}},
+		},
+		{
+			name:    "PV9 HardForkInitiation allowed",
+			pvMajor: 9,
+			actions: []common.GovAction{&common.HardForkInitiationGovAction{}},
+		},
+		{
+			name:    "PV9 ParameterChange allowed shape",
+			pvMajor: 9,
+			actions: []common.GovAction{&conway.ConwayParameterChangeGovAction{}},
+		},
+		{
+			name:        "PV9 TreasuryWithdrawal rejected",
+			pvMajor:     9,
+			actions:     []common.GovAction{&common.TreasuryWithdrawalGovAction{}},
+			wantErrType: conway.BootstrapDisallowedGovActionError{},
+		},
+		{
+			name:        "PV9 NoConfidence rejected",
+			pvMajor:     9,
+			actions:     []common.GovAction{&common.NoConfidenceGovAction{}},
+			wantErrType: conway.BootstrapDisallowedGovActionError{},
+		},
+		{
+			name:        "PV9 UpdateCommittee rejected",
+			pvMajor:     9,
+			actions:     []common.GovAction{&common.UpdateCommitteeGovAction{}},
+			wantErrType: conway.BootstrapDisallowedGovActionError{},
+		},
+		{
+			name:        "PV9 NewConstitution rejected",
+			pvMajor:     9,
+			actions:     []common.GovAction{&common.NewConstitutionGovAction{}},
+			wantErrType: conway.BootstrapDisallowedGovActionError{},
+		},
+		{
+			name:    "PV10 TreasuryWithdrawal allowed",
+			pvMajor: 10,
+			actions: []common.GovAction{&common.TreasuryWithdrawalGovAction{}},
+		},
+		{
+			name:    "PV10 NoConfidence allowed",
+			pvMajor: 10,
+			actions: []common.GovAction{&common.NoConfidenceGovAction{}},
+		},
+		{
+			name:    "PV11 all governance actions allowed",
+			pvMajor: 11,
+			actions: []common.GovAction{
+				&common.UpdateCommitteeGovAction{},
+				&common.NewConstitutionGovAction{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := mkTx(tt.actions...)
+			err := conway.UtxoValidateBootstrapAllowedGovActions(
+				tx,
+				0,
+				nil,
+				mkPp(tt.pvMajor),
+			)
+			if tt.wantErrType == nil {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			var bdErr conway.BootstrapDisallowedGovActionError
+			if !errors.As(err, &bdErr) {
+				t.Fatalf(
+					"got %T (%v), want BootstrapDisallowedGovActionError",
+					err,
+					err,
+				)
+			}
+		})
+	}
+
+	t.Run("PV9 with empty proposals is allowed", func(t *testing.T) {
+		tx := &conway.ConwayTransaction{}
+		if err := conway.UtxoValidateBootstrapAllowedGovActions(tx, 0, nil, mkPp(9)); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("PV9 mixed proposals fails on first disallowed action", func(t *testing.T) {
+		tx := mkTx(&common.InfoGovAction{}, &common.TreasuryWithdrawalGovAction{})
+		err := conway.UtxoValidateBootstrapAllowedGovActions(tx, 0, nil, mkPp(9))
+		var bdErr conway.BootstrapDisallowedGovActionError
+		if !errors.As(err, &bdErr) {
+			t.Fatalf("got %T (%v), want BootstrapDisallowedGovActionError", err, err)
+		}
+		if bdErr.ActionType != common.GovActionTypeTreasuryWithdrawal {
+			t.Fatalf("got ActionType %d, want %d (TreasuryWithdrawal)", bdErr.ActionType, common.GovActionTypeTreasuryWithdrawal)
+		}
+	})
+}
+
+func TestUtxoValidateBootstrapParameterGroups(t *testing.T) {
+	mkPp := func(major uint) *conway.ConwayProtocolParameters {
+		return &conway.ConwayProtocolParameters{
+			ProtocolVersion: common.ProtocolParametersProtocolVersion{
+				Major: major,
+			},
+		}
+	}
+	dep := uint64(500_000_000)
+	fee := uint(44)
+
+	mkTxWithParamChange := func(
+		update conway.ConwayProtocolParameterUpdate,
+	) *conway.ConwayTransaction {
+		tx := &conway.ConwayTransaction{}
+		tx.Body.TxProposalProcedures = []conway.ConwayProposalProcedure{
+			{
+				PPGovAction: conway.ConwayGovAction{
+					Action: &conway.ConwayParameterChangeGovAction{
+						ParamUpdate: update,
+					},
+				},
+			},
+		}
+		return tx
+	}
+
+	t.Run("PV9 with non-restricted ParameterChange is allowed", func(t *testing.T) {
+		tx := mkTxWithParamChange(
+			conway.ConwayProtocolParameterUpdate{MinFeeA: &fee},
+		)
+		if err := conway.UtxoValidateBootstrapParameterGroups(tx, 0, nil, mkPp(9)); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("PV9 with restricted ParameterChange is rejected", func(t *testing.T) {
+		tx := mkTxWithParamChange(
+			conway.ConwayProtocolParameterUpdate{DRepDeposit: &dep},
+		)
+		err := conway.UtxoValidateBootstrapParameterGroups(tx, 0, nil, mkPp(9))
+		var bgErr conway.BootstrapDisallowedParameterChangeError
+		if !errors.As(err, &bgErr) {
+			t.Fatalf(
+				"got %T (%v), want BootstrapDisallowedParameterChangeError",
+				err,
+				err,
+			)
+		}
+		if !reflect.DeepEqual(bgErr.Fields, []string{"DRepDeposit"}) {
+			t.Fatalf("got fields %v, want [DRepDeposit]", bgErr.Fields)
+		}
+	})
+
+	t.Run("PV10 with restricted ParameterChange is allowed", func(t *testing.T) {
+		tx := mkTxWithParamChange(
+			conway.ConwayProtocolParameterUpdate{DRepDeposit: &dep},
+		)
+		if err := conway.UtxoValidateBootstrapParameterGroups(tx, 0, nil, mkPp(10)); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("PV9 with MinFeeRefScriptCostPerByte ParameterChange is rejected", func(t *testing.T) {
+		rate := &cbor.Rat{Rat: big.NewRat(15, 1000)}
+		tx := mkTxWithParamChange(conway.ConwayProtocolParameterUpdate{MinFeeRefScriptCostPerByte: rate})
+		err := conway.UtxoValidateBootstrapParameterGroups(tx, 0, nil, mkPp(9))
+		var bgErr conway.BootstrapDisallowedParameterChangeError
+		if !errors.As(err, &bgErr) {
+			t.Fatalf("got %T (%v), want BootstrapDisallowedParameterChangeError", err, err)
+		}
+		if !reflect.DeepEqual(bgErr.Fields, []string{"MinFeeRefScriptCostPerByte"}) {
+			t.Fatalf("got fields %v, want [MinFeeRefScriptCostPerByte]", bgErr.Fields)
+		}
+	})
+
+	t.Run("PV9 with multi-field restricted ParameterChange surfaces all fields", func(t *testing.T) {
+		size := uint(7)
+		tx := mkTxWithParamChange(conway.ConwayProtocolParameterUpdate{
+			MinCommitteeSize: &size,
+			DRepDeposit:      &dep,
+		})
+		err := conway.UtxoValidateBootstrapParameterGroups(tx, 0, nil, mkPp(9))
+		var bgErr conway.BootstrapDisallowedParameterChangeError
+		if !errors.As(err, &bgErr) {
+			t.Fatalf("got %T (%v), want BootstrapDisallowedParameterChangeError", err, err)
+		}
+		want := []string{"MinCommitteeSize", "DRepDeposit"}
+		if !reflect.DeepEqual(bgErr.Fields, want) {
+			t.Fatalf("got fields %v, want %v", bgErr.Fields, want)
+		}
+	})
+
+	t.Run("PV9 with empty proposals is allowed", func(t *testing.T) {
+		tx := &conway.ConwayTransaction{}
+		if err := conway.UtxoValidateBootstrapParameterGroups(tx, 0, nil, mkPp(9)); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 	})
 }


### PR DESCRIPTION
Closes #1725 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Conway PV9 bootstrap gating to UTxO validation so restricted governance actions and parameter updates are blocked until Plomin (PV10). Aligns on-chain validation with protocol rules with full test coverage.

- **New Features**
  - Adds `UtxoValidateBootstrapAllowedGovActions` to reject PV9 proposals of `TreasuryWithdrawal`, `NoConfidence`, `UpdateCommittee`, and `NewConstitution`; allows `InfoAction`, `HardForkInitiation`, and `ParameterChange`.
  - Adds `UtxoValidateBootstrapParameterGroups` to reject PV9 `ParameterChange` proposals that touch bootstrap-restricted fields via `ConwayProtocolParameterUpdate.BootstrapRestrictedFields()` (e.g., `DRepDeposit`, `MinCommitteeSize`, `MinFeeRefScriptCostPerByte`).
  - Introduces `isInConwayBootstrapPhase` and new errors `BootstrapDisallowedGovActionError` and `BootstrapDisallowedParameterChangeError` with clear messages.
  - Wires new validators into `UtxoValidationRules` and adds tests covering PV9 vs PV10+ behavior, edge cases, and error strings.

<sup>Written for commit 33f99a111d4a36d75abda3739508762e94f23aa6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

