### PR TITLE
feat(leios): Add leios endorser block type as per CIP CDDL

### DIFF
--- a/ledger/leios.go
+++ b/ledger/leios.go
@@ -23,7 +23,8 @@ import "github.com/blinklabs-io/gouroboros/ledger/leios"
 type (
 	LeiosBlockHeader             = leios.LeiosBlockHeader
 	LeiosCertificate             = leios.LeiosCertificate
-	LeiosEndorderBlock           = leios.LeiosEndorserBlock
+	LeiosEndorserBlock           = leios.LeiosEndorserBlock
+	LeiosTransactionReference    = leios.LeiosTransactionReference
 	LeiosRankingBlock            = leios.LeiosRankingBlock
 	LeiosTransaction             = leios.LeiosTransaction
 	LeiosTransactionBody         = leios.LeiosTransactionBody

--- a/ledger/leios/endorser_block.go
+++ b/ledger/leios/endorser_block.go
@@ -1,0 +1,237 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leios
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// LeiosEndorserBlock implements the experimental CIP-0164 endorser_block CDDL:
+//
+//	endorser_block = [ transaction_references : omap<hash32, uint16> ]
+//
+// This is not a normal ledger block and intentionally does not implement
+// common.Block.
+type LeiosEndorserBlock struct {
+	cbor.DecodeStoreCbor
+	TransactionReferences []LeiosTransactionReference
+}
+
+type LeiosTransactionReference struct {
+	TransactionHash common.Blake2b256
+	TransactionSize uint16
+}
+
+func (b *LeiosEndorserBlock) UnmarshalCBOR(cborData []byte) error {
+	var items []cbor.RawMessage
+	if _, err := cbor.Decode(cborData, &items); err != nil {
+		return err
+	}
+	if len(items) != 1 {
+		return fmt.Errorf(
+			"invalid Leios endorser block: expected 1 component, got %d",
+			len(items),
+		)
+	}
+	refs, err := decodeLeiosTransactionReferences(items[0])
+	if err != nil {
+		return err
+	}
+	b.TransactionReferences = refs
+	b.SetCbor(cborData)
+	return nil
+}
+
+func (b LeiosEndorserBlock) MarshalCBOR() ([]byte, error) {
+	if raw := b.Cbor(); len(raw) > 0 {
+		return raw, nil
+	}
+	if err := validateLeiosTransactionReferences(b.TransactionReferences); err != nil {
+		return nil, err
+	}
+	refMap, err := encodeLeiosTransactionReferences(b.TransactionReferences)
+	if err != nil {
+		return nil, err
+	}
+	return cbor.Encode([]any{cbor.RawMessage(refMap)})
+}
+
+func (b LeiosEndorserBlock) Validate() error {
+	return validateLeiosTransactionReferences(b.TransactionReferences)
+}
+
+func NewLeiosEndorserBlockFromCbor(
+	data []byte,
+) (*LeiosEndorserBlock, error) {
+	var block LeiosEndorserBlock
+	if _, err := cbor.Decode(data, &block); err != nil {
+		return nil, err
+	}
+	return &block, nil
+}
+
+func validateLeiosTransactionReferences(
+	refs []LeiosTransactionReference,
+) error {
+	if len(refs) == 0 {
+		return errors.New(
+			"Leios endorser block must contain at least one transaction reference",
+		)
+	}
+	seen := make(map[common.Blake2b256]struct{}, len(refs))
+	for idx, ref := range refs {
+		if ref.TransactionSize == 0 {
+			return fmt.Errorf(
+				"Leios endorser block transaction reference at index %d has zero size",
+				idx,
+			)
+		}
+		if _, ok := seen[ref.TransactionHash]; ok {
+			return fmt.Errorf(
+				"duplicate Leios endorser block transaction reference at index %d",
+				idx,
+			)
+		}
+		seen[ref.TransactionHash] = struct{}{}
+	}
+	return nil
+}
+
+func encodeLeiosTransactionReferences(
+	refs []LeiosTransactionReference,
+) ([]byte, error) {
+	ret := encodeCborMapHeader(uint64(len(refs)))
+	for _, ref := range refs {
+		hashCbor, err := cbor.Encode(ref.TransactionHash)
+		if err != nil {
+			return nil, err
+		}
+		sizeCbor, err := cbor.Encode(ref.TransactionSize)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, hashCbor...)
+		ret = append(ret, sizeCbor...)
+	}
+	return ret, nil
+}
+
+func decodeLeiosTransactionReferences(
+	raw cbor.RawMessage,
+) ([]LeiosTransactionReference, error) {
+	dec, err := cbor.NewStreamDecoder(raw)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"decode Leios endorser block transaction references: %w",
+			err,
+		)
+	}
+	count, _, _, err := dec.DecodeMapHeader()
+	if err != nil {
+		return nil, fmt.Errorf(
+			"decode Leios endorser block transaction references: %w",
+			err,
+		)
+	}
+	refs := make([]LeiosTransactionReference, 0, count)
+	seen := make(map[common.Blake2b256]struct{}, count)
+	for idx := 0; idx < count; idx++ {
+		var hashBytes cbor.ByteString
+		if _, _, err := dec.Decode(&hashBytes); err != nil {
+			return nil, fmt.Errorf(
+				"decode Leios transaction reference %d hash: %w",
+				idx,
+				err,
+			)
+		}
+		hash := hashBytes.Bytes()
+		if len(hash) != common.Blake2b256Size {
+			return nil, fmt.Errorf(
+				"Leios transaction reference %d hash must be %d bytes, got %d",
+				idx,
+				common.Blake2b256Size,
+				len(hash),
+			)
+		}
+		txHash := common.NewBlake2b256(hash)
+		if _, ok := seen[txHash]; ok {
+			return nil, fmt.Errorf(
+				"duplicate Leios endorser block transaction reference at index %d",
+				idx,
+			)
+		}
+		seen[txHash] = struct{}{}
+		var size uint64
+		if _, _, err := dec.Decode(&size); err != nil {
+			return nil, fmt.Errorf(
+				"decode Leios transaction reference %d size: %w",
+				idx,
+				err,
+			)
+		}
+		if size > math.MaxUint16 {
+			return nil, fmt.Errorf(
+				"Leios transaction reference %d size exceeds uint16: %d",
+				idx,
+				size,
+			)
+		}
+		refs = append(refs, LeiosTransactionReference{
+			TransactionHash: txHash,
+			TransactionSize: uint16(size),
+		})
+	}
+	if !dec.EOF() {
+		return nil, fmt.Errorf(
+			"trailing bytes after Leios transaction references map: %d",
+			len(raw)-dec.Position(),
+		)
+	}
+	if err := validateLeiosTransactionReferences(refs); err != nil {
+		return nil, err
+	}
+	return refs, nil
+}
+
+func encodeCborMapHeader(count uint64) []byte {
+	return encodeCborTypeHeader(cbor.CborTypeMap, count)
+}
+
+func encodeCborTypeHeader(major uint8, value uint64) []byte {
+	switch {
+	case value <= 23:
+		return []byte{major | byte(value)}
+	case value <= math.MaxUint8:
+		return []byte{major | 24, byte(value)}
+	case value <= math.MaxUint16:
+		ret := []byte{major | 25, 0, 0}
+		binary.BigEndian.PutUint16(ret[1:], uint16(value))
+		return ret
+	case value <= math.MaxUint32:
+		ret := []byte{major | 26, 0, 0, 0, 0}
+		binary.BigEndian.PutUint32(ret[1:], uint32(value))
+		return ret
+	default:
+		ret := []byte{major | 27, 0, 0, 0, 0, 0, 0, 0, 0}
+		binary.BigEndian.PutUint64(ret[1:], value)
+		return ret
+	}
+}

