### PR TITLE
fix(ledger): fail closed with error on phase2

### DIFF
--- a/ledger/alonzo/errors.go
+++ b/ledger/alonzo/errors.go
@@ -84,4 +84,5 @@ type (
 	ConflictingMetadataHashError             = common.ConflictingMetadataHashError
 	MissingCostModelError                    = common.MissingCostModelError
 	InvalidIsValidFlagError                  = common.InvalidIsValidFlagError
+	PlutusScriptValidationUnsupportedError   = common.PlutusScriptValidationUnsupportedError
 )

--- a/ledger/alonzo/rules.go
+++ b/ledger/alonzo/rules.go
@@ -52,6 +52,7 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateMaxTxSizeUtxo,
 	UtxoValidateExUnitsTooBigUtxo,
 	UtxoValidateNativeScripts,
+	UtxoValidatePlutusScripts,
 	UtxoValidateDelegation,
 	UtxoValidateWithdrawals,
 }
@@ -141,6 +142,15 @@ func UtxoValidateExUnitsTooBigUtxo(
 		},
 		MaxTxExUnits: tmpPparams.MaxTxExUnits,
 	}
+}
+
+func UtxoValidatePlutusScripts(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return common.ValidateUnsupportedPlutusExecution(tx, "Alonzo")
 }
 
 func UtxoValidateOutsideValidityIntervalUtxo(

--- a/ledger/alonzo/rules_test.go
+++ b/ledger/alonzo/rules_test.go
@@ -1461,3 +1461,42 @@ func TestUtxoValidateWitnessRules_Alonzo(t *testing.T) {
 		assert.NoError(t, err)
 	})
 }
+
+func TestUtxoValidatePlutusScriptsUnsupported_Alonzo(t *testing.T) {
+	t.Run("valid tx with redeemer fails closed", func(t *testing.T) {
+		tx := &alonzo.AlonzoTransaction{
+			TxIsValid: true,
+		}
+		tx.WitnessSet.WsRedeemers = alonzo.AlonzoRedeemers{
+			Redeemers: []alonzo.AlonzoRedeemer{
+				{
+					Tag:     common.RedeemerTagSpend,
+					ExUnits: common.ExUnits{Steps: 1, Memory: 1},
+				},
+			},
+		}
+
+		err := alonzo.UtxoValidatePlutusScripts(tx, 0, nil, nil)
+		assert.Error(t, err)
+		assert.IsType(
+			t,
+			alonzo.PlutusScriptValidationUnsupportedError{},
+			err,
+		)
+	})
+
+	t.Run("invalid tx with redeemer is phase-1 valid", func(t *testing.T) {
+		tx := &alonzo.AlonzoTransaction{}
+		tx.WitnessSet.WsRedeemers = alonzo.AlonzoRedeemers{
+			Redeemers: []alonzo.AlonzoRedeemer{
+				{
+					Tag:     common.RedeemerTagSpend,
+					ExUnits: common.ExUnits{Steps: 1, Memory: 1},
+				},
+			},
+		}
+
+		err := alonzo.UtxoValidatePlutusScripts(tx, 0, nil, nil)
+		assert.NoError(t, err)
+	})
+}

--- a/ledger/babbage/errors.go
+++ b/ledger/babbage/errors.go
@@ -66,6 +66,7 @@ type (
 	ConflictingMetadataHashError             = common.ConflictingMetadataHashError
 	MissingCostModelError                    = common.MissingCostModelError
 	InvalidIsValidFlagError                  = common.InvalidIsValidFlagError
+	PlutusScriptValidationUnsupportedError   = common.PlutusScriptValidationUnsupportedError
 )
 
 // NonDisjointRefInputsError indicates reference inputs overlap with regular inputs

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -58,6 +58,7 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateExUnitsTooBigUtxo,
 	UtxoValidateTooManyCollateralInputs,
 	UtxoValidateNativeScripts,
+	UtxoValidatePlutusScripts,
 	UtxoValidateDelegation,
 	UtxoValidateWithdrawals,
 	UtxoValidateMalformedReferenceScripts,
@@ -95,6 +96,15 @@ func UtxoValidateIsValidFlag(
 
 	// IsValid=false but no redeemers present
 	return common.InvalidIsValidFlagError{}
+}
+
+func UtxoValidatePlutusScripts(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return common.ValidateUnsupportedPlutusExecution(tx, "Babbage")
 }
 
 // UtxoValidateRequiredVKeyWitnesses ensures required signers are accompanied by vkey witnesses

