### PR TITLE
test(ledger): cost model length variance tests

### DIFF
--- a/ledger/common/rules_test.go
+++ b/ledger/common/rules_test.go
@@ -123,6 +123,40 @@ func TestEncodeLangViews(t *testing.T) {
 		)
 		require.Error(t, err)
 	})
+
+	// Forward-compat for PV11 (vanRossem) and later: cost models may grow as
+	// new Plutus builtins are added. The langview hash is part of
+	// ScriptDataHash, so any silent truncation here would invalidate every
+	// Plutus tx after a hard fork. Encode arbitrary-length arrays for V2 and
+	// V3 and assert the produced bytes round-trip the full slice.
+	t.Run("encodes_longer_cost_models_for_v2_and_v3", func(t *testing.T) {
+		v2 := make([]int64, 220)
+		v3 := make([]int64, 350)
+		for i := range v2 {
+			v2[i] = int64(i + 1)
+		}
+		for i := range v3 {
+			v3[i] = int64(i + 100_000)
+		}
+
+		got, err := common.EncodeLangViews(
+			map[uint]struct{}{1: {}, 2: {}},
+			map[uint][]int64{1: v2, 2: v3},
+		)
+		require.NoError(t, err)
+
+		v2Params, err := cbor.Encode(v2)
+		require.NoError(t, err)
+		v3Params, err := cbor.Encode(v3)
+		require.NoError(t, err)
+
+		// Map header for 2 entries, then tag 0x01 + v2 params, tag 0x02 + v3 params.
+		want := append([]byte{0xa2, 0x01}, v2Params...)
+		want = append(want, 0x02)
+		want = append(want, v3Params...)
+
+		require.Equal(t, want, got)
+	})
 }
 
 // Tests for VerifyTransaction moved from verify_rules_test.go

--- a/ledger/conway/errors.go
+++ b/ledger/conway/errors.go
@@ -421,37 +421,3 @@ func (e CCVotingRestrictionError) Error() string {
 		e.VoterId[:8], e.ActionId.TransactionId[:8], e.ActionId.GovActionIdx, e.Restriction,
 	)
 }
-
-// NonMatchingWithdrawalError indicates a withdrawal amount doesn't match the
-// actual reward account balance. Enhanced in PV11 for clearer diagnostics.
-type NonMatchingWithdrawalError struct {
-	RewardAccount common.Address
-	Expected      uint64
-	Actual        uint64
-}
-
-func (e NonMatchingWithdrawalError) Error() string {
-	return fmt.Sprintf(
-		"non-matching withdrawal for %s: expected %d, actual %d",
-		e.RewardAccount.String(), e.Expected, e.Actual,
-	)
-}
-
-// PPViewHashesDontMatchError indicates protocol parameter hash mismatch.
-// PV11 enhances with expected data for better diagnostics.
-type PPViewHashesDontMatchError struct {
-	ProvidedHash   common.Blake2b256
-	ComputedHash   common.Blake2b256
-	ExpectedPPData []byte
-}
-
-func (e PPViewHashesDontMatchError) Error() string {
-	dataPreview := e.ExpectedPPData
-	if len(dataPreview) > 32 {
-		dataPreview = dataPreview[:32]
-	}
-	return fmt.Sprintf(
-		"protocol parameter view hashes don't match: provided %x, computed %x, expected data: %x...",
-		e.ProvidedHash[:8], e.ComputedHash[:8], dataPreview,
-	)
-}

--- a/ledger/conway/errors_test.go
+++ b/ledger/conway/errors_test.go
@@ -383,27 +383,6 @@ func TestCCVotingRestrictionError(t *testing.T) {
 	assert.Contains(t, err.Error(), "voting restriction")
 }
 
-func TestNonMatchingWithdrawalError(t *testing.T) {
-	err := conway.NonMatchingWithdrawalError{
-		RewardAccount: common.Address{},
-		Expected:      1000,
-		Actual:        500,
-	}
-	assert.Contains(t, err.Error(), "non-matching withdrawal")
-	assert.Contains(t, err.Error(), "expected 1000")
-}
-
-func TestPPViewHashesDontMatchError(t *testing.T) {
-	err := conway.PPViewHashesDontMatchError{
-		ProvidedHash:   common.Blake2b256{0x01},
-		ComputedHash:   common.Blake2b256{0x02},
-		ExpectedPPData: []byte{0x03, 0x04},
-	}
-	assert.Contains(t, err.Error(), "protocol parameter")
-	assert.Contains(t, err.Error(), "provided")
-	assert.Contains(t, err.Error(), "computed")
-}
-
 // TestConway_Rule7_ScriptDataHashWithWitnessDatumsNoRedeemers tests that
 // UtxoValidateRedeemerAndScriptWitnesses accepts a real-world transaction
 // that carries a ScriptDataHash and witness datums but no redeemers.

