### PR TITLE
chore(ledger): clean up rewards formatting

### DIFF
--- a/ledger/common/rewards.go
+++ b/ledger/common/rewards.go
@@ -448,7 +448,7 @@ func distributePoolRewards(
 
 	// Calculate operator (leader) reward
 	operatorRewards := poolCost
-	
+
 	// Find owner stake (owners are also delegators in the snapshot)
 	ownerStake := uint64(0)
 	for _, owner := range poolParams.PoolOwners {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Cleaned up whitespace in the rewards distribution code (`ledger/common/rewards.go`) near the operator reward calculation to match formatting conventions. No functional changes.

<sup>Written for commit e99bdb8d9d577f770ba4043aed64d7276cf95036. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code formatting adjustment with no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->