### PR TITLE
feat(protocol): LeiosVotes mini-protocol

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -206,6 +206,7 @@ Implements Ouroboros mini-protocols for network communication.
 | LocalMessageNotification | Local message notifications |
 | LeiosFetch | Leios block fetching |
 | LeiosNotify | Leios block notifications |
+| LeiosVotes | Leios vote diffusion |
 
 ### Protocol Structure
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ This is not an exhaustive list of existing and planned features, but it covers t
     - [X] LeiosNotify ([CIP-0164](https://cips.cardano.org/cip/CIP-0164))
       - [X] Client support
       - [X] Server support
+    - [X] LeiosVotes ([CIP-0164](https://cips.cardano.org/cip/CIP-0164))
+      - [X] Client support
+      - [X] Server support
     - [X] LocalMessageSubmission ([CIP-0137](https://cips.cardano.org/cip/CIP-0137) DMQ)
       - [X] Client support
       - [X] Server support

--- a/connection.go
+++ b/connection.go
@@ -41,6 +41,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/protocol/keepalive"
 	"github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
 	"github.com/blinklabs-io/gouroboros/protocol/leiosnotify"
+	"github.com/blinklabs-io/gouroboros/protocol/leiosvotes"
 	"github.com/blinklabs-io/gouroboros/protocol/localmessagenotification"
 	"github.com/blinklabs-io/gouroboros/protocol/localmessagesubmission"
 	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
@@ -98,6 +99,8 @@ type Connection struct {
 	leiosFetchConfig        *leiosfetch.Config
 	leiosNotify             *leiosnotify.LeiosNotify
 	leiosNotifyConfig       *leiosnotify.Config
+	leiosVotes              *leiosvotes.LeiosVotes
+	leiosVotesConfig        *leiosvotes.Config
 	localStateQuery         *localstatequery.LocalStateQuery
 	localStateQueryConfig   *localstatequery.Config
 	localTxMonitor          *localtxmonitor.LocalTxMonitor
@@ -233,6 +236,11 @@ func (c *Connection) LeiosFetch() *leiosfetch.LeiosFetch {
 // LeiosNotify returns the leios-notify protocol handler
 func (c *Connection) LeiosNotify() *leiosnotify.LeiosNotify {
 	return c.leiosNotify
+}
+
+// LeiosVotes returns the leios-votes protocol handler
+func (c *Connection) LeiosVotes() *leiosvotes.LeiosVotes {
+	return c.leiosVotes
 }
 
 // LocalStateQuery returns the local-state-query protocol handler
@@ -399,6 +407,14 @@ func (c *Connection) allProtocolsIdle() bool {
 		}
 		if c.leiosFetch.Server != nil {
 			protocols = append(protocols, c.leiosFetch.Server.ProtocolInstance())
+		}
+	}
+	if c.leiosVotes != nil {
+		if c.leiosVotes.Client != nil {
+			protocols = append(protocols, c.leiosVotes.Client.Protocol)
+		}
+		if c.leiosVotes.Server != nil {
+			protocols = append(protocols, c.leiosVotes.Server.ProtocolInstance())
 		}
 	}
 	if c.localMessageSubmission != nil {
@@ -628,6 +644,7 @@ func (c *Connection) setupConnection() error {
 		}
 		c.leiosNotify = leiosnotify.New(protoOptions, c.leiosNotifyConfig)
 		c.leiosFetch = leiosfetch.New(protoOptions, c.leiosFetchConfig)
+		c.leiosVotes = leiosvotes.New(protoOptions, c.leiosVotesConfig)
 		c.protocolsReady = true
 		c.protocolMu.Unlock()
 		// Register server protocols early to avoid race conditions where messages arrive
@@ -643,6 +660,7 @@ func (c *Connection) setupConnection() error {
 			}
 			c.leiosNotify.Server.EnsureRegistered()
 			c.leiosFetch.Server.EnsureRegistered()
+			c.leiosVotes.Server.EnsureRegistered()
 		}
 		// Start protocols
 		if !c.delayProtocolStart {
@@ -658,6 +676,7 @@ func (c *Connection) setupConnection() error {
 				}
 				c.leiosNotify.Client.Start()
 				c.leiosFetch.Client.Start()
+				c.leiosVotes.Client.Start()
 			}
 			if (c.fullDuplex && handshakeFullDuplex) || c.server {
 				c.blockFetch.Server.Start()
@@ -671,6 +690,7 @@ func (c *Connection) setupConnection() error {
 				}
 				c.leiosNotify.Server.Start()
 				c.leiosFetch.Server.Start()
+				c.leiosVotes.Server.Start()
 			}
 		}
 	} else if c.useDMQProtocol {

--- a/connection_options.go
+++ b/connection_options.go
@@ -23,6 +23,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/protocol/keepalive"
 	"github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
 	"github.com/blinklabs-io/gouroboros/protocol/leiosnotify"
+	"github.com/blinklabs-io/gouroboros/protocol/leiosvotes"
 	"github.com/blinklabs-io/gouroboros/protocol/localmessagenotification"
 	"github.com/blinklabs-io/gouroboros/protocol/localmessagesubmission"
 	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
@@ -177,6 +178,13 @@ func WithLeiosFetchConfig(cfg leiosfetch.Config) ConnectionOptionFunc {
 func WithLeiosNotifyConfig(cfg leiosnotify.Config) ConnectionOptionFunc {
 	return func(c *Connection) {
 		c.leiosNotifyConfig = &cfg
+	}
+}
+
+// WithLeiosVotesConfig specifies LeiosVotes protocol config
+func WithLeiosVotesConfig(cfg leiosvotes.Config) ConnectionOptionFunc {
+	return func(c *Connection) {
+		c.leiosVotesConfig = &cfg
 	}
 }
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/protocol/keepalive"
 	"github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
 	"github.com/blinklabs-io/gouroboros/protocol/leiosnotify"
+	"github.com/blinklabs-io/gouroboros/protocol/leiosvotes"
 	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
 	"github.com/blinklabs-io/gouroboros/protocol/localtxmonitor"
 	"github.com/blinklabs-io/gouroboros/protocol/localtxsubmission"
@@ -143,6 +144,7 @@ func TestConnectionOptions(t *testing.T) {
 		{"WithTxSubmissionConfig", ouroboros.WithTxSubmissionConfig(txsubmission.Config{})},
 		{"WithLeiosFetchConfig", ouroboros.WithLeiosFetchConfig(leiosfetch.Config{})},
 		{"WithLeiosNotifyConfig", ouroboros.WithLeiosNotifyConfig(leiosnotify.Config{})},
+		{"WithLeiosVotesConfig", ouroboros.WithLeiosVotesConfig(leiosvotes.Config{})},
 	}
 
 	for _, tc := range testCases {
@@ -239,6 +241,7 @@ func TestConnectionProtocolGettersBeforeSetup(t *testing.T) {
 	assert.Nil(t, conn.KeepAlive(), "KeepAlive should be nil before setup")
 	assert.Nil(t, conn.LeiosFetch(), "LeiosFetch should be nil before setup")
 	assert.Nil(t, conn.LeiosNotify(), "LeiosNotify should be nil before setup")
+	assert.Nil(t, conn.LeiosVotes(), "LeiosVotes should be nil before setup")
 	assert.Nil(t, conn.LocalStateQuery(), "LocalStateQuery should be nil before setup")
 	assert.Nil(t, conn.LocalTxMonitor(), "LocalTxMonitor should be nil before setup")
 	assert.Nil(t, conn.LocalTxSubmission(), "LocalTxSubmission should be nil before setup")

--- a/protocol/PROTOCOL_LIMITS.md
+++ b/protocol/PROTOCOL_LIMITS.md
@@ -119,8 +119,11 @@ All remaining protocols have appropriate timeout implementations:
 - **LocalTxMonitor** - Has AcquireTimeout (5s) and QueryTimeout (30s) for mempool monitoring  
 - **LocalTxSubmission** - Has Timeout (30s) for local transaction submission
 - **PeerSharing** - Has Timeout (5s) for peer discovery requests
-- **LeiosFetch** - Has Timeout (5s) for Leios block/transaction/vote fetching
-- **LeiosNotify** - Has Timeout (60s) for Leios block/vote notifications
+- **LeiosFetch** - Has Timeout (5s) for fetching Leios blocks, block
+  transactions, votes, and block ranges
+- **LeiosNotify** - Has Timeout (60s) for Leios block announcements/offers,
+  block transaction offers, and vote offers
+- **LeiosVotes** - Has Timeout (60s) for Leios vote diffusion
 - **Handshake** - Has ProposeTimeout (5s) and ConfirmTimeout (5s) for protocol negotiation
 - **Keepalive** - Has ClientTimeout (60s) and ServerTimeout (10s) for connection health
 
@@ -131,7 +134,7 @@ All remaining protocols have appropriate timeout implementations:
 - Tests configuration validation and panic behavior  
 - Verifies protocol violation errors are defined
 - Ensures default values are reasonable and within limits
-- Comprehensive timeout validation for all 11 mini-protocols
+- Comprehensive timeout validation for all 12 mini-protocols
 - Verifies StateMap entries use correct timeout constants
 
 ## Protocol State Timeouts

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -20,6 +20,7 @@ This directory contains implementations of the Ouroboros mini-protocols used for
 | [LocalMessageNotification](localmessagenotification/) | 15 | NtC | Local DMQ notifications |
 | [LeiosNotify](leiosnotify/) | 18 | NtN | Leios notifications |
 | [LeiosFetch](leiosfetch/) | 19 | NtN | Leios data retrieval |
+| [LeiosVotes](leiosvotes/) | 20 | NtN | Leios vote diffusion |
 
 **Mode Key:**
 - **NtN**: Node-to-Node (between full nodes)
@@ -87,8 +88,9 @@ Init → Idle → (request/reply cycle)
 - **LocalMessageNotification**: Receive message notifications
 
 ### Leios (Experimental)
-- **LeiosNotify**: Block/vote announcements
-- **LeiosFetch**: Block/vote retrieval
+- **LeiosNotify**: Block announcements and availability notifications
+- **LeiosFetch**: Block and transaction retrieval
+- **LeiosVotes**: Vote diffusion
 
 ## Usage
 

--- a/protocol/leiosvotes/README.md
+++ b/protocol/leiosvotes/README.md
@@ -1,0 +1,72 @@
+# LeiosVotes Protocol
+
+The LeiosVotes protocol diffuses votes on Leios endorser blocks. It is part
+of the experimental CIP-0164 Linear Leios protocol suite and follows the
+current upstream design where vote diffusion is separate from EB announce and
+fetch traffic.
+
+## Protocol Identifiers
+
+| Field | Value |
+|-------|-------|
+| Protocol Name | `leios-votes` |
+| Protocol ID | `20` |
+| Mode | Node-to-Node |
+
+## Messages
+
+| Message | ID | Direction | Purpose |
+|---------|----|-----------|---------|
+| `VotesRequestNext` | 0 | Client -> Server | Request `N` votes |
+| `Vote` | 1 | Server -> Client | Deliver one vote |
+| `Done` | 2 | Client -> Server | End protocol |
+
+`VotesRequestNext` carries a positive `Count`. The implementation currently
+caps this at `MaxRequestNextCount` to keep the receive buffer commitment
+bounded while CIP-0164 remains experimental.
+
+`Vote` carries the stake-based committee vote shape from the current
+CIP-0164 design:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `SlotNo` | `uint64` | Voting round / announcing RB slot |
+| `EndorserBlockHash` | `[]byte` | EB hash being endorsed |
+| `VoterId` | `uint16` | Index in the epoch committee |
+| `VoteSignature` | `[]byte` | BLS signature |
+
+## State Machine
+
+```text
+Idle --VotesRequestNext(N)--> Busy(tokens=N)
+Busy --Vote, tokens > 1--> Busy(tokens-1)
+Busy --Vote, tokens = 1--> Idle
+Idle --Done--> Done
+```
+
+## States
+
+| State | ID | Agency | Description |
+|-------|----|--------|-------------|
+| **Idle** | 1 | Client | Waiting for a vote request or termination |
+| **Busy** | 2 | Server | Delivering the requested vote batch |
+| **Done** | 3 | None | Terminal state |
+
+## Usage
+
+```go
+cfg := leiosvotes.NewConfig(
+    leiosvotes.WithRequestNextFunc(func(
+        ctx leiosvotes.CallbackContext,
+        count uint64,
+    ) ([]leiosvotes.Vote, error) {
+        return nextVotes(count)
+    }),
+    leiosvotes.WithVoteFunc(func(
+        ctx leiosvotes.CallbackContext,
+        vote leiosvotes.Vote,
+    ) error {
+        return handleVote(vote)
+    }),
+)
+```

--- a/protocol/leiosvotes/client.go
+++ b/protocol/leiosvotes/client.go
@@ -1,0 +1,250 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leiosvotes
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/blinklabs-io/gouroboros/protocol"
+)
+
+type Client struct {
+	*protocol.Protocol
+	busyMutex       sync.Mutex
+	callbackContext CallbackContext
+	config          *Config
+	onceStart       sync.Once
+	onceStop        sync.Once
+	sendMutex       sync.Mutex
+	stopErr         error
+	stopping        bool
+	syncRunning     bool
+	voteChan        chan Vote
+}
+
+func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
+	cfg = normalizeConfig(cfg)
+	c := &Client{
+		config:   cfg,
+		voteChan: make(chan Vote),
+	}
+	c.callbackContext = CallbackContext{
+		Client:       c,
+		ConnectionId: protoOptions.ConnectionId,
+	}
+	stateMap := StateMap.Copy()
+	if entry, ok := stateMap[StateBusy]; ok {
+		entry.Timeout = c.config.Timeout
+		stateMap[StateBusy] = entry
+	}
+	protoConfig := protocol.ProtocolConfig{
+		Name:                ProtocolName,
+		ProtocolId:          ProtocolId,
+		Muxer:               protoOptions.Muxer,
+		Logger:              protoOptions.Logger,
+		ErrorChan:           protoOptions.ErrorChan,
+		Mode:                protoOptions.Mode,
+		Role:                protocol.ProtocolRoleClient,
+		MessageHandlerFunc:  c.messageHandler,
+		MessageFromCborFunc: NewMsgFromCbor,
+		StateContext:        &stateContext{},
+		StateMap:            stateMap,
+		InitialState:        StateIdle,
+	}
+	c.Protocol = protocol.New(protoConfig)
+	return c
+}
+
+func (c *Client) Start() {
+	c.onceStart.Do(func() {
+		c.Protocol.Logger().
+			Debug("starting client protocol",
+				"component", "network",
+				"protocol", ProtocolName,
+				"connection_id", c.callbackContext.ConnectionId.String(),
+			)
+		c.Protocol.Start()
+	})
+}
+
+func (c *Client) Stop() error {
+	c.onceStop.Do(func() {
+		c.Protocol.Logger().
+			Debug("stopping client protocol",
+				"component", "network",
+				"protocol", ProtocolName,
+				"connection_id", c.callbackContext.ConnectionId.String(),
+			)
+		c.sendMutex.Lock()
+		defer c.sendMutex.Unlock()
+		c.stopping = true
+		c.stopErr = c.SendMessage(NewMsgDone())
+	})
+	return c.stopErr
+}
+
+func (c *Client) sendRequestNext(count uint64) error {
+	c.sendMutex.Lock()
+	defer c.sendMutex.Unlock()
+	if c.stopping || c.IsDone() {
+		return protocol.ErrProtocolShuttingDown
+	}
+	return c.SendMessage(NewMsgVotesRequestNext(count))
+}
+
+func (c *Client) isStopping() bool {
+	c.sendMutex.Lock()
+	defer c.sendMutex.Unlock()
+	return c.stopping || c.IsDone()
+}
+
+func (c *Client) RequestNext(count uint64) ([]Vote, error) {
+	if count == 0 {
+		return nil, errors.New("request count must be positive")
+	}
+	if count > MaxRequestNextCount {
+		return nil, fmt.Errorf(
+			"request count %d exceeds maximum allowed %d",
+			count,
+			MaxRequestNextCount,
+		)
+	}
+	c.busyMutex.Lock()
+	defer c.busyMutex.Unlock()
+	if c.syncRunning {
+		return nil, errors.New("vote sync loop is already running")
+	}
+	if err := c.sendRequestNext(count); err != nil {
+		return nil, err
+	}
+	votes := make([]Vote, 0, count)
+	for range count {
+		select {
+		case <-c.DoneChan():
+			return nil, protocol.ErrProtocolShuttingDown
+		case vote := <-c.voteChan:
+			votes = append(votes, vote)
+		}
+	}
+	return votes, nil
+}
+
+func (c *Client) Sync() error {
+	if c.config.VoteFunc == nil {
+		return errors.New("you must configure VoteFunc to receive votes")
+	}
+	c.busyMutex.Lock()
+	defer c.busyMutex.Unlock()
+	if c.syncRunning {
+		return errors.New("vote sync loop is already running")
+	}
+	pipelineLimit := max(c.config.PipelineLimit, 1)
+	c.sendMutex.Lock()
+	for range pipelineLimit {
+		if c.stopping || c.IsDone() {
+			c.sendMutex.Unlock()
+			return protocol.ErrProtocolShuttingDown
+		}
+		if err := c.SendMessage(
+			NewMsgVotesRequestNext(c.config.RequestNextCount),
+		); err != nil {
+			c.sendMutex.Unlock()
+			return err
+		}
+	}
+	c.syncRunning = true
+	c.sendMutex.Unlock()
+	go c.voteLoop(uint64(pipelineLimit) * c.config.RequestNextCount)
+	return nil
+}
+
+func (c *Client) voteLoop(outstanding uint64) {
+	defer func() {
+		c.busyMutex.Lock()
+		c.syncRunning = false
+		c.busyMutex.Unlock()
+	}()
+	refillThreshold := uint64(max(c.config.PipelineLimit-1, 0)) *
+		c.config.RequestNextCount
+	for {
+		select {
+		case vote := <-c.voteChan:
+			if outstanding > 0 {
+				outstanding--
+			}
+			if err := c.config.VoteFunc(c.callbackContext, vote); err != nil {
+				if errors.Is(err, ErrStopVoteProcess) {
+					c.drainVotes(outstanding)
+					return
+				}
+				c.SendError(err)
+				return
+			}
+			if c.isStopping() {
+				c.drainVotes(outstanding)
+				return
+			}
+			if outstanding <= refillThreshold {
+				if err := c.sendRequestNext(c.config.RequestNextCount); err != nil {
+					if errors.Is(err, protocol.ErrProtocolShuttingDown) {
+						c.drainVotes(outstanding)
+						return
+					}
+					c.SendError(err)
+					return
+				}
+				outstanding += c.config.RequestNextCount
+			}
+		case <-c.DoneChan():
+			return
+		}
+	}
+}
+
+func (c *Client) drainVotes(remaining uint64) {
+	for remaining > 0 {
+		select {
+		case <-c.voteChan:
+			remaining--
+		case <-c.DoneChan():
+			return
+		}
+	}
+}
+
+func (c *Client) messageHandler(msg protocol.Message) error {
+	var err error
+	switch msg.Type() {
+	case MessageTypeVote:
+		c.handleVote(msg)
+	default:
+		err = fmt.Errorf(
+			"%s: received unexpected message type %d",
+			ProtocolName,
+			msg.Type(),
+		)
+	}
+	return err
+}
+
+func (c *Client) handleVote(msg protocol.Message) {
+	msgVote := msg.(*MsgVote)
+	select {
+	case <-c.DoneChan():
+	case c.voteChan <- msgVote.Vote:
+	}
+}

--- a/protocol/leiosvotes/client_test.go
+++ b/protocol/leiosvotes/client_test.go
@@ -1,0 +1,370 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leiosvotes
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/muxer"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testConnectionId() connection.ConnectionId {
+	return connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+}
+
+func readTestSegment(
+	t *testing.T,
+	conn net.Conn,
+) (*muxer.Segment, error) {
+	t.Helper()
+	header := muxer.SegmentHeader{}
+	if err := binary.Read(conn, binary.BigEndian, &header); err != nil {
+		return nil, err
+	}
+	payload := make([]byte, header.PayloadLength)
+	if _, err := io.ReadFull(conn, payload); err != nil {
+		return nil, err
+	}
+	return &muxer.Segment{
+		SegmentHeader: header,
+		Payload:       payload,
+	}, nil
+}
+
+func requireReadTestSegment(t *testing.T, conn net.Conn) *muxer.Segment {
+	t.Helper()
+	segment, err := readTestSegment(t, conn)
+	require.NoError(t, err)
+	return segment
+}
+
+func writeTestSegment(
+	t *testing.T,
+	conn net.Conn,
+	segment *muxer.Segment,
+) {
+	t.Helper()
+	require.NotNil(t, segment)
+	buf := &bytes.Buffer{}
+	require.NoError(t, binary.Write(buf, binary.BigEndian, segment.SegmentHeader))
+	_, err := buf.Write(segment.Payload)
+	require.NoError(t, err)
+	_, err = conn.Write(buf.Bytes())
+	require.NoError(t, err)
+}
+
+func decodeTestMessageTypes(t *testing.T, payload []byte) []uint8 {
+	t.Helper()
+	var ret []uint8
+	for len(payload) > 0 {
+		tmpMsg := []cbor.RawMessage{}
+		numBytesRead, err := cbor.Decode(payload, &tmpMsg)
+		require.NoError(t, err)
+		require.NotZero(t, numBytesRead)
+		require.NotEmpty(t, tmpMsg)
+		msgType := uint(0)
+		_, err = cbor.Decode(tmpMsg[0], &msgType)
+		require.NoError(t, err)
+		ret = append(ret, uint8(msgType))
+		payload = payload[numBytesRead:]
+	}
+	return ret
+}
+
+func isTimeout(err error) bool {
+	netErr, ok := err.(net.Error)
+	return ok && netErr.Timeout()
+}
+
+func TestNewClient(t *testing.T) {
+	client := NewClient(
+		protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+		nil,
+	)
+
+	require.NotNil(t, client)
+	assert.NotNil(t, client.Protocol)
+	assert.NotNil(t, client.config)
+}
+
+func TestNewClientNormalizesZeroValueConfig(t *testing.T) {
+	cfg := Config{}
+	client := NewClient(
+		protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+		&cfg,
+	)
+
+	require.NotNil(t, client)
+	assert.Equal(t, DefaultTimeout, client.config.Timeout)
+	assert.Equal(t, DefaultPipelineLimit, client.config.PipelineLimit)
+	assert.Equal(t, DefaultRequestNextCount, client.config.RequestNextCount)
+}
+
+func TestNewClientWithConfig(t *testing.T) {
+	cfg := NewConfig(
+		WithTimeout(10*time.Second),
+		WithRequestNextCount(25),
+		WithPipelineLimit(2),
+	)
+
+	client := NewClient(
+		protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+		&cfg,
+	)
+
+	require.NotNil(t, client)
+	assert.Equal(t, 10*time.Second, client.config.Timeout)
+	assert.Equal(t, uint64(25), client.config.RequestNextCount)
+	assert.Equal(t, 2, client.config.PipelineLimit)
+}
+
+func TestClientMessageHandler(t *testing.T) {
+	client := NewClient(
+		protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+		nil,
+	)
+	vote := testVote()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		assert.Equal(t, vote, <-client.voteChan)
+	}()
+
+	err := client.messageHandler(NewMsgVote(vote))
+	require.NoError(t, err)
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timeout waiting for vote")
+	}
+}
+
+func TestClientMessageHandlerUnexpectedType(t *testing.T) {
+	client := NewClient(
+		protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+		nil,
+	)
+
+	err := client.messageHandler(NewMsgVotesRequestNext(1))
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected message type")
+}
+
+func TestStopReturnsOriginalErrorOnRepeatedCalls(t *testing.T) {
+	connA, connB := net.Pipe()
+	defer connA.Close()
+	defer connB.Close()
+
+	client := NewClient(
+		protocol.ProtocolOptions{
+			ConnectionId: testConnectionId(),
+			Muxer:        muxer.New(connA),
+		},
+		nil,
+	)
+	client.Protocol.Stop()
+
+	err := client.Stop()
+	require.ErrorIs(t, err, protocol.ErrProtocolShuttingDown)
+	err = client.Stop()
+	require.ErrorIs(t, err, protocol.ErrProtocolShuttingDown)
+}
+
+func TestStopDuringSyncDoesNotRefillAfterDone(t *testing.T) {
+	connA, connB := net.Pipe()
+	defer connA.Close()
+	defer connB.Close()
+
+	m := muxer.New(connA)
+	defer m.Stop()
+
+	stopErr := make(chan error, 1)
+	var client *Client
+	cfg := NewConfig(
+		WithPipelineLimit(1),
+		WithRequestNextCount(1),
+		WithVoteFunc(func(ctx CallbackContext, vote Vote) error {
+			stopErr <- client.Stop()
+			return nil
+		}),
+	)
+	client = NewClient(
+		protocol.ProtocolOptions{
+			ConnectionId: testConnectionId(),
+			Muxer:        m,
+		},
+		&cfg,
+	)
+	client.Start()
+	m.Start()
+	defer client.Protocol.Stop()
+
+	require.NoError(t, client.Sync())
+
+	firstSegment := requireReadTestSegment(t, connB)
+	assert.Equal(
+		t,
+		[]uint8{MessageTypeVotesRequestNext},
+		decodeTestMessageTypes(t, firstSegment.Payload),
+	)
+
+	voteData, err := cbor.Encode(NewMsgVote(testVote()))
+	require.NoError(t, err)
+	writeTestSegment(t, connB, muxer.NewSegment(ProtocolId, voteData, true))
+
+	select {
+	case err := <-stopErr:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for Stop from vote callback")
+	}
+
+	secondSegment := requireReadTestSegment(t, connB)
+	assert.Equal(
+		t,
+		[]uint8{MessageTypeDone},
+		decodeTestMessageTypes(t, secondSegment.Payload),
+	)
+
+	require.NoError(t, connB.SetReadDeadline(time.Now().Add(50*time.Millisecond)))
+	extraSegment, err := readTestSegment(t, connB)
+	if err != nil {
+		require.True(t, isTimeout(err), "unexpected read error: %v", err)
+		return
+	}
+	assert.NotContains(
+		t,
+		decodeTestMessageTypes(t, extraSegment.Payload),
+		MessageTypeVotesRequestNext,
+	)
+}
+
+func TestRequestNextRejectsWhileSyncRunning(t *testing.T) {
+	client := NewClient(
+		protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+		nil,
+	)
+	client.syncRunning = true
+
+	_, err := client.RequestNext(1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "vote sync loop is already running")
+}
+
+func TestStateMap(t *testing.T) {
+	assert.Equal(t, uint(1), StateIdle.Id)
+	assert.Equal(t, uint(2), StateBusy.Id)
+	assert.Equal(t, uint(3), StateDone.Id)
+
+	assert.Contains(t, StateMap, StateIdle)
+	assert.Contains(t, StateMap, StateBusy)
+	assert.Contains(t, StateMap, StateDone)
+
+	assert.Equal(t, protocol.AgencyClient, StateMap[StateIdle].Agency)
+	assert.Equal(t, protocol.AgencyServer, StateMap[StateBusy].Agency)
+	assert.Equal(t, protocol.AgencyNone, StateMap[StateDone].Agency)
+}
+
+func TestStateTransitions(t *testing.T) {
+	idleEntry := StateMap[StateIdle]
+	require.Len(t, idleEntry.Transitions, 2)
+
+	ctx := &stateContext{}
+	req := NewMsgVotesRequestNext(2)
+	assert.True(t, idleEntry.Transitions[0].MatchFunc(ctx, req))
+	assert.Equal(t, uint64(2), ctx.tokens)
+
+	busyEntry := StateMap[StateBusy]
+	require.Len(t, busyEntry.Transitions, 2)
+	assert.True(t, busyEntry.Transitions[0].MatchFunc(ctx, NewMsgVote(testVote())))
+	assert.Equal(t, uint64(1), ctx.tokens)
+	assert.True(t, busyEntry.Transitions[1].MatchFunc(ctx, NewMsgVote(testVote())))
+	assert.Equal(t, uint64(0), ctx.tokens)
+}
+
+func TestStateTransitionRejectsInvalidCount(t *testing.T) {
+	idleEntry := StateMap[StateIdle]
+	ctx := &stateContext{}
+
+	assert.False(
+		t,
+		idleEntry.Transitions[0].MatchFunc(ctx, NewMsgVotesRequestNext(0)),
+	)
+	assert.False(
+		t,
+		idleEntry.Transitions[0].MatchFunc(
+			ctx,
+			NewMsgVotesRequestNext(MaxRequestNextCount+1),
+		),
+	)
+}
+
+func TestConfig(t *testing.T) {
+	cfg := NewConfig()
+	assert.Equal(t, DefaultTimeout, cfg.Timeout)
+	assert.Equal(t, DefaultPipelineLimit, cfg.PipelineLimit)
+	assert.Equal(t, DefaultRequestNextCount, cfg.RequestNextCount)
+	assert.Nil(t, cfg.RequestNextFunc)
+	assert.Nil(t, cfg.VoteFunc)
+
+	requestNextCalled := false
+	voteCalled := false
+	cfg = NewConfig(
+		WithRequestNextFunc(func(ctx CallbackContext, count uint64) ([]Vote, error) {
+			requestNextCalled = true
+			return make([]Vote, count), nil
+		}),
+		WithVoteFunc(func(ctx CallbackContext, vote Vote) error {
+			voteCalled = true
+			return nil
+		}),
+	)
+
+	_, _ = cfg.RequestNextFunc(CallbackContext{}, 1)
+	assert.True(t, requestNextCalled)
+	_ = cfg.VoteFunc(CallbackContext{}, Vote{})
+	assert.True(t, voteCalled)
+}
+
+func TestConfigRejectsInvalidTimeout(t *testing.T) {
+	for _, timeout := range []time.Duration{0, -time.Second} {
+		cfg := Config{
+			PipelineLimit:    DefaultPipelineLimit,
+			RequestNextCount: DefaultRequestNextCount,
+			Timeout:          timeout,
+		}
+		assert.EqualError(t, cfg.validate(), "timeout must be positive")
+	}
+}
+
+func TestProtocolConstants(t *testing.T) {
+	assert.Equal(t, "leios-votes", ProtocolName)
+	assert.Equal(t, uint16(20), ProtocolId)
+}

--- a/protocol/leiosvotes/doc.go
+++ b/protocol/leiosvotes/doc.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package leiosvotes implements the Leios vote diffusion mini-protocol.
+//
+// # AI Navigation Guide
+//
+// This package implements the CIP-0164 vote diffusion protocol for
+// propagating votes on endorser blocks between node-to-node peers.
+//
+// # Key Files
+//
+//   - leiosvotes.go: Protocol definition, state machine, and config
+//   - messages.go: Request, vote, and done message types with CBOR encoding
+//   - client.go: Client implementation for requesting and processing votes
+//   - server.go: Server implementation for serving requested vote batches
+//
+// # State Machine
+//
+// The protocol follows bounded push semantics:
+//
+//	Idle -> Busy -> Idle
+//
+// The client sends MsgVotesRequestNext(N) from Idle. The server then has
+// agency and sends exactly N MsgVote messages. The first N-1 votes keep the
+// protocol in Busy, and the final vote returns it to Idle. MsgDone terminates
+// the protocol from Idle.
+//
+// # Vote Shape
+//
+// Votes contain the slot number, endorser block hash, voter ID, and vote
+// signature. This matches the current CIP-0164 stake-based committee direction,
+// where every committee member has the same uniform vote structure.
+package leiosvotes

--- a/protocol/leiosvotes/error.go
+++ b/protocol/leiosvotes/error.go
@@ -1,0 +1,21 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leiosvotes
+
+import "errors"
+
+// ErrStopVoteProcess is used as a special return value from a vote handler
+// function to stop the vote sync loop.
+var ErrStopVoteProcess = errors.New("stop vote process")

--- a/protocol/leiosvotes/leiosvotes.go
+++ b/protocol/leiosvotes/leiosvotes.go
@@ -1,0 +1,278 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leiosvotes
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/protocol"
+)
+
+const (
+	ProtocolName        = "leios-votes"
+	ProtocolId   uint16 = 20
+)
+
+const (
+	MaxRequestNextCount     uint64 = 1000
+	DefaultRequestNextCount uint64 = 1000
+	MaxPipelineLimit               = 100
+	DefaultPipelineLimit           = 1
+	DefaultTimeout                 = 60 * time.Second
+)
+
+var (
+	StateIdle = protocol.NewState(1, "Idle")
+	StateBusy = protocol.NewState(2, "Busy")
+	StateDone = protocol.NewState(3, "Done")
+)
+
+var StateMap = protocol.StateMap{
+	StateIdle: protocol.StateMapEntry{
+		Agency: protocol.AgencyClient,
+		Transitions: []protocol.StateTransition{
+			{
+				MsgType:   MessageTypeVotesRequestNext,
+				NewState:  StateBusy,
+				MatchFunc: matchRequestNext,
+			},
+			{
+				MsgType:  MessageTypeDone,
+				NewState: StateDone,
+			},
+		},
+	},
+	StateBusy: protocol.StateMapEntry{
+		Agency: protocol.AgencyServer,
+		Transitions: []protocol.StateTransition{
+			{
+				MsgType:   MessageTypeVote,
+				NewState:  StateBusy,
+				MatchFunc: matchVoteWithMorePending,
+			},
+			{
+				MsgType:   MessageTypeVote,
+				NewState:  StateIdle,
+				MatchFunc: matchFinalVote,
+			},
+		},
+	},
+	StateDone: protocol.StateMapEntry{
+		Agency: protocol.AgencyNone,
+	},
+}
+
+type stateContext struct {
+	tokens uint64
+}
+
+func matchRequestNext(ctx any, msg protocol.Message) bool {
+	stateCtx, ok := ctx.(*stateContext)
+	if !ok {
+		return false
+	}
+	req, ok := msg.(*MsgVotesRequestNext)
+	if !ok || req.Count == 0 || req.Count > MaxRequestNextCount {
+		return false
+	}
+	stateCtx.tokens = req.Count
+	return true
+}
+
+func matchVoteWithMorePending(ctx any, msg protocol.Message) bool {
+	stateCtx, ok := ctx.(*stateContext)
+	if !ok || msg.Type() != MessageTypeVote || stateCtx.tokens <= 1 {
+		return false
+	}
+	stateCtx.tokens--
+	return true
+}
+
+func matchFinalVote(ctx any, msg protocol.Message) bool {
+	stateCtx, ok := ctx.(*stateContext)
+	if !ok || msg.Type() != MessageTypeVote || stateCtx.tokens != 1 {
+		return false
+	}
+	stateCtx.tokens = 0
+	return true
+}
+
+type LeiosVotes struct {
+	Client *Client
+	Server *Server
+}
+
+type Config struct {
+	PipelineLimit    int
+	RequestNextCount uint64
+	RequestNextFunc  RequestNextFunc
+	Timeout          time.Duration
+	VoteFunc         VoteFunc
+}
+
+type CallbackContext struct {
+	ConnectionId connection.ConnectionId
+	Client       *Client
+	Server       *Server
+}
+
+type (
+	RequestNextFunc func(CallbackContext, uint64) ([]Vote, error)
+	VoteFunc        func(CallbackContext, Vote) error
+)
+
+func New(protoOptions protocol.ProtocolOptions, cfg *Config) *LeiosVotes {
+	cfg = normalizeConfig(cfg)
+	v := &LeiosVotes{
+		Client: NewClient(protoOptions, cfg),
+		Server: NewServer(protoOptions, cfg),
+	}
+	return v
+}
+
+type LeiosVotesOptionFunc func(*Config)
+
+func normalizeConfig(cfg *Config) *Config {
+	if cfg == nil {
+		tmpCfg := NewConfig()
+		return &tmpCfg
+	}
+	ret := *cfg
+	if ret.PipelineLimit == 0 {
+		ret.PipelineLimit = DefaultPipelineLimit
+	}
+	if ret.RequestNextCount == 0 {
+		ret.RequestNextCount = DefaultRequestNextCount
+	}
+	if ret.Timeout == 0 {
+		ret.Timeout = DefaultTimeout
+	}
+	if err := ret.validate(); err != nil {
+		panic("invalid LeiosVotes configuration: " + err.Error())
+	}
+	return &ret
+}
+
+func NewConfig(options ...LeiosVotesOptionFunc) Config {
+	c := Config{
+		PipelineLimit:    DefaultPipelineLimit,
+		RequestNextCount: DefaultRequestNextCount,
+		Timeout:          DefaultTimeout,
+	}
+	for _, option := range options {
+		option(&c)
+	}
+	if err := c.validate(); err != nil {
+		panic("invalid LeiosVotes configuration: " + err.Error())
+	}
+	return c
+}
+
+func (c *Config) validate() error {
+	if c.PipelineLimit < 0 {
+		return fmt.Errorf(
+			"PipelineLimit %d must be non-negative",
+			c.PipelineLimit,
+		)
+	}
+	if c.PipelineLimit > MaxPipelineLimit {
+		return fmt.Errorf(
+			"PipelineLimit %d exceeds maximum allowed %d",
+			c.PipelineLimit,
+			MaxPipelineLimit,
+		)
+	}
+	if c.RequestNextCount == 0 {
+		return errors.New("RequestNextCount must be positive")
+	}
+	if c.RequestNextCount > MaxRequestNextCount {
+		return fmt.Errorf(
+			"RequestNextCount %d exceeds maximum allowed %d",
+			c.RequestNextCount,
+			MaxRequestNextCount,
+		)
+	}
+	if c.Timeout <= 0 {
+		return errors.New("timeout must be positive")
+	}
+	return nil
+}
+
+func WithPipelineLimit(limit int) LeiosVotesOptionFunc {
+	return func(c *Config) {
+		if limit < 0 {
+			panic(
+				fmt.Sprintf(
+					"PipelineLimit %d must be non-negative",
+					limit,
+				),
+			)
+		}
+		if limit > MaxPipelineLimit {
+			panic(
+				fmt.Sprintf(
+					"PipelineLimit %d exceeds maximum allowed %d",
+					limit,
+					MaxPipelineLimit,
+				),
+			)
+		}
+		c.PipelineLimit = limit
+	}
+}
+
+func WithRequestNextCount(count uint64) LeiosVotesOptionFunc {
+	return func(c *Config) {
+		if count == 0 {
+			panic("RequestNextCount must be positive")
+		}
+		if count > MaxRequestNextCount {
+			panic(
+				fmt.Sprintf(
+					"RequestNextCount %d exceeds maximum allowed %d",
+					count,
+					MaxRequestNextCount,
+				),
+			)
+		}
+		c.RequestNextCount = count
+	}
+}
+
+func WithRequestNextFunc(
+	requestNextFunc RequestNextFunc,
+) LeiosVotesOptionFunc {
+	return func(c *Config) {
+		c.RequestNextFunc = requestNextFunc
+	}
+}
+
+func WithTimeout(timeout time.Duration) LeiosVotesOptionFunc {
+	return func(c *Config) {
+		if timeout <= 0 {
+			panic("Timeout must be positive")
+		}
+		c.Timeout = timeout
+	}
+}
+
+func WithVoteFunc(voteFunc VoteFunc) LeiosVotesOptionFunc {
+	return func(c *Config) {
+		c.VoteFunc = voteFunc
+	}
+}

--- a/protocol/leiosvotes/messages.go
+++ b/protocol/leiosvotes/messages.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leiosvotes
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/protocol"
+)
+
+// NOTE: Leios is still experimental and these message IDs may change as
+// CIP-0164 stabilizes.
+const (
+	MessageTypeVotesRequestNext = 0
+	MessageTypeVote             = 1
+	MessageTypeDone             = 2
+)
+
+func NewMsgFromCbor(msgType uint, data []byte) (protocol.Message, error) {
+	var ret protocol.Message
+	switch msgType {
+	case MessageTypeVotesRequestNext:
+		ret = &MsgVotesRequestNext{}
+	case MessageTypeVote:
+		ret = &MsgVote{}
+	case MessageTypeDone:
+		ret = &MsgDone{}
+	default:
+		return nil, fmt.Errorf("%s: unknown message type %d", ProtocolName, msgType)
+	}
+	if _, err := cbor.Decode(data, ret); err != nil {
+		return nil, fmt.Errorf("%s: decode error: %w", ProtocolName, err)
+	}
+	ret.SetCbor(data)
+	return ret, nil
+}
+
+type MsgVotesRequestNext struct {
+	protocol.MessageBase
+	Count uint64
+}
+
+func NewMsgVotesRequestNext(count uint64) *MsgVotesRequestNext {
+	m := &MsgVotesRequestNext{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeVotesRequestNext,
+		},
+		Count: count,
+	}
+	return m
+}
+
+type Vote struct {
+	cbor.StructAsArray
+	SlotNo            uint64
+	EndorserBlockHash []byte
+	VoterId           uint16
+	VoteSignature     []byte
+}
+
+type MsgVote struct {
+	protocol.MessageBase
+	Vote Vote
+}
+
+func NewMsgVote(vote Vote) *MsgVote {
+	m := &MsgVote{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeVote,
+		},
+		Vote: vote,
+	}
+	return m
+}
+
+type MsgDone struct {
+	protocol.MessageBase
+}
+
+func NewMsgDone() *MsgDone {
+	m := &MsgDone{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeDone,
+		},
+	}
+	return m
+}

