### PR TITLE
fix(leios): leios stake / params

### DIFF
--- a/ledger/dijkstra.go
+++ b/ledger/dijkstra.go
@@ -30,6 +30,7 @@ type (
 	DijkstraTransactionBody         = dijkstra.DijkstraTransactionBody
 	DijkstraTransactionOutput       = dijkstra.DijkstraTransactionOutput
 	DijkstraTransactionWitnessSet   = dijkstra.DijkstraTransactionWitnessSet
+	DijkstraGenesis                 = dijkstra.DijkstraGenesis
 	DijkstraProtocolParameters      = dijkstra.DijkstraProtocolParameters
 	DijkstraProtocolParameterUpdate = dijkstra.DijkstraProtocolParameterUpdate
 )
@@ -48,4 +49,6 @@ var (
 	NewDijkstraBlockHeaderFromCbor     = dijkstra.NewDijkstraBlockHeaderFromCbor
 	NewDijkstraTransactionFromCbor     = dijkstra.NewDijkstraTransactionFromCbor
 	NewDijkstraTransactionBodyFromCbor = dijkstra.NewDijkstraTransactionBodyFromCbor
+	NewDijkstraGenesisFromReader       = dijkstra.NewDijkstraGenesisFromReader
+	NewDijkstraGenesisFromFile         = dijkstra.NewDijkstraGenesisFromFile
 )

