### PR TITLE
fix(ledger): reject unknown conway redeemer tag fast-fail

### DIFF
--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -681,7 +681,7 @@ func UtxoValidateExtraneousRedeemers(
 		case common.RedeemerTagProposing:
 			maxIndex = proposalCount
 		default:
-			continue
+			return ExtraRedeemerError{RedeemerKey: redeemerKey}
 		}
 
 		if int(redeemerKey.Index) >= maxIndex {

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -309,6 +309,20 @@ func TestUtxoValidateWitnessRules_Conway(t *testing.T) {
 	)
 }
 
+func TestUtxoValidateExtraneousRedeemersUnknownTag(t *testing.T) {
+	redeemerKey := common.RedeemerKey{Tag: common.RedeemerTag(99)}
+	tx := &conway.ConwayTransaction{}
+	tx.WitnessSet.WsRedeemers = conway.ConwayRedeemers{
+		Redeemers: map[common.RedeemerKey]common.RedeemerValue{
+			redeemerKey: {},
+		},
+	}
+
+	err := conway.UtxoValidateExtraneousRedeemers(tx, 0, nil, nil)
+	require.Error(t, err)
+	assert.IsType(t, conway.ExtraRedeemerError{}, err)
+}
+
 func TestUtxoValidateOutsideValidityIntervalUtxo(t *testing.T) {
 	var testSlot uint64 = 555666777
 	var testZeroSlot uint64 = 0


### PR DESCRIPTION
This was reported by logcavq02@gmail.com

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unknown Conway redeemer tags now cause `UtxoValidateExtraneousRedeemers` to fast-fail with `ExtraRedeemerError` instead of being skipped. This prevents invalid or extraneous redeemers from passing validation and adds a unit test for this case.

<sup>Written for commit a4d79ae20c9862ce4f0b79846b38b70088d6cb1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

