### PR TITLE
fix(protocol): align dmq w/ spec from CIP PR 1185

### DIFF
--- a/protocol/common/authentication.go
+++ b/protocol/common/authentication.go
@@ -15,6 +15,7 @@
 package common
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"encoding/hex"
 	"errors"
@@ -199,7 +200,12 @@ func (m *MessageAuthenticator) verifyMessageInternal(
 		return errors.New("message is nil")
 	}
 
-	// Step 1: Verify operational certificate validity
+	// Step 1: Verify deterministic message ID before heavier auth checks.
+	if err := m.verifyMessageID(msg); err != nil {
+		return fmt.Errorf("message ID verification failed: %w", err)
+	}
+
+	// Step 2: Verify operational certificate validity
 	if err := m.verifyOperationalCertificate(&msg.OperationalCertificate, msg.ColdVerificationKey); err != nil {
 		return fmt.Errorf(
 			"operational certificate verification failed: %w",
@@ -207,23 +213,18 @@ func (m *MessageAuthenticator) verifyMessageInternal(
 		)
 	}
 
-	// Step 2: Verify KES signature over message payload
+	// Step 3: Verify KES signature over message payload
 	if err := m.verifyKESSignature(msg, slot); err != nil {
 		return fmt.Errorf("KES signature verification failed: %w", err)
 	}
 
-	// Step 3: Compute SPO pool ID from cold key and verify it's registered and active
+	// Step 4: Compute SPO pool ID from cold key and verify it's registered and active
 	poolID := m.computePoolID(msg.ColdVerificationKey)
 	m.mu.RLock()
 	registered := m.spoPoolIDs[poolID]
 	m.mu.RUnlock()
 	if !registered {
 		return fmt.Errorf("SPO pool %s is not registered or not active", poolID)
-	}
-
-	// Step 4: Verify message ID format and size constraints
-	if err := m.verifyMessageID(msg); err != nil {
-		return fmt.Errorf("message ID verification failed: %w", err)
 	}
 
 	// Step 5: Verify KES period rotation (opcert number doesn't go backwards)
@@ -292,15 +293,8 @@ func (m *MessageAuthenticator) verifyKESSignature(
 		)
 	}
 
-	// Create CBOR encoding of the message payload as required by spec
-	payload := []any{
-		msg.Payload.MessageID,
-		msg.Payload.MessageBody,
-		msg.Payload.KESPeriod,
-		msg.Payload.ExpiresAt,
-	}
-
-	payloadCbor, err := cbor.Encode(payload)
+	// Create CBOR encoding of the message payload as required by spec.
+	payloadCbor, err := cbor.Encode(msg.Payload)
 	if err != nil {
 		return fmt.Errorf("failed to encode payload: %w", err)
 	}