--- a/ledger/conway/pparams_test.go
+++ b/ledger/conway/pparams_test.go
@@ -442,6 +442,96 @@ func TestConwayProtocolParamsUpdate(t *testing.T) {
 	}
 }
 
+// TestConwayProtocolParameterUpdate_CostModelLengthForwardCompat asserts that
+// a ConwayProtocolParameterUpdate whose Plutus cost-model arrays are longer
+// than today's PV10 baselines round-trips through CBOR without truncation.
+// PV11 (vanRossem) and later hard forks may extend cost models with new
+// builtins; gouroboros must accept the longer arrays.
+func TestConwayProtocolParameterUpdate_CostModelLengthForwardCompat(
+	t *testing.T,
+) {
+	const v1Len, v2Len, v3Len = 200, 220, 350
+	v1 := make([]int64, v1Len)
+	v2 := make([]int64, v2Len)
+	v3 := make([]int64, v3Len)
+	for i := range v1 {
+		v1[i] = int64(i + 1)
+	}
+	for i := range v2 {
+		v2[i] = int64(1000 + i)
+	}
+	for i := range v3 {
+		v3[i] = int64(1_000_000 - i)
+	}
+
+	upd := conway.ConwayProtocolParameterUpdate{
+		CostModels: map[uint][]int64{0: v1, 1: v2, 2: v3},
+	}
+
+	cborData, err := cbor.Encode(upd)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, cborData)
+
+	var decoded conway.ConwayProtocolParameterUpdate
+	_, err = cbor.Decode(cborData, &decoded)
+	assert.NoError(t, err)
+
+	assert.Len(t, decoded.CostModels[0], v1Len)
+	assert.Len(t, decoded.CostModels[1], v2Len)
+	assert.Len(t, decoded.CostModels[2], v3Len)
+	assert.Equal(t, v1, decoded.CostModels[0])
+	assert.Equal(t, v2, decoded.CostModels[1])
+	assert.Equal(t, v3, decoded.CostModels[2])
+}
+
+// TestConwayProtocolParameters_UpdateAcceptsLongerCostModel asserts that
+// merging a ConwayProtocolParameterUpdate over existing protocol parameters
+// preserves the entire incoming cost-model slice, even when it is longer than
+// the existing one. Guards against silent truncation when PV11+ extends the
+// PlutusV3 cost model.
+func TestConwayProtocolParameters_UpdateAcceptsLongerCostModel(t *testing.T) {
+	const newV3Len = 350
+	newV3 := make([]int64, newV3Len)
+	for i := range newV3 {
+		newV3[i] = int64(i)
+	}
+
+	base := &conway.ConwayProtocolParameters{
+		CostModels: map[uint][]int64{2: {1, 2, 3}},
+	}
+	upd := &conway.ConwayProtocolParameterUpdate{
+		CostModels: map[uint][]int64{2: newV3},
+	}
+
+	base.Update(upd)
+
+	assert.Len(t, base.CostModels[2], newV3Len)
+	assert.Equal(t, newV3, base.CostModels[2])
+}
+
+// TestConwayUpdateFromGenesis_PlutusV3CostModelLengthForwardCompat asserts
+// that loading a ConwayGenesis whose PlutusV3CostModel is longer than today's
+// PV10 baseline copies the full slice into protocol parameters. Cardano
+// genesis files for PV11+ are expected to ship extended PlutusV3 cost models.
+func TestConwayUpdateFromGenesis_PlutusV3CostModelLengthForwardCompat(
+	t *testing.T,
+) {
+	const v3Len = 350
+	v3 := make([]int64, v3Len)
+	for i := range v3 {
+		v3[i] = int64(2_000_000 + i)
+	}
+	g := &conway.ConwayGenesis{PlutusV3CostModel: v3}
+
+	p := &conway.ConwayProtocolParameters{}
+	if err := p.UpdateFromGenesis(g); err != nil {
+		t.Fatalf("UpdateFromGenesis: %v", err)
+	}
+
+	assert.Len(t, p.CostModels[2], v3Len)
+	assert.Equal(t, v3, p.CostModels[2])
+}
+
 func TestConwayProtocolParameters_UpdateCopiesFields(t *testing.T) {
 	base := &conway.ConwayProtocolParameters{}
 	upd := &conway.ConwayProtocolParameterUpdate{}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add tests to guarantee longer Plutus cost-model arrays (beyond PV10) are preserved end-to-end for PV11+, covering CBOR round-trip in `EncodeLangViews`, parameter updates, and genesis loading. Remove unused `NonMatchingWithdrawalError` and `PPViewHashesDontMatchError` and their tests.

<sup>Written for commit 1f4e79e80d3b850342867bd1c18b36a4e167fbdf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for encoding and forward compatibility of extended cost model arrays
  * Enhanced test validation for governance voting restriction scenarios

* **Bug Fixes**
  * Improved error reporting for governance voting restrictions with voter and action details

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/gouroboros/pull/1734)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->