### PR TITLE
fix(ledger): reject too large collateral return

### DIFF
--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -493,8 +493,17 @@ func UtxoValidateCollateralEqBalance(
 	// Subtract collateral return amount with underflow protection
 	collReturn := tx.CollateralReturn()
 	if collReturn != nil {
-		if returnAmount := collReturn.Amount(); returnAmount != nil &&
-			collBalance.Cmp(returnAmount) >= 0 {
+		if returnAmount := collReturn.Amount(); returnAmount != nil {
+			if collBalance.Cmp(returnAmount) < 0 {
+				var totalCollU uint64
+				if totalCollateral.IsUint64() {
+					totalCollU = totalCollateral.Uint64()
+				}
+				return IncorrectTotalCollateralFieldError{
+					Provided:        0,
+					TotalCollateral: totalCollU,
+				}
+			}
 			collBalance.Sub(collBalance, returnAmount)
 		}
 	}

--- a/ledger/babbage/rules_test.go
+++ b/ledger/babbage/rules_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUtxoValidateOutsideValidityIntervalUtxo(t *testing.T) {
@@ -1564,6 +1565,7 @@ func TestUtxoValidateCollateralEqBalance(t *testing.T) {
 	var testTotalCollateral uint64 = 5_000_000
 	var testCollateralReturnAmountGood uint64 = 15_000_000
 	var testCollateralReturnAmountBad uint64 = 16_000_000
+	var testCollateralReturnAmountOverflow uint64 = 21_000_000
 	testTx := &babbage.BabbageTransaction{
 		Body: babbage.BabbageTransactionBody{
 			TxTotalCollateral: testTotalCollateral,
@@ -1619,6 +1621,31 @@ func TestUtxoValidateCollateralEqBalance(t *testing.T) {
 				err,
 				testErrType,
 			)
+		},
+	)
+	// Collateral return exceeds all consumed collateral
+	t.Run(
+		"collateral return exceeds collateral balance",
+		func(t *testing.T) {
+			testTx.Body.TxTotalCollateral = testInputAmount
+			testTx.Body.TxCollateralReturn = &babbage.BabbageTransactionOutput{
+				OutputAmount: mary.MaryTransactionOutputValue{
+					Amount: testCollateralReturnAmountOverflow,
+				},
+			}
+			err := babbage.UtxoValidateCollateralEqBalance(
+				testTx,
+				testSlot,
+				testLedgerState,
+				testProtocolParams,
+			)
+			require.Error(t, err)
+			assert.IsType(
+				t,
+				babbage.IncorrectTotalCollateralFieldError{},
+				err,
+			)
+			testTx.Body.TxTotalCollateral = testTotalCollateral
 		},
 	)
 	// Collateral equals balance

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -2119,6 +2119,7 @@ func TestUtxoValidateCollateralEqBalance(t *testing.T) {
 	var testTotalCollateral uint64 = 5_000_000
 	var testCollateralReturnAmountGood uint64 = 15_000_000
 	var testCollateralReturnAmountBad uint64 = 16_000_000
+	var testCollateralReturnAmountOverflow uint64 = 21_000_000
 	testTx := &conway.ConwayTransaction{
 		Body: conway.ConwayTransactionBody{
 			TxTotalCollateral: testTotalCollateral,
@@ -2171,6 +2172,31 @@ func TestUtxoValidateCollateralEqBalance(t *testing.T) {
 				err,
 				testErrType,
 			)
+		},
+	)
+	// Collateral return exceeds all consumed collateral
+	t.Run(
+		"collateral return exceeds collateral balance",
+		func(t *testing.T) {
+			testTx.Body.TxTotalCollateral = testInputAmount
+			testTx.Body.TxCollateralReturn = &babbage.BabbageTransactionOutput{
+				OutputAmount: mary.MaryTransactionOutputValue{
+					Amount: testCollateralReturnAmountOverflow,
+				},
+			}
+			err := conway.UtxoValidateCollateralEqBalance(
+				testTx,
+				testSlot,
+				testLedgerState,
+				testProtocolParams,
+			)
+			require.Error(t, err)
+			assert.IsType(
+				t,
+				babbage.IncorrectTotalCollateralFieldError{},
+				err,
+			)
+			testTx.Body.TxTotalCollateral = testTotalCollateral
 		},
 	)
 	// Collateral equals balance


### PR DESCRIPTION
This was reported by logcavq02@gmail.com

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject transactions where the collateral return exceeds the available collateral balance. This closes a gap in UTXO validation for Babbage/Conway and prevents invalid transactions from being accepted.

- **Bug Fixes**
  - In `ledger/babbage/rules.go` (`UtxoValidateCollateralEqBalance`), return `IncorrectTotalCollateralFieldError` when `TxCollateralReturn` amount is greater than the computed collateral balance.
  - Added tests in `ledger/babbage/rules_test.go` and `ledger/conway/rules_test.go` to cover the overflow case and validate the error type.

<sup>Written for commit 500ef81d7bfddc58581573703e65664c7bc7cc5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

