### PR TITLE
fix: update rewards calculation to handle case when total pool rewards are less than the fixed fee

### DIFF
--- a/ledger/common/rewards.go
+++ b/ledger/common/rewards.go
@@ -437,28 +437,36 @@ func distributePoolRewards(
 		totalPoolStake += stake
 	}
 
+	// Check if poolCost already uses up all the available rewards
+	if totalPoolRewards <= poolCost {
+		return &PoolRewards{
+			OperatorRewards:  totalPoolRewards,
+			DelegatorRewards: make(map[AddrKeyHash]uint64),
+			TotalRewards:     totalPoolRewards,
+		}
+	}
+
 	// Calculate operator (leader) reward
 	operatorRewards := poolCost
-	if totalPoolRewards > poolCost {
-		// Find owner stake (owners are also delegators in the snapshot)
-		ownerStake := uint64(0)
-		for _, owner := range poolParams.PoolOwners {
-			if stake, exists := delegatorStake[owner]; exists {
-				ownerStake += stake
-			}
+	
+	// Find owner stake (owners are also delegators in the snapshot)
+	ownerStake := uint64(0)
+	for _, owner := range poolParams.PoolOwners {
+		if stake, exists := delegatorStake[owner]; exists {
+			ownerStake += stake
 		}
+	}
 
-		if totalPoolStake > 0 {
-			ownerStakeRatio := float64(ownerStake) / float64(totalPoolStake)
-			operatorRewards += uint64(
-				float64(
-					totalPoolRewards-poolCost,
-				) * (margin + (1.0-margin)*ownerStakeRatio),
-			)
-		} else {
-			// If no stake, operator gets all rewards above cost
-			operatorRewards = totalPoolRewards
-		}
+	if totalPoolStake > 0 {
+		ownerStakeRatio := float64(ownerStake) / float64(totalPoolStake)
+		operatorRewards += uint64(
+			float64(
+				totalPoolRewards-poolCost,
+			) * (margin + (1.0-margin)*ownerStakeRatio),
+		)
+	} else {
+		// If no stake, operator gets all rewards above cost
+		operatorRewards = totalPoolRewards
 	}
 
 	// Remaining rewards go to all stakeholders (owners and delegators)


### PR DESCRIPTION
The current code only accounts for the case where `totalPoolRewards` equals `poolCost`. If `totalPoolRewards` is less than `poolCost`, the calculation of `stakeholderRewardsTotal` would cause an underflow, giving massive rewards to delegators.

I changed it that it immediately checks for this and returns with all rewards given to the operator, skipping the other unnecessary calculations. `DelegatorRewards` will be an empty map because of this, but this was already the case when `totalPoolRewards` equals `poolCost`, so I figured this behavior is fine.

As the check also contains the equals case, the check if `totalPoolRewards` is greater than `poolCost` later on can be skipped.

I wonder why this hasn't caused any issues yet, but maybe the situation doesn't occur yet on the testnet where Dingo is used? Setting a really high fixed fee for a pool should immediately cause an issue though...

On mannet this situation is already very common these days.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix rewards calculation when total pool rewards are less than or equal to the fixed fee. All rewards now go to the operator in this case, preventing underflow and bogus delegator payouts.

- **Bug Fixes**
  - Early return when `totalPoolRewards <= poolCost` with operator-only payout and empty `DelegatorRewards`.
  - Removed redundant `> poolCost` check; retained owner stake/margin math for remaining-rewards path.
  - Prevents underflow in stakeholder totals that could inflate delegator rewards.

<sup>Written for commit 888f561b756ea5b9ab94839b299869a13e0ce163. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reward distribution calculations to correctly handle scenarios where pool rewards are at or below operational costs, and refined stake-based allocation logic between operators and delegators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->