--- a/ledger/dijkstra/dijkstra.go
+++ b/ledger/dijkstra/dijkstra.go
@@ -785,7 +785,7 @@ type DijkstraTransactionBody struct {
 	TxTotalCollateral       uint64                                        `cbor:"17,keyasint,omitempty"`
 	TxReferenceInputs       cbor.SetType[shelley.ShelleyTransactionInput] `cbor:"18,keyasint,omitempty,omitzero"`
 	TxVotingProcedures      common.VotingProcedures                       `cbor:"19,keyasint,omitempty"`
-	TxProposalProcedures    []conway.ConwayProposalProcedure              `cbor:"20,keyasint,omitempty"`
+	TxProposalProcedures    []DijkstraProposalProcedure                   `cbor:"20,keyasint,omitempty"`
 	TxCurrentTreasuryValue  uint64                                        `cbor:"21,keyasint,omitempty"`
 	TxDonation              uint64                                        `cbor:"22,keyasint,omitempty"`
 	TxSubTransactions       cbor.SetType[DijkstraSubTransaction]          `cbor:"23,keyasint,omitempty,omitzero"`
@@ -966,7 +966,7 @@ func dijkstraReferenceInputs(
 }
 
 func dijkstraProposalProcedures(
-	proposalProcedures []conway.ConwayProposalProcedure,
+	proposalProcedures []DijkstraProposalProcedure,
 ) []common.ProposalProcedure {
 	ret := make([]common.ProposalProcedure, len(proposalProcedures))
 	for i, item := range proposalProcedures {
@@ -990,7 +990,7 @@ type DijkstraSubTransactionBody struct {
 	TxNetworkId               *uint8                                        `cbor:"15,keyasint,omitempty"`
 	TxReferenceInputs         cbor.SetType[shelley.ShelleyTransactionInput] `cbor:"18,keyasint,omitempty,omitzero"`
 	TxVotingProcedures        common.VotingProcedures                       `cbor:"19,keyasint,omitempty"`
-	TxProposalProcedures      []conway.ConwayProposalProcedure              `cbor:"20,keyasint,omitempty"`
+	TxProposalProcedures      []DijkstraProposalProcedure                   `cbor:"20,keyasint,omitempty"`
 	TxCurrentTreasuryValue    uint64                                        `cbor:"21,keyasint,omitempty"`
 	TxDonation                uint64                                        `cbor:"22,keyasint,omitempty"`
 	TxRequiredTopLevelGuards  *DijkstraRawCbor                              `cbor:"24,keyasint,omitempty"`

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -16,6 +16,7 @@ package dijkstra
 
 import (
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -355,6 +356,193 @@ func TestDijkstraProtocolParameterUpdateDecodesConwayAndDijkstraFields(t *testin
 	require.Equal(t, uint32(2000), pparams.MaxRefScriptSizePerTx)
 	require.Equal(t, uint32(16), pparams.RefScriptCostStride)
 	require.Equal(t, 0, pparams.RefScriptCostMultiplier.Cmp(big.NewRat(2, 1)))
+}
+
+func TestDijkstraProtocolParameterUpdateLeiosStakeFieldsExcludedFromCbor(t *testing.T) {
+	updateCbor, err := cbor.Encode(DijkstraProtocolParameterUpdate{
+		CommitteeStakeCoverage: &cbor.Rat{Rat: big.NewRat(99, 100)},
+		QuorumStakeThreshold:   &cbor.Rat{Rat: big.NewRat(3, 4)},
+	})
+	require.NoError(t, err)
+
+	var decoded map[uint]cbor.RawMessage
+	_, err = cbor.Decode(updateCbor, &decoded)
+	require.NoError(t, err)
+	require.Empty(t, decoded)
+}
+
+func TestDijkstraGenesisDecodesCurrentDevnetExample(t *testing.T) {
+	genesis, err := NewDijkstraGenesisFromReader(strings.NewReader(`{
+  "maxRefScriptSizePerBlock": 1048576,
+  "maxRefScriptSizePerTx": 204800,
+  "refScriptCostStride": 25600,
+  "refScriptCostMultiplier": 1.2
+}`))
+	require.NoError(t, err)
+	require.Equal(t, uint32(1048576), genesis.MaxRefScriptSizePerBlock)
+	require.Equal(t, uint32(204800), genesis.MaxRefScriptSizePerTx)
+	require.Equal(t, uint32(25600), genesis.RefScriptCostStride)
+	require.Equal(t, 0, genesis.RefScriptCostMultiplier.Cmp(big.NewRat(6, 5)))
+
+	var pparams DijkstraProtocolParameters
+	require.NoError(t, pparams.UpdateFromGenesis(&genesis))
+	require.Equal(t, uint32(1048576), pparams.MaxRefScriptSizePerBlock)
+	require.Equal(t, uint32(204800), pparams.MaxRefScriptSizePerTx)
+	require.Equal(t, uint32(25600), pparams.RefScriptCostStride)
+	require.Equal(t, 0, pparams.RefScriptCostMultiplier.Cmp(big.NewRat(6, 5)))
+}
+
+func TestDijkstraGenesisLeiosStakeParameters(t *testing.T) {
+	genesis, err := NewDijkstraGenesisFromReader(strings.NewReader(`{
+  "committeeStakeCoverage": 0.99,
+  "quorumStakeThreshold": 0.75
+}`))
+	require.NoError(t, err)
+
+	var pparams DijkstraProtocolParameters
+	require.NoError(t, pparams.UpdateFromGenesis(&genesis))
+	require.Equal(
+		t,
+		0,
+		pparams.CommitteeStakeCoverage.Cmp(big.NewRat(99, 100)),
+	)
+	require.Equal(
+		t,
+		0,
+		pparams.QuorumStakeThreshold.Cmp(big.NewRat(3, 4)),
+	)
+}
+
+func TestDijkstraGenesisRejectsInvalidLeiosStakeParameters(t *testing.T) {
+	genesis, err := NewDijkstraGenesisFromReader(strings.NewReader(`{
+  "committeeStakeCoverage": 0.75,
+  "quorumStakeThreshold": 0.75
+}`))
+	require.NoError(t, err)
+
+	var pparams DijkstraProtocolParameters
+	err = pparams.UpdateFromGenesis(&genesis)
+	require.ErrorAs(t, err, &LeiosCommitteeStakeParametersError{})
+}
+
+func TestDijkstraLeiosStakeParametersValidateSingleField(t *testing.T) {
+	tests := []struct {
+		name                   string
+		committeeStakeCoverage *cbor.Rat
+		quorumStakeThreshold   *cbor.Rat
+		expectErr              bool
+	}{
+		{
+			name:                   "valid coverage without quorum",
+			committeeStakeCoverage: &cbor.Rat{Rat: big.NewRat(1, 2)},
+		},
+		{
+			name:                 "valid quorum without coverage",
+			quorumStakeThreshold: &cbor.Rat{Rat: big.NewRat(1, 2)},
+		},
+		{
+			name:                   "invalid coverage without quorum",
+			committeeStakeCoverage: &cbor.Rat{Rat: big.NewRat(0, 1)},
+			expectErr:              true,
+		},
+		{
+			name:                 "invalid quorum without coverage",
+			quorumStakeThreshold: &cbor.Rat{Rat: big.NewRat(2, 1)},
+			expectErr:            true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateLeiosCommitteeStakeParameters(
+				tt.committeeStakeCoverage,
+				tt.quorumStakeThreshold,
+			)
+			if tt.expectErr {
+				require.ErrorAs(
+					t,
+					err,
+					&LeiosCommitteeStakeParametersError{},
+				)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestDijkstraProtocolParametersApplyUpdateLeiosStakeInvariant(t *testing.T) {
+	pparams := DijkstraProtocolParameters{
+		CommitteeStakeCoverage: &cbor.Rat{Rat: big.NewRat(99, 100)},
+		QuorumStakeThreshold:   &cbor.Rat{Rat: big.NewRat(3, 4)},
+	}
+	validQuorum := &cbor.Rat{Rat: big.NewRat(4, 5)}
+	require.NoError(t, pparams.ApplyUpdate(&DijkstraProtocolParameterUpdate{
+		QuorumStakeThreshold: validQuorum,
+	}))
+	require.Equal(t, 0, pparams.QuorumStakeThreshold.Cmp(big.NewRat(4, 5)))
+
+	invalidCoverage := &cbor.Rat{Rat: big.NewRat(4, 5)}
+	err := pparams.ApplyUpdate(&DijkstraProtocolParameterUpdate{
+		CommitteeStakeCoverage: invalidCoverage,
+	})
+	require.ErrorAs(t, err, &LeiosCommitteeStakeParametersError{})
+	require.Equal(
+		t,
+		0,
+		pparams.CommitteeStakeCoverage.Cmp(big.NewRat(99, 100)),
+	)
+}
+
+func TestDijkstraProtocolParametersUpdatePreservesLeiosStakeInvariant(t *testing.T) {
+	pparams := DijkstraProtocolParameters{
+		MaxRefScriptSizePerBlock: 1000,
+		CommitteeStakeCoverage:   &cbor.Rat{Rat: big.NewRat(99, 100)},
+		QuorumStakeThreshold:     &cbor.Rat{Rat: big.NewRat(3, 4)},
+	}
+	validQuorum := &cbor.Rat{Rat: big.NewRat(4, 5)}
+	pparams.Update(&DijkstraProtocolParameterUpdate{
+		QuorumStakeThreshold: validQuorum,
+	})
+	require.Equal(t, 0, pparams.QuorumStakeThreshold.Cmp(big.NewRat(4, 5)))
+
+	invalidCoverage := &cbor.Rat{Rat: big.NewRat(4, 5)}
+	maxRefScriptSizePerBlock := uint32(2000)
+	pparams.Update(&DijkstraProtocolParameterUpdate{
+		MaxRefScriptSizePerBlock: &maxRefScriptSizePerBlock,
+		CommitteeStakeCoverage:   invalidCoverage,
+	})
+	require.Equal(t, uint32(1000), pparams.MaxRefScriptSizePerBlock)
+	require.Equal(
+		t,
+		0,
+		pparams.CommitteeStakeCoverage.Cmp(big.NewRat(99, 100)),
+	)
+	require.Equal(t, 0, pparams.QuorumStakeThreshold.Cmp(big.NewRat(4, 5)))
+}
+
+func TestDijkstraParameterChangeGovActionDecodesDijkstraUpdateFields(t *testing.T) {
+	maxRefScriptSizePerBlock := uint32(1000)
+	action := &DijkstraParameterChangeGovAction{
+		Type: uint(common.GovActionTypeParameterChange),
+		ParamUpdate: DijkstraProtocolParameterUpdate{
+			MaxRefScriptSizePerBlock: &maxRefScriptSizePerBlock,
+		},
+	}
+	actionCbor, err := cbor.Encode(&DijkstraGovAction{Action: action})
+	require.NoError(t, err)
+
+	var decoded DijkstraGovAction
+	_, err = cbor.Decode(actionCbor, &decoded)
+	require.NoError(t, err)
+	decodedAction, ok := decoded.Action.(*DijkstraParameterChangeGovAction)
+	require.True(t, ok)
+	require.NotNil(t, decodedAction.ParamUpdate.MaxRefScriptSizePerBlock)
+	require.Equal(
+		t,
+		maxRefScriptSizePerBlock,
+		*decodedAction.ParamUpdate.MaxRefScriptSizePerBlock,
+	)
 }
 
 func TestDijkstraTransactionLeiosHashCaches(t *testing.T) {

--- a/ledger/dijkstra/doc.go
+++ b/ledger/dijkstra/doc.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package dijkstra implements the Dijkstra era, including the Leios
+// extensions maintained on top of it by the Leios team.
+//
+// # CDDL Reference
+//
+// The wire formats in this package target the canonical Dijkstra CDDL
+// maintained in IntersectMBO/cardano-ledger. The pinned version we aim to be
+// compatible with is:
+//
+//	https://github.com/IntersectMBO/cardano-ledger/blob/c47305fcf47bd77437b837d0dfb9cb4181bfbc77/eras/dijkstra/impl/cddl/data/dijkstra.cddl
+//
+// When updating types to track upstream changes, bump the commit hash above so
+// it always records the exact CDDL revision this package was validated against.
+package dijkstra

--- a/ledger/dijkstra/errors.go
+++ b/ledger/dijkstra/errors.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dijkstra
+
+import (
+	"math/big"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+)
+
+type LeiosCommitteeStakeParametersError struct {
+	Reason string
+}
+
+func (e LeiosCommitteeStakeParametersError) Error() string {
+	return "invalid Leios committee stake parameters: " + e.Reason
+}
+
+func validateLeiosCommitteeStakeParameters(
+	committeeStakeCoverage *cbor.Rat,
+	quorumStakeThreshold *cbor.Rat,
+) error {
+	one := big.NewRat(1, 1)
+	if committeeStakeCoverage != nil {
+		if committeeStakeCoverage.Rat == nil {
+			return LeiosCommitteeStakeParametersError{
+				Reason: "committee stake coverage is unset",
+			}
+		}
+		if committeeStakeCoverage.Sign() <= 0 ||
+			committeeStakeCoverage.Cmp(one) > 0 {
+			return LeiosCommitteeStakeParametersError{
+				Reason: "committee stake coverage must be in (0, 1]",
+			}
+		}
+	}
+	if quorumStakeThreshold != nil {
+		if quorumStakeThreshold.Rat == nil {
+			return LeiosCommitteeStakeParametersError{
+				Reason: "quorum stake threshold is unset",
+			}
+		}
+		if quorumStakeThreshold.Sign() < 0 ||
+			quorumStakeThreshold.Cmp(one) > 0 {
+			return LeiosCommitteeStakeParametersError{
+				Reason: "quorum stake threshold must be in [0, 1]",
+			}
+		}
+	}
+	if committeeStakeCoverage != nil &&
+		quorumStakeThreshold != nil &&
+		quorumStakeThreshold.Cmp(committeeStakeCoverage.Rat) >= 0 {
+		return LeiosCommitteeStakeParametersError{
+			Reason: "quorum stake threshold must be less than committee stake coverage",
+		}
+	}
+	return nil
+}

--- a/ledger/dijkstra/genesis.go
+++ b/ledger/dijkstra/genesis.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dijkstra
+
+import (
+	"encoding/json"
+	"io"
+	"math/big"
+	"os"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+)
+
+type DijkstraGenesis struct {
+	conway.ConwayGenesis
+	MaxRefScriptSizePerBlock uint32             `json:"maxRefScriptSizePerBlock"`
+	MaxRefScriptSizePerTx    uint32             `json:"maxRefScriptSizePerTx"`
+	RefScriptCostStride      uint32             `json:"refScriptCostStride"`
+	RefScriptCostMultiplier  *common.GenesisRat `json:"refScriptCostMultiplier"`
+	CommitteeStakeCoverage   *common.GenesisRat `json:"committeeStakeCoverage"`
+	QuorumStakeThreshold     *common.GenesisRat `json:"quorumStakeThreshold"`
+}
+
+func NewDijkstraGenesisFromReader(r io.Reader) (DijkstraGenesis, error) {
+	var ret DijkstraGenesis
+	dec := json.NewDecoder(r)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&ret); err != nil {
+		return ret, err
+	}
+	return ret, nil
+}
+
+func NewDijkstraGenesisFromFile(path string) (DijkstraGenesis, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return DijkstraGenesis{}, err
+	}
+	defer f.Close()
+	return NewDijkstraGenesisFromReader(f)
+}
+
+func (p *DijkstraProtocolParameters) UpdateFromGenesis(
+	genesis *DijkstraGenesis,
+) error {
+	if genesis == nil {
+		return nil
+	}
+	committeeStakeCoverage := genesisRatToRat(genesis.CommitteeStakeCoverage)
+	quorumStakeThreshold := genesisRatToRat(genesis.QuorumStakeThreshold)
+	if err := validateLeiosCommitteeStakeParameters(
+		committeeStakeCoverage,
+		quorumStakeThreshold,
+	); err != nil {
+		return err
+	}
+	if err := p.ConwayProtocolParameters.UpdateFromGenesis(
+		&genesis.ConwayGenesis,
+	); err != nil {
+		return err
+	}
+	p.MaxRefScriptSizePerBlock = genesis.MaxRefScriptSizePerBlock
+	p.MaxRefScriptSizePerTx = genesis.MaxRefScriptSizePerTx
+	p.RefScriptCostStride = genesis.RefScriptCostStride
+	p.RefScriptCostMultiplier = genesisRatToRat(genesis.RefScriptCostMultiplier)
+	p.CommitteeStakeCoverage = committeeStakeCoverage
+	p.QuorumStakeThreshold = quorumStakeThreshold
+	return nil
+}
+
+func genesisRatToRat(r *common.GenesisRat) *cbor.Rat {
+	if r == nil || r.Rat == nil {
+		return nil
+	}
+	return &cbor.Rat{Rat: new(big.Rat).Set(r.Rat)}
+}

--- a/ledger/dijkstra/gov.go
+++ b/ledger/dijkstra/gov.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dijkstra
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/plutigo/data"
+)
+
+type DijkstraProposalProcedure struct {
+	common.ProposalProcedureBase
+	cbor.StructAsArray
+	PPDeposit       uint64
+	PPRewardAccount common.Address
+	PPGovAction     DijkstraGovAction
+	PPAnchor        common.GovAnchor
+}
+
+func (p DijkstraProposalProcedure) ToPlutusData() data.PlutusData {
+	return data.NewConstr(0,
+		data.NewInteger(new(big.Int).SetUint64(p.PPDeposit)),
+		p.PPRewardAccount.ToPlutusData(),
+		p.PPGovAction.ToPlutusData(),
+	)
+}
+
+func (p DijkstraProposalProcedure) Deposit() uint64 {
+	return p.PPDeposit
+}
+
+func (p DijkstraProposalProcedure) RewardAccount() common.Address {
+	return p.PPRewardAccount
+}
+
+func (p DijkstraProposalProcedure) GovAction() common.GovAction {
+	return p.PPGovAction.Action
+}
+
+func (p DijkstraProposalProcedure) Anchor() common.GovAnchor {
+	return p.PPAnchor
+}
+
+type DijkstraGovAction struct {
+	Type   uint
+	Action common.GovAction
+}
+
+func (g DijkstraGovAction) ToPlutusData() data.PlutusData {
+	return g.Action.ToPlutusData()
+}
+
+func (g *DijkstraGovAction) UnmarshalCBOR(cborData []byte) error {
+	actionType, err := cbor.DecodeIdFromList(cborData)
+	if err != nil {
+		return err
+	}
+	if actionType < 0 {
+		return fmt.Errorf("invalid governance action type: %d", actionType)
+	}
+	var tmpAction common.GovAction
+	switch common.GovActionType(actionType) {
+	case common.GovActionTypeParameterChange:
+		tmpAction = &DijkstraParameterChangeGovAction{}
+	case common.GovActionTypeHardForkInitiation:
+		tmpAction = &common.HardForkInitiationGovAction{}
+	case common.GovActionTypeTreasuryWithdrawal:
+		tmpAction = &common.TreasuryWithdrawalGovAction{}
+	case common.GovActionTypeNoConfidence:
+		tmpAction = &common.NoConfidenceGovAction{}
+	case common.GovActionTypeUpdateCommittee:
+		tmpAction = &common.UpdateCommitteeGovAction{}
+	case common.GovActionTypeNewConstitution:
+		tmpAction = &common.NewConstitutionGovAction{}
+	case common.GovActionTypeInfo:
+		tmpAction = &common.InfoGovAction{}
+	default:
+		return fmt.Errorf("unknown governance action type: %d", actionType)
+	}
+	if _, err := cbor.Decode(cborData, tmpAction); err != nil {
+		return err
+	}
+	g.Type = uint(actionType) // #nosec G115
+	g.Action = tmpAction
+	return nil
+}
+
+func (g *DijkstraGovAction) MarshalCBOR() ([]byte, error) {
+	return cbor.Encode(g.Action)
+}
+
+type DijkstraParameterChangeGovAction struct {
+	common.GovActionBase
+	cbor.StructAsArray
+	Type        uint
+	ActionId    *common.GovActionId
+	ParamUpdate DijkstraProtocolParameterUpdate
+	PolicyHash  []byte
+}
+
+func (a *DijkstraParameterChangeGovAction) ToPlutusData() data.PlutusData {
+	actionId := data.NewConstr(1)
+	if a.ActionId != nil {
+		actionId = data.NewConstr(0, a.ActionId.ToPlutusData())
+	}
+	policyHash := data.NewConstr(1)
+	if len(a.PolicyHash) > 0 {
+		policyHash = data.NewConstr(
+			0,
+			data.NewByteString(a.PolicyHash),
+		)
+	}
+	return data.NewConstr(0,
+		actionId,
+		a.ParamUpdate.ToPlutusData(),
+		policyHash,
+	)
+}
+
+func (a *DijkstraParameterChangeGovAction) GetPolicyHash() []byte {
+	return a.PolicyHash
+}

--- a/ledger/dijkstra/pparams.go
+++ b/ledger/dijkstra/pparams.go
@@ -20,6 +20,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/plutigo/data"
 	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
 
@@ -30,6 +31,8 @@ type DijkstraProtocolParameters struct {
 	MaxRefScriptSizePerTx    uint32
 	RefScriptCostStride      uint32
 	RefScriptCostMultiplier  *cbor.Rat
+	CommitteeStakeCoverage   *cbor.Rat
+	QuorumStakeThreshold     *cbor.Rat
 }
 
 type dijkstraProtocolParametersCbor struct {
@@ -163,6 +166,12 @@ func (p DijkstraProtocolParameters) toCbor() dijkstraProtocolParametersCbor {
 func (p *DijkstraProtocolParameters) Update(
 	paramUpdate *DijkstraProtocolParameterUpdate,
 ) {
+	_ = p.ApplyUpdate(paramUpdate)
+}
+
+func (p *DijkstraProtocolParameters) updateUnchecked(
+	paramUpdate *DijkstraProtocolParameterUpdate,
+) {
 	if paramUpdate == nil {
 		return
 	}
@@ -179,6 +188,43 @@ func (p *DijkstraProtocolParameters) Update(
 	if paramUpdate.RefScriptCostMultiplier != nil {
 		p.RefScriptCostMultiplier = paramUpdate.RefScriptCostMultiplier
 	}
+	if paramUpdate.CommitteeStakeCoverage != nil {
+		p.CommitteeStakeCoverage = paramUpdate.CommitteeStakeCoverage
+	}
+	if paramUpdate.QuorumStakeThreshold != nil {
+		p.QuorumStakeThreshold = paramUpdate.QuorumStakeThreshold
+	}
+}
+
+func (p *DijkstraProtocolParameters) ApplyUpdate(
+	paramUpdate *DijkstraProtocolParameterUpdate,
+) error {
+	if paramUpdate == nil {
+		return nil
+	}
+	committeeStakeCoverage := p.CommitteeStakeCoverage
+	if paramUpdate.CommitteeStakeCoverage != nil {
+		committeeStakeCoverage = paramUpdate.CommitteeStakeCoverage
+	}
+	quorumStakeThreshold := p.QuorumStakeThreshold
+	if paramUpdate.QuorumStakeThreshold != nil {
+		quorumStakeThreshold = paramUpdate.QuorumStakeThreshold
+	}
+	if err := validateLeiosCommitteeStakeParameters(
+		committeeStakeCoverage,
+		quorumStakeThreshold,
+	); err != nil {
+		return err
+	}
+	p.updateUnchecked(paramUpdate)
+	return nil
+}
+
+func (p *DijkstraProtocolParameters) ValidateLeiosCommitteeParameters() error {
+	return validateLeiosCommitteeStakeParameters(
+		p.CommitteeStakeCoverage,
+		p.QuorumStakeThreshold,
+	)
 }
 
 func (p *DijkstraProtocolParameters) Utxorpc() (*utxorpc.PParams, error) {
@@ -246,6 +292,12 @@ type DijkstraProtocolParameterUpdate struct {
 	MaxRefScriptSizePerTx      *uint32                                   `cbor:"35,keyasint"`
 	RefScriptCostStride        *uint32                                   `cbor:"36,keyasint"`
 	RefScriptCostMultiplier    *cbor.Rat                                 `cbor:"37,keyasint"`
+	// The current Dijkstra CDDL assigns protocol_param_update keys through 37.
+	// These Leios stake parameters have no confirmed on-chain update keys yet,
+	// so they are intentionally excluded from CBOR and can only be applied from
+	// local genesis/configuration data for now.
+	CommitteeStakeCoverage *cbor.Rat `cbor:"-"`
+	QuorumStakeThreshold   *cbor.Rat `cbor:"-"`
 }
 
 func (DijkstraProtocolParameterUpdate) IsProtocolParameterUpdate() {}
@@ -263,6 +315,380 @@ func (u *DijkstraProtocolParameterUpdate) UnmarshalCBOR(cborData []byte) error {
 
 func (u DijkstraProtocolParameterUpdate) Cbor() []byte {
 	return u.DecodeStoreCbor.Cbor()
+}
+
+func (u DijkstraProtocolParameterUpdate) MarshalCBOR() ([]byte, error) {
+	if raw := u.Cbor(); len(raw) > 0 {
+		return raw, nil
+	}
+	fields := map[uint]any{}
+	if u.MinFeeA != nil {
+		fields[0] = *u.MinFeeA
+	}
+	if u.MinFeeB != nil {
+		fields[1] = *u.MinFeeB
+	}
+	if u.MaxBlockBodySize != nil {
+		fields[2] = *u.MaxBlockBodySize
+	}
+	if u.MaxTxSize != nil {
+		fields[3] = *u.MaxTxSize
+	}
+	if u.MaxBlockHeaderSize != nil {
+		fields[4] = *u.MaxBlockHeaderSize
+	}
+	if u.KeyDeposit != nil {
+		fields[5] = *u.KeyDeposit
+	}
+	if u.PoolDeposit != nil {
+		fields[6] = *u.PoolDeposit
+	}
+	if u.MaxEpoch != nil {
+		fields[7] = *u.MaxEpoch
+	}
+	if u.NOpt != nil {
+		fields[8] = *u.NOpt
+	}
+	if u.A0 != nil {
+		fields[9] = u.A0
+	}
+	if u.Rho != nil {
+		fields[10] = u.Rho
+	}
+	if u.Tau != nil {
+		fields[11] = u.Tau
+	}
+	if u.ProtocolVersion != nil {
+		fields[14] = *u.ProtocolVersion
+	}
+	if u.MinPoolCost != nil {
+		fields[16] = *u.MinPoolCost
+	}
+	if u.AdaPerUtxoByte != nil {
+		fields[17] = *u.AdaPerUtxoByte
+	}
+	if u.CostModels != nil {
+		fields[18] = u.CostModels
+	}
+	if u.ExecutionCosts != nil {
+		fields[19] = *u.ExecutionCosts
+	}
+	if u.MaxTxExUnits != nil {
+		fields[20] = *u.MaxTxExUnits
+	}
+	if u.MaxBlockExUnits != nil {
+		fields[21] = *u.MaxBlockExUnits
+	}
+	if u.MaxValueSize != nil {
+		fields[22] = *u.MaxValueSize
+	}
+	if u.CollateralPercentage != nil {
+		fields[23] = *u.CollateralPercentage
+	}
+	if u.MaxCollateralInputs != nil {
+		fields[24] = *u.MaxCollateralInputs
+	}
+	if u.PoolVotingThresholds != nil {
+		fields[25] = *u.PoolVotingThresholds
+	}
+	if u.DRepVotingThresholds != nil {
+		fields[26] = *u.DRepVotingThresholds
+	}
+	if u.MinCommitteeSize != nil {
+		fields[27] = *u.MinCommitteeSize
+	}
+	if u.CommitteeTermLimit != nil {
+		fields[28] = *u.CommitteeTermLimit
+	}
+	if u.GovActionValidityPeriod != nil {
+		fields[29] = *u.GovActionValidityPeriod
+	}
+	if u.GovActionDeposit != nil {
+		fields[30] = *u.GovActionDeposit
+	}
+	if u.DRepDeposit != nil {
+		fields[31] = *u.DRepDeposit
+	}
+	if u.DRepInactivityPeriod != nil {
+		fields[32] = *u.DRepInactivityPeriod
+	}
+	if u.MinFeeRefScriptCostPerByte != nil {
+		fields[33] = u.MinFeeRefScriptCostPerByte
+	}
+	if u.MaxRefScriptSizePerBlock != nil {
+		fields[34] = *u.MaxRefScriptSizePerBlock
+	}
+	if u.MaxRefScriptSizePerTx != nil {
+		fields[35] = *u.MaxRefScriptSizePerTx
+	}
+	if u.RefScriptCostStride != nil {
+		fields[36] = *u.RefScriptCostStride
+	}
+	if u.RefScriptCostMultiplier != nil {
+		fields[37] = u.RefScriptCostMultiplier
+	}
+	return cbor.Encode(fields)
+}
+
+func (u *DijkstraProtocolParameterUpdate) hasUpdate() bool {
+	return u.MinFeeA != nil ||
+		u.MinFeeB != nil ||
+		u.MaxBlockBodySize != nil ||
+		u.MaxTxSize != nil ||
+		u.MaxBlockHeaderSize != nil ||
+		u.KeyDeposit != nil ||
+		u.PoolDeposit != nil ||
+		u.MaxEpoch != nil ||
+		u.NOpt != nil ||
+		u.A0 != nil ||
+		u.Rho != nil ||
+		u.Tau != nil ||
+		u.ProtocolVersion != nil ||
+		u.MinPoolCost != nil ||
+		u.AdaPerUtxoByte != nil ||
+		len(u.CostModels) > 0 ||
+		u.ExecutionCosts != nil ||
+		u.MaxTxExUnits != nil ||
+		u.MaxBlockExUnits != nil ||
+		u.MaxValueSize != nil ||
+		u.CollateralPercentage != nil ||
+		u.MaxCollateralInputs != nil ||
+		u.PoolVotingThresholds != nil ||
+		u.DRepVotingThresholds != nil ||
+		u.MinCommitteeSize != nil ||
+		u.CommitteeTermLimit != nil ||
+		u.GovActionValidityPeriod != nil ||
+		u.GovActionDeposit != nil ||
+		u.DRepDeposit != nil ||
+		u.DRepInactivityPeriod != nil ||
+		u.MinFeeRefScriptCostPerByte != nil ||
+		u.MaxRefScriptSizePerBlock != nil ||
+		u.MaxRefScriptSizePerTx != nil ||
+		u.RefScriptCostStride != nil ||
+		u.RefScriptCostMultiplier != nil ||
+		u.CommitteeStakeCoverage != nil ||
+		u.QuorumStakeThreshold != nil
+}
+
+func (u *DijkstraProtocolParameterUpdate) BootstrapRestrictedFields() []string {
+	fields := u.conwayUpdate().BootstrapRestrictedFields()
+	if u.MaxRefScriptSizePerBlock != nil {
+		fields = append(fields, "MaxRefScriptSizePerBlock")
+	}
+	if u.MaxRefScriptSizePerTx != nil {
+		fields = append(fields, "MaxRefScriptSizePerTx")
+	}
+	if u.RefScriptCostStride != nil {
+		fields = append(fields, "RefScriptCostStride")
+	}
+	if u.RefScriptCostMultiplier != nil {
+		fields = append(fields, "RefScriptCostMultiplier")
+	}
+	if u.CommitteeStakeCoverage != nil {
+		fields = append(fields, "CommitteeStakeCoverage")
+	}
+	if u.QuorumStakeThreshold != nil {
+		fields = append(fields, "QuorumStakeThreshold")
+	}
+	return fields
+}
+
+func (u DijkstraProtocolParameterUpdate) ToPlutusData() data.PlutusData {
+	tmpPairs := make([][2]data.PlutusData, 0, 37)
+	push := func(idx int, pd data.PlutusData) {
+		tmpPairs = append(
+			tmpPairs,
+			[2]data.PlutusData{
+				data.NewInteger(new(big.Int).SetInt64(int64(idx))),
+				pd,
+			},
+		)
+	}
+	pushRat := func(idx int, r *cbor.Rat) {
+		push(idx,
+			data.NewList(
+				data.NewInteger(r.Num()),
+				data.NewInteger(r.Denom()),
+			),
+		)
+	}
+	if u.MinFeeA != nil {
+		push(0, data.NewInteger(new(big.Int).SetUint64(uint64(*u.MinFeeA))))
+	}
+	if u.MinFeeB != nil {
+		push(1, data.NewInteger(new(big.Int).SetUint64(uint64(*u.MinFeeB))))
+	}
+	if u.MaxBlockBodySize != nil {
+		push(
+			2,
+			data.NewInteger(
+				new(big.Int).SetUint64(uint64(*u.MaxBlockBodySize)),
+			),
+		)
+	}
+	if u.MaxTxSize != nil {
+		push(3, data.NewInteger(new(big.Int).SetUint64(uint64(*u.MaxTxSize))))
+	}
+	if u.MaxBlockHeaderSize != nil {
+		push(
+			4,
+			data.NewInteger(
+				new(big.Int).SetUint64(uint64(*u.MaxBlockHeaderSize)),
+			),
+		)
+	}
+	if u.KeyDeposit != nil {
+		push(5, data.NewInteger(new(big.Int).SetUint64(uint64(*u.KeyDeposit))))
+	}
+	if u.PoolDeposit != nil {
+		push(6, data.NewInteger(new(big.Int).SetUint64(uint64(*u.PoolDeposit))))
+	}
+	if u.MaxEpoch != nil {
+		push(7, data.NewInteger(new(big.Int).SetUint64(uint64(*u.MaxEpoch))))
+	}
+	if u.NOpt != nil {
+		push(8, data.NewInteger(new(big.Int).SetUint64(uint64(*u.NOpt))))
+	}
+	if u.A0 != nil {
+		pushRat(9, u.A0)
+	}
+	if u.Rho != nil {
+		pushRat(10, u.Rho)
+	}
+	if u.Tau != nil {
+		pushRat(11, u.Tau)
+	}
+	if u.MinPoolCost != nil {
+		push(
+			16,
+			data.NewInteger(new(big.Int).SetUint64(uint64(*u.MinPoolCost))),
+		)
+	}
+	if u.AdaPerUtxoByte != nil {
+		push(
+			17,
+			data.NewInteger(new(big.Int).SetUint64(uint64(*u.AdaPerUtxoByte))),
+		)
+	}
+	// TODO(enhancement): Add CostModels serialization for Plutus data conversion.
+	if u.ExecutionCosts != nil {
+		push(19,
+			data.NewList(
+				data.NewList(
+					data.NewInteger(u.ExecutionCosts.MemPrice.Num()),
+					data.NewInteger(u.ExecutionCosts.MemPrice.Denom()),
+				),
+				data.NewList(
+					data.NewInteger(u.ExecutionCosts.StepPrice.Num()),
+					data.NewInteger(u.ExecutionCosts.StepPrice.Denom()),
+				),
+			),
+		)
+	}
+	if u.MaxTxExUnits != nil {
+		push(20,
+			data.NewList(
+				data.NewInteger(big.NewInt(u.MaxTxExUnits.Memory)),
+				data.NewInteger(big.NewInt(u.MaxTxExUnits.Steps)),
+			),
+		)
+	}
+	if u.MaxBlockExUnits != nil {
+		push(21,
+			data.NewList(
+				data.NewInteger(big.NewInt(u.MaxBlockExUnits.Memory)),
+				data.NewInteger(big.NewInt(u.MaxBlockExUnits.Steps)),
+			),
+		)
+	}
+	if u.MaxValueSize != nil {
+		push(
+			22,
+			data.NewInteger(new(big.Int).SetUint64(uint64(*u.MaxValueSize))),
+		)
+	}
+	if u.CollateralPercentage != nil {
+		push(
+			23,
+			data.NewInteger(
+				new(big.Int).SetUint64(uint64(*u.CollateralPercentage)),
+			),
+		)
+	}
+	if u.MaxCollateralInputs != nil {
+		push(
+			24,
+			data.NewInteger(
+				new(big.Int).SetUint64(uint64(*u.MaxCollateralInputs)),
+			),
+		)
+	}
+	if u.PoolVotingThresholds != nil {
+		push(25, u.PoolVotingThresholds.ToPlutusData())
+	}
+	if u.DRepVotingThresholds != nil {
+		push(26, u.DRepVotingThresholds.ToPlutusData())
+	}
+	if u.MinCommitteeSize != nil {
+		push(
+			27,
+			data.NewInteger(
+				new(big.Int).SetUint64(uint64(*u.MinCommitteeSize)),
+			),
+		)
+	}
+	if u.CommitteeTermLimit != nil {
+		push(28, data.NewInteger(new(big.Int).SetUint64(*u.CommitteeTermLimit)))
+	}
+	if u.GovActionValidityPeriod != nil {
+		push(
+			29,
+			data.NewInteger(new(big.Int).SetUint64(*u.GovActionValidityPeriod)),
+		)
+	}
+	if u.GovActionDeposit != nil {
+		push(30, data.NewInteger(new(big.Int).SetUint64(*u.GovActionDeposit)))
+	}
+	if u.DRepDeposit != nil {
+		push(31, data.NewInteger(new(big.Int).SetUint64(*u.DRepDeposit)))
+	}
+	if u.DRepInactivityPeriod != nil {
+		push(
+			32,
+			data.NewInteger(new(big.Int).SetUint64(*u.DRepInactivityPeriod)),
+		)
+	}
+	if u.MinFeeRefScriptCostPerByte != nil {
+		pushRat(33, u.MinFeeRefScriptCostPerByte)
+	}
+	if u.MaxRefScriptSizePerBlock != nil {
+		push(
+			34,
+			data.NewInteger(new(big.Int).SetUint64(
+				uint64(*u.MaxRefScriptSizePerBlock),
+			)),
+		)
+	}
+	if u.MaxRefScriptSizePerTx != nil {
+		push(
+			35,
+			data.NewInteger(new(big.Int).SetUint64(
+				uint64(*u.MaxRefScriptSizePerTx),
+			)),
+		)
+	}
+	if u.RefScriptCostStride != nil {
+		push(
+			36,
+			data.NewInteger(new(big.Int).SetUint64(
+				uint64(*u.RefScriptCostStride),
+			)),
+		)
+	}
+	if u.RefScriptCostMultiplier != nil {
+		pushRat(37, u.RefScriptCostMultiplier)
+	}
+	return data.NewMap(tmpPairs)
 }
 
 func (u *DijkstraProtocolParameterUpdate) conwayUpdate() *conway.ConwayProtocolParameterUpdate {

--- a/ledger/dijkstra/rules.go
+++ b/ledger/dijkstra/rules.go
@@ -38,7 +38,7 @@ const minUtxoOverheadBytes = 160
 
 var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	conway.UtxoValidateMetadata,
-	conway.UtxoValidateProposalProcedures,
+	UtxoValidateProposalProcedures,
 	conway.UtxoValidateProposalNetworkIds,
 	conway.UtxoValidateEmptyTreasuryWithdrawals,
 	UtxoValidateBootstrapAllowedGovActions,
@@ -97,22 +97,82 @@ func conwayPparams(
 	}
 }
 
+func isInDijkstraBootstrapPhase(pp common.ProtocolParameters) (bool, error) {
+	conwayPp, err := conwayPparams(pp)
+	if err != nil {
+		return false, err
+	}
+	major := conwayPp.ProtocolVersion.Major
+	return major >= common.ProtocolVersionConway &&
+		major < common.ProtocolVersionPlomin, nil
+}
+
+func UtxoValidateProposalProcedures(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	for _, proposal := range tx.ProposalProcedures() {
+		govAction := proposal.GovAction()
+		if govAction == nil {
+			continue
+		}
+		paramChangeAction, ok := govAction.(*DijkstraParameterChangeGovAction)
+		if !ok {
+			continue
+		}
+		if err := validateDijkstraProtocolParameterUpdate(
+			&paramChangeAction.ParamUpdate,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func UtxoValidateBootstrapAllowedGovActions(
 	tx common.Transaction,
 	slot uint64,
 	ls common.LedgerState,
 	pp common.ProtocolParameters,
 ) error {
-	tmpPparams, err := conwayPparams(pp)
+	inBootstrap, err := isInDijkstraBootstrapPhase(pp)
 	if err != nil {
 		return err
 	}
-	return conway.UtxoValidateBootstrapAllowedGovActions(
-		tx,
-		slot,
-		ls,
-		tmpPparams,
-	)
+	if !inBootstrap {
+		return nil
+	}
+	for _, proposal := range tx.ProposalProcedures() {
+		govAction := proposal.GovAction()
+		if govAction == nil {
+			continue
+		}
+		switch govAction.(type) {
+		case *common.InfoGovAction:
+		case *common.HardForkInitiationGovAction:
+		case *DijkstraParameterChangeGovAction:
+		case *common.TreasuryWithdrawalGovAction:
+			return conway.BootstrapDisallowedGovActionError{
+				ActionType: common.GovActionTypeTreasuryWithdrawal,
+			}
+		case *common.NoConfidenceGovAction:
+			return conway.BootstrapDisallowedGovActionError{
+				ActionType: common.GovActionTypeNoConfidence,
+			}
+		case *common.UpdateCommitteeGovAction:
+			return conway.BootstrapDisallowedGovActionError{
+				ActionType: common.GovActionTypeUpdateCommittee,
+			}
+		case *common.NewConstitutionGovAction:
+			return conway.BootstrapDisallowedGovActionError{
+				ActionType: common.GovActionTypeNewConstitution,
+			}
+		default:
+		}
+	}
+	return nil
 }
 
 func UtxoValidateBootstrapParameterGroups(
@@ -121,15 +181,70 @@ func UtxoValidateBootstrapParameterGroups(
 	ls common.LedgerState,
 	pp common.ProtocolParameters,
 ) error {
-	tmpPparams, err := conwayPparams(pp)
+	inBootstrap, err := isInDijkstraBootstrapPhase(pp)
 	if err != nil {
 		return err
 	}
-	return conway.UtxoValidateBootstrapParameterGroups(
-		tx,
-		slot,
-		ls,
-		tmpPparams,
+	if !inBootstrap {
+		return nil
+	}
+	for _, proposal := range tx.ProposalProcedures() {
+		govAction := proposal.GovAction()
+		if govAction == nil {
+			continue
+		}
+		switch paramChange := govAction.(type) {
+		case *DijkstraParameterChangeGovAction:
+			fields := paramChange.ParamUpdate.BootstrapRestrictedFields()
+			if len(fields) > 0 {
+				return conway.BootstrapDisallowedParameterChangeError{
+					Fields: fields,
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func validateDijkstraProtocolParameterUpdate(
+	ppu *DijkstraProtocolParameterUpdate,
+) error {
+	if ppu == nil || !ppu.hasUpdate() {
+		return conway.ProtocolParameterUpdateEmptyError{}
+	}
+	if ppu.MaxBlockHeaderSize != nil && *ppu.MaxBlockHeaderSize == 0 {
+		return conway.ProtocolParameterUpdateFieldZeroError{
+			FieldName: "maxBHSize",
+			Value:     *ppu.MaxBlockHeaderSize,
+		}
+	}
+	if ppu.MaxTxSize != nil && *ppu.MaxTxSize == 0 {
+		return conway.ProtocolParameterUpdateFieldZeroError{
+			FieldName: "maxTxSize",
+			Value:     *ppu.MaxTxSize,
+		}
+	}
+	if ppu.MaxValueSize != nil && *ppu.MaxValueSize == 0 {
+		return conway.ProtocolParameterUpdateFieldZeroError{
+			FieldName: "maxValSize",
+			Value:     *ppu.MaxValueSize,
+		}
+	}
+	if ppu.MaxBlockBodySize != nil && *ppu.MaxBlockBodySize == 0 {
+		return conway.ProtocolParameterUpdateFieldZeroError{
+			FieldName: "maxBlockBodySize",
+			Value:     *ppu.MaxBlockBodySize,
+		}
+	}
+	if ppu.RefScriptCostStride != nil && *ppu.RefScriptCostStride == 0 {
+		return conway.ProtocolParameterUpdateFieldZeroError{
+			FieldName: "refScriptCostStride",
+			Value:     uint(*ppu.RefScriptCostStride),
+		}
+	}
+	return validateLeiosCommitteeStakeParameters(
+		ppu.CommitteeStakeCoverage,
+		ppu.QuorumStakeThreshold,
 	)
 }
 

--- a/ledger/dijkstra/rules_test.go
+++ b/ledger/dijkstra/rules_test.go
@@ -247,6 +247,77 @@ func TestUtxoValidateCostModelsPresentSubTransactionPlutus(t *testing.T) {
 	}
 }
 
+func TestUtxoValidateProposalProceduresDijkstraProtocolParameterUpdate(t *testing.T) {
+	tx := &DijkstraTransaction{
+		Body: DijkstraTransactionBody{
+			TxProposalProcedures: []DijkstraProposalProcedure{
+				{
+					PPGovAction: DijkstraGovAction{
+						Action: &DijkstraParameterChangeGovAction{
+							ParamUpdate: DijkstraProtocolParameterUpdate{},
+						},
+					},
+				},
+			},
+		},
+	}
+	err := UtxoValidateProposalProcedures(tx, 0, nil, nil)
+	require.ErrorAs(t, err, &conway.ProtocolParameterUpdateEmptyError{})
+
+	maxRefScriptSizePerBlock := uint32(1000)
+	tx.Body.TxProposalProcedures[0].PPGovAction.Action =
+		&DijkstraParameterChangeGovAction{
+			ParamUpdate: DijkstraProtocolParameterUpdate{
+				MaxRefScriptSizePerBlock: &maxRefScriptSizePerBlock,
+			},
+		}
+	require.NoError(t, UtxoValidateProposalProcedures(tx, 0, nil, nil))
+}
+
+func TestUtxoValidateBootstrapParameterGroupsDijkstraFields(t *testing.T) {
+	refScriptCostStride := uint32(25600)
+	tx := &DijkstraTransaction{
+		Body: DijkstraTransactionBody{
+			TxProposalProcedures: []DijkstraProposalProcedure{
+				{
+					PPGovAction: DijkstraGovAction{
+						Action: &DijkstraParameterChangeGovAction{
+							ParamUpdate: DijkstraProtocolParameterUpdate{
+								RefScriptCostStride: &refScriptCostStride,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	pv9Params := &DijkstraProtocolParameters{
+		ConwayProtocolParameters: conway.ConwayProtocolParameters{
+			ProtocolVersion: common.ProtocolParametersProtocolVersion{
+				Major: common.ProtocolVersionConway,
+			},
+		},
+	}
+	err := UtxoValidateBootstrapParameterGroups(tx, 0, nil, pv9Params)
+	var bootstrapErr conway.BootstrapDisallowedParameterChangeError
+	require.ErrorAs(t, err, &bootstrapErr)
+	require.Equal(t, []string{"RefScriptCostStride"}, bootstrapErr.Fields)
+
+	pv10Params := &DijkstraProtocolParameters{
+		ConwayProtocolParameters: conway.ConwayProtocolParameters{
+			ProtocolVersion: common.ProtocolParametersProtocolVersion{
+				Major: common.ProtocolVersionPlomin,
+			},
+		},
+	}
+	require.NoError(t, UtxoValidateBootstrapParameterGroups(
+		tx,
+		0,
+		nil,
+		pv10Params,
+	))
+}
+
 func TestUtxoValidateRedeemerAndScriptWitnessesPlutusV4(t *testing.T) {
 	tx := &DijkstraTransaction{
 		WitnessSet: DijkstraTransactionWitnessSet{

--- a/ledger/leios.go
+++ b/ledger/leios.go
@@ -28,6 +28,7 @@ type (
 	LeiosTransaction             = leios.LeiosTransaction
 	LeiosTransactionBody         = leios.LeiosTransactionBody
 	LeiosTransactionWitnessSet   = leios.LeiosTransactionWitnessSet
+	LeiosGenesis                 = leios.LeiosGenesis
 	LeiosProtocolParameters      = leios.LeiosProtocolParameters
 	LeiosProtocolParameterUpdate = leios.LeiosProtocolParameterUpdate
 )
@@ -48,4 +49,6 @@ var (
 	NewLeiosBlockHeaderFromCbor     = leios.NewLeiosBlockHeaderFromCbor
 	NewLeiosTransactionFromCbor     = leios.NewLeiosTransactionFromCbor
 	NewLeiosTransactionBodyFromCbor = leios.NewLeiosTransactionBodyFromCbor
+	NewLeiosGenesisFromReader       = leios.NewLeiosGenesisFromReader
+	NewLeiosGenesisFromFile         = leios.NewLeiosGenesisFromFile
 )

--- a/ledger/leios/leios.go
+++ b/ledger/leios/leios.go
@@ -27,6 +27,7 @@ type (
 	LeiosTransaction             = dijkstra.DijkstraTransaction
 	LeiosTransactionBody         = dijkstra.DijkstraTransactionBody
 	LeiosTransactionWitnessSet   = dijkstra.DijkstraTransactionWitnessSet
+	LeiosGenesis                 = dijkstra.DijkstraGenesis
 	LeiosProtocolParameters      = dijkstra.DijkstraProtocolParameters
 	LeiosProtocolParameterUpdate = dijkstra.DijkstraProtocolParameterUpdate
 )
@@ -51,4 +52,6 @@ var (
 	NewLeiosBlockHeaderFromCbor     = dijkstra.NewDijkstraBlockHeaderFromCbor
 	NewLeiosTransactionFromCbor     = dijkstra.NewDijkstraTransactionFromCbor
 	NewLeiosTransactionBodyFromCbor = dijkstra.NewDijkstraTransactionBodyFromCbor
+	NewLeiosGenesisFromReader       = dijkstra.NewDijkstraGenesisFromReader
+	NewLeiosGenesisFromFile         = dijkstra.NewDijkstraGenesisFromFile
 )


### PR DESCRIPTION
Closes #1783 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Leios stake parameters and genesis loaders for `dijkstra`/`leios`, plus Dijkstra-specific governance and stricter UTxO validation. Leios stake params remain genesis-only (not serialized in CBOR) and are validated in genesis, updates, and bootstrap; aligns with Linear issue 1783.

- New Features
  - Add `DijkstraGenesis` with `NewDijkstraGenesisFromReader/File` and `leios` aliases; loads ref-script sizing and Leios stake params into `DijkstraProtocolParameters`.
  - Add Dijkstra governance types (`DijkstraProposalProcedure`, `DijkstraGovAction`, `DijkstraParameterChangeGovAction`) with CBOR/PlutusData; tx bodies now use them.
  - Implement explicit CBOR/PlutusData for `DijkstraProtocolParameterUpdate`; exclude Leios stake params from CBOR; add `ApplyUpdate`, stake invariant checks (`LeiosCommitteeStakeParametersError`), and zero-value guards.
  - Tighten UTxO rules: validate Dijkstra param-change proposals; in bootstrap only allow safe actions; block restricted parameter groups (new ref-script fields and Leios stake params) until Plomin.

<sup>Written for commit de123426ea35a81fb5076f64ec992beed028d26a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Dijkstra era genesis configuration with Leios stake parameters
  * Introduced Dijkstra-specific governance action types and proposal procedures
  * Added committee stake coverage and quorum stake threshold parameters for Leios
  * Implemented Dijkstra era bootstrap governance validation

* **Tests**
  * Added comprehensive test coverage for Dijkstra genesis decoding and Leios stake parameter validation
  * Added validation tests for bootstrap-phase governance restrictions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/gouroboros/pull/1788?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->