### PR TITLE
fix(cbor):processMap uses broad panic recovery that masks bugs

### DIFF
--- a/cbor/value.go
+++ b/cbor/value.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"reflect"
 	"runtime"
 	"sort"
 	"strings"
@@ -146,7 +147,12 @@ func (v *Value) processMap(data []byte) (err error) {
 	// Extract actual value from each child value
 	newValue := map[any]any{}
 	for key, value := range tmpValue {
-		newValue[key.Value()] = value.Value()
+		keyValue := key.Value()
+		// Use a pointer for unhashable key types
+		if !reflect.TypeOf(keyValue).Comparable() {
+			keyValue = &keyValue
+		}
+		newValue[keyValue] = value.Value()
 	}
 	v.value = newValue
 	return nil

--- a/cbor/value.go
+++ b/cbor/value.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 )
@@ -130,6 +130,9 @@ func (v *Value) processMap(data []byte) (err error) {
 	// deferred function to recover from a possible panic and return an error
 	defer func() {
 		if r := recover(); r != nil {
+			if !isUnhashableMapKeyPanic(r) {
+				panic(r)
+			}
 			err = fmt.Errorf(
 				"decode failure, probably due to type unsupported by Go: %v",
 				r,
@@ -143,12 +146,7 @@ func (v *Value) processMap(data []byte) (err error) {
 	// Extract actual value from each child value
 	newValue := map[any]any{}
 	for key, value := range tmpValue {
-		keyValue := key.Value()
-		// Use a pointer for unhashable key types
-		if !reflect.TypeOf(keyValue).Comparable() {
-			keyValue = &keyValue
-		}
-		newValue[keyValue] = value.Value()
+		newValue[key.Value()] = value.Value()
 	}
 	v.value = newValue
 	return nil
@@ -166,6 +164,14 @@ func (v *Value) processArray(data []byte) error {
 	}
 	v.value = newValue
 	return nil
+}
+
+func isUnhashableMapKeyPanic(r any) bool {
+	runtimeErr, ok := r.(runtime.Error)
+	if !ok {
+		return false
+	}
+	return strings.Contains(runtimeErr.Error(), "hash of unhashable type")
 }
 
 func generateAstJson(obj any) ([]byte, error) {

--- a/cbor/value_test.go
+++ b/cbor/value_test.go
@@ -189,20 +189,29 @@ func TestValueDecode(t *testing.T) {
 	}
 }
 
-func TestValueDecodeMapWithUnhashableKeyReturnsError(t *testing.T) {
+func TestValueDecodeMapWithUnhashableKeyIsWrapped(t *testing.T) {
 	// { [1]: 2 }
 	cborData := test.DecodeHexString("a1810102")
 
 	var tmpValue cbor.Value
 	_, err := cbor.Decode(cborData, &tmpValue)
-	if err == nil {
-		t.Fatalf(
-			"expected decode error for unhashable CBOR map key, got: %#v",
-			tmpValue.Value(),
-		)
+	if err != nil {
+		t.Fatalf("failed to decode CBOR map with unhashable key: %s", err)
 	}
-	if !strings.Contains(err.Error(), "hash of unhashable type") {
-		t.Fatalf("unexpected decode error: %s", err)
+	valueMap, ok := tmpValue.Value().(map[any]any)
+	if !ok {
+		t.Fatalf("expected map[any]any, got: %T", tmpValue.Value())
+	}
+	if len(valueMap) != 1 {
+		t.Fatalf("expected one map item, got: %d", len(valueMap))
+	}
+	for key, value := range valueMap {
+		if reflect.TypeOf(key).Kind() != reflect.Ptr {
+			t.Fatalf("expected unhashable key to be wrapped as pointer, got: %T", key)
+		}
+		if value != uint64(2) {
+			t.Fatalf("unexpected map value: %#v", value)
+		}
 	}
 }
 

--- a/cbor/value_test.go
+++ b/cbor/value_test.go
@@ -189,6 +189,37 @@ func TestValueDecode(t *testing.T) {
 	}
 }
 
+func TestValueDecodeMapWithUnhashableKeyReturnsError(t *testing.T) {
+	// { [1]: 2 }
+	cborData := test.DecodeHexString("a1810102")
+
+	var tmpValue cbor.Value
+	_, err := cbor.Decode(cborData, &tmpValue)
+	if err == nil {
+		t.Fatalf(
+			"expected decode error for unhashable CBOR map key, got: %#v",
+			tmpValue.Value(),
+		)
+	}
+	if !strings.Contains(err.Error(), "hash of unhashable type") {
+		t.Fatalf("unexpected decode error: %s", err)
+	}
+}
+
+func TestValueDecodeMapUnexpectedPanicIsNotSwallowed(t *testing.T) {
+	// { null: 1 }
+	cborData := test.DecodeHexString("a1f601")
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected unexpected panic to be re-panicked")
+		}
+	}()
+
+	var tmpValue cbor.Value
+	_, _ = cbor.Decode(cborData, &tmpValue)
+}
+
 func TestValueMarshalJSON(t *testing.T) {
 	for _, testDef := range testDefs {
 		// Skip test if the CBOR decode is expected to fail


### PR DESCRIPTION
1.  Made changes in cbor map processing recovery so only unhashable map-key panics are converted to decode errors, while unexpected panics are re-thrown.
2. Added tests covering unhashable cbor map keys and verifying unrelated panics are not swallowed.

Closes #1584 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened panic recovery in `cbor` map decoding. Only unhashable map-key panics become decode errors; all other panics now rethrow. Closes #1584.

- **Bug Fixes**
  - `processMap` now re-panics unless `isUnhashableMapKeyPanic` matches "hash of unhashable type".
  - Tests added: unhashable keys are pointer-wrapped; unrelated panics are not swallowed.

<sup>Written for commit dbe7f177cd39dcd3e02085f7d025a5e36185ca61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when decoding CBOR maps with unhashable keys—now returns a proper decode error instead of panicking.

* **Tests**
  * Added tests to verify correct handling of maps with unhashable keys and to ensure unexpected panics are properly re-raised during decoding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/gouroboros/pull/1746)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->