@@ -380,19 +374,31 @@ func (m *MessageAuthenticator) verifyKESSignature(
 
 // verifyMessageID verifies the message ID format and size constraints.
 func (m *MessageAuthenticator) verifyMessageID(msg *DmqMessage) error {
-	if len(msg.Payload.MessageID) == 0 {
+	messageID := msg.ID()
+	if len(messageID) == 0 {
 		return errors.New("message ID cannot be empty")
 	}
 
-	if len(msg.Payload.MessageID) > 256 {
+	if len(messageID) != blake2b.Size256 {
 		return fmt.Errorf(
-			"message ID is too long: %d bytes",
-			len(msg.Payload.MessageID),
+			"message ID must be %d bytes, got %d",
+			blake2b.Size256,
+			len(messageID),
 		)
 	}
 
-	// In the actual implementation, message ID should be computed as a hash of the message
-	// For now, we just verify it exists and has reasonable size
+	expected, err := ComputeDmqMessageID(msg.Payload)
+	if err != nil {
+		return fmt.Errorf("failed to compute message ID: %w", err)
+	}
+	if !bytes.Equal(messageID, expected) {
+		return fmt.Errorf(
+			"message ID mismatch: expected %x, got %x",
+			expected,
+			messageID,
+		)
+	}
+	msg.SetMessageID(messageID)
 	return nil
 }
 

--- a/protocol/common/authentication_test.go
+++ b/protocol/common/authentication_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestMessageAuthenticatorCreation tests authenticator creation
@@ -58,7 +59,6 @@ func TestVerifyMessageInvalidCertificate(t *testing.T) {
 
 	msg := &DmqMessage{
 		Payload: DmqMessagePayload{
-			MessageID:   []byte("test-id"),
 			MessageBody: []byte("test-body"),
 			KESPeriod:   100,
 			ExpiresAt:   uint32(time.Now().Add(time.Hour).Unix()),
@@ -75,6 +75,7 @@ func TestVerifyMessageInvalidCertificate(t *testing.T) {
 		},
 		ColdVerificationKey: make([]byte, 32),
 	}
+	assert.NoError(t, msg.SetComputedMessageID())
 
 	err := auth.VerifyMessage(msg)
 	assert.Error(t, err)
@@ -348,7 +349,136 @@ func TestVerifyMessageIDTooLong(t *testing.T) {
 
 	err := auth.verifyMessageID(msg)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "too long")
+	assert.Contains(t, err.Error(), "must be 32 bytes")
+}
+
+func TestComputeDmqMessageIDGoldenVector(t *testing.T) {
+	messageID, err := ComputeDmqMessageID(DmqMessagePayload{
+		MessageBody: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		KESPeriod:   123,
+		ExpiresAt:   123456,
+	})
+	assert.NoError(t, err)
+	assert.Equal(
+		t,
+		[]byte{
+			202, 230, 133, 93, 29, 204, 161, 252,
+			87, 183, 156, 101, 193, 251, 172, 245,
+			171, 98, 179, 213, 232, 216, 239, 9,
+			94, 155, 194, 226, 246, 17, 50, 185,
+		},
+		messageID,
+	)
+}
+
+func TestVerifyMessageIDMismatch(t *testing.T) {
+	auth := NewMessageAuthenticator(nil)
+
+	msg := &DmqMessage{
+		MessageID: []byte{
+			202, 230, 133, 93, 29, 204, 161, 252,
+			87, 183, 156, 101, 193, 251, 172, 245,
+			171, 98, 179, 213, 232, 216, 239, 9,
+			94, 155, 194, 226, 246, 17, 50, 184,
+		},
+		Payload: DmqMessagePayload{
+			MessageBody: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			KESPeriod:   123,
+			ExpiresAt:   123456,
+		},
+	}
+
+	err := auth.verifyMessageID(msg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "message ID mismatch")
+}
+
+func TestVerifyMessageIDValid(t *testing.T) {
+	auth := NewMessageAuthenticator(nil)
+
+	msg := &DmqMessage{
+		Payload: DmqMessagePayload{
+			MessageBody: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			KESPeriod:   123,
+			ExpiresAt:   123456,
+		},
+	}
+	assert.NoError(t, msg.SetComputedMessageID())
+
+	err := auth.verifyMessageID(msg)
+	assert.NoError(t, err)
+}
+
+func TestDmqMessageCBORUsesCurrentCIPShape(t *testing.T) {
+	msg := DmqMessage{
+		Payload: DmqMessagePayload{
+			MessageID:   []byte("legacy-id"),
+			MessageBody: []byte("body"),
+			KESPeriod:   1,
+			ExpiresAt:   2,
+		},
+		KESSignature: make([]byte, 448),
+		OperationalCertificate: OperationalCertificate{
+			KESVerificationKey: make([]byte, 32),
+			IssueNumber:        1,
+			KESPeriod:          1,
+			ColdSignature:      make([]byte, 64),
+		},
+		ColdVerificationKey: make([]byte, 32),
+	}
+
+	data, err := cbor.Encode(msg)
+	assert.NoError(t, err)
+
+	var outer []cbor.RawMessage
+	_, err = cbor.Decode(data, &outer)
+	require.NoError(t, err)
+	require.Len(t, outer, 5)
+
+	var payload []cbor.RawMessage
+	_, err = cbor.Decode(outer[1], &payload)
+	require.NoError(t, err)
+	require.Len(t, payload, 3)
+
+	var decoded DmqMessage
+	_, err = cbor.Decode(data, &decoded)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("legacy-id"), decoded.MessageID)
+	assert.Equal(t, []byte("legacy-id"), decoded.Payload.MessageID)
+}
+
+func TestDmqMessageCBORDecodesLegacyShape(t *testing.T) {
+	msg := DmqMessage{
+		Payload: DmqMessagePayload{
+			MessageID:   []byte("legacy-id"),
+			MessageBody: []byte("body"),
+			KESPeriod:   1,
+			ExpiresAt:   2,
+		},
+		KESSignature: make([]byte, 448),
+		OperationalCertificate: OperationalCertificate{
+			KESVerificationKey: make([]byte, 32),
+			IssueNumber:        1,
+			KESPeriod:          1,
+			ColdSignature:      make([]byte, 64),
+		},
+		ColdVerificationKey: make([]byte, 32),
+	}
+
+	data, err := MarshalDmqMessageLegacyCBOR(msg)
+	assert.NoError(t, err)
+
+	var outer []cbor.RawMessage
+	_, err = cbor.Decode(data, &outer)
+	assert.NoError(t, err)
+	assert.Len(t, outer, 4)
+
+	var decoded DmqMessage
+	_, err = cbor.Decode(data, &decoded)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("legacy-id"), decoded.MessageID)
+	assert.Equal(t, []byte("legacy-id"), decoded.Payload.MessageID)
+	assert.Equal(t, []byte("body"), decoded.Payload.MessageBody)
 }
 
 // TestVerifyKESSignatureInvalidSize tests KES signature verification with invalid size
@@ -383,12 +513,12 @@ func TestVerifyKESSignatureInvalidSize(t *testing.T) {
 		OperationalCertificate: opcert,
 		ColdVerificationKey:    []byte(pub),
 		Payload: DmqMessagePayload{
-			MessageID:   []byte("test-id"),
 			MessageBody: []byte("body"),
 			KESPeriod:   1,
 			ExpiresAt:   uint32(time.Now().Add(time.Minute).Unix()),
 		},
 	}
+	assert.NoError(t, msg.SetComputedMessageID())
 
 	err = auth.VerifyMessage(msg)
 	assert.Error(t, err)
@@ -424,7 +554,6 @@ func buildTestMessage(t *testing.T) *DmqMessage {
 
 	msg := &DmqMessage{
 		Payload: DmqMessagePayload{
-			MessageID:   []byte("test-id"),
 			MessageBody: []byte("hello"),
 			KESPeriod:   100,
 			ExpiresAt:   uint32(time.Now().Add(time.Hour).Unix()),
@@ -432,6 +561,9 @@ func buildTestMessage(t *testing.T) *DmqMessage {
 		KESSignature:           make([]byte, 448),
 		OperationalCertificate: opcert,
 		ColdVerificationKey:    pub,
+	}
+	if err := msg.SetComputedMessageID(); err != nil {
+		t.Fatalf("failed to compute message id: %v", err)
 	}
 
 	return msg

--- a/protocol/common/dmq.go
+++ b/protocol/common/dmq.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	"golang.org/x/crypto/blake2b"
 )
 
 // DMQ Message structures following CIP-0137 specification
@@ -28,8 +29,9 @@ import (
 // DmqMessagePayload represents the unsigned message payload for DMQ messages.
 type DmqMessagePayload struct {
 	cbor.StructAsArray
-	// MessageID is the unique identifier for the message
-	MessageID []byte
+	// MessageID is a legacy alias kept for source compatibility. It is not
+	// part of the current CIP-0137 messagePayload CBOR encoding.
+	MessageID []byte `cbor:"-"`
 	// MessageBody contains the actual message data
 	MessageBody []byte
 	// KESPeriod is the KES key evolution step period
@@ -54,6 +56,8 @@ type OperationalCertificate struct {
 // DmqMessage represents a complete authenticated DMQ message with cryptographic proofs.
 type DmqMessage struct {
 	cbor.StructAsArray
+	// MessageID is the Blake2b-256 hash of the CBOR-encoded payload.
+	MessageID []byte
 	// Payload is the unsigned message payload
 	Payload DmqMessagePayload
 	// KESSignature is the 448-byte KES signature over the payload
@@ -62,6 +66,185 @@ type DmqMessage struct {
 	OperationalCertificate OperationalCertificate
 	// ColdVerificationKey is the 32-byte SPO cold public key
 	ColdVerificationKey []byte
+}
+
+// MarshalCBOR encodes the payload using the current CIP-0137 shape:
+// [messageBody, kesPeriod, expiresAt].
+func (p DmqMessagePayload) MarshalCBOR() ([]byte, error) {
+	return cbor.Encode([]any{
+		p.MessageBody,
+		p.KESPeriod,
+		p.ExpiresAt,
+	})
+}
+
+// UnmarshalCBOR decodes both the current payload shape and the legacy V1
+// implementation shape, which included messageId inside messagePayload.
+func (p *DmqMessagePayload) UnmarshalCBOR(data []byte) error {
+	var current struct {
+		cbor.StructAsArray
+		MessageBody []byte
+		KESPeriod   uint64
+		ExpiresAt   uint32
+	}
+	if _, err := cbor.Decode(data, &current); err == nil {
+		p.MessageID = nil
+		p.MessageBody = current.MessageBody
+		p.KESPeriod = current.KESPeriod
+		p.ExpiresAt = current.ExpiresAt
+		return nil
+	}
+
+	var legacy struct {
+		cbor.StructAsArray
+		MessageID   []byte
+		MessageBody []byte
+		KESPeriod   uint64
+		ExpiresAt   uint32
+	}
+	if _, err := cbor.Decode(data, &legacy); err != nil {
+		return err
+	}
+	p.MessageID = legacy.MessageID
+	p.MessageBody = legacy.MessageBody
+	p.KESPeriod = legacy.KESPeriod
+	p.ExpiresAt = legacy.ExpiresAt
+	return nil
+}
+
+// MarshalCBOR encodes the message using the current CIP-0137 shape:
+// [messageId, messagePayload, kesSignature, operationalCertificate,
+// coldVerificationKey].
+func (m DmqMessage) MarshalCBOR() ([]byte, error) {
+	msgID := m.ID()
+	if len(msgID) == 0 {
+		var err error
+		msgID, err = ComputeDmqMessageID(m.Payload)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return cbor.Encode([]any{
+		msgID,
+		m.Payload,
+		m.KESSignature,
+		m.OperationalCertificate,
+		m.ColdVerificationKey,
+	})
+}
+
+// UnmarshalCBOR decodes both the current CIP-0137 message shape and the
+// legacy V1 implementation shape, which encoded [payload, signature, opcert,
+// coldKey] and kept messageId inside payload.
+func (m *DmqMessage) UnmarshalCBOR(data []byte) error {
+	var current struct {
+		cbor.StructAsArray
+		MessageID              []byte
+		Payload                DmqMessagePayload
+		KESSignature           []byte
+		OperationalCertificate OperationalCertificate
+		ColdVerificationKey    []byte
+	}
+	if _, err := cbor.Decode(data, &current); err == nil {
+		m.MessageID = current.MessageID
+		m.Payload = current.Payload
+		m.Payload.MessageID = current.MessageID
+		m.KESSignature = current.KESSignature
+		m.OperationalCertificate = current.OperationalCertificate
+		m.ColdVerificationKey = current.ColdVerificationKey
+		return nil
+	}
+
+	var legacy struct {
+		cbor.StructAsArray
+		Payload                DmqMessagePayload
+		KESSignature           []byte
+		OperationalCertificate OperationalCertificate
+		ColdVerificationKey    []byte
+	}
+	if _, err := cbor.Decode(data, &legacy); err != nil {
+		return err
+	}
+	m.MessageID = legacy.Payload.MessageID
+	m.Payload = legacy.Payload
+	m.KESSignature = legacy.KESSignature
+	m.OperationalCertificate = legacy.OperationalCertificate
+	m.ColdVerificationKey = legacy.ColdVerificationKey
+	return nil
+}
+
+// ID returns the message id, accepting Payload.MessageID as a legacy alias.
+func (m DmqMessage) ID() []byte {
+	if len(m.MessageID) > 0 {
+		return m.MessageID
+	}
+	return m.Payload.MessageID
+}
+
+// SetMessageID updates both the current field and the legacy payload alias.
+func (m *DmqMessage) SetMessageID(messageID []byte) {
+	m.MessageID = cloneBytes(messageID)
+	m.Payload.MessageID = cloneBytes(messageID)
+}
+
+// SetComputedMessageID computes and stores the CIP-0137 message id.
+func (m *DmqMessage) SetComputedMessageID() error {
+	messageID, err := ComputeDmqMessageID(m.Payload)
+	if err != nil {
+		return err
+	}
+	m.SetMessageID(messageID)
+	return nil
+}
+
+// ComputeDmqMessageID returns Blake2b-256(cbor(messagePayload)).
+func ComputeDmqMessageID(payload DmqMessagePayload) ([]byte, error) {
+	payload.MessageID = nil
+	payloadCbor, err := cbor.Encode(payload)
+	if err != nil {
+		return nil, err
+	}
+	sum := blake2b.Sum256(payloadCbor)
+	return cloneBytes(sum[:]), nil
+}
+
+// MarshalDmqMessageLegacyCBOR encodes the legacy V1 wire shape used before
+// CIP-0137 moved messageId from messagePayload to message.
+func MarshalDmqMessageLegacyCBOR(msg DmqMessage) ([]byte, error) {
+	legacyPayload := struct {
+		cbor.StructAsArray
+		MessageID   []byte
+		MessageBody []byte
+		KESPeriod   uint64
+		ExpiresAt   uint32
+	}{
+		MessageID:   msg.ID(),
+		MessageBody: msg.Payload.MessageBody,
+		KESPeriod:   msg.Payload.KESPeriod,
+		ExpiresAt:   msg.Payload.ExpiresAt,
+	}
+	legacyMessage := struct {
+		cbor.StructAsArray
+		Payload                any
+		KESSignature           []byte
+		OperationalCertificate OperationalCertificate
+		ColdVerificationKey    []byte
+	}{
+		Payload:                legacyPayload,
+		KESSignature:           msg.KESSignature,
+		OperationalCertificate: msg.OperationalCertificate,
+		ColdVerificationKey:    msg.ColdVerificationKey,
+	}
+	return cbor.Encode(legacyMessage)
+}
+
+func cloneBytes(src []byte) []byte {
+	if src == nil {
+		return nil
+	}
+	ret := make([]byte, len(src))
+	copy(ret, src)
+	return ret
 }
 
 // MessageIDAndSize represents a message identifier with its serialized size in bytes.

--- a/protocol/localmessagenotification/server.go
+++ b/protocol/localmessagenotification/server.go
@@ -98,7 +98,7 @@ func (s *Server) AddMessage(msg *pcommon.DmqMessage) error {
 	defer s.lock.Unlock()
 
 	// Check if already acknowledged (non-zero timestamp means it was acknowledged)
-	msgID := string(msg.Payload.MessageID)
+	msgID := string(msg.ID())
 	if _, acknowledged := s.acknowledgedIDs[msgID]; acknowledged {
 		return errors.New("message already acknowledged")
 	}
@@ -207,7 +207,7 @@ func (s *Server) handleNonBlockingRequest() error {
 	// Mark all collected messages as acknowledged with current timestamp and clear the queue
 	now := time.Now()
 	for _, msg := range s.messageQueue {
-		s.acknowledgedIDs[string(msg.Payload.MessageID)] = now
+		s.acknowledgedIDs[string(msg.ID())] = now
 	}
 	s.messageQueue = s.messageQueue[:0]
 
@@ -246,7 +246,7 @@ func (s *Server) handleBlockingRequest() error {
 	// Mark all collected messages as acknowledged with current timestamp and clear the queue
 	now := time.Now()
 	for _, msg := range s.messageQueue {
-		s.acknowledgedIDs[string(msg.Payload.MessageID)] = now
+		s.acknowledgedIDs[string(msg.ID())] = now
 	}
 	s.messageQueue = s.messageQueue[:0]
 

--- a/protocol/messagesubmission/client.go
+++ b/protocol/messagesubmission/client.go
@@ -57,7 +57,7 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 	}
 
 	// Select state map and initial state based on negotiated version
-	isV2 := protoOptions.Version >= MessageSubmissionV2MinVersion
+	isV2 := isMessageSubmissionV2(protoOptions.Version)
 	var baseStateMap protocol.StateMap
 	var initialState protocol.State
 	if isV2 {
@@ -128,7 +128,7 @@ func (c *Client) Start() {
 // the client-side Stop is a no-op.
 func (c *Client) Stop() error {
 	c.onceStop.Do(func() {
-		if c.protoVersion >= MessageSubmissionV2MinVersion {
+		if isMessageSubmissionV2(c.protoVersion) {
 			// V2: client cannot send MsgDone; server controls termination
 			c.Protocol.Logger().
 				Debug("V2 client Stop() is a no-op; server sends MsgDone",
@@ -153,7 +153,7 @@ func (c *Client) Stop() error {
 // Init sends the initialization message to start the protocol.
 // This is only valid for V1; V2 starts directly in StIdle.
 func (c *Client) Init() error {
-	if c.protoVersion >= MessageSubmissionV2MinVersion {
+	if isMessageSubmissionV2(c.protoVersion) {
 		return errors.New(
 			"Init is not supported in MessageSubmission V2; protocol starts in StIdle",
 		)
@@ -195,6 +195,8 @@ func (c *Client) ReplyMessageIds(messages []pcommon.MessageIDAndSize) error {
 // ReplyMessages sends a reply with full messages
 func (c *Client) ReplyMessages(messages []pcommon.DmqMessage) error {
 	msg := NewMsgReplyMessages(messages)
+	msg.legacyMessageEncoding = c.config.LegacyV1MessageEncoding &&
+		!isMessageSubmissionV2(c.protoVersion)
 	if err := c.SendMessage(msg); err != nil {
 		return err
 	}

--- a/protocol/messagesubmission/messages.go
+++ b/protocol/messagesubmission/messages.go
@@ -106,7 +106,8 @@ func NewMsgRequestMessages(messageIDs [][]byte) *MsgRequestMessages {
 // MsgReplyMessages represents the reply with full messages
 type MsgReplyMessages struct {
 	protocol.MessageBase
-	Messages []pcommon.DmqMessage
+	Messages              []pcommon.DmqMessage
+	legacyMessageEncoding bool
 }
 
 // NewMsgReplyMessages creates a new MsgReplyMessages
@@ -117,6 +118,30 @@ func NewMsgReplyMessages(messages []pcommon.DmqMessage) *MsgReplyMessages {
 		},
 		Messages: messages,
 	}
+}
+
+// MarshalCBOR encodes MsgReplyMessages. V1 peers using the pre-CIP-0137-v4
+// message shape can be supported by setting legacyMessageEncoding.
+func (m MsgReplyMessages) MarshalCBOR() ([]byte, error) {
+	if !m.legacyMessageEncoding {
+		return cbor.Encode([]any{
+			MessageTypeReplyMessages,
+			m.Messages,
+		})
+	}
+
+	rawMessages := make([]cbor.RawMessage, 0, len(m.Messages))
+	for _, msg := range m.Messages {
+		msgCbor, err := pcommon.MarshalDmqMessageLegacyCBOR(msg)
+		if err != nil {
+			return nil, err
+		}
+		rawMessages = append(rawMessages, cbor.RawMessage(msgCbor))
+	}
+	return cbor.Encode([]any{
+		MessageTypeReplyMessages,
+		rawMessages,
+	})
 }
 
 // MsgDone represents the protocol completion message

--- a/protocol/messagesubmission/messages_test.go
+++ b/protocol/messagesubmission/messages_test.go
@@ -191,6 +191,38 @@ func TestMsgReplyMessagesEncoding(t *testing.T) {
 	assert.Equal(t, data, reencoded)
 }
 
+func TestMsgReplyMessagesLegacyEncodingDecodes(t *testing.T) {
+	msg := NewMsgReplyMessages([]pcommon.DmqMessage{
+		{
+			Payload: pcommon.DmqMessagePayload{
+				MessageID:   []byte("id1"),
+				MessageBody: []byte("body1"),
+				KESPeriod:   100,
+				ExpiresAt:   2000000000,
+			},
+			KESSignature: make([]byte, 448),
+			OperationalCertificate: pcommon.OperationalCertificate{
+				KESVerificationKey: make([]byte, 32),
+				IssueNumber:        1,
+				KESPeriod:          100,
+				ColdSignature:      make([]byte, 64),
+			},
+			ColdVerificationKey: make([]byte, 32),
+		},
+	})
+	msg.legacyMessageEncoding = true
+
+	data, err := cbor.Encode(msg)
+	assert.NoError(t, err)
+
+	parsed, err := NewMsgFromCbor(uint(MessageTypeReplyMessages), data)
+	assert.NoError(t, err)
+	decoded, ok := parsed.(*MsgReplyMessages)
+	assert.True(t, ok)
+	assert.Equal(t, []byte("id1"), decoded.Messages[0].MessageID)
+	assert.Equal(t, []byte("id1"), decoded.Messages[0].Payload.MessageID)
+}
+
 // TestMsgDoneEncoding tests MsgDone encoding
 func TestMsgDoneEncoding(t *testing.T) {
 	msg := &MsgDone{

--- a/protocol/messagesubmission/messagesubmission.go
+++ b/protocol/messagesubmission/messagesubmission.go
@@ -68,13 +68,15 @@ var (
 	)
 	protocolStateDone = protocol.NewState(stateDoneId, "done")
 
-	// MessageSubmissionV2MinVersion is the minimum NtN protocol version
-	// that uses Message Submission V2 (no StInit, MsgDone only from StIdle).
+	// MessageSubmissionV2MinVersion is the minimum Cardano NtN protocol
+	// version that uses Message Submission V2 (no StInit, MsgDone only from
+	// StIdle). Standalone DMQ NodeToNodeV_2 is version 2 and is handled by
+	// isMessageSubmissionV2.
 	MessageSubmissionV2MinVersion uint16 = 15
 
-	// stateMapV1 is the V1 state map (CIP-0137 original).
+	// stateMapV1 is the V1 state map.
 	// Includes StInit; MsgDone can be sent by client from
-	// StMessageIdsBlocking / StMessageIdsNonBlocking, or by server from StIdle.
+	// StMessageIdsBlocking.
 	stateMapV1 = protocol.StateMap{
 		protocolStateInit: protocol.StateMapEntry{
 			Agency:                  protocol.AgencyClient,
@@ -112,10 +114,6 @@ var (
 					MsgType:  MessageTypeRequestMessages,
 					NewState: protocolStateMessages,
 				},
-				{
-					MsgType:  MessageTypeDone,
-					NewState: protocolStateDone,
-				},
 			},
 		},
 		protocolStateMessageIdsBlock: protocol.StateMapEntry{
@@ -141,10 +139,6 @@ var (
 				{
 					MsgType:  MessageTypeReplyMessageIds,
 					NewState: protocolStateIdle,
-				},
-				{
-					MsgType:  MessageTypeDone,
-					NewState: protocolStateDone,
 				},
 			},
 		},
@@ -240,6 +234,11 @@ var (
 	}
 )
 
+func isMessageSubmissionV2(version uint16) bool {
+	return version == protocol.ProtocolVersionDMQNtN2 ||
+		version >= MessageSubmissionV2MinVersion
+}
+
 // MessageSubmission is a wrapper object that holds the client and server instances
 type MessageSubmission struct {
 	Client *Client
@@ -268,6 +267,10 @@ type Config struct {
 	MaxQueueSize  int
 	Authenticator *pcommon.MessageAuthenticator
 	TTLValidator  *pcommon.TTLValidator
+	// LegacyV1MessageEncoding preserves the pre-CIP-0137-v4 V1 message
+	// wire shape for peers that still expect messageId inside messagePayload.
+	// The default false value uses the current CIP-0137 message shape.
+	LegacyV1MessageEncoding bool
 	// Done callback invoked when peer sends Done
 	DoneFunc func(CallbackContext) error
 }
@@ -432,5 +435,13 @@ func WithTTLValidator(
 ) MessageSubmissionOptionFunc {
 	return func(c *Config) {
 		c.TTLValidator = ttlValidator
+	}
+}
+
+// WithLegacyV1MessageEncoding enables the pre-CIP-0137-v4 V1 message wire
+// shape when replying with messages on a V1 Message Submission connection.
+func WithLegacyV1MessageEncoding(enabled bool) MessageSubmissionOptionFunc {
+	return func(c *Config) {
+		c.LegacyV1MessageEncoding = enabled
 	}
 }

--- a/protocol/messagesubmission/messagesubmission_v2_test.go
+++ b/protocol/messagesubmission/messagesubmission_v2_test.go
@@ -107,7 +107,18 @@ func TestV1StateMapHasInitState(t *testing.T) {
 	)
 }
 
-func TestV1StateMapMsgDoneFromBlockingAndNonBlocking(t *testing.T) {
+func TestV1StateMapMsgDoneOnlyFromBlocking(t *testing.T) {
+	// StIdle must NOT have MsgDone in latest CIP-0137 V1.
+	idleEntry := stateMapV1[protocolStateIdle]
+	for _, tr := range idleEntry.Transitions {
+		assert.NotEqual(
+			t,
+			uint(MessageTypeDone),
+			tr.MsgType,
+			"V1 StIdle must not have MsgDone transition",
+		)
+	}
+
 	// StMessageIdsBlocking should have MsgDone
 	blockEntry := stateMapV1[protocolStateMessageIdsBlock]
 	hasDone := false
@@ -118,15 +129,16 @@ func TestV1StateMapMsgDoneFromBlockingAndNonBlocking(t *testing.T) {
 	}
 	assert.True(t, hasDone, "V1 StMessageIdsBlocking must have MsgDone transition")
 
-	// StMessageIdsNonBlocking should have MsgDone
+	// StMessageIdsNonBlocking must NOT have MsgDone
 	nonBlockEntry := stateMapV1[protocolStateMessageIdsNonBlk]
-	hasDone = false
 	for _, tr := range nonBlockEntry.Transitions {
-		if tr.MsgType == MessageTypeDone {
-			hasDone = true
-		}
+		assert.NotEqual(
+			t,
+			uint(MessageTypeDone),
+			tr.MsgType,
+			"V1 StMessageIdsNonBlocking must not have MsgDone transition",
+		)
 	}
-	assert.True(t, hasDone, "V1 StMessageIdsNonBlocking must have MsgDone transition")
 }
 
 // --- V2 client behavior tests ---
@@ -196,6 +208,18 @@ func TestV2VersionSelectsCorrectStateMap(t *testing.T) {
 	// V2 server (version 15)
 	v2Server := NewServer(newTestProtoOptions(MessageSubmissionV2MinVersion), &cfg)
 	assert.Equal(t, MessageSubmissionV2MinVersion, v2Server.protoVersion)
+}
+
+func TestDMQNtNVersionSelectsCorrectStateMap(t *testing.T) {
+	cfg := NewConfig()
+
+	v1Client := NewClient(newTestProtoOptions(protocol.ProtocolVersionDMQNtN1), &cfg)
+	assert.Equal(t, protocol.ProtocolVersionDMQNtN1, v1Client.protoVersion)
+	assert.False(t, isMessageSubmissionV2(v1Client.protoVersion))
+
+	v2Client := NewClient(newTestProtoOptions(protocol.ProtocolVersionDMQNtN2), &cfg)
+	assert.Equal(t, protocol.ProtocolVersionDMQNtN2, v2Client.protoVersion)
+	assert.True(t, isMessageSubmissionV2(v2Client.protoVersion))
 }
 
 func TestVersionZeroDefaultsToV1(t *testing.T) {

--- a/protocol/messagesubmission/server.go
+++ b/protocol/messagesubmission/server.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
@@ -56,7 +57,7 @@ func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 	}
 
 	// Select state map and initial state based on negotiated version
-	isV2 := protoOptions.Version >= MessageSubmissionV2MinVersion
+	isV2 := isMessageSubmissionV2(protoOptions.Version)
 	var baseStateMap protocol.StateMap
 	var initialState protocol.State
 	if isV2 {
@@ -114,7 +115,7 @@ func (s *Server) AddMessage(msg *pcommon.DmqMessage) error {
 			"protocol", ProtocolName,
 			"role", "server",
 			"connection_id", s.callbackContext.ConnectionId.String(),
-			"message_id", string(msg.Payload.MessageID),
+			"message_id", string(msg.ID()),
 			"queue_size", len(s.messageQueue),
 		)
 
@@ -277,11 +278,24 @@ func (s *Server) GetAvailableMessageIDs(count int) []pcommon.MessageIDAndSize {
 		if uint32(now) > msg.Payload.ExpiresAt {
 			continue // skip expired messages, don't add to filtered
 		}
-		// #nosec G115 -- message body size bounded by protocol limits
 		if len(ids) < count {
+			messageCbor, err := cbor.Encode(*msg)
+			if err != nil {
+				s.Protocol.Logger().
+					Warn("failed to encode message for size calculation",
+						"component", "network",
+						"protocol", ProtocolName,
+						"role", "server",
+						"connection_id", s.callbackContext.ConnectionId.String(),
+						"error", err,
+					)
+				filtered = append(filtered, msg)
+				continue
+			}
+			// #nosec G115 -- message size bounded by protocol limits
 			ids = append(ids, pcommon.MessageIDAndSize{
-				MessageID:   msg.Payload.MessageID,
-				SizeInBytes: uint32(len(msg.Payload.MessageBody)),
+				MessageID:   msg.ID(),
+				SizeInBytes: uint32(len(messageCbor)),
 			})
 		}
 		filtered = append(filtered, msg)
@@ -330,7 +344,7 @@ func (s *Server) GetMessagesByIDs(ids [][]byte) []pcommon.DmqMessage {
 		if uint32(now) > msg.Payload.ExpiresAt {
 			continue
 		}
-		if _, exists := idSet[string(msg.Payload.MessageID)]; exists {
+		if _, exists := idSet[string(msg.ID())]; exists {
 			messages = append(messages, *msg)
 		}
 	}

--- a/protocol/versions.go
+++ b/protocol/versions.go
@@ -26,6 +26,12 @@ const ProtocolVersionNtCOffset = 0x8000
 // dmq-node/src/DMQ/NodeToClient/Version.hs).
 const ProtocolVersionDMQNtCOffset = 0x1000
 
+// DMQ node-to-node protocol versions from CIP-0137.
+const (
+	ProtocolVersionDMQNtN1 uint16 = 1
+	ProtocolVersionDMQNtN2 uint16 = 2
+)
+
 type NewVersionDataFromCborFunc func([]byte) (VersionData, error)
 
 type ProtocolVersionMap map[uint16]VersionData
@@ -346,15 +352,26 @@ func GetProtocolVersionMap(
 	return ret
 }
 
-// dmqProtocolVersions maps supported DMQ N2C protocol versions to their
+// dmqProtocolVersionsNtC maps supported DMQ N2C protocol versions to their
 // version metadata. dmq-node currently advertises only NodeToClientV_1
 // (encoded with the 12th bit set: 1 | 0x1000 = 0x1001).
 //
 // VersionData is structurally [uint32 networkMagic, bool query] — identical
 // to Cardano's VersionDataNtC15andUp — so the same CBOR decoder is reused.
-var dmqProtocolVersions = map[uint16]ProtocolVersion{
+var dmqProtocolVersionsNtC = map[uint16]ProtocolVersion{
 	(1 + ProtocolVersionDMQNtCOffset): {
 		NewVersionDataFromCborFunc: NewVersionDataNtC15andUpFromCbor,
+	},
+}
+
+// dmqProtocolVersionsNtN maps supported DMQ N2N protocol versions to their
+// version metadata. CIP-0137 defines NodeToNodeV_1 and NodeToNodeV_2.
+var dmqProtocolVersionsNtN = map[uint16]ProtocolVersion{
+	ProtocolVersionDMQNtN1: {
+		NewVersionDataFromCborFunc: NewVersionDataNtN13andUpFromCbor,
+	},
+	ProtocolVersionDMQNtN2: {
+		NewVersionDataFromCborFunc: NewVersionDataNtN13andUpFromCbor,
 	},
 }
 
@@ -368,7 +385,7 @@ func GetProtocolVersionMapDMQNtC(
 	queryMode bool,
 ) ProtocolVersionMap {
 	ret := ProtocolVersionMap{}
-	for version := range dmqProtocolVersions {
+	for version := range dmqProtocolVersionsNtC {
 		ret[version] = VersionDataNtC15andUp{
 			CborNetworkMagic: networkMagic,
 			CborQuery:        queryMode,
@@ -377,11 +394,48 @@ func GetProtocolVersionMapDMQNtC(
 	return ret
 }
 
+// GetProtocolVersionMapDMQNtN returns a ProtocolVersionMap suitable for
+// handshaking against a DMQ node-to-node listener (CIP-0137).
+func GetProtocolVersionMapDMQNtN(
+	networkMagic uint32,
+	diffusionMode bool,
+	peerSharing bool,
+	queryMode bool,
+) ProtocolVersionMap {
+	ret := ProtocolVersionMap{}
+	for version := range dmqProtocolVersionsNtN {
+		var tmpPeerSharing uint = PeerSharingModeNoPeerSharing
+		if peerSharing {
+			tmpPeerSharing = PeerSharingModePeerSharingPublic
+		}
+		ret[version] = VersionDataNtN13andUp{
+			VersionDataNtN11to12{
+				CborNetworkMagic:                       networkMagic,
+				CborInitiatorAndResponderDiffusionMode: diffusionMode,
+				CborPeerSharing:                        tmpPeerSharing,
+				CborQuery:                              queryMode,
+			},
+		}
+	}
+	return ret
+}
+
 // GetProtocolVersionsDMQNtC returns a list of supported DMQ N2C protocol
 // versions in ascending order.
 func GetProtocolVersionsDMQNtC() []uint16 {
-	versions := make([]uint16, 0, len(dmqProtocolVersions))
-	for key := range dmqProtocolVersions {
+	versions := make([]uint16, 0, len(dmqProtocolVersionsNtC))
+	for key := range dmqProtocolVersionsNtC {
+		versions = append(versions, key)
+	}
+	slices.Sort(versions)
+	return versions
+}
+
+// GetProtocolVersionsDMQNtN returns a list of supported DMQ N2N protocol
+// versions in ascending order.
+func GetProtocolVersionsDMQNtN() []uint16 {
+	versions := make([]uint16, 0, len(dmqProtocolVersionsNtN))
+	for key := range dmqProtocolVersionsNtN {
 		versions = append(versions, key)
 	}
 	slices.Sort(versions)
@@ -419,11 +473,15 @@ func GetProtocolVersionsNtN() []uint16 {
 }
 
 // GetProtocolVersion returns the protocol version config for the specified protocol version.
-// It searches both the Cardano NtN/NtC map and the DMQ N2C map, whose key spaces
-// are disjoint (DMQ uses the 0x1000 offset, Cardano NtC uses 0x8000, NtN uses 7-15).
+// It searches Cardano NtN/NtC plus DMQ N2C/N2N maps. The key spaces are
+// disjoint for supported Cardano versions: DMQ N2C uses the 0x1000 offset,
+// DMQ N2N uses 1/2, Cardano NtC uses 0x8000, and supported Cardano NtN uses 7-15.
 func GetProtocolVersion(version uint16) ProtocolVersion {
 	if v, ok := protocolVersions[version]; ok {
 		return v
 	}
-	return dmqProtocolVersions[version]
+	if v, ok := dmqProtocolVersionsNtC[version]; ok {
+		return v
+	}
+	return dmqProtocolVersionsNtN[version]
 }

--- a/protocol/versions_test.go
+++ b/protocol/versions_test.go
@@ -59,6 +59,37 @@ func TestGetProtocolVersionMapDMQNtC(t *testing.T) {
 	assert.True(t, vq.Query(), "Query flag did not propagate from caller to VersionData")
 }
 
+func TestGetProtocolVersionMapDMQNtN(t *testing.T) {
+	const dmqDefaultMagic uint32 = 3_141_592
+	m := GetProtocolVersionMapDMQNtN(
+		dmqDefaultMagic,
+		DiffusionModeInitiatorAndResponder,
+		true,
+		true,
+	)
+	require.Len(t, m, 2, "DMQ N2N should advertise V1 and V2")
+
+	for _, version := range []uint16{
+		ProtocolVersionDMQNtN1,
+		ProtocolVersionDMQNtN2,
+	} {
+		v, ok := m[version]
+		require.True(t, ok, "DMQ N2N version %d missing", version)
+		assert.Equal(t, dmqDefaultMagic, v.NetworkMagic())
+		assert.Equal(t, DiffusionModeInitiatorAndResponder, v.DiffusionMode())
+		assert.True(t, v.PeerSharing())
+		assert.True(t, v.Query())
+	}
+}
+
+func TestGetProtocolVersionsDMQNtN(t *testing.T) {
+	assert.Equal(
+		t,
+		[]uint16{ProtocolVersionDMQNtN1, ProtocolVersionDMQNtN2},
+		GetProtocolVersionsDMQNtN(),
+	)
+}
+
 // TestGetProtocolVersionDMQResolvable verifies that GetProtocolVersion can
 // resolve DMQ N2C versions. Without this, handshake.Client.handleAcceptVersion
 // and handshake.Server.handleProposeVersions would panic when calling
@@ -69,6 +100,11 @@ func TestGetProtocolVersionDMQResolvable(t *testing.T) {
 		t,
 		GetProtocolVersion(0x1001).NewVersionDataFromCborFunc,
 		"DMQ versions are not reachable via GetProtocolVersion",
+	)
+	require.NotNil(
+		t,
+		GetProtocolVersion(ProtocolVersionDMQNtN2).NewVersionDataFromCborFunc,
+		"DMQ N2N versions are not reachable via GetProtocolVersion",
 	)
 }
 


### PR DESCRIPTION
Update our implementation to match the behavior specified in cardano-foundation/CIPs#1185

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns DMQ message format, authentication, and versioning with CIP-0137 PR 1185. Moves `messageId` to the outer `DmqMessage`, adds deterministic IDs, dual-shape CBOR, and DMQ NodeToNode v1/v2 support.

- **New Features**
  - Deterministic message ID = Blake2b-256(CBOR(messagePayload)); verified first and moved to outer `DmqMessage` with `ID()`/`SetComputedMessageID()` helpers.
  - Dual-shape CBOR: encode/decode both current payload/message shapes and legacy V1; `MsgReplyMessages` can emit legacy V1 encoding via `WithLegacyV1MessageEncoding`.
  - DMQ NodeToNode V1/V2 supported with new version maps/constants and `GetProtocolVersionMapDMQNtN`; version selection unified via `isMessageSubmissionV2`.
  - Server reports message sizes using full CBOR-encoded message and uses `msg.ID()` for indexing/acknowledgment.

- **Bug Fixes**
  - KES signature computed over CBOR-encoded payload as per spec; payload encoding updated.
  - V1 state machine: `MsgDone` allowed only from blocking requests; removed from idle/non-blocking; V2 remains server-driven.
  - Auth flow checks message ID first and enforces a 32-byte hash, with mismatch/size errors surfaced clearly.

<sup>Written for commit e3ff5dba18f7360214821124b1c43eac63b8368b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for DMQ node-to-node protocol versions V1 and V2
  * Enhanced message ID computation with cryptographic hashing
  * Added legacy message encoding compatibility

* **Bug Fixes**
  * Improved message authentication verification order

* **Tests**
  * Added comprehensive test coverage for message ID validation and encoding compatibility

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/gouroboros/pull/1745)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->