### PR TITLE
fix(protocol): normal nil configs in n2c constructors

### DIFF
--- a/protocol/localstatequery/messages_test.go
+++ b/protocol/localstatequery/messages_test.go
@@ -18,11 +18,13 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"net"
 	"os"
 	"reflect"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
@@ -207,6 +209,23 @@ func TestEncode(t *testing.T) {
 				test.CborHex,
 			)
 		}
+	}
+}
+
+func TestServerNilConfigAcquireReturnsError(t *testing.T) {
+	server := NewServer(protocol.ProtocolOptions{
+		ConnectionId: connection.ConnectionId{
+			LocalAddr:  &net.TCPAddr{},
+			RemoteAddr: &net.TCPAddr{},
+		},
+	}, nil)
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("handleAcquire panicked: %v", r)
+		}
+	}()
+	if err := server.handleAcquire(&MsgAcquire{}); err == nil {
+		t.Fatal("expected missing callback error")
 	}
 }
 

--- a/protocol/localstatequery/server.go
+++ b/protocol/localstatequery/server.go
@@ -34,6 +34,10 @@ type Server struct {
 
 // NewServer returns a new LocalStateQuery server object
 func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
+	if cfg == nil {
+		tmpCfg := NewConfig()
+		cfg = &tmpCfg
+	}
 	s := &Server{
 		config: cfg,
 	}

--- a/protocol/localtxmonitor/messages_test.go
+++ b/protocol/localtxmonitor/messages_test.go
@@ -17,10 +17,12 @@ package localtxmonitor
 import (
 	"encoding/hex"
 	"fmt"
+	"net"
 	"reflect"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/protocol"
 )
 
@@ -125,5 +127,22 @@ func TestEncode(t *testing.T) {
 				test.CborHex,
 			)
 		}
+	}
+}
+
+func TestServerNilConfigAcquireReturnsError(t *testing.T) {
+	server := NewServer(protocol.ProtocolOptions{
+		ConnectionId: connection.ConnectionId{
+			LocalAddr:  &net.TCPAddr{},
+			RemoteAddr: &net.TCPAddr{},
+		},
+	}, nil)
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("handleAcquire panicked: %v", r)
+		}
+	}()
+	if err := server.handleAcquire(); err == nil {
+		t.Fatal("expected missing callback error")
 	}
 }

--- a/protocol/localtxmonitor/server.go
+++ b/protocol/localtxmonitor/server.go
@@ -36,6 +36,10 @@ type Server struct {
 
 // NewServer returns a new Server object
 func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
+	if cfg == nil {
+		tmpCfg := NewConfig()
+		cfg = &tmpCfg
+	}
 	s := &Server{
 		config: cfg,
 	}

--- a/protocol/localtxsubmission/messages_test.go
+++ b/protocol/localtxsubmission/messages_test.go
@@ -17,11 +17,13 @@ package localtxsubmission
 import (
 	"encoding/hex"
 	"fmt"
+	"net"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/protocol"
 )
@@ -110,5 +112,22 @@ func TestEncode(t *testing.T) {
 				test.CborHex,
 			)
 		}
+	}
+}
+
+func TestServerNilConfigSubmitTxReturnsError(t *testing.T) {
+	server := NewServer(protocol.ProtocolOptions{
+		ConnectionId: connection.ConnectionId{
+			LocalAddr:  &net.TCPAddr{},
+			RemoteAddr: &net.TCPAddr{},
+		},
+	}, nil)
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("handleSubmitTx panicked: %v", r)
+		}
+	}()
+	if err := server.handleSubmitTx(NewMsgSubmitTx(0, nil)); err == nil {
+		t.Fatal("expected missing callback error")
 	}
 }

--- a/protocol/localtxsubmission/server.go
+++ b/protocol/localtxsubmission/server.go
@@ -30,6 +30,10 @@ type Server struct {
 
 // NewServer returns a new Server object
 func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
+	if cfg == nil {
+		tmpCfg := NewConfig()
+		cfg = &tmpCfg
+	}
 	s := &Server{
 		config: cfg,
 	}


### PR DESCRIPTION
This was reported by logcavq02@gmail.com

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Create default configs when `nil` is passed to N2C server constructors (`localstatequery`, `localtxmonitor`, `localtxsubmission`) to prevent panics and surface proper callback errors.
Improves stability when servers are constructed without explicit configs.

- **Bug Fixes**
  - Constructors now use `NewConfig()` when `cfg` is `nil`.
  - Added tests to ensure `handleAcquire` and `handleSubmitTx` return errors instead of panicking.

<sup>Written for commit 649819ef1e64dd64f174e61b88ecc7f010e38ddf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

