### PR TITLE
fix(protocol) : fix for blockfetch panics on invalid configurations

### DIFF
--- a/examples/chain-sync/main.go
+++ b/examples/chain-sync/main.go
@@ -107,7 +107,7 @@ func buildChainSyncConfig() chainsync.Config {
 	)
 }
 
-func buildBlockFetchConfig() blockfetch.Config {
+func buildBlockFetchConfig() (blockfetch.Config, error) {
 	return blockfetch.NewConfig(
 		blockfetch.WithBlockFunc(blockFetchBlockHandler),
 	)
@@ -267,13 +267,18 @@ func main() {
 	}()
 
 	// Configure Ouroboros
+	blockFetchCfg, err := buildBlockFetchConfig()
+	if err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		os.Exit(1)
+	}
 	o, err := ouroboros.NewConnection(
 		ouroboros.WithNetworkMagic(cfg.Magic),
 		ouroboros.WithErrorChan(errorChan),
 		ouroboros.WithNodeToNode(isNtN),
 		ouroboros.WithKeepAlive(true),
 		ouroboros.WithChainSyncConfig(buildChainSyncConfig()),
-		ouroboros.WithBlockFetchConfig(buildBlockFetchConfig()),
+		ouroboros.WithBlockFetchConfig(blockFetchCfg),
 	)
 	if err != nil {
 		fmt.Printf("ERROR: %s\n", err)

--- a/protocol/blockfetch/blockfetch.go
+++ b/protocol/blockfetch/blockfetch.go
@@ -175,8 +175,8 @@ func New(protoOptions protocol.ProtocolOptions, cfg *Config) *BlockFetch {
 type BlockFetchOptionFunc func(*Config)
 
 // NewConfig creates a new Config for Block Fetch, applying any provided option functions.
-// It panics if the resulting configuration is invalid.
-func NewConfig(options ...BlockFetchOptionFunc) Config {
+// It returns an error if the resulting configuration is invalid.
+func NewConfig(options ...BlockFetchOptionFunc) (Config, error) {
 	c := Config{
 		BatchStartTimeout: 5 * time.Second,
 		BlockTimeout:      60 * time.Second,
@@ -189,10 +189,10 @@ func NewConfig(options ...BlockFetchOptionFunc) Config {
 
 	// Validate configuration against protocol limits
 	if err := c.validate(); err != nil {
-		panic("invalid BlockFetch configuration: " + err.Error())
+		return Config{}, fmt.Errorf("invalid BlockFetch configuration: %w", err)
 	}
 
-	return c
+	return c, nil
 }
 
 // validate checks that the configuration values are within protocol limits.
@@ -258,26 +258,9 @@ func WithBlockTimeout(timeout time.Duration) BlockFetchOptionFunc {
 }
 
 // WithRecvQueueSize specifies the size of the received messages queue in the Config.
-// Panics if the size is negative or exceeds MaxRecvQueueSize.
+// Validation is deferred to NewConfig; invalid values are caught there.
 func WithRecvQueueSize(size int) BlockFetchOptionFunc {
 	return func(c *Config) {
-		if size < 0 {
-			panic(
-				fmt.Sprintf(
-					"RecvQueueSize %d must be non-negative",
-					size,
-				),
-			)
-		}
-		if size > MaxRecvQueueSize {
-			panic(
-				fmt.Sprintf(
-					"RecvQueueSize %d exceeds maximum %d",
-					size,
-					MaxRecvQueueSize,
-				),
-			)
-		}
 		c.RecvQueueSize = size
 	}
 }

--- a/protocol/blockfetch/client.go
+++ b/protocol/blockfetch/client.go
@@ -62,7 +62,7 @@ type Client struct {
 // NewClient creates a new Block Fetch protocol client with the given options and configuration.
 func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 	if cfg == nil {
-		tmpCfg := NewConfig()
+		tmpCfg, _ := NewConfig()
 		cfg = &tmpCfg
 	}
 	c := &Client{

--- a/protocol/blockfetch/config_test.go
+++ b/protocol/blockfetch/config_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blockfetch_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/protocol/blockfetch"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewConfigReturnsErrorForNegativeRecvQueueSize(t *testing.T) {
+	_, err := blockfetch.NewConfig(blockfetch.WithRecvQueueSize(-1))
+	require.Error(t, err, "NewConfig should return an error for negative RecvQueueSize")
+}
+
+func TestNewConfigReturnsErrorForExceedingMaxRecvQueueSize(t *testing.T) {
+	_, err := blockfetch.NewConfig(
+		blockfetch.WithRecvQueueSize(blockfetch.MaxRecvQueueSize + 1),
+	)
+	require.Error(t, err, "NewConfig should return an error when RecvQueueSize exceeds maximum")
+}
+
+func TestNewConfigSucceedsWithValidOptions(t *testing.T) {
+	cfg, err := blockfetch.NewConfig(
+		blockfetch.WithRecvQueueSize(blockfetch.DefaultRecvQueueSize),
+	)
+	require.NoError(t, err)
+	require.Equal(t, blockfetch.DefaultRecvQueueSize, cfg.RecvQueueSize)
+}
+
+func TestNewConfigSucceedsWithDefaults(t *testing.T) {
+	cfg, err := blockfetch.NewConfig()
+	require.NoError(t, err)
+	require.Equal(t, blockfetch.DefaultRecvQueueSize, cfg.RecvQueueSize)
+}

--- a/protocol/limits_test.go
+++ b/protocol/limits_test.go
@@ -271,27 +271,23 @@ func TestBlockFetchDefaultValuesAreReasonable(t *testing.T) {
 	}
 }
 
-// TestBlockFetchConfigurationValidation tests configuration validation and panic behavior
+// TestBlockFetchConfigurationValidation tests that NewConfig returns an error for invalid queue size
 func TestBlockFetchConfigurationValidation(t *testing.T) {
-	// Test that invalid queue size causes panic
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("Expected panic for invalid queue size")
-		}
-	}()
-	blockfetch.NewConfig(blockfetch.WithRecvQueueSize(-1))
+	_, err := blockfetch.NewConfig(blockfetch.WithRecvQueueSize(-1))
+	if err == nil {
+		t.Errorf("Expected error for invalid queue size, got nil")
+	}
 }
 
 func TestBlockFetchConfigurationValidationExceedsMax(t *testing.T) {
-	// Test that exceeding max queue size causes panic
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("Expected panic for queue size exceeding maximum")
-		}
-	}()
-	blockfetch.NewConfig(
+	_, err := blockfetch.NewConfig(
 		blockfetch.WithRecvQueueSize(blockfetch.MaxRecvQueueSize + 1),
 	)
+	if err == nil {
+		t.Errorf(
+			"Expected error for queue size exceeding maximum, got nil",
+		)
+	}
 }
 
 // TestTxSubmissionLimitsAreDefined validates that TxSubmission limits are properly defined and positive


### PR DESCRIPTION
closes #1583 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop BlockFetch from crashing on bad configs by making `blockfetch.NewConfig` return `(Config, error)` instead of panicking. Examples, client fallback, and tests now use error-based validation.

- **Bug Fixes**
  - `blockfetch.NewConfig` now validates options and returns an error on invalid configs.
  - `WithRecvQueueSize` no longer panics; validation happens in `NewConfig`.
  - `protocol/blockfetch.Client.NewClient` uses `NewConfig()` when `cfg` is nil to ensure a validated default.
  - Updated `examples/chain-sync` to handle config errors; added `protocol/blockfetch/config_test.go` and updated `protocol/limits_test.go`.

- **Migration**
  - Update call sites to handle `blockfetch.NewConfig(...)` returning `(Config, error)`.
  - If you wrap config creation, change signatures to return `(blockfetch.Config, error)` and propagate errors.

<sup>Written for commit f984532bddab4171dae4d0684b59b1ed000c1aac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Block fetch configuration now returns errors for invalid queue sizes instead of panicking, enabling graceful error handling.
  * Configuration validation consolidated into a dedicated phase with descriptive error messages.

* **Tests**
  * Added comprehensive tests for queue size validation scenarios (negative, exceeding maximum, valid configurations).
  * Updated existing validation tests to verify error returns instead of panic behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->