--- a/ledger/leios/endorser_block.go
+++ b/ledger/leios/endorser_block.go
@@ -42,8 +42,15 @@ type LeiosTransactionReference struct {
 
 func (b *LeiosEndorserBlock) UnmarshalCBOR(cborData []byte) error {
 	var items []cbor.RawMessage
-	if _, err := cbor.Decode(cborData, &items); err != nil {
+	bytesRead, err := cbor.Decode(cborData, &items)
+	if err != nil {
 		return err
+	}
+	if bytesRead != len(cborData) {
+		return fmt.Errorf(
+			"trailing bytes after leios endorser block: %d",
+			len(cborData)-bytesRead,
+		)
 	}
 	if len(items) != 1 {
 		return fmt.Errorf(
@@ -82,8 +89,15 @@ func NewLeiosEndorserBlockFromCbor(
 	data []byte,
 ) (*LeiosEndorserBlock, error) {
 	var block LeiosEndorserBlock
-	if _, err := cbor.Decode(data, &block); err != nil {
+	bytesRead, err := cbor.Decode(data, &block)
+	if err != nil {
 		return nil, err
+	}
+	if bytesRead != len(data) {
+		return nil, fmt.Errorf(
+			"trailing bytes after leios endorser block: %d",
+			len(data)-bytesRead,
+		)
 	}
 	return &block, nil
 }

--- a/ledger/leios/endorser_block.go
+++ b/ledger/leios/endorser_block.go
@@ -47,7 +47,7 @@ func (b *LeiosEndorserBlock) UnmarshalCBOR(cborData []byte) error {
 	}
 	if len(items) != 1 {
 		return fmt.Errorf(
-			"invalid Leios endorser block: expected 1 component, got %d",
+			"invalid leios endorser block: expected 1 component, got %d",
 			len(items),
 		)
 	}
@@ -93,20 +93,20 @@ func validateLeiosTransactionReferences(
 ) error {
 	if len(refs) == 0 {
 		return errors.New(
-			"Leios endorser block must contain at least one transaction reference",
+			"leios endorser block must contain at least one transaction reference",
 		)
 	}
 	seen := make(map[common.Blake2b256]struct{}, len(refs))
 	for idx, ref := range refs {
 		if ref.TransactionSize == 0 {
 			return fmt.Errorf(
-				"Leios endorser block transaction reference at index %d has zero size",
+				"leios endorser block transaction reference at index %d has zero size",
 				idx,
 			)
 		}
 		if _, ok := seen[ref.TransactionHash]; ok {
 			return fmt.Errorf(
-				"duplicate Leios endorser block transaction reference at index %d",
+				"duplicate leios endorser block transaction reference at index %d",
 				idx,
 			)
 		}
@@ -140,14 +140,14 @@ func decodeLeiosTransactionReferences(
 	dec, err := cbor.NewStreamDecoder(raw)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"decode Leios endorser block transaction references: %w",
+			"decode leios endorser block transaction references: %w",
 			err,
 		)
 	}
 	count, _, _, err := dec.DecodeMapHeader()
 	if err != nil {
 		return nil, fmt.Errorf(
-			"decode Leios endorser block transaction references: %w",
+			"decode leios endorser block transaction references: %w",
 			err,
 		)
 	}
@@ -157,7 +157,7 @@ func decodeLeiosTransactionReferences(
 		var hashBytes cbor.ByteString
 		if _, _, err := dec.Decode(&hashBytes); err != nil {
 			return nil, fmt.Errorf(
-				"decode Leios transaction reference %d hash: %w",
+				"decode leios transaction reference %d hash: %w",
 				idx,
 				err,
 			)
@@ -165,7 +165,7 @@ func decodeLeiosTransactionReferences(
 		hash := hashBytes.Bytes()
 		if len(hash) != common.Blake2b256Size {
 			return nil, fmt.Errorf(
-				"Leios transaction reference %d hash must be %d bytes, got %d",
+				"leios transaction reference %d hash must be %d bytes, got %d",
 				idx,
 				common.Blake2b256Size,
 				len(hash),
@@ -174,7 +174,7 @@ func decodeLeiosTransactionReferences(
 		txHash := common.NewBlake2b256(hash)
 		if _, ok := seen[txHash]; ok {
 			return nil, fmt.Errorf(
-				"duplicate Leios endorser block transaction reference at index %d",
+				"duplicate leios endorser block transaction reference at index %d",
 				idx,
 			)
 		}
@@ -182,14 +182,14 @@ func decodeLeiosTransactionReferences(
 		var size uint64
 		if _, _, err := dec.Decode(&size); err != nil {
 			return nil, fmt.Errorf(
-				"decode Leios transaction reference %d size: %w",
+				"decode leios transaction reference %d size: %w",
 				idx,
 				err,
 			)
 		}
 		if size > math.MaxUint16 {
 			return nil, fmt.Errorf(
-				"Leios transaction reference %d size exceeds uint16: %d",
+				"leios transaction reference %d size exceeds uint16: %d",
 				idx,
 				size,
 			)
@@ -201,7 +201,7 @@ func decodeLeiosTransactionReferences(
 	}
 	if !dec.EOF() {
 		return nil, fmt.Errorf(
-			"trailing bytes after Leios transaction references map: %d",
+			"trailing bytes after leios transaction references map: %d",
 			len(raw)-dec.Position(),
 		)
 	}

--- a/ledger/leios/endorser_block_test.go
+++ b/ledger/leios/endorser_block_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leios
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLeiosEndorserBlockRoundTrip(t *testing.T) {
+	block := LeiosEndorserBlock{
+		TransactionReferences: []LeiosTransactionReference{
+			{
+				TransactionHash: common.NewBlake2b256([]byte{0x01}),
+				TransactionSize: 42,
+			},
+			{
+				TransactionHash: common.NewBlake2b256([]byte{0x02}),
+				TransactionSize: 65535,
+			},
+		},
+	}
+
+	blockCbor, err := cbor.Encode(&block)
+	require.NoError(t, err)
+
+	decoded, err := NewLeiosEndorserBlockFromCbor(blockCbor)
+	require.NoError(t, err)
+	require.Equal(t, block.TransactionReferences, decoded.TransactionReferences)
+	require.Equal(t, blockCbor, decoded.Cbor())
+
+	encodedAgain, err := cbor.Encode(decoded)
+	require.NoError(t, err)
+	require.Equal(t, blockCbor, encodedAgain)
+}
+
+func TestLeiosEndorserBlockRejectsDuplicateReferences(t *testing.T) {
+	hash := common.NewBlake2b256([]byte{0x01})
+	block := LeiosEndorserBlock{
+		TransactionReferences: []LeiosTransactionReference{
+			{TransactionHash: hash, TransactionSize: 1},
+			{TransactionHash: hash, TransactionSize: 2},
+		},
+	}
+
+	_, err := cbor.Encode(&block)
+	require.ErrorContains(t, err, "duplicate")
+}
+
+func TestLeiosEndorserBlockRejectsEmptyReferences(t *testing.T) {
+	block := LeiosEndorserBlock{}
+
+	_, err := cbor.Encode(&block)
+	require.ErrorContains(t, err, "at least one transaction reference")
+
+	refMap, err := cbor.Encode(map[common.Blake2b256]uint16{})
+	require.NoError(t, err)
+	blockCbor, err := cbor.Encode([]any{cbor.RawMessage(refMap)})
+	require.NoError(t, err)
+
+	_, err = NewLeiosEndorserBlockFromCbor(blockCbor)
+	require.ErrorContains(t, err, "at least one transaction reference")
+}
+
+func TestLeiosEndorserBlockRejectsZeroTxSize(t *testing.T) {
+	block := LeiosEndorserBlock{
+		TransactionReferences: []LeiosTransactionReference{
+			{
+				TransactionHash: common.NewBlake2b256([]byte{0x01}),
+				TransactionSize: 0,
+			},
+		},
+	}
+
+	_, err := cbor.Encode(&block)
+	require.ErrorContains(t, err, "zero size")
+
+	refMap, err := cbor.Encode(map[common.Blake2b256]uint16{
+		common.NewBlake2b256([]byte{0x01}): 0,
+	})
+	require.NoError(t, err)
+	blockCbor, err := cbor.Encode([]any{cbor.RawMessage(refMap)})
+	require.NoError(t, err)
+
+	_, err = NewLeiosEndorserBlockFromCbor(blockCbor)
+	require.ErrorContains(t, err, "zero size")
+}
+
+func TestLeiosEndorserBlockRejectsWrongEnvelopeSize(t *testing.T) {
+	blockCbor, err := cbor.Encode([]any{})
+	require.NoError(t, err)
+
+	_, err = NewLeiosEndorserBlockFromCbor(blockCbor)
+	require.ErrorContains(t, err, "expected 1 component")
+}
+
+func TestLeiosEndorserBlockRejectsOversizedTxSize(t *testing.T) {
+	hash := common.NewBlake2b256([]byte{0x01})
+	refMap, err := cbor.Encode(map[common.Blake2b256]uint64{
+		hash: 65536,
+	})
+	require.NoError(t, err)
+	blockCbor, err := cbor.Encode([]any{cbor.RawMessage(refMap)})
+	require.NoError(t, err)
+
+	_, err = NewLeiosEndorserBlockFromCbor(blockCbor)
+	require.ErrorContains(t, err, "exceeds uint16")
+}

--- a/ledger/leios/endorser_block_test.go
+++ b/ledger/leios/endorser_block_test.go
@@ -109,6 +109,27 @@ func TestLeiosEndorserBlockRejectsWrongEnvelopeSize(t *testing.T) {
 	require.ErrorContains(t, err, "expected 1 component")
 }
 
+func TestLeiosEndorserBlockRejectsTrailingBytes(t *testing.T) {
+	block := LeiosEndorserBlock{
+		TransactionReferences: []LeiosTransactionReference{
+			{
+				TransactionHash: common.NewBlake2b256([]byte{0x01}),
+				TransactionSize: 42,
+			},
+		},
+	}
+	blockCbor, err := cbor.Encode(&block)
+	require.NoError(t, err)
+	blockCbor = append(blockCbor, 0xff)
+
+	_, err = NewLeiosEndorserBlockFromCbor(blockCbor)
+	require.ErrorContains(t, err, "trailing bytes")
+
+	var decoded LeiosEndorserBlock
+	err = decoded.UnmarshalCBOR(blockCbor)
+	require.ErrorContains(t, err, "trailing bytes")
+}
+
 func TestLeiosEndorserBlockRejectsOversizedTxSize(t *testing.T) {
 	hash := common.NewBlake2b256([]byte{0x01})
 	refMap, err := cbor.Encode(map[common.Blake2b256]uint64{

--- a/ledger/leios/leios.go
+++ b/ledger/leios/leios.go
@@ -22,7 +22,6 @@ import "github.com/blinklabs-io/gouroboros/ledger/dijkstra"
 type (
 	LeiosBlockHeader             = dijkstra.DijkstraBlockHeader
 	LeiosCertificate             = dijkstra.DijkstraLeiosCertificate
-	LeiosEndorserBlock           = dijkstra.DijkstraBlock
 	LeiosRankingBlock            = dijkstra.DijkstraBlock
 	LeiosTransaction             = dijkstra.DijkstraTransaction
 	LeiosTransactionBody         = dijkstra.DijkstraTransactionBody
@@ -48,7 +47,6 @@ var (
 	EraLeios = dijkstra.EraDijkstra
 
 	NewLeiosRankingBlockFromCbor    = dijkstra.NewDijkstraBlockFromCbor
-	NewLeiosEndorserBlockFromCbor   = dijkstra.NewDijkstraBlockFromCbor
 	NewLeiosBlockHeaderFromCbor     = dijkstra.NewDijkstraBlockHeaderFromCbor
 	NewLeiosTransactionFromCbor     = dijkstra.NewDijkstraTransactionFromCbor
 	NewLeiosTransactionBodyFromCbor = dijkstra.NewDijkstraTransactionBodyFromCbor


### PR DESCRIPTION
1. Added a CIP-0164 shaped LeiosEndorserBlock wire type where the current dijkstra ledger CDDL already represents ranking blocks through DijkstraBlock and did not add a separate ranking block type.
2. Added LeiosEndorserBlock and LeiosTransactionReference.
3. Added CBOR encode/decode and constructor. Also, preserved ordered transaction references and added structural validation.
4. Added unit tests for round-trip and invalid EB cases.

This change is related to the issue (https://github.com/blinklabs-io/dingo/issues/1859)

Reference: https://cips.cardano.org/cip/CIP-0164#endorser-block-cddl

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the CIP-0164 Leios endorser block wire type with CBOR encode/decode, strict parsing (rejects trailing bytes), and validation. Updates exports to the new `ledger/leios` types and fixes lint errors.

- **New Features**
  - Implement `LeiosEndorserBlock` per CIP-0164 with CBOR encode/decode and `NewLeiosEndorserBlockFromCbor`.
  - Enforce strict CBOR decoding; reject trailing bytes in the block and transaction reference map.
  - Add `LeiosTransactionReference`; preserve order and validate refs (≥1, unique hashes, non-zero size, uint16 bound). Tests cover round‑trip and invalid cases, including trailing bytes.
  - Update exports: alias `LeiosEndorserBlock` and `LeiosTransactionReference` in `ledger/leios.go`; remove the old `dijkstra` alias in `ledger/leios/leios.go`.

- **Refactors**
  - Fixed lint errors in new Leios files.

<sup>Written for commit a28f0616ccb7dae1ebdabccef0ad186a502c3a19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed misspelled ledger type alias for endorser blocks.

* **New Features**
  * Added endorser block implementation with CBOR serialization, deserialization, and validation of transaction references including duplicate detection and size verification.

* **Tests**
  * Added comprehensive unit tests for endorser block encoding and decoding with error validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->