### PR TITLE
feat: migrated example commands from gouroboros-starter-kit

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -23,8 +23,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
         with:
           submodules: true
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
           go-version: ${{ matrix.go-version }}
+          cache: false
       - name: build-examples
         run: make build

--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -1,0 +1,30 @@
+name: build-examples
+
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build-examples:
+    name: build-examples
+    strategy:
+      matrix:
+        go-version: [1.25.x, 1.26.x]
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 https://github.com/actions/checkout/releases/tag/v6.0.2
+        with:
+          submodules: true
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: build-examples
+        run: make build

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ROOT_DIR=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 GO_FILES=$(shell find $(ROOT_DIR) -name '*.go')
 
 # Gather list of example binaries from cmd/
-EXAMPLES=$(shell cd $(ROOT_DIR)/cmd && ls -1)
+EXAMPLES=$(shell find $(ROOT_DIR)/cmd -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
 
 NILAWAY_FLAGS ?= -include-pkgs=github.com/blinklabs-io/gouroboros
 
@@ -38,5 +38,5 @@ nilaway: mod-tidy ## Run nilaway nil safety analysis
 
 # Build example binaries
 # Depends on GO_FILES to determine when rebuild is needed
-$(EXAMPLES): mod-tidy $(GO_FILES)
+$(EXAMPLES): $(GO_FILES)
 	go build -o $(@) ./cmd/$(@)

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,21 @@ ROOT_DIR=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 # Gather all .go files for use in dependencies below
 GO_FILES=$(shell find $(ROOT_DIR) -name '*.go')
 
+# Gather list of example binaries from cmd/
+EXAMPLES=$(shell cd $(ROOT_DIR)/cmd && ls -1)
+
 NILAWAY_FLAGS ?= -include-pkgs=github.com/blinklabs-io/gouroboros
 
-.PHONY: mod-tidy format golines test lint
+.PHONY: mod-tidy build format golines test lint clean
 
 mod-tidy:
 	# Needed to fetch new dependencies and add them to go.mod
 	go mod tidy
+
+build: $(EXAMPLES)
+
+clean:
+	rm -f $(EXAMPLES)
 
 format:
 	go fmt ./...
@@ -27,3 +35,8 @@ lint:
 
 nilaway: mod-tidy ## Run nilaway nil safety analysis
 	go run go.uber.org/nilaway/cmd/nilaway@latest $(NILAWAY_FLAGS) ./...
+
+# Build example binaries
+# Depends on GO_FILES to determine when rebuild is needed
+$(EXAMPLES): mod-tidy $(GO_FILES)
+	go build -o $(@) ./cmd/$(@)

--- a/README.md
+++ b/README.md
@@ -209,6 +209,35 @@ This is not an exhaustive list of existing and planned features, but it covers t
     - [X] Deserialize from CBOR
     - [X] Retrieve staking key
 
+## Examples
+
+The `cmd/` directory contains self-contained example programs demonstrating how to use the library:
+
+| Example | Protocol | Description |
+|---------|----------|-------------|
+| `block-fetch` | Node-to-Node | Fetch a specific block by slot and hash |
+| `chain-sync` | NtC / NtN | Sync blocks from genesis or a specific era; supports rollback/rollforward |
+| `chain-tip` | Node-to-Client | Get the current chain tip via ChainSync |
+| `peer-sharing` | Node-to-Node | Request a list of peers from a remote node |
+| `ping` | Node-to-Client | Measure connection and protocol handshake latency |
+| `state-query` | Node-to-Client | Query protocol parameters and other node state |
+| `tx-monitor` | Node-to-Client | Inspect the node mempool contents |
+| `tx-submission` | Node-to-Client | Submit a signed transaction to the node |
+
+Build all examples:
+
+```
+make build
+```
+
+Run an example directly (e.g. check the current chain tip over a local socket):
+
+```
+go run ./cmd/chain-tip
+```
+
+See the inline comments in each `main.go` and the environment variables each command accepts for full usage details.
+
 ## Testing
 
 gOuroboros includes automated tests that cover various aspects of its functionality, but not all. For more than the basics,
@@ -231,17 +260,21 @@ make lint
 
 ### Manual testing
 
-Various small test programs can be found in the [gOuroboros Starter Kit](https://github.com/blinklabs-io/gouroboros-starter-kit) repo.
-Some of them can be run against public nodes via NtN protocols, but some may require access to the UNIX socket of a local node for NtC protocols.
+Example programs are included in the `cmd/` directory of this repo. Some can be run against public nodes
+via NtN protocols; others require access to the UNIX socket of a local node for NtC protocols.
+
+Build all examples:
+
+```
+make build
+```
 
 #### Run chain-sync from the start of a particular era
 
 This is useful for testing changes to the handling of ledger types for a particular era. It will decode each block and either print
 a summary line for the block or an error.
 
-You can use the `chain-sync` program from `gouroboros-starter-kit` to start a ChainSync from a public node.
-
-Run the chain-sync test program against a public mainnet node, starting at the beginning of the Shelley era:
+Run the chain-sync example against a public mainnet node, starting at the beginning of the Shelley era:
 
 ```
 CARDANO_NODE_ADDRESS=backbone.cardano.iog.io:3001 CARDANO_NODE_NETWORK=mainnet ./chain-sync -bulk -start-era shelley
@@ -252,7 +285,7 @@ all blocks of the chosen start era before hitting the next era or chain tip
 
 #### Dump details of a particular block
 
-You can use the `block-fetch` program from `gouroboros-starter-kit` to fetch a particular block and dump its details. You must provide at least
+You can use the `block-fetch` example to fetch a particular block and dump its details. You must provide at least
 the block slot and hash. This is useful for debugging decoding problems, since it allows fetching a specific block and decoding it over and over.
 
 ```

--- a/README.md
+++ b/README.md
@@ -263,12 +263,6 @@ make lint
 Example programs are included in the `cmd/` directory of this repo. Some can be run against public nodes
 via NtN protocols; others require access to the UNIX socket of a local node for NtC protocols.
 
-Build all examples:
-
-```
-make build
-```
-
 #### Run chain-sync from the start of a particular era
 
 This is useful for testing changes to the handling of ledger types for a particular era. It will decode each block and either print

--- a/cmd/block-fetch/main.go
+++ b/cmd/block-fetch/main.go
@@ -1,0 +1,268 @@
+// Copyright 2024 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/kelseyhightower/envconfig"
+)
+
+// We parse environment variables using envconfig into this struct
+type Config struct {
+	Address      string
+	Hash         string
+	Network      string
+	NetworkMagic uint32 `split_words:"true"`
+	ReturnCbor   bool   `split_words:"true"`
+	Slot         uint64
+}
+
+// This code will be executed when run
+func main() {
+	// Set config defaults (first mainnet Babbage block)
+	cfg := Config{
+		Address:      "backbone.cardano.iog.io:3001",
+		Network:      "mainnet",
+		NetworkMagic: 0,
+		ReturnCbor:   false,
+		// Byron
+		// Hash: "37e8df8fe301e8187b1dbfc50713ab0b7ab74c441cef1461bba710e5f05a1959",
+		// Slot: 2656803,
+		// Shelley
+		// Hash: "89b237ee673ef79f065d699aa539bba9644d34b9aa8a49510ab14ad8735c293e",
+		// Slot: 4506600,
+		// Allegra
+		// Hash: "078d102d0247463f91eef69fc77f3fbbf120f3118e68cd5e6a493c15446dbf8c",
+		// Slot: 16588800,
+		// Alonzo
+		// Hash: "8959c0323b94cc670afe44222ab8b4e72cfcad3b5ab665f334bbe642dc6e9ef4",
+		// Slot: 39916975,
+		// Babbage
+		Hash: "eea1247726ababb0b15ef7068b6917ceb6ebe3021c40fe44608585bba44e24b6",
+		Slot: 72316896,
+	}
+	// Parse environment variables
+	if err := envconfig.Process("block_fetch", &cfg); err != nil {
+		panic(err)
+	}
+	// Configure NetworkMagic
+	if cfg.NetworkMagic == 0 {
+		network, ok := ouroboros.NetworkByName(cfg.Network)
+		if !ok {
+			fmt.Printf("invalid network specified: %v\n", cfg.Network)
+			os.Exit(1)
+		}
+		cfg.NetworkMagic = network.NetworkMagic
+	}
+	// Create error channel
+	errorChan := make(chan error)
+	// start error handler
+	go func() {
+		for {
+			err := <-errorChan
+			panic(err)
+		}
+	}()
+	// Configure Ouroboros
+	o, err := ouroboros.NewConnection(
+		ouroboros.WithNetworkMagic(cfg.NetworkMagic),
+		ouroboros.WithErrorChan(errorChan),
+		ouroboros.WithNodeToNode(true),
+		ouroboros.WithKeepAlive(true),
+	)
+	if err != nil {
+		panic(err)
+	}
+	// Connect to Node address
+	if err = o.Dial("tcp", cfg.Address); err != nil {
+		panic(err)
+	}
+	// Decode hash string into bytes
+	blockHash, err := hex.DecodeString(cfg.Hash)
+	if err != nil {
+		panic(err)
+	}
+	// Get requested block from Node via NtN BlockFetch
+	block, err := o.BlockFetch().Client.GetBlock(
+		ocommon.NewPoint(cfg.Slot, blockHash),
+	)
+	if block == nil {
+		panic("empty block! this shouldn't happen")
+	}
+	if err != nil {
+		panic(err)
+	}
+	// Check if we want CBOR or text output
+	if cfg.ReturnCbor {
+		// Write our binary CBOR block to stdout
+		_ = binary.Write(
+			os.Stdout,
+			binary.LittleEndian,
+			block.Cbor(),
+		)
+		os.Exit(0)
+	}
+
+	// Display simple block info
+
+	switch v := block.(type) {
+	case *ledger.ByronEpochBoundaryBlock:
+		fmt.Printf(
+			"Block: era = Byron (EBB), epoch = %d, id = %s\n",
+			v.BlockHeader.ConsensusData.Epoch,
+			v.Hash(),
+		)
+	case *ledger.ByronMainBlock:
+		fmt.Printf(
+			"Block: era = Byron, epoch = %d, slot = %d, id = %s\n",
+			v.BlockHeader.ConsensusData.SlotId.Epoch,
+			v.SlotNumber(),
+			v.Hash(),
+		)
+	case ledger.Block:
+		fmt.Printf(
+			"Block: era = %s, slot = %d, block_no = %d, id = %s\n",
+			v.Era().Name,
+			v.SlotNumber(),
+			v.BlockNumber(),
+			v.Hash(),
+		)
+	}
+
+	fmt.Printf(
+		"Block CBOR: %x\n",
+		block.Cbor(),
+	)
+
+	// Extended block info
+
+	// Issuer
+	fmt.Printf(
+		"Minted by: %s (%s)\n",
+		block.IssuerVkey().PoolId(),
+		block.IssuerVkey().Hash(),
+	)
+	// Transactions
+	fmt.Println("Transactions:")
+	for _, tx := range block.Transactions() {
+		fmt.Printf("- Hash: %s\n", tx.Hash())
+		fmt.Printf("- CBOR: %x\n", tx.Cbor())
+		// Show metadata, if present
+		if tx.Metadata() != nil {
+			fmt.Printf(
+				"  Metadata: %#v (%x)\n",
+				tx.Metadata().TypeName(),
+				tx.Metadata().Cbor(),
+			)
+		}
+		// Inputs
+		if len(tx.Inputs()) > 0 {
+			fmt.Println("  Inputs:")
+			for _, input := range tx.Inputs() {
+				fmt.Printf(
+					"  - index = %d, id = %s\n",
+					input.Index(),
+					input.Id(),
+				)
+			}
+		}
+		// Outputs
+		if len(tx.Outputs()) > 0 {
+			fmt.Println("  Outputs:")
+			for _, output := range tx.Outputs() {
+				// Output our normal address and amount, in all transactions
+				fmt.Printf(
+					"  - address = %s, amount = %d, cbor (hex) = %x\n",
+					output.Address(),
+					output.Amount(),
+					output.Cbor(),
+				)
+				// Check for optional assets
+				assets := output.Assets()
+				if assets != nil {
+					fmt.Println("  - Assets:")
+					for _, policyId := range assets.Policies() {
+						for _, assetName := range assets.Assets(policyId) {
+							fmt.Printf(
+								"    - Asset: name = %s, amount = %d, policy = %s\n",
+								assetName,
+								assets.Asset(policyId, assetName),
+								policyId,
+							)
+						}
+					}
+				}
+				// Check for optional datum
+				datum := output.Datum()
+				if datum != nil {
+					jsonData, err := json.Marshal(datum)
+					if err != nil {
+						fmt.Printf(
+							"  - Datum: (hex) %x\n",
+							datum.Cbor(),
+						)
+					} else {
+						fmt.Printf(
+							"  - Datum: %s\n",
+							jsonData,
+						)
+					}
+				}
+			}
+		}
+		// Collateral
+		if len(tx.Collateral()) > 0 {
+			fmt.Println("  Collateral inputs:")
+			for _, input := range tx.Collateral() {
+				fmt.Printf(
+					"  - index = %d, id = %s\n",
+					input.Index(),
+					input.Id(),
+				)
+			}
+		}
+		// Certificates
+		if len(tx.Certificates()) > 0 {
+			fmt.Println("  Certificates:")
+			for _, cert := range tx.Certificates() {
+				fmt.Printf("  - %T\n", cert)
+			}
+		}
+		// Asset mints
+		if tx.AssetMint() != nil {
+			fmt.Println("  Asset mints:")
+			assets := tx.AssetMint()
+			for _, policyId := range assets.Policies() {
+				for _, assetName := range assets.Assets(policyId) {
+					fmt.Printf(
+						"    - Asset: name = %s, amount = %d, policy = %s\n",
+						assetName,
+						assets.Asset(policyId, assetName),
+						policyId,
+					)
+				}
+			}
+		}
+	}
+	fmt.Println()
+}

--- a/cmd/block-fetch/main.go
+++ b/cmd/block-fetch/main.go
@@ -102,24 +102,29 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	if len(blockHash) != 32 {
+		panic(fmt.Sprintf("invalid block hash: expected 32 bytes, got %d", len(blockHash)))
+	}
 	// Get requested block from Node via NtN BlockFetch
 	block, err := o.BlockFetch().Client.GetBlock(
 		ocommon.NewPoint(cfg.Slot, blockHash),
 	)
-	if block == nil {
-		panic("empty block! this shouldn't happen")
-	}
 	if err != nil {
 		panic(err)
+	}
+	if block == nil {
+		panic("empty block! this shouldn't happen")
 	}
 	// Check if we want CBOR or text output
 	if cfg.ReturnCbor {
 		// Write our binary CBOR block to stdout
-		_ = binary.Write(
+		if err := binary.Write(
 			os.Stdout,
 			binary.LittleEndian,
 			block.Cbor(),
-		)
+		); err != nil {
+			panic(fmt.Sprintf("failed to write CBOR to stdout: %s", err))
+		}
 		os.Exit(0)
 	}
 

--- a/cmd/chain-sync/main.go
+++ b/cmd/chain-sync/main.go
@@ -1,0 +1,347 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/hex"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/protocol/blockfetch"
+	"github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/kelseyhightower/envconfig"
+)
+
+// We parse environment variables using envconfig into this struct
+type Config struct {
+	SocketPath string `split_words:"true"`
+	Address    string
+	Network    string
+	Magic      uint32
+	StartEra   string `split_words:"true"`
+	Tip        bool
+	Bulk       bool
+	BlockRange bool `split_words:"true"`
+}
+
+// Intersect points (last block of previous era) for each era on testnet/mainnet
+var eraIntersect = map[string]map[string][]any{
+	"unknown": {
+		"genesis": {},
+	},
+	"mainnet": {
+		"genesis": {},
+		// Chain genesis, but explicit
+		"byron": {},
+		// Last block of epoch 207 (Byron era)
+		"shelley": {
+			4492799,
+			"f8084c61b6a238acec985b59310b6ecec49c0ab8352249afd7268da5cff2a457",
+		},
+		// Last block of epoch 235 (Shelley era)
+		"allegra": {
+			16588737,
+			"4e9bbbb67e3ae262133d94c3da5bffce7b1127fc436e7433b87668dba34c354a",
+		},
+		// Last block of epoch 250 (Allegra era)
+		"mary": {
+			23068793,
+			"69c44ac1dda2ec74646e4223bc804d9126f719b1c245dadc2ad65e8de1b276d7",
+		},
+		// Last block of epoch 289 (Mary era)
+		"alonzo": {
+			39916796,
+			"e72579ff89dc9ed325b723a33624b596c08141c7bd573ecfff56a1f7229e4d09",
+		},
+		// Last block of epoch 364 (Alonzo era)
+		"babbage": {
+			72316796,
+			"c58a24ba8203e7629422a24d9dc68ce2ed495420bf40d9dab124373655161a20",
+		},
+		// Last block of epoch 506 (Babbage era)
+		"conway": []any{
+			133660799,
+			"e757d57eb8dc9500a61c60a39fadb63d9be6973ba96ae337fd24453d4d15c343",
+		},
+	},
+	"preprod": {
+		"genesis": {},
+		"alonzo":  {},
+	},
+	"preview": {
+		"genesis": {},
+		"alonzo":  {},
+		// Last block of epoch 3 (Alonzo era)
+		"babbage": {
+			345594,
+			"e47ac07272e95d6c3dc8279def7b88ded00e310f99ac3dfbae48ed9ff55e6001",
+		},
+	},
+}
+
+var oConn *ouroboros.Connection
+
+func buildChainSyncConfig() chainsync.Config {
+	return chainsync.NewConfig(
+		chainsync.WithRollBackwardFunc(chainSyncRollBackwardHandler),
+		chainsync.WithRollForwardFunc(chainSyncRollForwardHandler),
+		chainsync.WithPipelineLimit(10),
+	)
+}
+
+func buildBlockFetchConfig() blockfetch.Config {
+	return blockfetch.NewConfig(
+		blockfetch.WithBlockFunc(blockFetchBlockHandler),
+	)
+}
+
+func chainSyncRollBackwardHandler(
+	ctx chainsync.CallbackContext,
+	point pcommon.Point,
+	tip chainsync.Tip,
+) error {
+	fmt.Printf("roll backward: point = %#v, tip = %#v\n", point, tip)
+	return nil
+}
+
+func chainSyncRollForwardHandler(
+	ctx chainsync.CallbackContext,
+	blockType uint,
+	blockData any,
+	tip chainsync.Tip,
+) error {
+	var block lcommon.Block
+	switch v := blockData.(type) {
+	case lcommon.Block:
+		block = v
+	case lcommon.BlockHeader:
+		blockSlot := v.SlotNumber()
+		blockHash := v.Hash().Bytes()
+		var err error
+		if oConn == nil {
+			return errors.New("empty ouroboros connection, aborting")
+		}
+		block, err = oConn.BlockFetch().Client.GetBlock(pcommon.NewPoint(blockSlot, blockHash))
+		if err != nil {
+			return err
+		}
+	}
+	// Display block info
+	switch blockType {
+	case ledger.BlockTypeByronEbb:
+		byronEbbBlock := block.(*ledger.ByronEpochBoundaryBlock)
+		fmt.Printf(
+			"era = Byron (EBB), epoch = %d, slot = %d, block_no = %d, id = %s\n",
+			byronEbbBlock.BlockHeader.ConsensusData.Epoch,
+			byronEbbBlock.SlotNumber(),
+			byronEbbBlock.BlockNumber(),
+			byronEbbBlock.Hash(),
+		)
+	case ledger.BlockTypeByronMain:
+		byronBlock := block.(*ledger.ByronMainBlock)
+		fmt.Printf(
+			"era = Byron, epoch = %d, slot = %d, block_no = %d, id = %s\n",
+			byronBlock.BlockHeader.ConsensusData.SlotId.Epoch,
+			byronBlock.SlotNumber(),
+			byronBlock.BlockNumber(),
+			byronBlock.Hash(),
+		)
+	default:
+		if block == nil {
+			return errors.New("block is nil")
+		}
+		fmt.Printf(
+			"era = %s, slot = %d, block_no = %d, id = %s\n",
+			block.Era().Name,
+			block.SlotNumber(),
+			block.BlockNumber(),
+			block.Hash(),
+		)
+	}
+	return nil
+}
+
+func blockFetchBlockHandler(
+	ctx blockfetch.CallbackContext,
+	blockType uint,
+	blockData lcommon.Block,
+) error {
+	switch block := blockData.(type) {
+	case *ledger.ByronEpochBoundaryBlock:
+		fmt.Printf("era = Byron (EBB), epoch = %d, slot = %d, block_no = %d, id = %s\n", block.BlockHeader.ConsensusData.Epoch, block.SlotNumber(), block.BlockNumber(), block.Hash())
+	case *ledger.ByronMainBlock:
+		fmt.Printf("era = Byron, epoch = %d, slot = %d, block_no = %d, id = %s\n", block.BlockHeader.ConsensusData.SlotId.Epoch, block.SlotNumber(), block.BlockNumber(), block.Hash())
+	case lcommon.Block:
+		fmt.Printf("era = %s, slot = %d, block_no = %d, id = %s\n", block.Era().Name, block.SlotNumber(), block.BlockNumber(), block.Hash())
+	}
+	return nil
+}
+
+// This code will be executed when run
+func main() {
+	// Set config defaults
+	cfg := Config{
+		SocketPath: "/ipc/node.socket",
+		StartEra:   "genesis",
+	}
+	// Parse environment variables
+	if err := envconfig.Process("cardano_node", &cfg); err != nil {
+		panic(err)
+	}
+
+	// Parse command-line flags
+	flag.StringVar(&cfg.StartEra, "start-era", cfg.StartEra, "era which to start chain-sync at")
+	flag.BoolVar(&cfg.Tip, "tip", false, "start chain-sync at current chain tip")
+	flag.BoolVar(&cfg.Bulk, "bulk", false, "use bulk chain-sync mode with NtN")
+	flag.BoolVar(&cfg.BlockRange, "range", false, "show start/end block of range")
+	flag.Parse()
+
+	// Determine connection type: if Address is set, use NtN (TCP), otherwise use NtC (UNIX socket)
+	isNtN := cfg.Address != ""
+	networkType := "unix"
+	address := cfg.SocketPath
+	if isNtN {
+		networkType = "tcp"
+		address = cfg.Address
+	}
+
+	// Configure NetworkMagic
+	if cfg.Magic == 0 {
+		if cfg.Network == "" {
+			// Default to preview network if not specified
+			cfg.Network = "preview"
+		}
+		network, ok := ouroboros.NetworkByName(cfg.Network)
+		if !ok {
+			fmt.Printf("ERROR: invalid network specified: %v\n", cfg.Network)
+			os.Exit(1)
+		}
+		cfg.Magic = network.NetworkMagic
+	}
+
+	// Determine era intersection point
+	var intersectPoint []any
+	if _, ok := eraIntersect[cfg.Network]; !ok {
+		if cfg.StartEra != "genesis" {
+			fmt.Printf(
+				"ERROR: only 'genesis' is supported for -start-era for unknown networks\n",
+			)
+			os.Exit(1)
+		}
+		intersectPoint = eraIntersect["unknown"]["genesis"]
+	} else {
+		if _, ok := eraIntersect[cfg.Network][cfg.StartEra]; !ok {
+			fmt.Printf("ERROR: unknown era '%s' specified as chain-sync start point\n", cfg.StartEra)
+			os.Exit(1)
+		}
+		intersectPoint = eraIntersect[cfg.Network][cfg.StartEra]
+	}
+
+	// Create error channel
+	errorChan := make(chan error)
+	// Start error handler
+	go func() {
+		for {
+			err := <-errorChan
+			fmt.Printf("ERROR: %s\n", err)
+			os.Exit(1)
+		}
+	}()
+
+	// Configure Ouroboros
+	o, err := ouroboros.NewConnection(
+		ouroboros.WithNetworkMagic(cfg.Magic),
+		ouroboros.WithErrorChan(errorChan),
+		ouroboros.WithNodeToNode(isNtN),
+		ouroboros.WithKeepAlive(true),
+		ouroboros.WithChainSyncConfig(buildChainSyncConfig()),
+		ouroboros.WithBlockFetchConfig(buildBlockFetchConfig()),
+	)
+	if err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		os.Exit(1)
+	}
+	oConn = o
+
+	// Connect to Node
+	if err = o.Dial(networkType, address); err != nil {
+		fmt.Printf("ERROR: connection failed: %s\n", err)
+		os.Exit(1)
+	}
+
+	// Determine starting point
+	var point pcommon.Point
+	if cfg.Tip {
+		tip, err := oConn.ChainSync().Client.GetCurrentTip()
+		if err != nil {
+			fmt.Printf("ERROR: failed to get current tip: %s\n", err)
+			os.Exit(1)
+		}
+		point = tip.Point
+	} else if len(intersectPoint) > 0 {
+		// Slot
+		slot := uint64(intersectPoint[0].(int)) // #nosec G115
+		// Block hash
+		hash, _ := hex.DecodeString(intersectPoint[1].(string))
+		point = pcommon.NewPoint(slot, hash)
+	} else {
+		point = pcommon.NewPointOrigin()
+	}
+
+	// Handle different modes
+	if cfg.BlockRange {
+		start, end, err := oConn.ChainSync().Client.GetAvailableBlockRange(
+			[]pcommon.Point{point},
+		)
+		if err != nil {
+			fmt.Printf("ERROR: failed to get available block range: %s\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Start:     slot %d, hash %x\n", start.Slot, start.Hash)
+		fmt.Printf("End (tip): slot %d, hash %x\n", end.Slot, end.Hash)
+		return
+	} else if !isNtN || !cfg.Bulk {
+		// Standard chain-sync mode (NtC or NtN non-bulk)
+		if err := oConn.ChainSync().Client.Sync([]pcommon.Point{point}); err != nil {
+			fmt.Printf("ERROR: failed to start chain-sync: %s\n", err)
+			os.Exit(1)
+		}
+	} else {
+		// Bulk mode (NtN only)
+		start, end, err := oConn.ChainSync().Client.GetAvailableBlockRange([]pcommon.Point{point})
+		if err != nil {
+			fmt.Printf("ERROR: failed to get available block range: %s\n", err)
+			os.Exit(1)
+		}
+		// Stop the chain-sync client to prevent the connection getting closed due to chain-sync idle timeout
+		if err := oConn.ChainSync().Client.Stop(); err != nil {
+			fmt.Printf("ERROR: failed to shutdown chain-sync: %s\n", err)
+			os.Exit(1)
+		}
+		if err := oConn.BlockFetch().Client.GetBlockRange(start, end); err != nil {
+			fmt.Printf("ERROR: failed to request block range: %s\n", err)
+			os.Exit(1)
+		}
+	}
+
+	// Wait forever...the rest of the sync operations are async
+	select {}
+}

