### PR TITLE
fix: 32-bit targets (widen int overflows of MaxUint32/MaxInt64 constants)

### DIFF
--- a/consensus/byron/byron.go
+++ b/consensus/byron/byron.go
@@ -156,8 +156,9 @@ func NewByronConfigFromGenesis(genesis *ledgerbyron.ByronGenesis) (ByronConfig, 
 	}
 
 	// Validate protocol magic fits in uint32
-	if genesis.ProtocolConsts.ProtocolMagic < 0 || genesis.ProtocolConsts.ProtocolMagic > math.MaxUint32 {
-		return ByronConfig{}, fmt.Errorf("invalid protocol magic: %d (must be 0 to %d)", genesis.ProtocolConsts.ProtocolMagic, math.MaxUint32)
+	// int64 cast: on 32-bit targets untyped math.MaxUint32 overflows int
+	if genesis.ProtocolConsts.ProtocolMagic < 0 || int64(genesis.ProtocolConsts.ProtocolMagic) > math.MaxUint32 {
+		return ByronConfig{}, fmt.Errorf("invalid protocol magic: %d (must be 0 to %d)", genesis.ProtocolConsts.ProtocolMagic, uint32(math.MaxUint32))
 	}
 
 	// Extract genesis delegate key hashes

--- a/consensus/byron/validate.go
+++ b/consensus/byron/validate.go
@@ -1278,7 +1278,8 @@ func validateTxProof(txProof ByronTxProof, txPayload []byron.ByronTransaction) e
 	// Validate transaction count
 	txPayloadLen := len(txPayload)
 	// #nosec G115 -- len() cannot be negative, and a block with >2^32 txs is impossible
-	if txPayloadLen > 0xFFFFFFFF || uint32(txPayloadLen) != txProof.TxCount {
+	// int64 cast: on 32-bit targets untyped 0xFFFFFFFF overflows int
+	if int64(txPayloadLen) > 0xFFFFFFFF || uint32(txPayloadLen) != txProof.TxCount {
 		return &common.ValidationError{
 			Type:    common.ValidationErrorTypeBodyHash,
 			Message: "transaction count mismatch",
@@ -1545,7 +1546,8 @@ func toUint32(v any) (uint32, error) {
 		if x < 0 {
 			return 0, fmt.Errorf("negative value %d", x)
 		}
-		if x > 0xFFFFFFFF {
+		// int64 cast: on 32-bit targets untyped 0xFFFFFFFF overflows int
+		if int64(x) > 0xFFFFFFFF {
 			return 0, fmt.Errorf("value %d overflows uint32", x)
 		}
 		return uint32(x), nil

--- a/ledger/byron/byron.go
+++ b/ledger/byron/byron.go
@@ -719,7 +719,10 @@ func NewByronTransactionInput(hash string, idx int) ByronTransactionInput {
 	if err != nil {
 		panic(fmt.Sprintf("failed to decode transaction hash: %s", err))
 	}
-	if idx < 0 || idx > math.MaxUint32 {
+	// Compare the upper bound via int64 so this builds on 32-bit GOARCHs, where
+	// int is 32-bit and the untyped math.MaxUint32 constant would overflow the
+	// int comparison type. On 32-bit a positive int can never exceed MaxUint32.
+	if idx < 0 || int64(idx) > math.MaxUint32 {
 		panic("index out of range")
 	}
 	return ByronTransactionInput{

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -433,7 +433,10 @@ func NewShelleyTransactionInput(hash string, idx int) ShelleyTransactionInput {
 	if err != nil {
 		panic(fmt.Sprintf("failed to decode transaction hash: %s", err))
 	}
-	if idx < 0 || idx > math.MaxUint32 {
+	// Compare the upper bound via int64 so this builds on 32-bit GOARCHs, where
+	// int is 32-bit and the untyped math.MaxUint32 constant would overflow the
+	// int comparison type. On 32-bit a positive int can never exceed MaxUint32.
+	if idx < 0 || int64(idx) > math.MaxUint32 {
 		panic("index out of range")
 	}
 	return ShelleyTransactionInput{

--- a/ledger/verify_block.go
+++ b/ledger/verify_block.go
@@ -312,7 +312,7 @@ func VerifyBlock(
 				"slot":         slot,
 				"block_number": blockNo,
 				"era":          era,
-				"max_int64":    math.MaxInt64,
+				"max_int64":    int64(math.MaxInt64), // int64 for 32-bit build
 			},
 			nil,
 		)

--- a/protocol/localtxmonitor/server.go
+++ b/protocol/localtxmonitor/server.go
@@ -216,21 +216,22 @@ func (s *Server) handleGetSizes() error {
 			"role", "server",
 			"connection_id", s.callbackContext.ConnectionId.String(),
 		)
-	totalTxSize := 0
+	const maxUint32 = uint64(math.MaxUint32)
+	totalTxSize := uint64(0)
 	for _, tx := range s.mempoolTxs {
-		totalTxSize += len(tx.Tx)
+		txSize := uint64(len(tx.Tx))
+		if txSize > maxUint32 || totalTxSize > maxUint32-txSize {
+			return errors.New("integrer overflow in total tx size")
+		}
+		totalTxSize += txSize
 	}
-	numTxs := len(s.mempoolTxs)
-	// check for over/underflows
-	if totalTxSize < 0 || totalTxSize > math.MaxUint32 {
-		return errors.New("integrer overflow in total tx size")
-	}
-	if numTxs < 0 || numTxs > math.MaxUint32 {
+	numTxs := uint64(len(s.mempoolTxs))
+	if numTxs > maxUint32 {
 		return errors.New("integrer overflow in tx count")
 	}
 	newMsg := NewMsgReplyGetSizes(
 		s.mempoolCapacity,
-		uint32(totalTxSize), // #nosec G115
+		uint32(totalTxSize),
 		uint32(numTxs),
 	)
 	if err := s.SendMessage(newMsg); err != nil {


### PR DESCRIPTION
On 32-bit GOARCHs (386, arm) the platform int is 32-bit, so untyped constants math.MaxUint32 / 0xFFFFFFFF / math.MaxInt64 overflow int in bounds checks, map literals, and format args, breaking cross-compilation (e.g. gomobile bind for armeabi-v7a/x86). Widen the comparisons/types so the package builds on all targets; no behavior change on valid inputs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix 32-bit builds by widening int comparisons against `math.MaxUint32`, `0xFFFFFFFF`, and `math.MaxInt64`. This prevents overflows on `386`/`arm` and restores cross-compilation (e.g., gomobile `armeabi-v7a`/`x86`) with no behavior change.

- **Bug Fixes**
  - Compare against `math.MaxUint32`/`0xFFFFFFFF` via `int64` in `consensus/byron` bounds checks.
  - Validate transaction input indices via `int64` in `ledger/byron` and `ledger/shelley`.
  - Use `int64(math.MaxInt64)` in `ledger/verify_block` logging context.
  - Rework mempool size/count checks in `protocol/localtxmonitor` to use `uint64` with overflow-safe accumulation and validate against `math.MaxUint32` before casting to `uint32`.

<sup>Written for commit 406f3fcfc163e59ceb24e82ee4f9bda26910e823. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced platform compatibility by improving integer overflow handling across validation and transaction processing logic to ensure stable operation on 32-bit architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->