### PR TITLE
docs: block-local verification clarification

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -376,16 +376,22 @@ err = ts.SubmitTx(txCbor)
    |- Metadata
 5. VerifyBlock() validates:
    |- Body hash matches header
-   |- Consensus rules (VRF, KES)
+   |- Block-local VRF proof bytes and KES signature
    |- Ledger rules per era
 6. For each transaction:
    |- Verify signatures
    |- Check fees, TTL
    |- Validate UTxO consumption
-   |- Execute Plutus scripts
+   |- Execute supported Plutus scripts
    |- Process certificates
 7. Update ledger state
 ```
+
+`VerifyBlock()` and `pipeline.ValidateStage` are block-local validation helpers,
+not complete consensus gates. They do not receive the previous header, active
+stake distribution, active slot coefficient, max KES evolutions, or operational
+certificate sequence state. Production chain validation must combine these
+checks with chain-context consensus validation before accepting a block.
 
 ## Block Pipeline (pipeline/)
 
@@ -399,7 +405,7 @@ The `pipeline` package provides a staged block processing pipeline with worker p
 ```
 
 - **DecodeStage**: CBOR decoding of raw block bytes (parallelizable)
-- **ValidateStage**: Block validation (VRF, KES, ledger rules)
+- **ValidateStage**: Block-local validation (VRF proof bytes, KES signature, ledger rules)
 - **ApplyStage**: State updates (must preserve ordering)
 
 Usage:

--- a/ledger/verify_block.go
+++ b/ledger/verify_block.go
@@ -179,6 +179,16 @@ func extractHeaderFields(
 	}
 }
 
+// VerifyBlock performs block-local structural, cryptographic, and ledger
+// validation. It checks data available from the block and supplied verification
+// config, including body hash, VRF proof bytes, KES signature, transactions,
+// and optional stake pool registration.
+//
+// VerifyBlock is not full chain-context consensus validation. It does not
+// receive the previous header, active stake distribution, active slot
+// coefficient, max KES evolutions, or operational certificate sequence state,
+// so callers must combine it with chain-state validation before using a block
+// as a production consensus decision.
 func VerifyBlock(
 	block Block,
 	eta0Hex string,

--- a/pipeline/validate_stage.go
+++ b/pipeline/validate_stage.go
@@ -56,7 +56,8 @@ func StaticEta0Provider(eta0 string) Eta0Provider {
 	}
 }
 
-// ValidateStage validates decoded blocks using VRF, KES, and other checks.
+// ValidateStage validates decoded blocks using VerifyBlock's block-local
+// checks. It is not a complete chain-context consensus gate by itself.
 type ValidateStage struct {
 	config ValidateStageConfig
 }


### PR DESCRIPTION
This was reported by logcavq02@gmail.com

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that `VerifyBlock` and `pipeline.ValidateStage` perform block‑local validation only (body hash, VRF proof bytes, KES signature, ledger checks), not full chain‑context consensus. Updates ARCHITECTURE.md and inline comments to list missing chain inputs (previous header, active stake distribution, active slot coefficient, max KES evolutions, operational certificate sequence) and direct callers to combine with consensus validation.

<sup>Written for commit 97cf75362ffb142e05b04034703c7ae6c045819e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

