### PR TITLE
fix(ledger): key credential withdrawals require matching witness

### DIFF
--- a/ledger/common/rules.go
+++ b/ledger/common/rules.go
@@ -189,9 +189,20 @@ func (e ExtraneousScriptWitnessesError) Error() string {
 	)
 }
 
-// ValidateRequiredVKeyWitnesses checks that all required signers have a vkey witness.
+// ValidateRequiredVKeyWitnesses checks that all required key credentials have a
+// vkey witness. This includes explicitly required signers and key-based reward
+// withdrawal credentials.
 func ValidateRequiredVKeyWitnesses(tx Transaction) error {
-	required := tx.RequiredSigners()
+	required := make([]Blake2b224, 0, len(tx.RequiredSigners())+len(tx.Withdrawals()))
+	required = append(required, tx.RequiredSigners()...)
+	for addr := range tx.Withdrawals() {
+		if addr == nil {
+			continue
+		}
+		if payload, ok := addr.StakingPayload().(AddressPayloadKeyHash); ok {
+			required = append(required, payload.Hash)
+		}
+	}
 	if len(required) == 0 {
 		return nil
 	}

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -38,6 +38,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func makeConwayRewardAddress(
+	t *testing.T,
+	keyHash common.Blake2b224,
+) common.Address {
+	t.Helper()
+	addrBytes := make([]byte, 0, 29)
+	addrBytes = append(addrBytes, 0xE1)
+	addrBytes = append(addrBytes, keyHash.Bytes()...)
+	addr, err := common.NewAddressFromBytes(addrBytes)
+	require.NoError(t, err)
+	return addr
+}
+
 func TestUtxoValidateWitnessRules_Conway(t *testing.T) {
 	// Required vkey witnesses
 	t.Run("no required signers", func(t *testing.T) {
@@ -90,6 +103,28 @@ func TestUtxoValidateWitnessRules_Conway(t *testing.T) {
 			false,
 		)
 		err := conway.UtxoValidateRequiredVKeyWitnesses(tx, 0, nil, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("key withdrawal requires matching vkey", func(t *testing.T) {
+		stakeVkey := []byte("stake-key")
+		stakeKeyHash := common.Blake2b224Hash(stakeVkey)
+		rewardAddr := makeConwayRewardAddress(t, stakeKeyHash)
+
+		tx := &conway.ConwayTransaction{}
+		tx.Body.TxWithdrawals = map[*common.Address]uint64{
+			&rewardAddr: 1_000_000,
+		}
+
+		err := conway.UtxoValidateRequiredVKeyWitnesses(tx, 0, nil, nil)
+		require.Error(t, err)
+		assert.IsType(t, conway.MissingVKeyWitnessesError{}, err)
+
+		tx.WitnessSet.VkeyWitnesses = cbor.NewSetType(
+			[]common.VkeyWitness{{Vkey: stakeVkey}},
+			false,
+		)
+		err = conway.UtxoValidateRequiredVKeyWitnesses(tx, 0, nil, nil)
 		assert.NoError(t, err)
 	})
 

--- a/ledger/shelley/rules.go
+++ b/ledger/shelley/rules.go
@@ -390,30 +390,7 @@ func UtxoValidateRequiredVKeyWitnesses(
 	ls common.LedgerState,
 	pp common.ProtocolParameters,
 ) error {
-	required := tx.RequiredSigners()
-	if len(required) == 0 {
-		return nil
-	}
-
-	w := tx.Witnesses()
-	if w == nil || len(w.Vkey()) == 0 {
-		return MissingVKeyWitnessesError{}
-	}
-
-	// Build a set of hashes from the provided vkey witnesses for quick lookup
-	vkeyHashes := make(map[common.Blake2b224]struct{})
-	for _, vw := range w.Vkey() {
-		h := common.Blake2b224Hash(vw.Vkey)
-		vkeyHashes[h] = struct{}{}
-	}
-
-	// Ensure each required signer hash has a matching vkey witness
-	for _, req := range required {
-		if _, ok := vkeyHashes[req]; !ok {
-			return MissingRequiredVKeyWitnessForSignerError{Signer: req}
-		}
-	}
-	return nil
+	return common.ValidateRequiredVKeyWitnesses(tx)
 }
 
 // MinFeeTx calculates the minimum required fee for a transaction based on


### PR DESCRIPTION
This was reported by logcavq02@gmail.com

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces that key-credential reward withdrawals require a matching vkey witness. Consolidates the validation in common code and adds a Conway test to prevent regressions.

- **Bug Fixes**
  - `ValidateRequiredVKeyWitnesses` now treats key-hash reward withdrawal credentials from `tx.Withdrawals()` as required signers.
  - Added a Conway test that fails without the stake-key vkey witness and passes when it is provided.

- **Refactors**
  - `shelley.UtxoValidateRequiredVKeyWitnesses` now delegates to `common.ValidateRequiredVKeyWitnesses`, removing duplicate logic.

<sup>Written for commit fe878c86714c38d46eeb1dc0abe4e7b54c97df61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