--- a/ledger/babbage/rules_test.go
+++ b/ledger/babbage/rules_test.go
@@ -1742,3 +1742,42 @@ func TestUtxoValidateTooManyCollateralInputs(t *testing.T) {
 		},
 	)
 }
+
+func TestUtxoValidatePlutusScriptsUnsupported_Babbage(t *testing.T) {
+	t.Run("valid tx with redeemer fails closed", func(t *testing.T) {
+		tx := &babbage.BabbageTransaction{
+			TxIsValid: true,
+		}
+		tx.WitnessSet.WsRedeemers = alonzo.AlonzoRedeemers{
+			Redeemers: []alonzo.AlonzoRedeemer{
+				{
+					Tag:     common.RedeemerTagSpend,
+					ExUnits: common.ExUnits{Steps: 1, Memory: 1},
+				},
+			},
+		}
+
+		err := babbage.UtxoValidatePlutusScripts(tx, 0, nil, nil)
+		assert.Error(t, err)
+		assert.IsType(
+			t,
+			babbage.PlutusScriptValidationUnsupportedError{},
+			err,
+		)
+	})
+
+	t.Run("invalid tx with redeemer is phase-1 valid", func(t *testing.T) {
+		tx := &babbage.BabbageTransaction{}
+		tx.WitnessSet.WsRedeemers = alonzo.AlonzoRedeemers{
+			Redeemers: []alonzo.AlonzoRedeemer{
+				{
+					Tag:     common.RedeemerTagSpend,
+					ExUnits: common.ExUnits{Steps: 1, Memory: 1},
+				},
+			},
+		}
+
+		err := babbage.UtxoValidatePlutusScripts(tx, 0, nil, nil)
+		assert.NoError(t, err)
+	})
+}

--- a/ledger/common/errors.go
+++ b/ledger/common/errors.go
@@ -26,6 +26,16 @@ func (InvalidIsValidFlagError) Error() string {
 	return "transaction marked as invalid but has no Plutus scripts requiring phase-2 validation"
 }
 
+// PlutusScriptValidationUnsupportedError indicates a transaction needs phase-2
+// Plutus execution in an era path that cannot perform it.
+type PlutusScriptValidationUnsupportedError struct {
+	Era string
+}
+
+func (e PlutusScriptValidationUnsupportedError) Error() string {
+	return e.Era + " Plutus phase-2 validation is not supported"
+}
+
 // MissingCostModelError indicates a missing cost model for a Plutus version
 type MissingCostModelError struct {
 	Version uint

--- a/ledger/common/rules.go
+++ b/ledger/common/rules.go
@@ -211,6 +211,22 @@ func ValidateRequiredVKeyWitnesses(tx Transaction) error {
 	return nil
 }
 
+// ValidateUnsupportedPlutusExecution fails closed when a transaction requires
+// phase-2 Plutus execution in an era that does not implement it.
+func ValidateUnsupportedPlutusExecution(tx Transaction, era string) error {
+	if !tx.IsValid() {
+		return nil
+	}
+	wits := tx.Witnesses()
+	if wits == nil || wits.Redeemers() == nil {
+		return nil
+	}
+	for range wits.Redeemers().Iter() {
+		return PlutusScriptValidationUnsupportedError{Era: era}
+	}
+	return nil
+}
+
 // ValidateScriptWitnesses checks that script witnesses are provided for all script address inputs
 // and that there are no extraneous script witnesses.
 func ValidateScriptWitnesses(tx Transaction, ls LedgerState) error {


### PR DESCRIPTION
This was reported by logcavq02@gmail.com

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fail closed for phase-2 Plutus execution in Alonzo and Babbage: transactions marked valid with redeemers now error instead of being accepted. This guards the phase-1-only path and returns a clear `PlutusScriptValidationUnsupportedError`.

- **Bug Fixes**
  - Added `PlutusScriptValidationUnsupportedError` and `ValidateUnsupportedPlutusExecution` in `ledger/common`.
  - Hooked `UtxoValidatePlutusScripts` into `UtxoValidationRules` for `ledger/alonzo` and `ledger/babbage`.
  - Behavior: valid tx + redeemers => error; invalid tx + redeemers => no error (phase-1 valid). Added tests for both eras.

<sup>Written for commit 6ae092f3133652af9f297bdcc30aad542ec82b69. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

