### PR TITLE
fix(consensus): validate canonical blake2b vrf key hashes

### DIFF
--- a/consensus/validate.go
+++ b/consensus/validate.go
@@ -468,8 +468,8 @@ func (v *HeaderValidator) validateVRFKeyRegistration(
 		)
 	}
 
-	// Compute hash of the VRF key (Blake2b-224)
-	vrfKeyHash := common.Blake2b224Hash(input.VrfKey)
+	// Pool registrations store the canonical Blake2b-256 hash of the VRF key.
+	vrfKeyHash := common.Blake2b256Hash(input.VrfKey)
 
 	if !bytes.Equal(vrfKeyHash.Bytes(), input.RegisteredVrfKeyHash) {
 		return fmt.Errorf(

--- a/consensus/validate_test.go
+++ b/consensus/validate_test.go
@@ -665,8 +665,8 @@ func TestValidateVRFKeyRegistration(t *testing.T) {
 		t.Fatalf("vrf.KeyGen failed: %v", err)
 	}
 
-	// Compute expected hash (Blake2b-224) using the common function
-	expectedHash := common.Blake2b224Hash(vrfPk)
+	// Compute expected hash using the canonical ledger registration width.
+	expectedHash := common.Blake2b256Hash(vrfPk)
 
 	// Test matching hash
 	input := &ValidateHeaderInput{
@@ -677,6 +677,13 @@ func TestValidateVRFKeyRegistration(t *testing.T) {
 	err = validator.validateVRFKeyRegistration(input)
 	if err != nil {
 		t.Errorf("expected valid VRF key registration, got error: %v", err)
+	}
+
+	legacyHash := common.Blake2b224Hash(vrfPk)
+	input.RegisteredVrfKeyHash = legacyHash.Bytes()
+	err = validator.validateVRFKeyRegistration(input)
+	if err == nil {
+		t.Error("expected error for legacy 28-byte VRF key hash")
 	}
 
 	// Test mismatched hash


### PR DESCRIPTION
This was reported by logcavq02@gmail.com

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Validate VRF key registrations using the canonical Blake2b-256 hash. Replaces the prior Blake2b-224 check and rejects legacy 28-byte hashes.

<sup>Written for commit 96bac468fe50c1892b122e4ce801c5b9584b4037. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

