### PR TITLE
fix(protocol): avoid nil on unsupported handshake version

### DIFF
--- a/protocol/handshake/client.go
+++ b/protocol/handshake/client.go
@@ -135,6 +135,12 @@ func (c *Client) handleAcceptVersion(msg protocol.Message) error {
 	}
 	msgAcceptVersion := msg.(*MsgAcceptVersion)
 	protoVersion := protocol.GetProtocolVersion(msgAcceptVersion.Version)
+	if protoVersion.NewVersionDataFromCborFunc == nil {
+		return fmt.Errorf(
+			"unsupported protocol version accepted by peer: %d",
+			msgAcceptVersion.Version,
+		)
+	}
 	versionData, err := protoVersion.NewVersionDataFromCborFunc(
 		msgAcceptVersion.VersionData,
 	)

--- a/protocol/handshake/messages_test.go
+++ b/protocol/handshake/messages_test.go
@@ -16,10 +16,12 @@ package handshake
 
 import (
 	"encoding/hex"
+	"net"
 	"reflect"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/protocol"
 )
 
@@ -140,5 +142,35 @@ func TestEncode(t *testing.T) {
 				test.CborHex,
 			)
 		}
+	}
+}
+
+func TestClientHandleAcceptVersionUnsupportedVersion(t *testing.T) {
+	cfg := NewConfig(WithFinishedFunc(
+		func(CallbackContext, uint16, protocol.VersionData) error {
+			t.Fatal("finished callback should not be called")
+			return nil
+		},
+	))
+	client := NewClient(protocol.ProtocolOptions{
+		ConnectionId: connection.ConnectionId{
+			LocalAddr:  &net.TCPAddr{},
+			RemoteAddr: &net.TCPAddr{},
+		},
+	}, &cfg)
+	msg := &MsgAcceptVersion{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeAcceptVersion,
+		},
+		Version: 0xffff,
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("handleAcceptVersion panicked: %v", r)
+		}
+	}()
+	if err := client.handleAcceptVersion(msg); err == nil {
+		t.Fatal("expected unsupported version error")
 	}
 }


### PR DESCRIPTION
This was reported by logcavq02@gmail.com

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented a nil dereference during the handshake when a peer accepts an unsupported protocol version. The client now returns a clear error in `protocol/handshake` and skips the finished callback.

- **Bug Fixes**
  - Return an "unsupported protocol version" error when `NewVersionDataFromCborFunc` is nil in `handleAcceptVersion`.
  - Added a test for an unsupported version (0xffff) to ensure no panic and that the finished callback is not called.

<sup>Written for commit c4b67220605e3036ba17d60390ef875ea3aaca95. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

