### PR TITLE
feat: leios testnet network definition

### DIFF
--- a/networks.go
+++ b/networks.go
@@ -70,6 +70,17 @@ var (
 			},
 		},
 	}
+	NetworkCardanoLeios = Network{
+		Id:           common.AddressNetworkTestnet,
+		Name:         "leios",
+		NetworkMagic: 164,
+		BootstrapPeers: []NetworkBootstrapPeer{
+			{
+				Address: "leios-node.play.dev.cardano.org",
+				Port:    3001,
+			},
+		},
+	}
 	// NetworkPrimeMainnet intentionally shares the same NetworkMagic as NetworkCardanoMainnet
 	// because both networks use unaltered cardano-node binaries. Network differentiation
 	// occurs through the bootstrap peers configuration.
@@ -139,6 +150,7 @@ var networks = []Network{
 	NetworkCardanoPreprod,
 	NetworkCardanoPreview,
 	NetworkCardanoSancho,
+	NetworkCardanoLeios,
 	NetworkPrimeMainnet,
 	NetworkPrimeTestnet,
 	NetworkDevnet,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added the Leios testnet network to the registry so clients can connect without extra config. Includes network magic 164 and a bootstrap peer at leios-node.play.dev.cardano.org:3001.

<sup>Written for commit 0e7561084359ff6b7ac1a4007a8ec7c6f50eef19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