--- a/protocol/leiosvotes/messages_test.go
+++ b/protocol/leiosvotes/messages_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leiosvotes
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testDefinition struct {
+	Name        string
+	Message     protocol.Message
+	MessageType uint
+}
+
+func testVote() Vote {
+	return Vote{
+		SlotNo:            12345,
+		EndorserBlockHash: []byte{0x01, 0x02, 0x03, 0x04},
+		VoterId:           42,
+		VoteSignature:     []byte{0xaa, 0xbb, 0xcc, 0xdd},
+	}
+}
+
+func getTestDefinitions() []testDefinition {
+	return []testDefinition{
+		{
+			Name:        "MsgVotesRequestNext",
+			Message:     NewMsgVotesRequestNext(10),
+			MessageType: MessageTypeVotesRequestNext,
+		},
+		{
+			Name:        "MsgVote",
+			Message:     NewMsgVote(testVote()),
+			MessageType: MessageTypeVote,
+		},
+		{
+			Name:        "MsgDone",
+			Message:     NewMsgDone(),
+			MessageType: MessageTypeDone,
+		},
+	}
+}
+
+func TestCborRoundTrip(t *testing.T) {
+	for _, test := range getTestDefinitions() {
+		t.Run(test.Name, func(t *testing.T) {
+			encoded, err := cbor.Encode(test.Message)
+			require.NoError(t, err)
+
+			decoded, err := NewMsgFromCbor(test.MessageType, encoded)
+			require.NoError(t, err)
+
+			reencoded, err := cbor.Encode(decoded)
+			require.NoError(t, err)
+			assert.Equal(t, encoded, reencoded)
+		})
+	}
+}
+
+func TestDecode(t *testing.T) {
+	for _, test := range getTestDefinitions() {
+		t.Run(test.Name, func(t *testing.T) {
+			encoded, err := cbor.Encode(test.Message)
+			require.NoError(t, err)
+
+			decoded, err := NewMsgFromCbor(test.MessageType, encoded)
+			require.NoError(t, err)
+			test.Message.SetCbor(encoded)
+
+			assert.True(t, reflect.DeepEqual(decoded, test.Message))
+		})
+	}
+}
+
+func TestMsgVotesRequestNext(t *testing.T) {
+	msg := NewMsgVotesRequestNext(100)
+
+	assert.Equal(t, uint8(MessageTypeVotesRequestNext), msg.Type())
+	assert.Equal(t, uint64(100), msg.Count)
+}
+
+func TestMsgVote(t *testing.T) {
+	vote := testVote()
+	msg := NewMsgVote(vote)
+
+	assert.Equal(t, uint8(MessageTypeVote), msg.Type())
+	assert.Equal(t, vote, msg.Vote)
+}
+
+func TestMsgDone(t *testing.T) {
+	msg := NewMsgDone()
+
+	assert.Equal(t, uint8(MessageTypeDone), msg.Type())
+}
+
+func TestNewMsgFromCborUnknownType(t *testing.T) {
+	msg, err := NewMsgFromCbor(999, []byte{0x80})
+
+	assert.Error(t, err)
+	assert.Nil(t, msg)
+}

