### PR TITLE
test(ledger): defer reset collateral return

### DIFF
--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -2228,6 +2228,7 @@ func TestUtxoValidateCollateralEqBalance(t *testing.T) {
 		"collateral return exceeds collateral balance",
 		func(t *testing.T) {
 			testTx.Body.TxTotalCollateral = testInputAmount
+			defer func() { testTx.Body.TxTotalCollateral = testTotalCollateral }()
 			testTx.Body.TxCollateralReturn = &babbage.BabbageTransactionOutput{
 				OutputAmount: mary.MaryTransactionOutputValue{
 					Amount: testCollateralReturnAmountOverflow,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a deferred reset of TxTotalCollateral in TestUtxoValidateCollateralEqBalance to restore the original value after the test runs. This prevents state leakage across subtests and reduces flakiness.

<sup>Written for commit 96f3ccf376c7efc9ae75fc64e6bdbb08f3430184. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

