### PR TITLE
fix(leios): vote and EB certificate for stake-based committee

### DIFF
--- a/ledger/common/certs.go
+++ b/ledger/common/certs.go
@@ -50,7 +50,6 @@ const (
 	CertificateTypeRegistrationDrep                CertificateType = 16
 	CertificateTypeDeregistrationDrep              CertificateType = 17
 	CertificateTypeUpdateDrep                      CertificateType = 18
-	CertificateTypeLeiosEb                         CertificateType = 19
 )
 
 type CertificateWrapper struct {
@@ -107,8 +106,6 @@ func (c *CertificateWrapper) UnmarshalCBOR(data []byte) error {
 		tmpCert = &DeregistrationDrepCertificate{}
 	case CertificateTypeUpdateDrep:
 		tmpCert = &UpdateDrepCertificate{}
-	case CertificateTypeLeiosEb:
-		tmpCert = &LeiosEbCertificate{}
 	default:
 		return fmt.Errorf("unknown certificate type: %d", certType)
 	}
@@ -1473,71 +1470,4 @@ func (c *UpdateDrepCertificate) Utxorpc() (*utxorpc.Certificate, error) {
 
 func (c *UpdateDrepCertificate) Type() uint {
 	return c.CertType
-}
-
-type LeiosEbCertificate struct {
-	cbor.StructAsArray
-	cbor.DecodeStoreCbor
-	ElectionId          Blake2b256
-	EndorserBlockHash   Blake2b256
-	PersistentVoters    []uint
-	NonpersistentVoters map[Blake2b256][]byte
-	AggregatedVoteSig   []byte
-}
-
-func (c LeiosEbCertificate) isCertificate() {}
-
-func (c *LeiosEbCertificate) UnmarshalCBOR(
-	cborData []byte,
-) error {
-	type tLeiosEbCertificate LeiosEbCertificate
-	var tmp tLeiosEbCertificate
-	if _, err := cbor.Decode(cborData, &tmp); err != nil {
-		return err
-	}
-	// Validate BLS signature sizes per CIP-0164 (BLS12-381 MinSig)
-	if len(tmp.AggregatedVoteSig) != 48 {
-		return fmt.Errorf(
-			"LeiosEbCertificate: AggregatedVoteSig must be 48 bytes (BLS signature), got %d",
-			len(tmp.AggregatedVoteSig),
-		)
-	}
-	for poolId, sig := range tmp.NonpersistentVoters {
-		if len(sig) != 48 {
-			return fmt.Errorf(
-				"LeiosEbCertificate: NonpersistentVoters signature for pool %x must be 48 bytes, got %d",
-				poolId[:8],
-				len(sig),
-			)
-		}
-	}
-	*c = LeiosEbCertificate(tmp)
-	c.SetCbor(cborData)
-	return nil
-}
-
-func (c *LeiosEbCertificate) Utxorpc() (*utxorpc.Certificate, error) {
-	return &utxorpc.Certificate{}, nil
-}
-
-func (c *LeiosEbCertificate) Type() uint {
-	return uint(CertificateTypeLeiosEb)
-}
-
-// GetAggregatedVoteSig returns the aggregated vote signature as a byte slice
-func (c *LeiosEbCertificate) GetAggregatedVoteSig() []byte {
-	return c.AggregatedVoteSig
-}
-
-// SetAggregatedVoteSig sets the aggregated vote signature from a byte slice
-// and validates it meets the 48-byte BLS signature requirement per CIP-0164
-func (c *LeiosEbCertificate) SetAggregatedVoteSig(sig []byte) error {
-	if len(sig) != 48 {
-		return fmt.Errorf(
-			"LeiosEbCertificate: AggregatedVoteSig must be 48 bytes (BLS signature), got %d",
-			len(sig),
-		)
-	}
-	c.AggregatedVoteSig = sig
-	return nil
 }

--- a/ledger/common/common_test.go
+++ b/ledger/common/common_test.go
@@ -1147,11 +1147,6 @@ var certificateTypeTests = []struct {
 		&UpdateDrepCertificate{CertType: uint(CertificateTypeUpdateDrep)},
 		uint(CertificateTypeUpdateDrep),
 	},
-	{
-		"LeiosEb",
-		&LeiosEbCertificate{},
-		uint(CertificateTypeLeiosEb),
-	},
 }
 
 func TestCertificateTypeMethods(t *testing.T) {
@@ -1208,7 +1203,6 @@ func TestCertificateTypeCoverage(t *testing.T) {
 		uint(CertificateTypeRegistrationDrep):                "CertificateTypeRegistrationDrep",
 		uint(CertificateTypeDeregistrationDrep):              "CertificateTypeDeregistrationDrep",
 		uint(CertificateTypeUpdateDrep):                      "CertificateTypeUpdateDrep",
-		uint(CertificateTypeLeiosEb):                         "CertificateTypeLeiosEb",
 	}
 
 	for certType, name := range expectedTypes {

--- a/ledger/common/leios.go
+++ b/ledger/common/leios.go
@@ -1,0 +1,197 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+)
+
+const LeiosBlsSignatureSize = 48
+
+type LeiosVoteId struct {
+	cbor.StructAsArray
+	SlotNo  uint64
+	VoterId uint64
+}
+
+type LeiosVote struct {
+	cbor.StructAsArray
+	cbor.DecodeStoreCbor
+	SlotNo            uint64
+	EndorserBlockHash Blake2b256
+	VoterId           uint64
+	VoteSignature     []byte
+}
+
+func (v LeiosVote) MarshalCBOR() ([]byte, error) {
+	if raw := v.Cbor(); len(raw) > 0 {
+		return raw, nil
+	}
+	return cbor.Encode([]any{
+		v.SlotNo,
+		v.EndorserBlockHash,
+		v.VoterId,
+		v.VoteSignature,
+	})
+}
+
+func (v *LeiosVote) UnmarshalCBOR(cborData []byte) error {
+	type tLeiosVote LeiosVote
+	var tmp tLeiosVote
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	if err := LeiosVote(tmp).Validate(); err != nil {
+		return err
+	}
+	*v = LeiosVote(tmp)
+	v.SetCbor(cborData)
+	return nil
+}
+
+func (v LeiosVote) Validate() error {
+	return ValidateLeiosSignature("LeiosVote: VoteSignature", v.VoteSignature)
+}
+
+// LeiosEbCertificate is the CIP-0164 EB certificate payload shape used by
+// Leios vote aggregation helpers. It is intentionally separate from Dijkstra
+// block certificate slots: the generated Dijkstra CDDL currently defines
+// leios_cert = [] and peras_cert = [], implemented by ledger/dijkstra.
+type LeiosEbCertificate struct {
+	cbor.StructAsArray
+	cbor.DecodeStoreCbor
+	SlotNo              uint64
+	EndorserBlockHash   Blake2b256
+	Signers             []byte
+	AggregatedSignature []byte
+}
+
+func (c LeiosEbCertificate) MarshalCBOR() ([]byte, error) {
+	if raw := c.Cbor(); len(raw) > 0 {
+		return raw, nil
+	}
+	return cbor.Encode([]any{
+		c.SlotNo,
+		c.EndorserBlockHash,
+		c.Signers,
+		c.AggregatedSignature,
+	})
+}
+
+func (c *LeiosEbCertificate) UnmarshalCBOR(
+	cborData []byte,
+) error {
+	type tLeiosEbCertificate LeiosEbCertificate
+	var tmp tLeiosEbCertificate
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	if len(tmp.AggregatedSignature) != LeiosBlsSignatureSize {
+		return fmt.Errorf(
+			"LeiosEbCertificate: AggregatedSignature must be %d bytes (BLS signature), got %d",
+			LeiosBlsSignatureSize,
+			len(tmp.AggregatedSignature),
+		)
+	}
+	*c = LeiosEbCertificate(tmp)
+	c.SetCbor(cborData)
+	return nil
+}
+
+// Validate checks committee-dependent fields that cannot be verified from CBOR
+// alone.
+func (c *LeiosEbCertificate) Validate(committeeSize uint64) error {
+	if err := ValidateLeiosSignature(
+		"LeiosEbCertificate: AggregatedSignature",
+		c.AggregatedSignature,
+	); err != nil {
+		return err
+	}
+	return ValidateLeiosSignerBitfield(c.Signers, committeeSize)
+}
+
+func (c *LeiosEbCertificate) Signer(voterId uint64) bool {
+	return LeiosSignerBit(c.Signers, voterId)
+}
+
+// GetAggregatedSignature returns the aggregated vote signature as a byte slice.
+func (c *LeiosEbCertificate) GetAggregatedSignature() []byte {
+	return c.AggregatedSignature
+}
+
+// SetAggregatedSignature sets the aggregated vote signature from a byte slice
+// and validates it meets the 48-byte BLS signature requirement per CIP-0164.
+func (c *LeiosEbCertificate) SetAggregatedSignature(sig []byte) error {
+	if err := ValidateLeiosSignature(
+		"LeiosEbCertificate: AggregatedSignature",
+		sig,
+	); err != nil {
+		return err
+	}
+	c.AggregatedSignature = sig
+	c.SetCbor(nil)
+	return nil
+}
+
+func ValidateLeiosSignature(name string, sig []byte) error {
+	if len(sig) != LeiosBlsSignatureSize {
+		return fmt.Errorf(
+			"%s must be %d bytes (BLS signature), got %d",
+			name,
+			LeiosBlsSignatureSize,
+			len(sig),
+		)
+	}
+	return nil
+}
+
+func LeiosSignerBitfieldSize(committeeSize uint64) uint64 {
+	return (committeeSize + 7) / 8
+}
+
+func ValidateLeiosSignerBitfield(signers []byte, committeeSize uint64) error {
+	expectedLen := LeiosSignerBitfieldSize(committeeSize)
+	if uint64(len(signers)) != expectedLen {
+		return fmt.Errorf(
+			"leios signer bitfield must be %d bytes for committee size %d, got %d",
+			expectedLen,
+			committeeSize,
+			len(signers),
+		)
+	}
+	if committeeSize == 0 || committeeSize%8 == 0 {
+		return nil
+	}
+	unusedBits := uint(8 - committeeSize%8)
+	unusedMask := byte((1 << unusedBits) - 1)
+	if signers[len(signers)-1]&unusedMask != 0 {
+		return fmt.Errorf(
+			"leios signer bitfield has non-zero unused bits for committee size %d",
+			committeeSize,
+		)
+	}
+	return nil
+}
+
+func LeiosSignerBit(signers []byte, voterId uint64) bool {
+	byteIdx := voterId / 8
+	if byteIdx >= uint64(len(signers)) {
+		return false
+	}
+	bitIdx := 7 - voterId%8
+	return signers[byteIdx]&(1<<bitIdx) != 0
+}

--- a/ledger/common/leios_test.go
+++ b/ledger/common/leios_test.go
@@ -1,0 +1,286 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func leiosTestSignature(fill byte) []byte {
+	ret := make([]byte, LeiosBlsSignatureSize)
+	for i := range ret {
+		ret[i] = fill
+	}
+	return ret
+}
+
+func TestLeiosVoteCborRoundTrip(t *testing.T) {
+	vote := LeiosVote{
+		SlotNo:            12345,
+		EndorserBlockHash: NewBlake2b256([]byte{0x01, 0x02, 0x03}),
+		VoterId:           42,
+		VoteSignature:     leiosTestSignature(0xaa),
+	}
+
+	encoded, err := cbor.Encode(vote)
+	require.NoError(t, err)
+
+	var decoded LeiosVote
+	_, err = cbor.Decode(encoded, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, vote.SlotNo, decoded.SlotNo)
+	assert.Equal(t, vote.EndorserBlockHash, decoded.EndorserBlockHash)
+	assert.Equal(t, vote.VoterId, decoded.VoterId)
+	assert.Equal(t, vote.VoteSignature, decoded.VoteSignature)
+	assert.Equal(t, encoded, decoded.Cbor())
+
+	reencoded, err := cbor.Encode(decoded)
+	require.NoError(t, err)
+	assert.Equal(t, encoded, reencoded)
+}
+
+func TestLeiosVoteCddlVector(t *testing.T) {
+	hash := NewBlake2b256([]byte{0x01, 0x02, 0x03})
+	signature := leiosTestSignature(0xaa)
+	raw, err := cbor.Encode([]any{
+		uint64(12345),
+		hash,
+		uint64(42),
+		signature,
+	})
+	require.NoError(t, err)
+	require.Equal(t, byte(0x84), raw[0])
+
+	var decoded LeiosVote
+	_, err = cbor.Decode(raw, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(12345), decoded.SlotNo)
+	assert.Equal(t, hash, decoded.EndorserBlockHash)
+	assert.Equal(t, uint64(42), decoded.VoterId)
+	assert.Equal(t, signature, decoded.VoteSignature)
+	assert.Equal(t, raw, decoded.Cbor())
+
+	reencoded, err := cbor.Encode(decoded)
+	require.NoError(t, err)
+	assert.Equal(t, raw, reencoded)
+}
+
+func TestLeiosVoteRejectsInvalidSignatureLength(t *testing.T) {
+	vote := LeiosVote{
+		SlotNo:            12345,
+		EndorserBlockHash: NewBlake2b256([]byte{0x01}),
+		VoterId:           42,
+		VoteSignature:     []byte{0xaa},
+	}
+	encoded, err := cbor.Encode([]any{
+		vote.SlotNo,
+		vote.EndorserBlockHash,
+		vote.VoterId,
+		vote.VoteSignature,
+	})
+	require.NoError(t, err)
+
+	var decoded LeiosVote
+	_, err = cbor.Decode(encoded, &decoded)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "VoteSignature")
+}
+
+func TestLeiosEbCertificateCborRoundTrip(t *testing.T) {
+	cert := LeiosEbCertificate{
+		SlotNo:              99,
+		EndorserBlockHash:   NewBlake2b256([]byte{0x11, 0x22, 0x33}),
+		Signers:             []byte{0x80, 0x40},
+		AggregatedSignature: leiosTestSignature(0xbb),
+	}
+
+	encoded, err := cbor.Encode(cert)
+	require.NoError(t, err)
+
+	var decoded LeiosEbCertificate
+	_, err = cbor.Decode(encoded, &decoded)
+	require.NoError(t, err)
+	require.NoError(t, decoded.Validate(10))
+	assert.Equal(t, cert.SlotNo, decoded.SlotNo)
+	assert.Equal(t, cert.EndorserBlockHash, decoded.EndorserBlockHash)
+	assert.Equal(t, cert.Signers, decoded.Signers)
+	assert.Equal(t, cert.AggregatedSignature, decoded.AggregatedSignature)
+	assert.True(t, decoded.Signer(0))
+	assert.True(t, decoded.Signer(9))
+	assert.False(t, decoded.Signer(8))
+
+	reencoded, err := cbor.Encode(&decoded)
+	require.NoError(t, err)
+	assert.Equal(t, encoded, reencoded)
+}
+
+func TestLeiosEbCertificateSetAggregatedSignatureClearsCachedCbor(t *testing.T) {
+	cert := LeiosEbCertificate{
+		SlotNo:              99,
+		EndorserBlockHash:   NewBlake2b256([]byte{0x11, 0x22, 0x33}),
+		Signers:             []byte{0x80},
+		AggregatedSignature: leiosTestSignature(0xbb),
+	}
+	encoded, err := cbor.Encode(cert)
+	require.NoError(t, err)
+
+	var decoded LeiosEbCertificate
+	_, err = cbor.Decode(encoded, &decoded)
+	require.NoError(t, err)
+	require.NotEmpty(t, decoded.Cbor())
+
+	newSig := leiosTestSignature(0xcc)
+	require.NoError(t, decoded.SetAggregatedSignature(newSig))
+	require.Empty(t, decoded.Cbor())
+
+	reencoded, err := cbor.Encode(&decoded)
+	require.NoError(t, err)
+	assert.NotEqual(t, encoded, reencoded)
+
+	var redecoded LeiosEbCertificate
+	_, err = cbor.Decode(reencoded, &redecoded)
+	require.NoError(t, err)
+	assert.Equal(t, newSig, redecoded.AggregatedSignature)
+}
+
+func TestLeiosEbCertificatePayloadVector(t *testing.T) {
+	hash := NewBlake2b256([]byte{0x11, 0x22, 0x33})
+	signers := []byte{0x80}
+	signature := leiosTestSignature(0xbb)
+	raw, err := cbor.Encode([]any{
+		uint64(99),
+		hash,
+		signers,
+		signature,
+	})
+	require.NoError(t, err)
+	require.Equal(t, byte(0x84), raw[0])
+
+	var decoded LeiosEbCertificate
+	_, err = cbor.Decode(raw, &decoded)
+	require.NoError(t, err)
+	require.NoError(t, decoded.Validate(1))
+	assert.Equal(t, uint64(99), decoded.SlotNo)
+	assert.Equal(t, hash, decoded.EndorserBlockHash)
+	assert.Equal(t, signers, decoded.Signers)
+	assert.Equal(t, signature, decoded.AggregatedSignature)
+	assert.True(t, decoded.Signer(0))
+	assert.False(t, decoded.Signer(1))
+	assert.Equal(t, raw, decoded.Cbor())
+
+	reencoded, err := cbor.Encode(decoded)
+	require.NoError(t, err)
+	assert.Equal(t, raw, reencoded)
+}
+
+func TestLeiosEbCertificateEmptySignerBitfield(t *testing.T) {
+	cert := LeiosEbCertificate{
+		SlotNo:              99,
+		EndorserBlockHash:   NewBlake2b256([]byte{0x11}),
+		Signers:             []byte{},
+		AggregatedSignature: leiosTestSignature(0xbb),
+	}
+
+	encoded, err := cbor.Encode(cert)
+	require.NoError(t, err)
+
+	var decoded LeiosEbCertificate
+	_, err = cbor.Decode(encoded, &decoded)
+	require.NoError(t, err)
+	require.NoError(t, decoded.Validate(0))
+}
+
+func TestLeiosEbCertificateMultiByteSignerBitfield(t *testing.T) {
+	cert := LeiosEbCertificate{
+		SlotNo:              99,
+		EndorserBlockHash:   NewBlake2b256([]byte{0x11}),
+		Signers:             []byte{0x80, 0x20, 0x01},
+		AggregatedSignature: leiosTestSignature(0xbb),
+	}
+
+	require.NoError(t, cert.Validate(24))
+	assert.True(t, cert.Signer(0))
+	assert.True(t, cert.Signer(10))
+	assert.True(t, cert.Signer(23))
+	assert.False(t, cert.Signer(24))
+}
+
+func TestLeiosEbCertificateRejectsInvalidSignatureLength(t *testing.T) {
+	encoded, err := cbor.Encode([]any{
+		uint64(99),
+		NewBlake2b256([]byte{0x11}),
+		[]byte{0x80},
+		[]byte{0xbb},
+	})
+	require.NoError(t, err)
+
+	var decoded LeiosEbCertificate
+	_, err = cbor.Decode(encoded, &decoded)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AggregatedSignature")
+}
+
+func TestValidateLeiosSignerBitfield(t *testing.T) {
+	tests := []struct {
+		name          string
+		signers       []byte
+		committeeSize uint64
+		wantErr       string
+	}{
+		{
+			name:          "empty for zero committee",
+			signers:       []byte{},
+			committeeSize: 0,
+		},
+		{
+			name:          "one byte for one committee member",
+			signers:       []byte{0x80},
+			committeeSize: 1,
+		},
+		{
+			name:          "two bytes for nine committee members",
+			signers:       []byte{0x01, 0x80},
+			committeeSize: 9,
+		},
+		{
+			name:          "wrong length",
+			signers:       []byte{},
+			committeeSize: 1,
+			wantErr:       "must be 1 bytes",
+		},
+		{
+			name:          "unused bits set",
+			signers:       []byte{0x81},
+			committeeSize: 1,
+			wantErr:       "unused bits",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateLeiosSignerBitfield(tt.signers, tt.committeeSize)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}

--- a/ledger/dijkstra/dijkstra.go
+++ b/ledger/dijkstra/dijkstra.go
@@ -192,6 +192,16 @@ func (b *DijkstraBlock) CalculatedBlockBodyHash() common.Blake2b256 {
 	return b.BlockBody.Hash()
 }
 
+// DijkstraLeiosCertificate matches the generated Dijkstra CDDL in
+// IntersectMBO/cardano-ledger at c47305fcf47bd77437b837d0dfb9cb4181bfbc77:
+//
+//	block = [..., leios_cert : leios_cert / nil, peras_cert : peras_cert / nil]
+//	leios_cert = []
+//	peras_cert = []
+//
+// The Leios and Peras slots are always present and nullable. When non-null,
+// the current Dijkstra CDDL placeholder is an empty CBOR list, not the CIP-0164
+// stake-committee EB certificate payload.
 type DijkstraLeiosCertificate struct {
 	cbor.DecodeStoreCbor
 }

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -178,6 +178,25 @@ func TestDijkstraBlockBodyHashIncludesLeiosAndPerasCertSlots(t *testing.T) {
 	require.NotEqual(t, withoutCerts.Hash(), withCerts.Hash())
 }
 
+func TestDijkstraLeiosCertificateMatchesCddlPlaceholder(t *testing.T) {
+	raw, err := cbor.Encode([]any{})
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x80}, raw)
+
+	var cert DijkstraLeiosCertificate
+	require.NoError(t, cert.UnmarshalCBOR(raw))
+	require.Equal(t, raw, cert.Cbor())
+
+	encoded, err := cbor.Encode(&cert)
+	require.NoError(t, err)
+	require.Equal(t, raw, encoded)
+
+	nonEmpty, err := cbor.Encode([]any{uint64(99)})
+	require.NoError(t, err)
+	err = cert.UnmarshalCBOR(nonEmpty)
+	require.ErrorContains(t, err, "empty list")
+}
+
 func TestDijkstraBlockRoundTripWithBodyHash(t *testing.T) {
 	blockBody := DijkstraBlockBody{
 		TransactionBodies:      []DijkstraTransactionBody{},

--- a/protocol/leiosfetch/README.md
+++ b/protocol/leiosfetch/README.md
@@ -120,6 +120,11 @@ The LeiosFetch protocol retrieves Leios-specific data including blocks, block tr
 | `NextBlockAndTxsInRange` | BlockRange |
 | `LastBlockAndTxsInRange` | Idle |
 
+`VotesRequest` identifies each requested vote by `(SlotNo, VoterId)`, where
+`VoterId` is the voter's index in the epoch's stake-based committee.
+`Votes` keeps the wire payload as raw CBOR and provides typed helpers for
+validated `common.LeiosVote` values.
+
 ## Timeouts
 
 | Timeout | Default | Description |

--- a/protocol/leiosfetch/messages.go
+++ b/protocol/leiosfetch/messages.go
@@ -20,6 +20,7 @@ import (
 	"slices"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
@@ -145,11 +146,7 @@ type MsgVotesRequest struct {
 	VoteIds []MsgVotesRequestVoteId
 }
 
-type MsgVotesRequestVoteId struct {
-	cbor.StructAsArray
-	Slot         uint64
-	VoteIssuerId []byte
-}
+type MsgVotesRequestVoteId = lcommon.LeiosVoteId
 
 func NewMsgVotesRequest(voteIds []MsgVotesRequestVoteId) *MsgVotesRequest {
 	m := &MsgVotesRequest{
@@ -174,6 +171,33 @@ func NewMsgVotes(votes []cbor.RawMessage) *MsgVotes {
 		VotesRaw: slices.Clone(votes),
 	}
 	return m
+}
+
+func NewMsgVotesFromVotes(votes []lcommon.LeiosVote) (*MsgVotes, error) {
+	votesRaw := make([]cbor.RawMessage, 0, len(votes))
+	for _, vote := range votes {
+		if err := vote.Validate(); err != nil {
+			return nil, err
+		}
+		voteCbor, err := cbor.Encode(vote)
+		if err != nil {
+			return nil, err
+		}
+		votesRaw = append(votesRaw, cbor.RawMessage(voteCbor))
+	}
+	return NewMsgVotes(votesRaw), nil
+}
+
+func (m *MsgVotes) DecodeVotes() ([]lcommon.LeiosVote, error) {
+	ret := make([]lcommon.LeiosVote, 0, len(m.VotesRaw))
+	for idx, voteRaw := range m.VotesRaw {
+		var vote lcommon.LeiosVote
+		if _, err := cbor.Decode(voteRaw, &vote); err != nil {
+			return nil, fmt.Errorf("decode vote %d: %w", idx, err)
+		}
+		ret = append(ret, vote)
+	}
+	return ret, nil
 }
 
 type MsgBlockRangeRequest struct {

--- a/protocol/leiosfetch/messages_test.go
+++ b/protocol/leiosfetch/messages_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
@@ -29,6 +30,14 @@ type testDefinition struct {
 	Name        string
 	Message     protocol.Message
 	MessageType uint
+}
+
+func testLeiosSignature(fill byte) []byte {
+	ret := make([]byte, lcommon.LeiosBlsSignatureSize)
+	for i := range ret {
+		ret[i] = fill
+	}
+	return ret
 }
 
 func getTestDefinitions() []testDefinition {
@@ -78,8 +87,8 @@ func getTestDefinitions() []testDefinition {
 			Name: "MsgVotesRequest",
 			Message: NewMsgVotesRequest(
 				[]MsgVotesRequestVoteId{
-					{Slot: 100, VoteIssuerId: []byte{0x01, 0x02, 0x03, 0x04}},
-					{Slot: 200, VoteIssuerId: []byte{0x05, 0x06, 0x07, 0x08}},
+					{SlotNo: 100, VoterId: 1},
+					{SlotNo: 200, VoterId: 2},
 				},
 			),
 			MessageType: MessageTypeVotesRequest,
@@ -244,8 +253,8 @@ func TestMsgBlockTxs(t *testing.T) {
 
 func TestMsgVotesRequest(t *testing.T) {
 	voteIds := []MsgVotesRequestVoteId{
-		{Slot: 100, VoteIssuerId: []byte{0x01, 0x02, 0x03, 0x04}},
-		{Slot: 200, VoteIssuerId: []byte{0x05, 0x06, 0x07, 0x08}},
+		{SlotNo: 100, VoterId: 1},
+		{SlotNo: 200, VoterId: 2},
 	}
 
 	msg := NewMsgVotesRequest(voteIds)
@@ -263,6 +272,43 @@ func TestMsgVotes(t *testing.T) {
 
 	assert.Equal(t, uint8(MessageTypeVotes), msg.Type())
 	assert.Equal(t, votes, msg.VotesRaw)
+}
+
+func TestMsgVotesTypedHelpers(t *testing.T) {
+	votes := []lcommon.LeiosVote{
+		{
+			SlotNo:            100,
+			EndorserBlockHash: lcommon.NewBlake2b256([]byte{0x01}),
+			VoterId:           7,
+			VoteSignature:     testLeiosSignature(0xaa),
+		},
+	}
+
+	msg, err := NewMsgVotesFromVotes(votes)
+	require.NoError(t, err)
+
+	decodedVotes, err := msg.DecodeVotes()
+	require.NoError(t, err)
+	require.Len(t, decodedVotes, len(votes))
+	assert.Equal(t, votes[0].SlotNo, decodedVotes[0].SlotNo)
+	assert.Equal(t, votes[0].EndorserBlockHash, decodedVotes[0].EndorserBlockHash)
+	assert.Equal(t, votes[0].VoterId, decodedVotes[0].VoterId)
+	assert.Equal(t, votes[0].VoteSignature, decodedVotes[0].VoteSignature)
+	assert.Equal(t, []byte(msg.VotesRaw[0]), decodedVotes[0].Cbor())
+}
+
+func TestMsgVotesDecodeVotesRejectsInvalidVote(t *testing.T) {
+	invalidVoteCbor, err := cbor.Encode([]any{
+		uint64(100),
+		lcommon.NewBlake2b256([]byte{0x01}),
+		uint64(7),
+		[]byte{0xaa},
+	})
+	require.NoError(t, err)
+
+	msg := NewMsgVotes([]cbor.RawMessage{invalidVoteCbor})
+	_, err = msg.DecodeVotes()
+	require.Error(t, err)
 }
 
 func TestMsgBlockRangeRequest(t *testing.T) {

--- a/protocol/leiosfetch/server_test.go
+++ b/protocol/leiosfetch/server_test.go
@@ -233,7 +233,7 @@ func TestHandleVotesRequest_CallbackIsCalled(t *testing.T) {
 
 	called := false
 	expectedVoteIds := []MsgVotesRequestVoteId{
-		{Slot: 100, VoteIssuerId: []byte{0x01, 0x02, 0x03, 0x04}},
+		{SlotNo: 100, VoterId: 1},
 	}
 
 	cfg := NewConfig(

--- a/protocol/leiosnotify/README.md
+++ b/protocol/leiosnotify/README.md
@@ -62,6 +62,9 @@ The LeiosNotify protocol provides notifications about new Leios blocks, transact
 | `BlockTxsOffer` | Idle |
 | `VotesOffer` | Idle |
 
+`VotesOffer` advertises available votes by `(SlotNo, VoterId)`, where
+`VoterId` is the voter's index in the epoch's stake-based committee.
+
 ## Timeouts
 
 | Timeout | Default | Description |

--- a/protocol/leiosnotify/client_test.go
+++ b/protocol/leiosnotify/client_test.go
@@ -321,7 +321,7 @@ func TestClientHandleVotesOffer(t *testing.T) {
 	client := NewClient(protoOptions, nil)
 
 	msg := NewMsgVotesOffer([]MsgVotesOfferVote{
-		{Slot: 100, VoteIssuerId: []byte{0x01, 0x02, 0x03, 0x04}},
+		{SlotNo: 100, VoterId: 1},
 	})
 
 	// Start a goroutine to receive the message

--- a/protocol/leiosnotify/messages.go
+++ b/protocol/leiosnotify/messages.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
@@ -125,11 +126,7 @@ type MsgVotesOffer struct {
 	Votes []MsgVotesOfferVote
 }
 
-type MsgVotesOfferVote struct {
-	cbor.StructAsArray
-	Slot         uint64
-	VoteIssuerId []byte
-}
+type MsgVotesOfferVote = lcommon.LeiosVoteId
 
 func NewMsgVotesOffer(votes []MsgVotesOfferVote) *MsgVotesOffer {
 	m := &MsgVotesOffer{

--- a/protocol/leiosnotify/messages_test.go
+++ b/protocol/leiosnotify/messages_test.go
@@ -70,8 +70,8 @@ func getTestDefinitions() []testDefinition {
 			Name: "MsgVotesOffer",
 			Message: NewMsgVotesOffer(
 				[]MsgVotesOfferVote{
-					{Slot: 100, VoteIssuerId: []byte{0x01, 0x02, 0x03, 0x04}},
-					{Slot: 200, VoteIssuerId: []byte{0x05, 0x06, 0x07, 0x08}},
+					{SlotNo: 100, VoterId: 1},
+					{SlotNo: 200, VoterId: 2},
 				},
 			),
 			MessageType: MessageTypeVotesOffer,
@@ -181,8 +181,8 @@ func TestMsgBlockTxsOffer(t *testing.T) {
 
 func TestMsgVotesOffer(t *testing.T) {
 	votes := []MsgVotesOfferVote{
-		{Slot: 100, VoteIssuerId: []byte{0x01, 0x02, 0x03, 0x04}},
-		{Slot: 200, VoteIssuerId: []byte{0x05, 0x06, 0x07, 0x08}},
+		{SlotNo: 100, VoterId: 1},
+		{SlotNo: 200, VoterId: 2},
 	}
 
 	msg := NewMsgVotesOffer(votes)

--- a/protocol/leiosnotify/server_test.go
+++ b/protocol/leiosnotify/server_test.go
@@ -265,7 +265,7 @@ func TestCallbackResponseTypes(t *testing.T) {
 		{
 			name: "VotesOffer response",
 			response: NewMsgVotesOffer([]MsgVotesOfferVote{
-				{Slot: 100, VoteIssuerId: []byte{0x01, 0x02, 0x03, 0x04}},
+				{SlotNo: 100, VoterId: 1},
 			}),
 		},
 	}

--- a/protocol/leiosvotes/README.md
+++ b/protocol/leiosvotes/README.md
@@ -31,9 +31,9 @@ CIP-0164 design:
 | Field | Type | Purpose |
 |-------|------|---------|
 | `SlotNo` | `uint64` | Voting round / announcing RB slot |
-| `EndorserBlockHash` | `[]byte` | EB hash being endorsed |
-| `VoterId` | `uint16` | Index in the epoch committee |
-| `VoteSignature` | `[]byte` | BLS signature |
+| `EndorserBlockHash` | `common.Blake2b256` | EB hash being endorsed |
+| `VoterId` | `uint64` | Index in the epoch committee |
+| `VoteSignature` | `[]byte` | 48-byte BLS12-381 MinSig signature |
 
 ## State Machine
 

--- a/protocol/leiosvotes/messages.go
+++ b/protocol/leiosvotes/messages.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/protocol"
 )
 
@@ -63,13 +64,7 @@ func NewMsgVotesRequestNext(count uint64) *MsgVotesRequestNext {
 	return m
 }
 
-type Vote struct {
-	cbor.StructAsArray
-	SlotNo            uint64
-	EndorserBlockHash []byte
-	VoterId           uint16
-	VoteSignature     []byte
-}
+type Vote = lcommon.LeiosVote
 
 type MsgVote struct {
 	protocol.MessageBase

--- a/protocol/leiosvotes/messages_test.go
+++ b/protocol/leiosvotes/messages_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,10 +34,18 @@ type testDefinition struct {
 func testVote() Vote {
 	return Vote{
 		SlotNo:            12345,
-		EndorserBlockHash: []byte{0x01, 0x02, 0x03, 0x04},
+		EndorserBlockHash: lcommon.NewBlake2b256([]byte{0x01, 0x02, 0x03, 0x04}),
 		VoterId:           42,
-		VoteSignature:     []byte{0xaa, 0xbb, 0xcc, 0xdd},
+		VoteSignature:     testSignature(0xaa),
 	}
+}
+
+func testSignature(fill byte) []byte {
+	ret := make([]byte, lcommon.LeiosBlsSignatureSize)
+	for i := range ret {
+		ret[i] = fill
+	}
+	return ret
 }
 
 func getTestDefinitions() []testDefinition {
@@ -85,6 +94,26 @@ func TestDecode(t *testing.T) {
 			require.NoError(t, err)
 			test.Message.SetCbor(encoded)
 
+			if test.MessageType == MessageTypeVote {
+				expected := test.Message.(*MsgVote)
+				actual := decoded.(*MsgVote)
+				assert.Equal(t, expected.Type(), actual.Type())
+				assert.Equal(t, expected.Cbor(), actual.Cbor())
+				assert.Equal(t, expected.Vote.SlotNo, actual.Vote.SlotNo)
+				assert.Equal(
+					t,
+					expected.Vote.EndorserBlockHash,
+					actual.Vote.EndorserBlockHash,
+				)
+				assert.Equal(t, expected.Vote.VoterId, actual.Vote.VoterId)
+				assert.Equal(
+					t,
+					expected.Vote.VoteSignature,
+					actual.Vote.VoteSignature,
+				)
+				require.NotEmpty(t, actual.Vote.Cbor())
+				return
+			}
 			assert.True(t, reflect.DeepEqual(decoded, test.Message))
 		})
 	}


### PR DESCRIPTION
Closes #1782 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Leios votes and EB certificate with CIP-0164’s stake-based committee. Uses `(SlotNo, VoterId)`, a signer bitfield, and strict 48-byte BLS signatures; updates `protocol/leiosfetch`, `protocol/leiosnotify`, `protocol/leiosvotes`, and clarifies Dijkstra’s placeholder cert slots.

- **Refactors**
  - `ledger/common`: added `LeiosVoteId`, `LeiosVote`, `LeiosEbCertificate`, `LeiosBlsSignatureSize`, signer bitfield helpers (`LeiosSignerBitfieldSize`, `ValidateLeiosSignerBitfield`, `LeiosSignerBit`), and signature validation; EB payload now `{SlotNo, EndorserBlockHash, Signers, AggregatedSignature}` with CBOR, `Validate(committeeSize)`, `Signer(voterId)`, and `Get/SetAggregatedSignature`.
  - `ledger/common/certs`: removed legacy `CertificateTypeLeiosEb` and wrapper handling.
  - `ledger/dijkstra`: documented and tested that `leios_cert`/`peras_cert` remain empty-list placeholders per current CDDL; EB payload is separate.
  - `protocol/leiosfetch`: vote IDs are `(SlotNo, VoterId)`; added `NewMsgVotesFromVotes` and `MsgVotes.DecodeVotes`.
  - `protocol/leiosnotify`: `VotesOffer` now advertises `(SlotNo, VoterId)`.
  - `protocol/leiosvotes`: `Vote` now aliases `ledger/common.LeiosVote`; docs note `Blake2b256` hash and 48-byte BLS.

- **Migration**
  - Replace `ElectionId` with `SlotNo`; replace `PersistentVoters`/`NonpersistentVoters` with `Signers` bitfield and validate size and unused bits.
  - Rename `AggregatedVoteSig` to `AggregatedSignature`.
  - Update `MsgVotesRequest`/`MsgVotesOffer` to `{SlotNo, VoterId}`.
  - Enforce 48-byte BLS signatures via `LeiosVote.Validate()` or typed encode/decode helpers.
  - Note: Dijkstra block cert slots remain CDDL placeholders; use the standalone EB payload struct for CIP-0164 data.

<sup>Written for commit 456fa0e52850f48564b4eeb18e5f9b5639c58dba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stronger vote/certificate validation including aggregated-signature and signer-bitfield checks
  * Votes identified by slot number and numeric voter ID

* **Bug Fixes**
  * Enforced exact BLS signature size for votes and certificates

* **Refactor**
  * Unified vote and certificate data shapes across protocol modules

* **Tests**
  * Added extensive LEIOS validation and CBOR round‑trip tests

* **Documentation**
  * Updated protocol docs for vote request/response formats

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/gouroboros/pull/1787?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->