### PR TITLE
fix(cbor): reject duplicate map keys

### DIFF
--- a/cbor/decode.go
+++ b/cbor/decode.go
@@ -45,6 +45,7 @@ func getDecMode() (_cbor.DecMode, error) {
 	cachedDecModeOnce.Do(func() {
 		decOptions := _cbor.DecOptions{
 			ExtraReturnErrors: _cbor.ExtraDecErrorUnknownField,
+			DupMapKey:         _cbor.DupMapKeyEnforcedAPF,
 			// This defaults to 32, but there are blocks in the wild using >64 nested levels
 			MaxNestedLevels: cborMaxNestedLevels,
 			// The fxamacker default is 131072, but Cardano ledger state
@@ -79,6 +80,7 @@ func getStrictDecMode() (_cbor.DecMode, error) {
 	cachedStrictDecModeOnce.Do(func() {
 		decOptions := _cbor.DecOptions{
 			ExtraReturnErrors: _cbor.ExtraDecErrorUnknownField,
+			DupMapKey:         _cbor.DupMapKeyEnforcedAPF,
 			MaxNestedLevels:   cborMaxNestedLevels,
 			// Stricter limits for untrusted network messages to prevent
 			// OOM from crafted payloads claiming excessive collection sizes.

--- a/cbor/decode_test.go
+++ b/cbor/decode_test.go
@@ -75,6 +75,16 @@ func TestDecode(t *testing.T) {
 	}
 }
 
+func TestDecodeRejectsDuplicateMapKeys(t *testing.T) {
+	cborData, err := hex.DecodeString("a201010102")
+	require.NoError(t, err)
+
+	var dest map[uint64]uint64
+	_, err = cbor.Decode(cborData, &dest)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate map key")
+}
+
 type listLenTestDefinition struct {
 	CborHex string
 	Length  int


### PR DESCRIPTION
This was reported by logcavq02@gmail.com

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate CBOR map keys during decoding to prevent ambiguous data and ensure strict parsing across all decode modes.

- **Bug Fixes**
  - Set `DupMapKey` to `DupMapKeyEnforcedAPF` for both standard and strict `cbor` decoders.
  - Added a test that verifies decoding fails with an error on duplicate map keys.

<sup>Written for commit ae303f8df26f51911df71dfe43d8f7a40d652f43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

