### PR TITLE
fix(pipeline): count in-flight apply work during drain

### DIFF
--- a/pipeline/apply_stage.go
+++ b/pipeline/apply_stage.go
@@ -41,6 +41,7 @@ type ApplyStage struct {
 	pending map[uint64]*BlockItem
 	// nextSequence is the next sequence number to apply
 	nextSequence uint64
+	inFlight     int
 }
 
 // NewApplyStage creates a new ApplyStage with the given apply function.
@@ -123,6 +124,15 @@ func (s *ApplyStage) applyItem(ctx context.Context, item *BlockItem) {
 	default:
 	}
 
+	s.mu.Lock()
+	s.inFlight++
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.inFlight--
+		s.mu.Unlock()
+	}()
+
 	start := time.Now()
 	var err error
 	if s.applyFunc != nil {
@@ -180,7 +190,7 @@ func (s *ApplyStage) Reset() {
 func (s *ApplyStage) PendingCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return len(s.pending)
+	return len(s.pending) + s.inFlight
 }
 
 // ApplyStageRunner runs the apply stage as a single goroutine.

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -747,6 +747,51 @@ func TestApplyStage_PendingCount(t *testing.T) {
 	assert.Equal(t, 0, applyStage.PendingCount())
 }
 
+func TestApplyStage_PendingCountIncludesInFlightApply(t *testing.T) {
+	rawCbor := getValidBlockCbor(t)
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	applyStage := NewApplyStage(func(item *BlockItem) error {
+		close(started)
+		<-release
+		return nil
+	}, 0)
+
+	tip := createTestTip(1000, 500)
+	item := NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, 0)
+	block, err := ledger.NewBlockFromCbor(
+		uint(ledger.BlockTypeConway),
+		rawCbor,
+		common.VerifyConfig{SkipBodyHashValidation: true},
+	)
+	require.NoError(t, err)
+	item.SetBlock(block, time.Millisecond)
+	item.SetValidation(true, "vrf", nil, time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = applyStage.Process(context.Background(), item)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("apply function did not start")
+	}
+
+	assert.Equal(t, 1, applyStage.PendingCount())
+	close(release)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("apply function did not finish")
+	}
+	assert.Equal(t, 0, applyStage.PendingCount())
+}
+
 func TestApplyStage_Reset(t *testing.T) {
 	rawCbor := getValidBlockCbor(t)
 


### PR DESCRIPTION
This was reported by logcavq02@gmail.com

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PendingCount to include in-flight apply work so drain waits for active operations and doesn’t exit early.

- **Bug Fixes**
  - Track in-flight apply calls with a mutex-backed `inFlight` counter.
  - Update PendingCount to return pending + inFlight.
  - Add a test that holds an apply in progress and asserts the count reflects it.

<sup>Written for commit 96878cf6b18562c77b4761d966a28900ee359e8f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