--- a/protocol/leiosvotes/server.go
+++ b/protocol/leiosvotes/server.go
@@ -1,0 +1,154 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leiosvotes
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/blinklabs-io/gouroboros/protocol"
+)
+
+type Server struct {
+	*protocol.Protocol
+	callbackContext CallbackContext
+	config          *Config
+	protocolMu      sync.RWMutex
+	protoOptions    protocol.ProtocolOptions
+}
+
+func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
+	cfg = normalizeConfig(cfg)
+	s := &Server{
+		config:       cfg,
+		protoOptions: protoOptions,
+	}
+	s.callbackContext = CallbackContext{
+		Server:       s,
+		ConnectionId: protoOptions.ConnectionId,
+	}
+	s.initProtocol()
+	return s
+}
+
+func (s *Server) initProtocol() {
+	stateMap := StateMap.Copy()
+	if entry, ok := stateMap[StateBusy]; ok {
+		timeout := DefaultTimeout
+		if s.config != nil && s.config.Timeout != 0 {
+			timeout = s.config.Timeout
+		}
+		entry.Timeout = timeout
+		stateMap[StateBusy] = entry
+	}
+	protoConfig := protocol.ProtocolConfig{
+		Name:                ProtocolName,
+		ProtocolId:          ProtocolId,
+		Muxer:               s.protoOptions.Muxer,
+		Logger:              s.protoOptions.Logger,
+		ErrorChan:           s.protoOptions.ErrorChan,
+		Mode:                s.protoOptions.Mode,
+		Role:                protocol.ProtocolRoleServer,
+		MessageHandlerFunc:  s.messageHandler,
+		MessageFromCborFunc: NewMsgFromCbor,
+		StateContext:        &stateContext{},
+		StateMap:            stateMap,
+		InitialState:        StateIdle,
+	}
+	p := protocol.New(protoConfig)
+	s.protocolMu.Lock()
+	s.Protocol = p
+	s.protocolMu.Unlock()
+}
+
+func (s *Server) ProtocolInstance() *protocol.Protocol {
+	s.protocolMu.RLock()
+	defer s.protocolMu.RUnlock()
+	return s.Protocol
+}
+
+func (s *Server) messageHandler(msg protocol.Message) error {
+	var err error
+	switch msg.Type() {
+	case MessageTypeVotesRequestNext:
+		err = s.handleRequestNext(msg)
+	case MessageTypeDone:
+		s.handleDone()
+	default:
+		err = fmt.Errorf(
+			"%s: received unexpected message type %d",
+			ProtocolName,
+			msg.Type(),
+		)
+	}
+	return err
+}
+
+func (s *Server) handleRequestNext(msg protocol.Message) error {
+	msgRequestNext := msg.(*MsgVotesRequestNext)
+	s.Protocol.Logger().
+		Debug("votes request next",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "server",
+			"connection_id", s.callbackContext.ConnectionId.String(),
+			"count", msgRequestNext.Count,
+		)
+	if msgRequestNext.Count == 0 || msgRequestNext.Count > MaxRequestNextCount {
+		return fmt.Errorf(
+			"received leios-votes VotesRequestNext message with invalid count %d",
+			msgRequestNext.Count,
+		)
+	}
+	if s.config == nil || s.config.RequestNextFunc == nil {
+		return errors.New(
+			"received leios-votes VotesRequestNext message but no callback function is defined",
+		)
+	}
+	votes, err := s.config.RequestNextFunc(
+		s.callbackContext,
+		msgRequestNext.Count,
+	)
+	if err != nil {
+		return err
+	}
+	if len(votes) != int(msgRequestNext.Count) {
+		return fmt.Errorf(
+			"received leios-votes VotesRequestNext message for %d votes but callback returned %d",
+			msgRequestNext.Count,
+			len(votes),
+		)
+	}
+	for _, vote := range votes {
+		if err := s.SendMessage(NewMsgVote(vote)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Server) handleDone() {
+	s.Protocol.Logger().
+		Debug("client done",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "server",
+			"connection_id", s.callbackContext.ConnectionId.String(),
+		)
+	s.Stop()
+	s.initProtocol()
+	s.Start()
+}

--- a/protocol/leiosvotes/server_test.go
+++ b/protocol/leiosvotes/server_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leiosvotes
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewServer(t *testing.T) {
+	cfg := NewConfig()
+	server := NewServer(
+		protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+		&cfg,
+	)
+
+	require.NotNil(t, server)
+	assert.NotNil(t, server.Protocol)
+	assert.NotNil(t, server.config)
+}
+
+func TestHandleRequestNextCallbackIsCalled(t *testing.T) {
+	called := false
+	cfg := NewConfig(
+		WithRequestNextFunc(func(ctx CallbackContext, count uint64) ([]Vote, error) {
+			called = true
+			assert.Equal(t, uint64(2), count)
+			return nil, errors.New("test: stopping before send")
+		}),
+	)
+	server := &Server{
+		config:          &cfg,
+		callbackContext: CallbackContext{ConnectionId: testConnectionId()},
+	}
+	server.initProtocol()
+
+	err := server.handleRequestNext(NewMsgVotesRequestNext(2))
+
+	assert.Error(t, err)
+	assert.True(t, called)
+}
+
+func TestHandleRequestNextNilCallback(t *testing.T) {
+	cfg := NewConfig()
+	server := &Server{
+		config:          &cfg,
+		callbackContext: CallbackContext{ConnectionId: testConnectionId()},
+	}
+	server.initProtocol()
+
+	err := server.handleRequestNext(NewMsgVotesRequestNext(1))
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no callback function is defined")
+}
+
+func TestHandleRequestNextNilConfig(t *testing.T) {
+	server := &Server{
+		config:          nil,
+		callbackContext: CallbackContext{ConnectionId: testConnectionId()},
+	}
+	server.initProtocol()
+
+	err := server.handleRequestNext(NewMsgVotesRequestNext(1))
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no callback function is defined")
+}
+
+func TestHandleRequestNextInvalidCount(t *testing.T) {
+	cfg := NewConfig()
+	server := &Server{
+		config:          &cfg,
+		callbackContext: CallbackContext{ConnectionId: testConnectionId()},
+	}
+	server.initProtocol()
+
+	err := server.handleRequestNext(NewMsgVotesRequestNext(0))
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid count")
+}
+
+func TestHandleRequestNextWrongVoteCount(t *testing.T) {
+	cfg := NewConfig(
+		WithRequestNextFunc(func(ctx CallbackContext, count uint64) ([]Vote, error) {
+			return []Vote{testVote()}, nil
+		}),
+	)
+	server := &Server{
+		config:          &cfg,
+		callbackContext: CallbackContext{ConnectionId: testConnectionId()},
+	}
+	server.initProtocol()
+
+	err := server.handleRequestNext(NewMsgVotesRequestNext(2))
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "callback returned 1")
+}
+
+func TestServerMessageHandlerUnexpectedType(t *testing.T) {
+	cfg := NewConfig()
+	server := NewServer(
+		protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+		&cfg,
+	)
+
+	err := server.messageHandler(NewMsgVote(testVote()))
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected message type")
+}
+
+func TestServerMessageHandlerRequestNext(t *testing.T) {
+	called := false
+	cfg := NewConfig(
+		WithRequestNextFunc(func(ctx CallbackContext, count uint64) ([]Vote, error) {
+			called = true
+			return nil, errors.New("test: callback error")
+		}),
+	)
+	server := NewServer(
+		protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+		&cfg,
+	)
+
+	err := server.messageHandler(NewMsgVotesRequestNext(1))
+
+	assert.Error(t, err)
+	assert.True(t, called)
+}
+
+func TestNew(t *testing.T) {
+	cfg := NewConfig()
+	leiosVotes := New(
+		protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+		&cfg,
+	)
+
+	require.NotNil(t, leiosVotes)
+	assert.NotNil(t, leiosVotes.Client)
+	assert.NotNil(t, leiosVotes.Server)
+}
+
+func TestNewNormalizesZeroValueConfig(t *testing.T) {
+	cfg := Config{}
+	leiosVotes := New(
+		protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+		&cfg,
+	)
+
+	require.NotNil(t, leiosVotes)
+	assert.Equal(t, DefaultRequestNextCount, leiosVotes.Client.config.RequestNextCount)
+	assert.Equal(t, DefaultRequestNextCount, leiosVotes.Server.config.RequestNextCount)
+}
+
+func TestNewPanicsOnInvalidConfig(t *testing.T) {
+	cfg := Config{
+		PipelineLimit:    MaxPipelineLimit + 1,
+		RequestNextCount: DefaultRequestNextCount,
+	}
+
+	assert.Panics(t, func() {
+		New(protocol.ProtocolOptions{ConnectionId: testConnectionId()}, &cfg)
+	})
+}
+
+func TestServerCallbackContext(t *testing.T) {
+	cfg := NewConfig()
+	server := NewServer(
+		protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+		&cfg,
+	)
+
+	assert.Equal(t, testConnectionId(), server.callbackContext.ConnectionId)
+	assert.Equal(t, server, server.callbackContext.Server)
+}

--- a/protocol/limits_test.go
+++ b/protocol/limits_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/protocol/keepalive"
 	"github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
 	"github.com/blinklabs-io/gouroboros/protocol/leiosnotify"
+	"github.com/blinklabs-io/gouroboros/protocol/leiosvotes"
 	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
 	"github.com/blinklabs-io/gouroboros/protocol/localtxmonitor"
 	"github.com/blinklabs-io/gouroboros/protocol/localtxsubmission"
@@ -756,6 +757,13 @@ func TestProtocolStateTimeouts(t *testing.T) {
 				cfg.Timeout,
 			)
 		}
