### PR TITLE
feat(ledger): voting procedure helpers

### DIFF
--- a/ledger/common/gov.go
+++ b/ledger/common/gov.go
@@ -29,6 +29,119 @@ import (
 // VotingProcedures is a convenience type to avoid needing to duplicate the full type definition everywhere
 type VotingProcedures map[*Voter]map[*GovActionId]VotingProcedure
 
+// AddOrReplace adds or replaces a vote using Voter and GovActionId value
+// equality. It returns the map so callers can assign the result when adding to
+// a nil VotingProcedures value.
+func (vps VotingProcedures) AddOrReplace(
+	voter Voter,
+	govActionId GovActionId,
+	votingProcedure VotingProcedure,
+) VotingProcedures {
+	if vps == nil {
+		vps = VotingProcedures{}
+	}
+
+	voterKey, actions, ok := vps.LookupVoter(voter)
+	if !ok {
+		voterCopy := voter
+		voterKey = &voterCopy
+		actions = map[*GovActionId]VotingProcedure{}
+		vps[voterKey] = actions
+	} else if actions == nil {
+		actions = map[*GovActionId]VotingProcedure{}
+		vps[voterKey] = actions
+	}
+
+	actionKey, _, ok := lookupGovActionId(actions, govActionId)
+	if !ok {
+		actionCopy := govActionId
+		actionKey = &actionCopy
+	}
+	actions[actionKey] = cloneVotingProcedure(votingProcedure)
+	return vps
+}
+
+// Lookup returns the vote for the logical voter/action pair.
+func (vps VotingProcedures) Lookup(
+	voter Voter,
+	govActionId GovActionId,
+) (VotingProcedure, bool) {
+	_, procedure, ok := vps.LookupGovActionId(voter, govActionId)
+	return procedure, ok
+}
+
+// LookupVoter returns the existing voter key and vote map for a logically
+// equal voter.
+func (vps VotingProcedures) LookupVoter(
+	voter Voter,
+) (*Voter, map[*GovActionId]VotingProcedure, bool) {
+	for voterKey, actions := range vps {
+		if voterKey != nil && voterKey.Equal(voter) {
+			return voterKey, actions, true
+		}
+	}
+	return nil, nil, false
+}
+
+// LookupGovActionId returns the existing action key and vote for a logical
+// voter/action pair.
+func (vps VotingProcedures) LookupGovActionId(
+	voter Voter,
+	govActionId GovActionId,
+) (*GovActionId, VotingProcedure, bool) {
+	_, actions, ok := vps.LookupVoter(voter)
+	if !ok {
+		return nil, VotingProcedure{}, false
+	}
+	return lookupGovActionId(actions, govActionId)
+}
+
+// Clone returns a deep copy of the voting procedures map, including copied map
+// keys and voting procedure anchors.
+func (vps VotingProcedures) Clone() VotingProcedures {
+	if vps == nil {
+		return nil
+	}
+	ret := make(VotingProcedures, len(vps))
+	for voterKey, actions := range vps {
+		var voterCopy *Voter
+		if voterKey != nil {
+			voter := *voterKey
+			voterCopy = &voter
+		}
+
+		var actionCopies map[*GovActionId]VotingProcedure
+		if actions != nil {
+			actionCopies = make(
+				map[*GovActionId]VotingProcedure,
+				len(actions),
+			)
+			for actionKey, procedure := range actions {
+				var actionCopy *GovActionId
+				if actionKey != nil {
+					action := *actionKey
+					actionCopy = &action
+				}
+				actionCopies[actionCopy] = cloneVotingProcedure(procedure)
+			}
+		}
+		ret[voterCopy] = actionCopies
+	}
+	return ret
+}
+
+func lookupGovActionId(
+	actions map[*GovActionId]VotingProcedure,
+	govActionId GovActionId,
+) (*GovActionId, VotingProcedure, bool) {
+	for actionKey, procedure := range actions {
+		if actionKey != nil && actionKey.Equal(govActionId) {
+			return actionKey, procedure, true
+		}
+	}
+	return nil, VotingProcedure{}, false
+}
+
 const (
 	VoterTypeConstitutionalCommitteeHotKeyHash    uint8 = 0
 	VoterTypeConstitutionalCommitteeHotScriptHash uint8 = 1
@@ -41,6 +154,11 @@ type Voter struct {
 	cbor.StructAsArray
 	Type uint8
 	Hash [28]byte
+}
+
+// Equal reports whether two voters have the same logical value.
+func (v Voter) Equal(other Voter) bool {
+	return v.Type == other.Type && v.Hash == other.Hash
 }
 
 func encodeCip129Voter(
@@ -271,6 +389,14 @@ type VotingProcedure struct {
 	Anchor *GovAnchor
 }
 
+func cloneVotingProcedure(vp VotingProcedure) VotingProcedure {
+	if vp.Anchor != nil {
+		anchor := *vp.Anchor
+		vp.Anchor = &anchor
+	}
+	return vp
+}
+
 func (vp VotingProcedure) ToPlutusData() data.PlutusData {
 	return Vote(vp.Vote).ToPlutusData()
 }
@@ -312,6 +438,12 @@ type GovActionId struct {
 	cbor.StructAsArray
 	TransactionId [32]byte
 	GovActionIdx  uint32
+}
+
+// Equal reports whether two governance action IDs have the same logical value.
+func (id GovActionId) Equal(other GovActionId) bool {
+	return id.TransactionId == other.TransactionId &&
+		id.GovActionIdx == other.GovActionIdx
 }
 
 func (id *GovActionId) ToPlutusData() data.PlutusData {

--- a/ledger/common/gov_test.go
+++ b/ledger/common/gov_test.go
@@ -384,6 +384,227 @@ func TestVotingProcedureToPlutusData(t *testing.T) {
 	}
 }
 
+func TestVotingProceduresAddOrReplaceValueSemantics(t *testing.T) {
+	voter := testVotingProceduresVoter(
+		VoterTypeDRepKeyHash,
+		0x11,
+	)
+	action := testVotingProceduresGovActionId(0x22, 0)
+
+	votes := VotingProcedures(nil)
+	votes = votes.AddOrReplace(
+		voter,
+		action,
+		VotingProcedure{Vote: GovVoteNo},
+	)
+	votes = votes.AddOrReplace(
+		testVotingProceduresVoter(VoterTypeDRepKeyHash, 0x11),
+		testVotingProceduresGovActionId(0x22, 0),
+		VotingProcedure{Vote: GovVoteYes},
+	)
+
+	require.Len(t, votes, 1)
+	_, actions, ok := votes.LookupVoter(voter)
+	require.True(t, ok)
+	require.Len(t, actions, 1)
+
+	procedure, ok := votes.Lookup(voter, action)
+	require.True(t, ok)
+	assert.Equal(t, GovVoteYes, procedure.Vote)
+}
+
+func TestVotingProceduresAddOrReplaceDistinctActionsForOneVoter(
+	t *testing.T,
+) {
+	voter := testVotingProceduresVoter(
+		VoterTypeDRepKeyHash,
+		0x11,
+	)
+	action1 := testVotingProceduresGovActionId(0x22, 0)
+	action2 := testVotingProceduresGovActionId(0x22, 1)
+
+	votes := VotingProcedures(nil)
+	votes = votes.AddOrReplace(
+		voter,
+		action1,
+		VotingProcedure{Vote: GovVoteYes},
+	)
+	votes = votes.AddOrReplace(
+		testVotingProceduresVoter(VoterTypeDRepKeyHash, 0x11),
+		action2,
+		VotingProcedure{Vote: GovVoteAbstain},
+	)
+
+	require.Len(t, votes, 1)
+	_, actions, ok := votes.LookupVoter(voter)
+	require.True(t, ok)
+	require.Len(t, actions, 2)
+
+	procedure1, ok := votes.Lookup(voter, action1)
+	require.True(t, ok)
+	assert.Equal(t, GovVoteYes, procedure1.Vote)
+
+	procedure2, ok := votes.Lookup(voter, action2)
+	require.True(t, ok)
+	assert.Equal(t, GovVoteAbstain, procedure2.Vote)
+}
+
+func TestVotingProceduresAddOrReplaceDistinctVotersForOneAction(
+	t *testing.T,
+) {
+	voter1 := testVotingProceduresVoter(
+		VoterTypeDRepKeyHash,
+		0x11,
+	)
+	voter2 := testVotingProceduresVoter(
+		VoterTypeDRepKeyHash,
+		0x12,
+	)
+	action := testVotingProceduresGovActionId(0x22, 0)
+
+	votes := VotingProcedures(nil)
+	votes = votes.AddOrReplace(
+		voter1,
+		action,
+		VotingProcedure{Vote: GovVoteYes},
+	)
+	votes = votes.AddOrReplace(
+		voter2,
+		testVotingProceduresGovActionId(0x22, 0),
+		VotingProcedure{Vote: GovVoteNo},
+	)
+
+	require.Len(t, votes, 2)
+
+	procedure1, ok := votes.Lookup(voter1, action)
+	require.True(t, ok)
+	assert.Equal(t, GovVoteYes, procedure1.Vote)
+
+	procedure2, ok := votes.Lookup(voter2, action)
+	require.True(t, ok)
+	assert.Equal(t, GovVoteNo, procedure2.Vote)
+}
+
+func TestVotingProceduresAddOrReplaceCopiesInputValues(t *testing.T) {
+	voter := testVotingProceduresVoter(
+		VoterTypeDRepKeyHash,
+		0x11,
+	)
+	action := testVotingProceduresGovActionId(0x22, 0)
+	anchor := testVotingProceduresAnchor("https://example.com/a", 0x33)
+	originalVoter := voter
+	originalAction := action
+
+	votes := VotingProcedures(nil).AddOrReplace(
+		voter,
+		action,
+		VotingProcedure{
+			Vote:   GovVoteYes,
+			Anchor: anchor,
+		},
+	)
+
+	voter.Hash[0] = 0xff
+	action.GovActionIdx = 99
+	anchor.Url = "https://example.com/changed"
+
+	procedure, ok := votes.Lookup(originalVoter, originalAction)
+	require.True(t, ok)
+	require.NotNil(t, procedure.Anchor)
+	assert.Equal(t, GovVoteYes, procedure.Vote)
+	assert.Equal(t, "https://example.com/a", procedure.Anchor.Url)
+}
+
+func TestVotingProceduresCloneIndependence(t *testing.T) {
+	voter := testVotingProceduresVoter(
+		VoterTypeDRepKeyHash,
+		0x11,
+	)
+	action := testVotingProceduresGovActionId(0x22, 0)
+	anchor := testVotingProceduresAnchor("https://example.com/a", 0x33)
+
+	original := VotingProcedures(nil).AddOrReplace(
+		voter,
+		action,
+		VotingProcedure{
+			Vote:   GovVoteYes,
+			Anchor: anchor,
+		},
+	)
+	clone := original.Clone()
+
+	cloneVoterKey, cloneActions, ok := clone.LookupVoter(voter)
+	require.True(t, ok)
+	require.NotNil(t, cloneActions)
+	cloneActionKey, cloneProcedure, ok := clone.LookupGovActionId(
+		voter,
+		action,
+	)
+	require.True(t, ok)
+	require.NotNil(t, cloneProcedure.Anchor)
+
+	cloneVoterKey.Hash[0] = 0xff
+	cloneActionKey.GovActionIdx = 99
+	cloneProcedure.Anchor.Url = "https://example.com/changed"
+	cloneActions[cloneActionKey] = VotingProcedure{Vote: GovVoteNo}
+
+	originalProcedure, ok := original.Lookup(voter, action)
+	require.True(t, ok)
+	require.NotNil(t, originalProcedure.Anchor)
+	assert.Equal(t, GovVoteYes, originalProcedure.Vote)
+	assert.Equal(t, "https://example.com/a", originalProcedure.Anchor.Url)
+}
+
+func TestVotingProceduresClonePreservesNilActions(t *testing.T) {
+	voter := testVotingProceduresVoter(
+		VoterTypeDRepKeyHash,
+		0x11,
+	)
+	voterKey := voter
+	original := VotingProcedures{
+		&voterKey: nil,
+	}
+
+	clone := original.Clone()
+	_, actions, ok := clone.LookupVoter(voter)
+
+	require.True(t, ok)
+	assert.Nil(t, actions)
+}
+
+func TestVotingProceduresAddOrReplaceCborEncodingUnchanged(t *testing.T) {
+	voter := testVotingProceduresVoter(
+		VoterTypeDRepKeyHash,
+		0x11,
+	)
+	action := testVotingProceduresGovActionId(0x22, 0)
+	procedure := VotingProcedure{
+		Vote: GovVoteYes,
+		Anchor: testVotingProceduresAnchor(
+			"https://example.com/a",
+			0x33,
+		),
+	}
+	directVoter := voter
+	directAction := action
+	direct := VotingProcedures{
+		&directVoter: {
+			&directAction: procedure,
+		},
+	}
+	viaHelper := VotingProcedures(nil).AddOrReplace(
+		voter,
+		action,
+		procedure,
+	)
+
+	directCbor, err := cbor.Encode(direct)
+	require.NoError(t, err)
+	helperCbor, err := cbor.Encode(viaHelper)
+	require.NoError(t, err)
+	assert.Equal(t, directCbor, helperCbor)
+}
+
 func TestGovActionIdToPlutusData(t *testing.T) {
 	txId := [32]byte{1, 2, 3, 4}
 	govActionId := &GovActionId{
@@ -672,6 +893,39 @@ func TestVoterTextRoundTrip(t *testing.T) {
 			assert.Equal(t, tc.voter.Type, decoded.Type)
 			assert.Equal(t, tc.voter.Hash, decoded.Hash)
 		})
+	}
+}
+
+func testVotingProceduresVoter(voterType uint8, seed byte) Voter {
+	var hash [28]byte
+	for i := range hash {
+		hash[i] = seed + byte(i)
+	}
+	return Voter{
+		Type: voterType,
+		Hash: hash,
+	}
+}
+
+func testVotingProceduresGovActionId(seed byte, idx uint32) GovActionId {
+	var txId [32]byte
+	for i := range txId {
+		txId[i] = seed + byte(i)
+	}
+	return GovActionId{
+		TransactionId: txId,
+		GovActionIdx:  idx,
+	}
+}
+
+func testVotingProceduresAnchor(url string, seed byte) *GovAnchor {
+	var dataHash [32]byte
+	for i := range dataHash {
+		dataHash[i] = seed + byte(i)
+	}
+	return &GovAnchor{
+		Url:      url,
+		DataHash: dataHash,
 	}
 }
 


### PR DESCRIPTION
Closes #1800 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds value-based helpers for governance voting procedures with deep-clone safety and no CBOR changes. Implements safe add/replace, lookups, and cloning to meet issue #1800.

- **New Features**
  - `VotingProcedures.AddOrReplace` inserts/replaces by logical equality; handles nil maps and copies anchors.
  - `Lookup`, `LookupVoter`, `LookupGovActionId` retrieve by value and return existing keys.
  - `VotingProcedures.Clone` deep-copies map keys and `Anchor`; preserves nil submaps and nil-in → nil-out.
  - `Voter.Equal` and `GovActionId.Equal` define value equality; tests cover value semantics, clone independence, and CBOR parity.

<sup>Written for commit a6666f0bb16f48abb5e5b6b0d68222cfc8e21e44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added helper methods for governance voting: vote addition/replacement, voter and action lookups, and deep cloning with value semantics preservation.

* **Tests**
  * Added comprehensive test coverage for voting procedures including add/replace behavior, distinct voters/actions per procedure, input value copying, cloning independence, and CBOR encoding validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->