### PR TITLE
fix(protocol): dmq notification drains filter expired messages

### DIFF
--- a/protocol/localmessagenotification/messages_test.go
+++ b/protocol/localmessagenotification/messages_test.go
@@ -16,6 +16,7 @@ package localmessagenotification
 
 import (
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/protocol"
@@ -206,6 +207,36 @@ func TestMsgReplyMessagesBlocking(t *testing.T) {
 	reencoded, err := cbor.Encode(decoded)
 	assert.NoError(t, err)
 	assert.Equal(t, data, reencoded)
+}
+
+func TestServerDrainValidMessagesDropsExpired(t *testing.T) {
+	server := NewServer(protocol.ProtocolOptions{}, nil)
+	now := time.Unix(100, 0)
+	expired := &pcommon.DmqMessage{
+		MessageID: []byte("expired"),
+		Payload: pcommon.DmqMessagePayload{
+			ExpiresAt: 99,
+		},
+	}
+	valid := &pcommon.DmqMessage{
+		MessageID: []byte("valid"),
+		Payload: pcommon.DmqMessagePayload{
+			ExpiresAt: 101,
+		},
+	}
+
+	server.lock.Lock()
+	server.messageQueue = append(server.messageQueue, expired, valid)
+	messages := server.drainValidMessagesLocked(now)
+	server.lock.Unlock()
+
+	require.Len(t, messages, 1)
+	assert.Equal(t, []byte("valid"), messages[0].ID())
+	_, expiredAcked := server.acknowledgedIDs[string(expired.ID())]
+	_, validAcked := server.acknowledgedIDs[string(valid.ID())]
+	assert.False(t, expiredAcked)
+	assert.True(t, validAcked)
+	assert.Empty(t, server.messageQueue)
 }
 
 // TestMsgClientDoneEncoding tests MsgClientDone encoding

--- a/protocol/localmessagenotification/server.go
+++ b/protocol/localmessagenotification/server.go
@@ -198,19 +198,7 @@ func (s *Server) handleRequestMessages(msg protocol.Message) error {
 
 func (s *Server) handleNonBlockingRequest() error {
 	s.lock.Lock()
-
-	messages := make([]pcommon.DmqMessage, 0, len(s.messageQueue))
-	for _, msg := range s.messageQueue {
-		messages = append(messages, *msg)
-	}
-
-	// Mark all collected messages as acknowledged with current timestamp and clear the queue
-	now := time.Now()
-	for _, msg := range s.messageQueue {
-		s.acknowledgedIDs[string(msg.ID())] = now
-	}
-	s.messageQueue = s.messageQueue[:0]
-
+	messages := s.drainValidMessagesLocked(time.Now())
 	s.lock.Unlock()
 
 	// After clearing the queue, hasMore should always be false
@@ -222,9 +210,11 @@ func (s *Server) handleBlockingRequest() error {
 	// For blocking requests, wait until at least one message is available
 	for {
 		s.lock.Lock()
-		hasMessages := len(s.messageQueue) > 0
-		if hasMessages {
-			break
+		messages := s.drainValidMessagesLocked(time.Now())
+		if len(messages) > 0 {
+			s.lock.Unlock()
+			replyMsg := NewMsgReplyMessagesBlocking(messages)
+			return s.SendMessage(replyMsg)
 		}
 		s.lock.Unlock()
 
@@ -235,25 +225,19 @@ func (s *Server) handleBlockingRequest() error {
 			return s.SendMessage(replyMsg)
 		}
 	}
+}
 
-	// At this point, lock is held and hasMessages is true
-
+func (s *Server) drainValidMessagesLocked(now time.Time) []pcommon.DmqMessage {
 	messages := make([]pcommon.DmqMessage, 0, len(s.messageQueue))
 	for _, msg := range s.messageQueue {
+		if msg == nil || !msg.IsValidAt(now) {
+			continue
+		}
 		messages = append(messages, *msg)
-	}
-
-	// Mark all collected messages as acknowledged with current timestamp and clear the queue
-	now := time.Now()
-	for _, msg := range s.messageQueue {
 		s.acknowledgedIDs[string(msg.ID())] = now
 	}
 	s.messageQueue = s.messageQueue[:0]
-
-	s.lock.Unlock()
-
-	replyMsg := NewMsgReplyMessagesBlocking(messages)
-	return s.SendMessage(replyMsg)
+	return messages
 }
 
 //nolint:unparam


### PR DESCRIPTION
This was reported by logcavq02@gmail.com

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters out expired DMQ messages when draining the local message notification queue. Only valid messages are returned to clients and acknowledged; expired messages are dropped.

- **Bug Fixes**
  - Added `drainValidMessagesLocked` to select messages valid at `time.Now()` and acknowledge only those.
  - Applied filtering to both blocking and non-blocking requests, preventing expired messages from being sent.
  - Added a unit test to ensure expired messages are dropped, valid ones are acknowledged, and the queue is cleared.

<sup>Written for commit 85c0f924945407c24e88bcad1b79e92a0d3ef4b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