+	})
+
+	t.Run("LeiosVotes timeouts", func(t *testing.T) {
+		cfg := leiosvotes.NewConfig()
+		assert.Greater(t, cfg.Timeout, time.Duration(0))
+		assert.GreaterOrEqual(t, cfg.Timeout, time.Second)
+		assert.LessOrEqual(t, cfg.Timeout, time.Hour)
 	})
 }
 

--- a/protocol/message_fuzz_test.go
+++ b/protocol/message_fuzz_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/protocol/keepalive"
 	"github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
 	"github.com/blinklabs-io/gouroboros/protocol/leiosnotify"
+	"github.com/blinklabs-io/gouroboros/protocol/leiosvotes"
 	"github.com/blinklabs-io/gouroboros/protocol/localmessagenotification"
 	"github.com/blinklabs-io/gouroboros/protocol/localmessagesubmission"
 	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
@@ -90,6 +91,11 @@ var protocolMessageDecoders = []protocolMessageDecoder{
 		name:       "leiosnotify",
 		maxMsgType: leiosnotify.MessageTypeDone,
 		decode:     leiosnotify.NewMsgFromCbor,
+	},
+	{
+		name:       "leiosvotes",
+		maxMsgType: leiosvotes.MessageTypeDone,
+		decode:     leiosvotes.NewMsgFromCbor,
 	},
 	{
 		name:       "localmessagenotification",


### PR DESCRIPTION
Closes #1678 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `LeiosVotes` mini-protocol (ID 20) per CIP-0164 to diffuse Leios votes, fully integrated into the connection lifecycle with client and server support. Implements the vote diffusion path for issue #1678 with bounded, pipelined pulls and a configurable timeout (default 60s).

- **New Features**
  - Added `protocol/leiosvotes` with `VotesRequestNext`, `Vote`, `Done` and an Idle/Busy/Done state machine (Busy uses the configured timeout).
  - Client: `Sync()` with `PipelineLimit`/`RequestNextCount`, `RequestNext(n)`, `VoteFunc`, `ErrStopVoteProcess`, and `Stop()` (sends `Done`).
  - Server: `RequestNextFunc` must return exactly N votes; enforces `MaxRequestNextCount`; handles `Done` by resetting.
  - Connection: `Connection.LeiosVotes()`, `WithLeiosVotesConfig`; auto register/start; added to idle checks; updated docs, PROTOCOL_LIMITS (now 12 protocols), timeout/state tests, and CBOR fuzzing.

- **Migration**
  - Pass `ouroboros.WithLeiosVotesConfig(leiosvotes.Config{})` when creating a connection.
  - Server: implement `RequestNextFunc` to return exactly N votes per request.
  - Client: set `VoteFunc` and use `LeiosVotes.Client.Sync()` for continuous diffusion or `RequestNext(n)` for batch pulls.

<sup>Written for commit e1ee344c48953aa8eff93a67dbced0d8b2eeaa75. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1773?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the LeiosVotes protocol (CIP-0164) to enable vote diffusion between nodes, with client and server endpoints and connection-level integration.

* **Documentation**
  * Updated README, protocol overview, and docs to list LeiosVotes and clarify Leios sub-protocol responsibilities.

* **Tests**
  * Added unit, integration, and fuzz tests covering LeiosVotes messages, client/server behavior, and protocol timeouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/gouroboros/pull/1773?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->