--- a/cmd/chain-sync/main.go
+++ b/cmd/chain-sync/main.go
@@ -145,6 +145,9 @@ func chainSyncRollForwardHandler(
 		}
 	}
 	// Display block info
+	if block == nil {
+		return errors.New("block is nil")
+	}
 	switch blockType {
 	case ledger.BlockTypeByronEbb:
 		byronEbbBlock := block.(*ledger.ByronEpochBoundaryBlock)
@@ -165,9 +168,6 @@ func chainSyncRollForwardHandler(
 			byronBlock.Hash(),
 		)
 	default:
-		if block == nil {
-			return errors.New("block is nil")
-		}
 		fmt.Printf(
 			"era = %s, slot = %d, block_no = %d, id = %s\n",
 			block.Era().Name,
@@ -300,7 +300,11 @@ func main() {
 		// Slot
 		slot := uint64(intersectPoint[0].(int)) // #nosec G115
 		// Block hash
-		hash, _ := hex.DecodeString(intersectPoint[1].(string))
+		hash, err := hex.DecodeString(intersectPoint[1].(string))
+		if err != nil {
+			fmt.Printf("ERROR: invalid block hash: %s\n", err)
+			os.Exit(1)
+		}
 		point = pcommon.NewPoint(slot, hash)
 	} else {
 		point = pcommon.NewPointOrigin()

--- a/cmd/chain-tip/main.go
+++ b/cmd/chain-tip/main.go
@@ -43,8 +43,7 @@ func main() {
 	errorChan := make(chan error)
 	// start error handler
 	go func() {
-		for {
-			err := <-errorChan
+		for err := range errorChan {
 			panic(err)
 		}
 	}()

--- a/cmd/chain-tip/main.go
+++ b/cmd/chain-tip/main.go
@@ -1,0 +1,84 @@
+// Copyright 2024 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/kelseyhightower/envconfig"
+)
+
+// We parse environment variables using envconfig into this struct
+type Config struct {
+	Magic      uint32
+	SocketPath string `split_words:"true"`
+	Address    string
+}
+
+// This code will be executed when run
+func main() {
+	// Set config defaults
+	cfg := Config{
+		Magic:      764824073,
+		SocketPath: "/ipc/node.socket",
+	}
+	// Parse environment variables
+	if err := envconfig.Process("cardano_node", &cfg); err != nil {
+		panic(err)
+	}
+	// Create error channel
+	errorChan := make(chan error)
+	// start error handler
+	go func() {
+		for {
+			err := <-errorChan
+			panic(err)
+		}
+	}()
+
+	isNtN := cfg.Address != ""
+	networkType := "unix"
+	address := cfg.SocketPath
+	if isNtN {
+		networkType = "tcp"
+		address = cfg.Address
+	}
+
+	// Configure Ouroboros
+	o, err := ouroboros.NewConnection(
+		ouroboros.WithNetworkMagic(cfg.Magic),
+		ouroboros.WithErrorChan(errorChan),
+		ouroboros.WithNodeToNode(isNtN),
+	)
+	if err != nil {
+		panic(err)
+	}
+	// Connect to Node socket
+	if err = o.Dial(networkType, address); err != nil {
+		panic(err)
+	}
+	// Get current tip from Node via NtC ChainSync Ouroboros mini-protocol
+	tip, err := o.ChainSync().Client.GetCurrentTip()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf(
+		"Chain Tip:\nSlot: %-10d Block Hash: %x\n",
+		tip.Point.Slot,
+		tip.Point.Hash,
+	)
+	fmt.Println()
+}

--- a/cmd/peer-sharing/main.go
+++ b/cmd/peer-sharing/main.go
@@ -1,0 +1,102 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"math"
+	"os"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/kelseyhightower/envconfig"
+)
+
+// We parse environment variables using envconfig into this struct
+type Config struct {
+	Address      string
+	Network      string
+	NetworkMagic uint32 `split_words:"true"`
+	Peers        uint
+}
+
+// This code will be executed when run
+func main() {
+	// Set config defaults
+	cfg := Config{
+		Address:      "backbone.cardano.iog.io:3001",
+		Network:      "mainnet",
+		NetworkMagic: 0,
+		Peers:        10,
+	}
+	// Parse environment variables
+	if err := envconfig.Process("peer_sharing", &cfg); err != nil {
+		panic(err)
+	}
+	// Error check peers
+	if cfg.Peers > math.MaxUint8 {
+		panic(
+			fmt.Sprintf(
+				"peers not within range: given: %d, max: %d",
+				cfg.Peers,
+				math.MaxUint8,
+			),
+		)
+	}
+	// Configure NetworkMagic
+	if cfg.NetworkMagic == 0 {
+		network, ok := ouroboros.NetworkByName(cfg.Network)
+		if !ok {
+			fmt.Printf("invalid network specified: %v\n", cfg.Network)
+			os.Exit(1)
+		}
+		cfg.NetworkMagic = network.NetworkMagic
+	}
+	// Create error channel
+	errorChan := make(chan error)
+	// start error handler
+	go func() {
+		for {
+			err := <-errorChan
+			panic(err)
+		}
+	}()
+	// Configure Ouroboros
+	o, err := ouroboros.NewConnection(
+		ouroboros.WithNetworkMagic(cfg.NetworkMagic),
+		ouroboros.WithErrorChan(errorChan),
+		ouroboros.WithNodeToNode(true),
+		ouroboros.WithKeepAlive(true),
+		ouroboros.WithPeerSharing(true),
+		ouroboros.WithFullDuplex(true),
+	)
+	if err != nil {
+		panic(err)
+	}
+	// Connect to Node address
+	if err = o.Dial("tcp", cfg.Address); err != nil {
+		panic(err)
+	}
+	// Get requested number of peers from Node via NtN PeerSharing
+	peers, err := o.PeerSharing().Client.GetPeers(uint8(cfg.Peers))
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Peers:")
+	fmt.Println()
+	for _, peer := range peers {
+		fmt.Printf("%s:%d\n", peer.IP.String(), peer.Port)
+	}
+}

--- a/cmd/ping/main.go
+++ b/cmd/ping/main.go
@@ -1,8 +1,23 @@
+// Copyright 2024 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
@@ -106,25 +121,26 @@ func main() {
 	var cfg Config
 	if err := envconfig.Process("cardano_node", &cfg); err != nil {
 		fmt.Printf("Config error: %v\n", err)
-		return
+		os.Exit(1)
 	}
 
 	conn, err := NewConnection(&cfg)
 	if err != nil {
 		fmt.Printf("Connection error: %v\n", err)
-		return
+		os.Exit(1)
 	}
 	defer conn.Close()
 
 	result := PingNode(conn, &cfg)
 	if result.Error != nil {
 		fmt.Printf("Ping failed: %v\n", result.Error)
-		return
+		os.Exit(1)
 	}
 
-	connType := "Node-to-Node"
-	if cfg.SocketPath != "" {
-		connType = "UNIX socket"
+	_, _, isTcp := GetConnectionDetails(&cfg)
+	connType := "UNIX socket"
+	if isTcp {
+		connType = "Node-to-Node"
 	}
 	fmt.Printf("%s Ping Results:\n", connType)
 	fmt.Printf("Connection established in: %s\n", result.ConnectionTime)

--- a/cmd/ping/main.go
+++ b/cmd/ping/main.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	"github.com/kelseyhightower/envconfig"
+)
+
+type Config struct {
+	Magic      uint32
+	SocketPath string `split_words:"true"`
+	Address    string
+	Network    string
+}
+
+type NodeConnection interface {
+	Dial(network, address string) error
+	ChainSync() *chainsync.ChainSync
+	Close() error
+}
+
+type PingResult struct {
+	ConnectionTime time.Duration
+	ProtocolTime   time.Duration
+	Error          error
+}
+
+func GetConnectionDetails(cfg *Config) (string, string, bool) {
+	// Prefer TCP address if both are provided
+	if cfg.Address != "" {
+		return "tcp", cfg.Address, true
+	}
+	if cfg.SocketPath != "" {
+		return "unix", cfg.SocketPath, false
+	}
+	return "", "", false
+}
+
+func NewConnection(cfg *Config) (NodeConnection, error) {
+	if cfg.Magic == 0 {
+		network, ok := ouroboros.NetworkByName(cfg.Network)
+		if !ok {
+			return nil, fmt.Errorf("invalid network specified: %v", cfg.Network)
+		}
+		cfg.Magic = network.NetworkMagic
+	}
+
+	errorChan := make(chan error)
+	go func() {
+		for err := range errorChan {
+			fmt.Printf("connection error: %v\n", err)
+		}
+	}()
+
+	_, _, isTcp := GetConnectionDetails(cfg)
+
+	return ouroboros.NewConnection(
+		ouroboros.WithNetworkMagic(cfg.Magic),
+		ouroboros.WithNodeToNode(isTcp),
+		ouroboros.WithKeepAlive(true),
+		ouroboros.WithErrorChan(errorChan),
+	)
+}
+
+var getTip = func(sync *chainsync.ChainSync) (*chainsync.Tip, error) {
+	return sync.Client.GetCurrentTip()
+}
+
+func PingNode(conn NodeConnection, cfg *Config) PingResult {
+	network, address, ok := GetConnectionDetails(cfg)
+	if !ok {
+		return PingResult{
+			Error: errors.New(
+				"no connection details provided, must specify either socket path or TCP address",
+			),
+		}
+	}
+
+	start := time.Now()
+	if err := conn.Dial(network, address); err != nil {
+		return PingResult{Error: fmt.Errorf("connection failed: %w", err)}
+	}
+	connTime := time.Since(start)
+
+	start = time.Now()
+
+	if _, err := getTip(conn.ChainSync()); err != nil {
+		return PingResult{
+			ConnectionTime: connTime,
+			Error:          fmt.Errorf("protocol error: %w", err),
+		}
+	}
+	protoTime := time.Since(start)
+
+	return PingResult{
+		ConnectionTime: connTime,
+		ProtocolTime:   protoTime,
+	}
+}
+
+func main() {
+	var cfg Config
+	if err := envconfig.Process("cardano_node", &cfg); err != nil {
+		fmt.Printf("Config error: %v\n", err)
+		return
+	}
+
+	conn, err := NewConnection(&cfg)
+	if err != nil {
+		fmt.Printf("Connection error: %v\n", err)
+		return
+	}
+	defer conn.Close()
+
+	result := PingNode(conn, &cfg)
+	if result.Error != nil {
+		fmt.Printf("Ping failed: %v\n", result.Error)
+		return
+	}
+
+	connType := "Node-to-Node"
+	if cfg.SocketPath != "" {
+		connType = "UNIX socket"
+	}
+	fmt.Printf("%s Ping Results:\n", connType)
+	fmt.Printf("Connection established in: %s\n", result.ConnectionTime)
+	fmt.Printf("Protocol response time:   %s\n", result.ProtocolTime)
+}

--- a/cmd/ping/main_test.go
+++ b/cmd/ping/main_test.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/protocol/chainsync"
+)
+
+// testConnection implements a simplified NodeConnection for testing
+type testConnection struct {
+	dialFunc    func(string, string) error
+	getTipFunc  func() (*chainsync.Tip, error)
+	closeFunc   func() error
+	dialed      bool
+	networkType string
+}
+
+func (t *testConnection) Dial(network, address string) error {
+	t.dialed = true
+	t.networkType = network
+	if t.dialFunc != nil {
+		return t.dialFunc(network, address)
+	}
+	return nil
+}
+
+func (t *testConnection) ChainSync() *chainsync.ChainSync {
+	// We don't actually need the real ChainSync implementation for testing
+	// We'll override getTip globally for our tests
+	return nil
+}
+
+func (t *testConnection) Close() error {
+	if t.closeFunc != nil {
+		return t.closeFunc()
+	}
+	return nil
+}
+
+func restoreDefaultGetTip() {
+	getTip = func(sync *chainsync.ChainSync) (*chainsync.Tip, error) {
+		return sync.Client.GetCurrentTip()
+	}
+}
+
+func TestPingNode_Success(t *testing.T) {
+	// Override getTip for this test
+	getTip = func(_ *chainsync.ChainSync) (*chainsync.Tip, error) {
+		return &chainsync.Tip{}, nil
+	}
+	defer restoreDefaultGetTip()
+
+	conn := &testConnection{}
+
+	cfg := &Config{
+		Address: "test.example.com:3001",
+		Network: "testnet",
+	}
+
+	result := PingNode(conn, cfg)
+
+	if !conn.dialed {
+		t.Error("Expected connection to be dialed")
+	}
+	if conn.networkType != "tcp" {
+		t.Error("Expected TCP connection")
+	}
+	if result.Error != nil {
+		t.Errorf("Expected no error, got: %v", result.Error)
+	}
+	if result.ConnectionTime <= 0 {
+		t.Error("Expected positive connection time")
+	}
+	if result.ProtocolTime <= 0 {
+		t.Error("Expected positive protocol time")
+	}
+}
+
+func TestPingNode_ProtocolError(t *testing.T) {
+	// Override getTip for this test
+	getTip = func(_ *chainsync.ChainSync) (*chainsync.Tip, error) {
+		return nil, errors.New("protocol error")
+	}
+	defer restoreDefaultGetTip()
+
+	conn := &testConnection{}
+
+	cfg := &Config{
+		Address: "test.example.com:3001",
+		Network: "testnet",
+	}
+
+	result := PingNode(conn, cfg)
+
+	if result.Error == nil ||
+		result.Error.Error() != "protocol error: protocol error" {
+		t.Errorf("Expected protocol error, got: %v", result.Error)
+	}
+}
+
+func TestPingNode_ConnectionError(t *testing.T) {
+	// Override getTip for this test
+	getTip = func(_ *chainsync.ChainSync) (*chainsync.Tip, error) {
+		t.Error("getTip should not be called when connection fails")
+		return nil, nil
+	}
+	defer restoreDefaultGetTip()
+
+	conn := &testConnection{
+		dialFunc: func(_, _ string) error {
+			return errors.New("connection failed")
+		},
+	}
+
+	cfg := &Config{
+		Address: "test.example.com:3001",
+		Network: "testnet",
+	}
+
+	result := PingNode(conn, cfg)
+
+	if result.Error == nil ||
+		result.Error.Error() != "connection failed: connection failed" {
+		t.Errorf("Expected connection error, got: %v", result.Error)
+	}
+}
+
+func TestPingNode_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	socketPath := os.Getenv("CARDANO_NODE_SOCKET_PATH")
+	network := os.Getenv("CARDANO_NODE_NETWORK")
+	address := os.Getenv("CARDANO_NODE_ADDRESS")
+
+	if socketPath == "" && address == "" {
+		t.Skip(
+			"skipping integration test: set CARDANO_NODE_SOCKET_PATH or CARDANO_NODE_ADDRESS to run",
+		)
+	}
+
+	cfg := &Config{
+		SocketPath: socketPath,
+		Address:    address,
+		Network:    network,
+	}
+
+	conn, err := NewConnection(cfg)
+	if err != nil {
+		t.Fatalf("failed to create connection: %v", err)
+	}
+	defer conn.Close()
+
+	resultChan := make(chan PingResult)
+	go func() {
+		resultChan <- PingNode(conn, cfg)
+	}()
+
+	select {
+	case result := <-resultChan:
+		if result.Error != nil {
+			t.Fatalf("ping failed: %v", result.Error)
+		}
+		t.Logf("Integration test successful:")
+		t.Logf("Connection time: %v", result.ConnectionTime)
+		t.Logf("Protocol time: %v", result.ProtocolTime)
+	case <-time.After(30 * time.Second):
+		t.Fatal("test timed out after 30 seconds")
+	}
+}

--- a/cmd/ping/main_test.go
+++ b/cmd/ping/main_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (
@@ -7,6 +21,8 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // testConnection implements a simplified NodeConnection for testing
@@ -62,21 +78,11 @@ func TestPingNode_Success(t *testing.T) {
 
 	result := PingNode(conn, cfg)
 
-	if !conn.dialed {
-		t.Error("Expected connection to be dialed")
-	}
-	if conn.networkType != "tcp" {
-		t.Error("Expected TCP connection")
-	}
-	if result.Error != nil {
-		t.Errorf("Expected no error, got: %v", result.Error)
-	}
-	if result.ConnectionTime <= 0 {
-		t.Error("Expected positive connection time")
-	}
-	if result.ProtocolTime <= 0 {
-		t.Error("Expected positive protocol time")
-	}
+	assert.True(t, conn.dialed, "Expected connection to be dialed")
+	assert.Equal(t, "tcp", conn.networkType, "Expected TCP connection")
+	require.NoError(t, result.Error)
+	assert.Positive(t, result.ConnectionTime, "Expected positive connection time")
+	assert.Positive(t, result.ProtocolTime, "Expected positive protocol time")
 }
 
 func TestPingNode_ProtocolError(t *testing.T) {
@@ -95,10 +101,8 @@ func TestPingNode_ProtocolError(t *testing.T) {
 
 	result := PingNode(conn, cfg)
 
-	if result.Error == nil ||
-		result.Error.Error() != "protocol error: protocol error" {
-		t.Errorf("Expected protocol error, got: %v", result.Error)
-	}
+	require.Error(t, result.Error)
+	assert.Equal(t, "protocol error: protocol error", result.Error.Error())
 }
 
 func TestPingNode_ConnectionError(t *testing.T) {
@@ -122,10 +126,8 @@ func TestPingNode_ConnectionError(t *testing.T) {
 
 	result := PingNode(conn, cfg)
 
-	if result.Error == nil ||
-		result.Error.Error() != "connection failed: connection failed" {
-		t.Errorf("Expected connection error, got: %v", result.Error)
-	}
+	require.Error(t, result.Error)
+	assert.Equal(t, "connection failed: connection failed", result.Error.Error())
 }
 
 func TestPingNode_Integration(t *testing.T) {
@@ -150,21 +152,17 @@ func TestPingNode_Integration(t *testing.T) {
 	}
 
 	conn, err := NewConnection(cfg)
-	if err != nil {
-		t.Fatalf("failed to create connection: %v", err)
-	}
+	require.NoError(t, err, "failed to create connection")
 	defer conn.Close()
 
-	resultChan := make(chan PingResult)
+	resultChan := make(chan PingResult, 1)
 	go func() {
 		resultChan <- PingNode(conn, cfg)
 	}()
 
 	select {
 	case result := <-resultChan:
-		if result.Error != nil {
-			t.Fatalf("ping failed: %v", result.Error)
-		}
+		require.NoError(t, result.Error, "ping failed")
 		t.Logf("Integration test successful:")
 		t.Logf("Connection time: %v", result.ConnectionTime)
 		t.Logf("Protocol time: %v", result.ProtocolTime)

--- a/cmd/state-query/main.go
+++ b/cmd/state-query/main.go
@@ -126,9 +126,17 @@ func main() {
 	// Auto-resolve network magic if not provided
 	if cfg.Magic == 0 && cfg.Network != "" {
 		network, ok := ouroboros.NetworkByName(cfg.Network)
-		if ok {
-			cfg.Magic = network.NetworkMagic
+		if !ok {
+			fmt.Printf("ERROR: unknown network name: %s\n", cfg.Network)
+			os.Exit(1)
 		}
+		cfg.Magic = network.NetworkMagic
+	}
+	if cfg.Magic == 0 {
+		fmt.Println(
+			"ERROR: must specify CARDANO_NODE_MAGIC or a valid CARDANO_NODE_NETWORK",
+		)
+		os.Exit(1)
 	}
 	// Check that we have a query type
 	if len(os.Args) < 2 {
@@ -360,6 +368,10 @@ func main() {
 			txIdHex, err := hex.DecodeString(txInParts[0])
 			if err != nil {
 				fmt.Printf("ERROR: Invalid UTxO ID %q: %s\n", txIn, err)
+				os.Exit(1)
+			}
+			if len(txIdHex) != 32 {
+				fmt.Printf("ERROR: Invalid UTxO ID %q: expected 32-byte txid, got %d bytes\n", txIn, len(txIdHex))
 				os.Exit(1)
 			}
 			txOutputIdx, err := strconv.ParseUint(txInParts[1], 10, 32)

--- a/cmd/state-query/main.go
+++ b/cmd/state-query/main.go
@@ -1,0 +1,462 @@
+// Copyright 2023 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/kelseyhightower/envconfig"
+)
+
+// We parse environment variables using envconfig into this struct
+type Config struct {
+	Magic      uint32
+	Network    string
+	SocketPath string `split_words:"true"`
+}
+
+// convertToJSONValue recursively converts values to JSON-serializable types
+func convertToJSONValue(v interface{}) interface{} {
+	if v == nil {
+		return nil
+	}
+	switch val := v.(type) {
+	case map[interface{}]interface{}:
+		result := make(map[string]interface{})
+		for k, v := range val {
+			keyStr := fmt.Sprintf("%v", k)
+			result[keyStr] = convertToJSONValue(v)
+		}
+		return result
+	case []interface{}:
+		result := make([]interface{}, len(val))
+		for i, v := range val {
+			result[i] = convertToJSONValue(v)
+		}
+		return result
+	default:
+		// Use reflection to handle structs, maps, and other types
+		rv := reflect.ValueOf(v)
+		if rv.Kind() == reflect.Ptr {
+			if rv.IsNil() {
+				return nil
+			}
+			rv = rv.Elem()
+		}
+		//nolint:exhaustive // We handle all cases with default fallback
+		switch rv.Kind() {
+		case reflect.Map:
+			// Convert map with any key type to map[string]interface{}
+			result := make(map[string]interface{})
+			for _, key := range rv.MapKeys() {
+				keyStr := fmt.Sprintf("%v", key.Interface())
+				result[keyStr] = convertToJSONValue(rv.MapIndex(key).Interface())
+			}
+			return result
+		case reflect.Struct:
+			// Convert struct to map for JSON
+			result := make(map[string]interface{})
+			rt := rv.Type()
+			for i := 0; i < rv.NumField(); i++ {
+				field := rt.Field(i)
+				// Skip unexported fields
+				if !field.IsExported() {
+					continue
+				}
+				fieldValue := rv.Field(i).Interface()
+				result[field.Name] = convertToJSONValue(fieldValue)
+			}
+			return result
+		case reflect.Slice:
+			// Convert slice to []interface{}
+			if rv.IsNil() {
+				return nil
+			}
+			result := make([]interface{}, rv.Len())
+			for i := 0; i < rv.Len(); i++ {
+				result[i] = convertToJSONValue(rv.Index(i).Interface())
+			}
+			return result
+		default:
+			// For all other types (int, string, bool, etc.), return as-is
+			return v
+		}
+	}
+}
+
+// convertStructToJSONSafe converts a struct to a JSON-safe representation
+func convertStructToJSONSafe(v interface{}) interface{} {
+	// Use reflection-based conversion which handles map[interface{}]interface{}
+	return convertToJSONValue(v)
+}
+
+// This code will be executed when run
+func main() {
+	// Set config defaults
+	cfg := Config{
+		Magic:      0,
+		SocketPath: "/ipc/node.socket",
+	}
+	// Parse environment variables
+	if err := envconfig.Process("cardano_node", &cfg); err != nil {
+		panic(err)
+	}
+	// Auto-resolve network magic if not provided
+	if cfg.Magic == 0 && cfg.Network != "" {
+		network, ok := ouroboros.NetworkByName(cfg.Network)
+		if ok {
+			cfg.Magic = network.NetworkMagic
+		}
+	}
+	// Check that we have a query type
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: state-query <query-type> [arguments...]")
+		fmt.Println()
+		fmt.Println("Query types:")
+		fmt.Println("  current-era")
+		fmt.Println("  tip")
+		fmt.Println("  system-start")
+		fmt.Println("  era-history")
+		fmt.Println("  protocol-params")
+		fmt.Println("  stake-distribution")
+		fmt.Println("  stake-pools")
+		fmt.Println("  genesis-config")
+		fmt.Println("  pool-params <pool-id> [pool-id...]")
+		fmt.Println("  utxos-by-address <address> [address...]")
+		fmt.Println("  utxos-by-txin <txid#idx> [txid#idx...]")
+		fmt.Println("  utxo-whole-result [limit]  (WARNING: May timeout on large networks)")
+		os.Exit(1)
+	}
+	queryType := os.Args[1]
+	// Create error channel
+	errorChan := make(chan error, 1)
+	// start error handler
+	go func() {
+		for {
+			err := <-errorChan
+			panic(err)
+		}
+	}()
+	// Configure Ouroboros
+	o, err := ouroboros.NewConnection(
+		ouroboros.WithNetworkMagic(uint32(cfg.Magic)),
+		ouroboros.WithErrorChan(errorChan),
+		ouroboros.WithNodeToNode(false),
+	)
+	if err != nil {
+		panic(err)
+	}
+	// Connect to Node socket
+	if err = o.Dial("unix", cfg.SocketPath); err != nil {
+		panic(err)
+	}
+	// Execute query based on type
+	switch queryType {
+	case "current-era":
+		era, err := o.LocalStateQuery().Client.GetCurrentEra()
+		if err != nil {
+			panic(fmt.Errorf("failure querying current era: %w", err))
+		}
+		fmt.Printf("current-era: %d\n", era)
+	case "tip":
+		era, err := o.LocalStateQuery().Client.GetCurrentEra()
+		if err != nil {
+			panic(fmt.Errorf("failure querying current era: %w", err))
+		}
+		epochNo, err := o.LocalStateQuery().Client.GetEpochNo()
+		if err != nil {
+			panic(fmt.Errorf("failure querying current epoch: %w", err))
+		}
+		blockNo, err := o.LocalStateQuery().Client.GetChainBlockNo()
+		if err != nil {
+			panic(fmt.Errorf("failure querying current chain block number: %w", err))
+		}
+		point, err := o.LocalStateQuery().Client.GetChainPoint()
+		if err != nil {
+			panic(fmt.Errorf("failure querying current chain point: %w", err))
+		}
+		fmt.Printf(
+			"tip: era = %d, epoch = %d, blockNo = %d, slot = %d, hash = %x\n",
+			era,
+			epochNo,
+			blockNo,
+			point.Slot,
+			point.Hash,
+		)
+	case "system-start":
+		systemStart, err := o.LocalStateQuery().Client.GetSystemStart()
+		if err != nil {
+			panic(fmt.Errorf("failure querying system start: %w", err))
+		}
+		fmt.Printf(
+			"system-start: year = %v, day = %d, picoseconds = %v\n",
+			systemStart.Year,
+			systemStart.Day,
+			systemStart.Picoseconds,
+		)
+	case "era-history":
+		eraHistory, err := o.LocalStateQuery().Client.GetEraHistory()
+		if err != nil {
+			panic(fmt.Errorf("failure querying era history: %w", err))
+		}
+		fmt.Printf("era-history:\n")
+		for eraId, era := range eraHistory {
+			fmt.Printf(
+				"id = %d, begin slot/epoch = %d/%d, end slot/epoch = %d/%d, epoch length = %d, slot length (ms) = %d, slots per KES period = %d\n",
+				eraId,
+				era.Begin.SlotNo,
+				era.Begin.EpochNo,
+				era.End.SlotNo,
+				era.End.EpochNo,
+				era.Params.EpochLength,
+				era.Params.SlotLength,
+				era.Params.SlotsPerKESPeriod.Value,
+			)
+		}
+	case "protocol-params":
+		protoParams, err := o.LocalStateQuery().Client.GetCurrentProtocolParams()
+		if err != nil {
+			panic(fmt.Errorf("failure querying protocol params: %w", err))
+		}
+		// Marshal to JSON for readable output
+		jsonData, err := json.MarshalIndent(protoParams, "", "  ")
+		if err != nil {
+			panic(fmt.Errorf("failure marshaling protocol params to JSON: %w", err))
+		}
+		fmt.Printf("protocol-params:\n%s\n", string(jsonData))
+	case "stake-distribution":
+		stakeDistribution, err := o.LocalStateQuery().Client.GetStakeDistribution()
+		if err != nil {
+			panic(fmt.Errorf("failure querying stake distribution: %w", err))
+		}
+		fmt.Printf("stake-distribution:\n")
+		for poolID, entry := range stakeDistribution.Results {
+			stakePercent := "N/A"
+			if entry.StakeFraction != nil {
+				// Convert to percentage: (num/denom) * 100
+				hundred := big.NewRat(100, 1)
+				percent := new(big.Rat).Mul(entry.StakeFraction.Rat, hundred)
+				stakePercent = percent.FloatString(6) + "%"
+			}
+			vrfHashStr := "N/A"
+			if entry.VrfHash != (ledger.Blake2b256{}) {
+				vrfHashStr = entry.VrfHash.String()
+			}
+			fmt.Printf("  Pool: %s, Stake: %s, VRF Hash: %s\n", poolID.String(), stakePercent, vrfHashStr)
+		}
+	case "stake-pools":
+		stakePools, err := o.LocalStateQuery().Client.GetStakePools()
+		if err != nil {
+			panic(fmt.Errorf("failure querying stake pools: %w", err))
+		}
+		fmt.Printf("stake-pools:\n")
+		for _, poolID := range stakePools.Results {
+			fmt.Printf("  %s\n", poolID.String())
+		}
+	case "genesis-config":
+		genesisConfig, err := o.LocalStateQuery().Client.GetGenesisConfig()
+		if err != nil {
+			panic(fmt.Errorf("failure querying genesis config: %w", err))
+		}
+		// Convert struct to JSON-safe representation
+		jsonSafe := convertStructToJSONSafe(genesisConfig)
+		jsonData, err := json.MarshalIndent(jsonSafe, "", "  ")
+		if err != nil {
+			panic(fmt.Errorf("failed to marshal genesis config to JSON: %w", err))
+		}
+		fmt.Printf("genesis-config:\n%s\n", jsonData)
+	case "pool-params":
+		if len(os.Args) < 3 {
+			fmt.Println("ERROR: No pools specified")
+			os.Exit(1)
+		}
+
+		tmpPools := make([]lcommon.PoolId, 0, len(os.Args[2:]))
+		for _, pool := range os.Args[2:] {
+			tmpPoolId, err := lcommon.NewPoolIdFromBech32(pool)
+			if err != nil {
+				fmt.Printf("ERROR: Invalid bech32 pool ID %q: %s\n", pool, err)
+				os.Exit(1)
+			}
+			tmpPools = append(tmpPools, tmpPoolId)
+		}
+		poolParams, err := o.LocalStateQuery().Client.GetStakePoolParams(tmpPools)
+		if err != nil {
+			panic(fmt.Errorf("failure querying stake pool params: %w", err))
+		}
+		// Convert struct to JSON-safe representation
+		jsonSafe := convertStructToJSONSafe(poolParams)
+		jsonData, err := json.MarshalIndent(jsonSafe, "", "  ")
+		if err != nil {
+			panic(fmt.Errorf("failed to marshal pool params to JSON: %w", err))
+		}
+		fmt.Printf("pool-params:\n%s\n", jsonData)
+	case "utxos-by-address":
+		if len(os.Args) < 3 {
+			fmt.Println("ERROR: No addresses specified")
+			os.Exit(1)
+		}
+		tmpAddrs := make([]lcommon.Address, 0, len(os.Args[2:]))
+		for _, addr := range os.Args[2:] {
+			tmpAddr, err := lcommon.NewAddress(addr)
+			if err != nil {
+				fmt.Printf("ERROR: Invalid address %q: %s\n", addr, err)
+				os.Exit(1)
+			}
+			tmpAddrs = append(tmpAddrs, tmpAddr)
+		}
+		utxos, err := o.LocalStateQuery().Client.GetUTxOByAddress(tmpAddrs)
+		if err != nil {
+			panic(fmt.Errorf("failure querying UTxOs by address: %w", err))
+		}
+		for utxoId, utxo := range utxos.Results {
+			fmt.Println("---")
+			fmt.Printf("UTxO ID: %s#%d\n", utxoId.Hash.String(), utxoId.Idx)
+			fmt.Printf("Amount: %d\n", utxo.OutputAmount.Amount)
+			if utxo.OutputAmount.Assets != nil {
+				assetsJson, err := json.Marshal(utxo.OutputAmount.Assets)
+				if err != nil {
+					fmt.Printf("ERROR: failed to marshal asset JSON: %s\n", err)
+					os.Exit(1)
+				}
+				fmt.Printf("Assets: %s\n", assetsJson)
+			}
+		}
+	case "utxos-by-txin":
+		if len(os.Args) < 3 {
+			fmt.Println("ERROR: No UTxO IDs specified")
+			os.Exit(1)
+		}
+
+		tmpTxIns := make([]lcommon.TransactionInput, 0, len(os.Args[2:]))
+		for _, txIn := range os.Args[2:] {
+			txInParts := strings.SplitN(txIn, `#`, 2)
+			if len(txInParts) != 2 {
+				fmt.Printf("ERROR: Invalid UTxO ID %q\n", txIn)
+				os.Exit(1)
+			}
+			txIdHex, err := hex.DecodeString(txInParts[0])
+			if err != nil {
+				fmt.Printf("ERROR: Invalid UTxO ID %q: %s\n", txIn, err)
+				os.Exit(1)
+			}
+			txOutputIdx, err := strconv.ParseUint(txInParts[1], 10, 32)
+			if err != nil {
+				fmt.Printf("ERROR: Invalid UTxO ID %q: %s\n", txIn, err)
+				os.Exit(1)
+			}
+			tmpTxIn := ledger.ShelleyTransactionInput{
+				TxId:        ledger.Blake2b256(txIdHex),
+				OutputIndex: uint32(txOutputIdx),
+			}
+			tmpTxIns = append(tmpTxIns, tmpTxIn)
+		}
+		utxos, err := o.LocalStateQuery().Client.GetUTxOByTxIn(tmpTxIns)
+		if err != nil {
+			panic(fmt.Errorf("failure querying UTxOs by TxIn: %w", err))
+		}
+		for utxoId, utxo := range utxos.Results {
+			fmt.Println("---")
+			fmt.Printf("UTxO ID: %s#%d\n", utxoId.Hash.String(), utxoId.Idx)
+			fmt.Printf("Amount: %d\n", utxo.OutputAmount.Amount)
+			if utxo.OutputAmount.Assets != nil {
+				assetsJson, err := json.Marshal(utxo.OutputAmount.Assets)
+				if err != nil {
+					fmt.Printf("ERROR: failed to marshal asset JSON: %s\n", err)
+					os.Exit(1)
+				}
+				fmt.Printf("Assets: %s\n", assetsJson)
+			}
+		}
+	case "utxo-whole-result":
+		limit := -1 // -1 means no limit
+		if len(os.Args) >= 3 {
+			limitVal, err := strconv.Atoi(os.Args[2])
+			if err != nil {
+				fmt.Printf("ERROR: Invalid limit value %q: %s\n", os.Args[2], err)
+				os.Exit(1)
+			}
+			limit = limitVal
+		}
+		fmt.Fprintf(os.Stderr, "WARNING: utxo-whole-result queries the entire UTxO set and may timeout on large networks.\n")
+		fmt.Fprintf(os.Stderr, "Consider using 'utxos-by-address' or 'utxos-by-txin' for specific queries instead.\n\n")
+		utxos, err := o.LocalStateQuery().Client.GetUTxOWhole()
+		if err != nil {
+			if strings.Contains(err.Error(), "timeout") {
+				fmt.Fprintf(os.Stderr, "\nERROR: Query timed out. The UTxO set is too large to query all at once.\n")
+				fmt.Fprintf(os.Stderr, "This is a known limitation - the protocol doesn't support range queries for UTxO whole.\n")
+				fmt.Fprintf(os.Stderr, "Please use one of these alternatives instead:\n")
+				fmt.Fprintf(os.Stderr, "  - utxos-by-address <address> [address...]  - Query UTxOs for specific addresses\n")
+				fmt.Fprintf(os.Stderr, "  - utxos-by-txin <txid#idx> [txid#idx...]  - Query specific UTxOs by transaction input\n")
+				os.Exit(1)
+			}
+			panic(fmt.Errorf("failure querying UTxO whole: %w", err))
+		}
+		count := 0
+		total := len(utxos.Results)
+		for utxoId, utxo := range utxos.Results {
+			if limit >= 0 && count >= limit {
+				break
+			}
+			fmt.Println("---")
+			fmt.Printf("UTxO ID: %s#%d\n", utxoId.Hash.String(), utxoId.Idx)
+			fmt.Printf("Address: %x\n", utxo.Address())
+			fmt.Printf("Amount: %d\n", utxo.Amount())
+			assets := utxo.Assets()
+			if assets != nil {
+				fmt.Printf("Assets: %+v\n", assets)
+			}
+			datum := utxo.Datum()
+			if datum != nil {
+				if cborData := datum.Cbor(); cborData != nil {
+					fmt.Printf("Datum CBOR: %x\n", cborData)
+				} else {
+					fmt.Printf("Datum present (error decoding)\n")
+				}
+			}
+			count++
+		}
+		if limit >= 0 && count < total {
+			fmt.Printf("\n(Showing %d of %d total UTxOs. Use 'utxo-whole-result <limit>' to specify limit)\n", count, total)
+		}
+	default:
+		fmt.Printf("ERROR: unknown query: %s\n", queryType)
+		fmt.Println()
+		fmt.Println("Available query types:")
+		fmt.Println("  current-era")
+		fmt.Println("  tip")
+		fmt.Println("  system-start")
+		fmt.Println("  era-history")
+		fmt.Println("  protocol-params")
+		fmt.Println("  stake-distribution")
+		fmt.Println("  stake-pools")
+		fmt.Println("  genesis-config")
+		fmt.Println("  pool-params <pool-id> [pool-id...]")
+		fmt.Println("  utxos-by-address <address> [address...]")
+		fmt.Println("  utxos-by-txin <txid#idx> [txid#idx...]")
+		fmt.Println("  utxo-whole-result [limit]  (WARNING: May timeout on large networks)")
+		os.Exit(1)
+	}
+}

--- a/cmd/state-query/main.go
+++ b/cmd/state-query/main.go
@@ -59,7 +59,7 @@ func convertToJSONValue(v interface{}) interface{} {
 	default:
 		// Use reflection to handle structs, maps, and other types
 		rv := reflect.ValueOf(v)
-		if rv.Kind() == reflect.Ptr {
+		if rv.Kind() == reflect.Pointer {
 			if rv.IsNil() {
 				return nil
 			}

--- a/cmd/tx-monitor/main.go
+++ b/cmd/tx-monitor/main.go
@@ -1,0 +1,214 @@
+// Copyright 2023 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/fxamacker/cbor/v2"
+	"github.com/kelseyhightower/envconfig"
+)
+
+// We parse environment variables using envconfig into this struct
+type Config struct {
+	Magic      uint32
+	SocketPath string `split_words:"true"`
+}
+
+// This code will be executed when run
+func main() {
+	// Set config defaults
+	cfg := Config{
+		Magic:      764824073,
+		SocketPath: "/ipc/node.socket",
+	}
+	// Parse environment variables
+	if err := envconfig.Process("cardano_node", &cfg); err != nil {
+		panic(err)
+	}
+	// Create error channel
+	errorChan := make(chan error)
+	// start error handler
+	go func() {
+		for {
+			err := <-errorChan
+			panic(err)
+		}
+	}()
+	// Configure Ouroboros
+	o, err := ouroboros.NewConnection(
+		ouroboros.WithNetworkMagic(uint32(cfg.Magic)),
+		ouroboros.WithErrorChan(errorChan),
+		ouroboros.WithNodeToNode(false),
+	)
+	if err != nil {
+		panic(err)
+	}
+	// Connect to Node socket
+	if err = o.Dial("unix", cfg.SocketPath); err != nil {
+		panic(err)
+	}
+	// Get mempool sizes from Node via LocalTxMonitor Ouroboros mini-protocol
+	capacity, size, numberOfTxs, err := o.LocalTxMonitor().Client.GetSizes()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf(
+		"Mempool size (bytes): %-10d Mempool capacity (bytes): %-10d Transactions: %-10d\n",
+		size,
+		capacity,
+		numberOfTxs,
+	)
+	fmt.Println()
+
+	// Get all transactions
+	fmt.Println("Transactions:")
+
+	// The Ouroboros LocalTxMonitor mini-protocol allows fetching all of the
+	// contents of the Node mempool. However, you have to loop and fetch
+	// each Tx until the mempool is empty.
+	for {
+		// Get raw Tx bytes from Node via LocalTxMonitor
+		txRawBytes, err := o.LocalTxMonitor().Client.NextTx()
+		if err != nil {
+			panic(err)
+		}
+		// Break loop if empty
+		if txRawBytes == nil {
+			break
+		}
+		// Get Tx size of raw Tx bytes
+		size := len(txRawBytes)
+		// Determine transaction type (era) from raw Tx bytes
+		txType, err := ledger.DetermineTransactionType(txRawBytes)
+		if err != nil {
+			panic(err)
+		}
+		// Get ledger.Transaction from raw Tx bytes
+		tx, err := ledger.NewTransactionFromCbor(txType, txRawBytes)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Println(" ---")
+		// Print Tx size and Tx Hash (of Tx Body)
+		fmt.Printf(
+			" %-20s %d\n",
+			"Size:",
+			size,
+		)
+		fmt.Printf(
+			" %-20s %s\n",
+			"TxHash:",
+			tx.Hash(),
+		)
+		// Print number of inputs
+		fmt.Printf(
+			" %-20s %d\n",
+			"Inputs:",
+			len(tx.Inputs()),
+		)
+		// Loop through transaction inputs and print ID#Index
+		for i, input := range tx.Inputs() {
+			fmt.Printf(
+				" %-20s %s\n",
+				fmt.Sprintf("Input[%d]:", i),
+				fmt.Sprintf("%s#%d", input.Id().String(), input.Index()),
+			)
+		}
+		// Print number of outputs
+		fmt.Printf(
+			" %-20s %d\n",
+			"Outputs:",
+			len(tx.Outputs()),
+		)
+		// Loop through transaction outputs
+		for o, output := range tx.Outputs() {
+			fmt.Printf(
+				" %-20s %s\n",
+				fmt.Sprintf("Output[%d]:", o),
+				"Address: "+output.Address().String(),
+			)
+			fmt.Printf(
+				" %-20s %s\n",
+				fmt.Sprintf("Output[%d]:", o),
+				fmt.Sprintf("Amount: %d", output.Amount()),
+			)
+			if output.Assets() == nil {
+				continue
+			}
+			// We do not have a direct way to go from the Assets()
+			// output from gOuroboros to an easily iterable list
+			// of assets ([]Asset), so we use JSON parsing as an
+			// intermediary step.
+
+			// Marshal to JSON bytes from ledger.MultiAsset
+			j, _ := output.Assets().MarshalJSON()
+			var assets []lcommon.MultiAsset[*big.Int]
+			// Unmarshal JSON bytes to list of Assets
+			err := json.Unmarshal(j, &assets)
+			if err != nil {
+				panic(err)
+			}
+			// Loop through each asset and display
+			for a, asset := range assets {
+				fmt.Printf(
+					" %-20s %s\n",
+					fmt.Sprintf("Output[%d]:", o),
+					fmt.Sprintf("Asset[%d]: %+v", a, asset),
+				)
+			}
+		}
+		// Check if transaction has any metadata
+		if tx.Metadata() != nil {
+			// Get CBOR bytes of metadata
+			mdCbor := tx.Metadata().Cbor()
+
+			// Check if the CBOR bytes matches one of our known
+			// metadata types exposed in our models. Currently,
+			// only CIP-20 messages are supported.
+
+			// Check if the CBOR bytes matches CIP-20
+			// Cip20Metadata represents CIP-20 transaction message metadata
+			type cip20Num674 struct {
+				Msg []string `cbor:"msg"`
+			}
+			type cip20Metadata struct {
+				Num674 cip20Num674 `cbor:"674,keyasint"`
+			}
+			var msgMetadata cip20Metadata
+			err := cbor.Unmarshal(mdCbor, &msgMetadata)
+			if err != nil {
+				// Do nothing on error
+				continue
+			}
+			// Display message if found
+			if msgMetadata.Num674.Msg != nil {
+				for m, msg := range msgMetadata.Num674.Msg {
+					fmt.Printf(
+						" %-20s %s\n",
+						fmt.Sprintf("Metadata[Msg][%d]:", m),
+						msg,
+					)
+				}
+			}
+		}
+		fmt.Println()
+	}
+}

--- a/cmd/tx-monitor/main.go
+++ b/cmd/tx-monitor/main.go
@@ -20,9 +20,9 @@ import (
 	"math/big"
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
+	gCbor "github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
-	"github.com/fxamacker/cbor/v2"
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -159,7 +159,10 @@ func main() {
 			// intermediary step.
 
 			// Marshal to JSON bytes from ledger.MultiAsset
-			j, _ := output.Assets().MarshalJSON()
+			j, marshalErr := output.Assets().MarshalJSON()
+			if marshalErr != nil {
+				panic(fmt.Sprintf("failed to marshal assets: %s", marshalErr))
+			}
 			var assets []lcommon.MultiAsset[*big.Int]
 			// Unmarshal JSON bytes to list of Assets
 			err := json.Unmarshal(j, &assets)
@@ -193,7 +196,7 @@ func main() {
 				Num674 cip20Num674 `cbor:"674,keyasint"`
 			}
 			var msgMetadata cip20Metadata
-			err := cbor.Unmarshal(mdCbor, &msgMetadata)
+			_, err := gCbor.Decode(mdCbor, &msgMetadata)
 			if err != nil {
 				// Do nothing on error
 				continue

--- a/cmd/tx-submission/main.go
+++ b/cmd/tx-submission/main.go
@@ -1,0 +1,148 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/protocol/localtxsubmission"
+	"github.com/kelseyhightower/envconfig"
+)
+
+// We parse environment variables using envconfig into this struct
+type Config struct {
+	Magic      uint32
+	SocketPath string `split_words:"true"`
+	Network    string
+	TxFile     string
+	RawTxFile  string
+}
+
+// This code will be executed when run
+func main() {
+	// Set config defaults
+	cfg := Config{
+		SocketPath: "/ipc/node.socket",
+	}
+	// Parse environment variables
+	if err := envconfig.Process("cardano_node", &cfg); err != nil {
+		panic(err)
+	}
+
+	// Parse command-line flags
+	flag.StringVar(&cfg.TxFile, "tx-file", "", "path to the JSON transaction file to submit")
+	flag.StringVar(&cfg.RawTxFile, "raw-tx-file", "", "path to the raw transaction file to submit")
+	flag.Parse()
+
+	// Validate that at least one transaction file is provided
+	if cfg.TxFile == "" && cfg.RawTxFile == "" {
+		fmt.Printf("ERROR: you must specify -tx-file or -raw-tx-file\n")
+		os.Exit(1)
+	}
+
+	// Configure NetworkMagic
+	if cfg.Magic == 0 {
+		if cfg.Network == "" {
+			// Default to preview network if not specified
+			cfg.Network = "preview"
+		}
+		network, ok := ouroboros.NetworkByName(cfg.Network)
+		if !ok {
+			fmt.Printf("ERROR: invalid network specified: %v\n", cfg.Network)
+			os.Exit(1)
+		}
+		cfg.Magic = network.NetworkMagic
+	}
+
+	// Create error channel
+	errorChan := make(chan error)
+	// Start error handler
+	go func() {
+		for {
+			err := <-errorChan
+			fmt.Printf("ERROR: %s\n", err)
+			os.Exit(1)
+		}
+	}()
+
+	// Configure Ouroboros
+	o, err := ouroboros.NewConnection(
+		ouroboros.WithNetworkMagic(cfg.Magic),
+		ouroboros.WithErrorChan(errorChan),
+		ouroboros.WithNodeToNode(false), // Use NtC protocol (UNIX socket)
+		ouroboros.WithKeepAlive(true),
+		ouroboros.WithLocalTxSubmissionConfig(localtxsubmission.NewConfig()),
+	)
+	if err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		os.Exit(1)
+	}
+
+	// Connect to Node socket
+	if err = o.Dial("unix", cfg.SocketPath); err != nil {
+		fmt.Printf("ERROR: connection failed: %s\n", err)
+		os.Exit(1)
+	}
+
+	// Load transaction bytes
+	var txBytes []byte
+	if cfg.TxFile != "" {
+		txData, err := os.ReadFile(cfg.TxFile)
+		if err != nil {
+			fmt.Printf("ERROR: failed to load transaction file: %s\n", err)
+			os.Exit(1)
+		}
+
+		var jsonData map[string]string
+		err = json.Unmarshal(txData, &jsonData)
+		if err != nil {
+			fmt.Printf("ERROR: failed to parse transaction file: %s\n", err)
+			os.Exit(1)
+		}
+
+		txBytes, err = hex.DecodeString(jsonData["cborHex"])
+		if err != nil {
+			fmt.Printf("ERROR: failed to decode transaction: %s\n", err)
+			os.Exit(1)
+		}
+	} else {
+		txBytes, err = os.ReadFile(cfg.RawTxFile)
+		if err != nil {
+			fmt.Printf("ERROR: failed to load transaction file: %s\n", err)
+			os.Exit(1)
+		}
+	}
+
+	// Determine transaction type from raw bytes
+	txType, err := ledger.DetermineTransactionType(txBytes)
+	if err != nil {
+		fmt.Printf("ERROR: failed to determine transaction type: %s\n", err)
+		os.Exit(1)
+	}
+
+	// Submit transaction
+	if err = o.LocalTxSubmission().Client.SubmitTx(uint16(txType) /* #nosec G115 */, txBytes); err != nil {
+		fmt.Printf("ERROR: failed to submit transaction: %s\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Print("The transaction was accepted\n")
+}

--- a/cmd/tx-submission/main.go
+++ b/cmd/tx-submission/main.go
@@ -48,11 +48,17 @@ func main() {
 	}
 
 	// Parse command-line flags
-	flag.StringVar(&cfg.TxFile, "tx-file", "", "path to the JSON transaction file to submit")
-	flag.StringVar(&cfg.RawTxFile, "raw-tx-file", "", "path to the raw transaction file to submit")
+	flag.StringVar(&cfg.TxFile, "tx-file", cfg.TxFile, "path to the JSON transaction file to submit")
+	flag.StringVar(&cfg.RawTxFile, "raw-tx-file", cfg.RawTxFile, "path to the raw transaction file to submit")
 	flag.Parse()
 
-	// Validate that at least one transaction file is provided
+	// Validate transaction file flags
+	if cfg.TxFile != "" && cfg.RawTxFile != "" {
+		fmt.Printf(
+			"ERROR: specify only one of -tx-file or -raw-tx-file, not both\n",
+		)
+		os.Exit(1)
+	}
 	if cfg.TxFile == "" && cfg.RawTxFile == "" {
 		fmt.Printf("ERROR: you must specify -tx-file or -raw-tx-file\n")
 		os.Exit(1)
@@ -118,6 +124,10 @@ func main() {
 			os.Exit(1)
 		}
 
+		if jsonData["cborHex"] == "" {
+			fmt.Printf("ERROR: transaction file missing cborHex field\n")
+			os.Exit(1)
+		}
 		txBytes, err = hex.DecodeString(jsonData["cborHex"])
 		if err != nil {
 			fmt.Printf("ERROR: failed to decode transaction: %s\n", err)

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/btcsuite/btcd/btcutil v1.2.0
 	github.com/fxamacker/cbor/v2 v2.9.2
 	github.com/jinzhu/copier v0.4.0
+	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/stretchr/testify v1.11.1
 	github.com/utxorpc/go-codegen v0.19.0
 	go.uber.org/goleak v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/holiman/uint256 v1.3.2 h1:a9EgMPSC1AAaj1SZL5zIQD3WbwTuHrMGOerLjGmM/TA
 github.com/holiman/uint256 v1.3.2/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
 github.com/jinzhu/copier v0.4.0 h1:w3ciUoD19shMCRargcpm0cm91ytaBhDvuRpz1ODO/U8=
 github.com/jinzhu/copier v0.4.0/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/klauspost/cpuid/v2 v2.2.3 h1:sxCkb+qR91z4vsqw4vGGZlDgPz3G7gjaLyK3V8y70BU=
 github.com/klauspost/cpuid/v2 v2.2.3/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=


### PR DESCRIPTION
closes #1635 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated example CLI commands from `gouroboros-starter-kit` into `cmd/` with `make` targets, CI, and README docs so developers can build and run examples easily.

- **New Features**
  - Added example commands: `block-fetch`, `chain-sync`, `chain-tip`, `peer-sharing`, `ping` (with tests), `state-query`, `tx-monitor`, `tx-submission`.
  - Added `make build` to build all examples and `clean` to remove binaries; new CI workflow builds examples on Go 1.25.x/1.26.x; README documents examples and quick usage.

- **Dependencies**
  - Added `github.com/kelseyhightower/envconfig` for environment-based configuration.

<sup>Written for commit 7f890c1ddf833601c3798a467f68da2410b0fc2a. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1774?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multiple example CLI tools for interacting with Cardano nodes: block-fetch, chain-sync, chain-tip, peer-sharing, ping, state-query, tx-monitor, and tx-submission.

* **Documentation**
  * Updated README with examples section documenting available CLI tools and build instructions.

* **Chores**
  * Added automated build workflow for example programs.
  * Enhanced build system with new targets for building and cleaning example binaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/gouroboros/pull/1774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->