### PR TITLE
fix(protocol): blockfetch shutdown race

### DIFF
--- a/protocol/blockfetch/client.go
+++ b/protocol/blockfetch/client.go
@@ -300,6 +300,9 @@ func (c *Client) Stop() error {
 	if !c.IsDone() {
 		msg := NewMsgClientDone()
 		sendErr = c.SendMessage(msg)
+		if errors.Is(sendErr, protocol.ErrProtocolShuttingDown) {
+			sendErr = nil
+		}
 		_ = c.WaitSendQueueDrained(250 * time.Millisecond)
 	}
 

--- a/protocol/blockfetch/client_test.go
+++ b/protocol/blockfetch/client_test.go
@@ -332,6 +332,71 @@ func TestStopAfterConnectionClose(t *testing.T) {
 	}
 }
 
+func TestStopAfterConnectionCloseStress(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	for i := 0; i < 20; i++ {
+		t.Run(fmt.Sprintf("iteration_%02d", i), func(t *testing.T) {
+			conversation := []ouroboros_mock.ConversationEntry{
+				ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+				ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+			}
+			mockConn := ouroboros_mock.NewConnection(
+				ouroboros_mock.ProtocolRoleClient,
+				conversation,
+			)
+			asyncErrChan := make(chan error, 1)
+			go func() {
+				err := <-mockConn.(*ouroboros_mock.Connection).ErrorChan()
+				if err != nil {
+					asyncErrChan <- fmt.Errorf(
+						"received unexpected error: %w",
+						err,
+					)
+				}
+				close(asyncErrChan)
+			}()
+
+			oConn, err := ouroboros.New(
+				ouroboros.WithConnection(mockConn),
+				ouroboros.WithNetworkMagic(
+					ouroboros_mock.MockNetworkMagic,
+				),
+				ouroboros.WithNodeToNode(true),
+				ouroboros.WithDelayProtocolStart(true),
+				ouroboros.WithBlockFetchConfig(
+					blockfetch.Config{SkipBlockValidation: true},
+				),
+			)
+			require.NoError(t, err)
+
+			client := oConn.BlockFetch().Client
+			client.Start()
+
+			require.NoError(t, oConn.Close())
+			select {
+			case <-oConn.ErrorChan():
+			case <-time.After(5 * time.Second):
+				require.Fail(t, "connection did not close within timeout")
+			}
+
+			for stopAttempt := 0; stopAttempt < 3; stopAttempt++ {
+				require.NoError(t, client.Stop())
+			}
+			require.True(t, client.IsDone())
+
+			select {
+			case err, ok := <-asyncErrChan:
+				if ok {
+					require.Fail(t, err.Error())
+				}
+			case <-time.After(2 * time.Second):
+				require.Fail(t, "mock connection did not shut down")
+			}
+		})
+	}
+}
+
 func TestGetBlockRangeReleasesBusyOnDisconnectBeforeBatchDone(t *testing.T) {
 	conversation := append(
 		conversationHandshakeRequestRange,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a shutdown race in `protocol/blockfetch` by making `Client.Stop()` succeed after the connection starts closing. This prevents spurious errors when shutting down the blockfetch client.

- **Bug Fixes**
  - Ignore `protocol.ErrProtocolShuttingDown` from `SendMessage` in `Client.Stop()`, making Stop idempotent after connection close.
  - Added a stress test that closes the connection, calls `Stop()` repeatedly, and checks for clean shutdown and no goroutine leaks.

<sup>Written for commit bbeac07a9e60a6912d43f81fd4707313207d4aa8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

