### PR TITLE
fix(ledger): nil pointer in generic metadata map decode

### DIFF
--- a/ledger/common/metadata.go
+++ b/ledger/common/metadata.go
@@ -611,6 +611,9 @@ func decodeMapGeneric(b []byte) (TransactionMetadatum, bool, error) {
 	}
 	pairs := make([]MetaPair, 0, len(m))
 	for k, rv := range m {
+		if k == nil {
+			return nil, true, errors.New("decode map key: unsupported nil CBOR value")
+		}
 		keyMd, err := DecodeMetadatumRaw(k.Cbor())
 		if err != nil {
 			return nil, true, fmt.Errorf("decode map key: %w", err)

--- a/ledger/common/metadata_test.go
+++ b/ledger/common/metadata_test.go
@@ -149,6 +149,17 @@ func TestMetadataSetIgnoresUnknownAuxiliaryDataKeys(t *testing.T) {
 	assertMetadataEntry(t, md)
 }
 
+func TestDecodeMetadatumRawRejectsNilGenericMapKey(t *testing.T) {
+	raw, err := hex.DecodeString("a28031f730")
+	if err != nil {
+		t.Fatalf("bad hex: %v", err)
+	}
+
+	if _, err := DecodeMetadatumRaw(raw); err == nil {
+		t.Fatal("expected error for unsupported metadata map key")
+	}
+}
+
 func assertMetadataEntry(t *testing.T, md TransactionMetadatum) {
 	t.Helper()
 

--- a/ledger/testdata/fuzz/FuzzNewBlockFromCbor/8396d0ba9300cb98
+++ b/ledger/testdata/fuzz/FuzzNewBlockFromCbor/8396d0ba9300cb98
@@ -1,0 +1,3 @@
+go test fuzz v1
+uint(4)
+[]byte("\x84000\xa2\x14\xa2\x801\xf70\x130")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed a nil-pointer panic when decoding generic metadata maps by rejecting nil CBOR map keys. `DecodeMetadatumRaw` now returns a clear error instead of crashing during block parsing.

- **Bug Fixes**
  - Added a nil-key guard in `decodeMapGeneric` that returns "decode map key: unsupported nil CBOR value".
  - Added `TestDecodeMetadatumRawRejectsNilGenericMapKey` and a fuzz corpus entry to cover this case.

<sup>Written for commit d890252ba97ed4a3f552550498f013e1eeab0828. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

