### PR TITLE
docs: note about releases

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,6 +30,8 @@ This release migrates starter-kit example commands into gOuroboros and reorganiz
 * Refreshed the `golangci-lint` GitHub Action to `v9.2.1`.
 * Documented the prior `v0.171.0` release entry in `RELEASE_NOTES.md`.
 
+## There were no releases between v0.171.0 and v0.178.0 due to a mistagging
+
 ## v0.171.0 - local state query expansion and ledger validation fixes
 
 - **Date:** 2026-05-21


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a note in `RELEASE_NOTES.md` explaining the version gap: no releases between v0.171.0 and v0.178.0 due to a mistag. This clarifies the release history and prevents confusion.

<sup>Written for commit bd35a42983db107848dc6f2ef73432b88b99cb86. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1781?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

