### PR TITLE
feat: add constructors for Conway proposal procedures and governance actions

### DIFF
--- a/ledger/common/gov.go
+++ b/ledger/common/gov.go
@@ -434,6 +434,20 @@ func (a *GovAnchor) ToPlutusData() data.PlutusData {
 	)
 }
 
+// NewGovAnchor builds a GovAnchor from a URL and a 32-byte data hash.
+func NewGovAnchor(url string, dataHash []byte) (GovAnchor, error) {
+	if len(dataHash) != 32 {
+		return GovAnchor{}, fmt.Errorf(
+			"invalid gov anchor data hash length: expected 32 bytes, got %d",
+			len(dataHash),
+		)
+	}
+	return GovAnchor{
+		Url:      url,
+		DataHash: [32]byte(dataHash),
+	}, nil
+}
+
 type GovActionId struct {
 	cbor.StructAsArray
 	TransactionId [32]byte
@@ -527,6 +541,20 @@ func (id *GovActionId) UnmarshalText(text []byte) error {
 	return nil
 }
 
+// NewGovActionId builds a GovActionId from a 32-byte transaction id and an index.
+func NewGovActionId(txId []byte, idx uint32) (GovActionId, error) {
+	if len(txId) != 32 {
+		return GovActionId{}, fmt.Errorf(
+			"invalid gov action id transaction id length: expected 32 bytes, got %d",
+			len(txId),
+		)
+	}
+	return GovActionId{
+		TransactionId: [32]byte(txId),
+		GovActionIdx:  idx,
+	}, nil
+}
+
 type ProposalProcedure interface {
 	isProposalProcedure()
 	ToPlutusData() data.PlutusData
@@ -601,6 +629,22 @@ func (a *HardForkInitiationGovAction) ToPlutusData() data.PlutusData {
 
 func (a HardForkInitiationGovAction) isGovAction() {}
 
+// NewHardForkInitiationGovAction builds a hard fork initiation governance
+// action. actionId is optional (nil means no parent action).
+func NewHardForkInitiationGovAction(
+	actionId *GovActionId,
+	major uint,
+	minor uint,
+) (*HardForkInitiationGovAction, error) {
+	a := &HardForkInitiationGovAction{
+		Type:     uint(GovActionTypeHardForkInitiation),
+		ActionId: actionId,
+	}
+	a.ProtocolVersion.Major = major
+	a.ProtocolVersion.Minor = minor
+	return a, nil
+}
+
 type TreasuryWithdrawalGovAction struct {
 	cbor.StructAsArray
 	Type        uint
@@ -636,6 +680,32 @@ func (a *TreasuryWithdrawalGovAction) GetPolicyHash() []byte {
 	return a.PolicyHash
 }
 
+// NewTreasuryWithdrawalGovAction builds a treasury withdrawal governance
+// action. policyHash is optional, but when provided must be a 28-byte script
+// hash.
+func NewTreasuryWithdrawalGovAction(
+	withdrawals map[*Address]uint64,
+	policyHash []byte,
+) (*TreasuryWithdrawalGovAction, error) {
+	if len(withdrawals) == 0 {
+		return nil, errors.New(
+			"treasury withdrawal requires at least one withdrawal",
+		)
+	}
+	if len(policyHash) != 0 && len(policyHash) != Blake2b224Size {
+		return nil, fmt.Errorf(
+			"invalid policy hash length: expected %d bytes, got %d",
+			Blake2b224Size,
+			len(policyHash),
+		)
+	}
+	return &TreasuryWithdrawalGovAction{
+		Type:        uint(GovActionTypeTreasuryWithdrawal),
+		Withdrawals: withdrawals,
+		PolicyHash:  policyHash,
+	}, nil
+}
+
 type NoConfidenceGovAction struct {
 	cbor.StructAsArray
 	Type     uint
@@ -653,6 +723,17 @@ func (a *NoConfidenceGovAction) ToPlutusData() data.PlutusData {
 }
 
 func (a NoConfidenceGovAction) isGovAction() {}
+
+// NewNoConfidenceGovAction builds a no confidence governance action. actionId
+// is optional (nil means no parent action).
+func NewNoConfidenceGovAction(
+	actionId *GovActionId,
+) (*NoConfidenceGovAction, error) {
+	return &NoConfidenceGovAction{
+		Type:     uint(GovActionTypeNoConfidence),
+		ActionId: actionId,
+	}, nil
+}
 
 type UpdateCommitteeGovAction struct {
 	cbor.StructAsArray
@@ -705,6 +786,25 @@ func (a *UpdateCommitteeGovAction) ToPlutusData() data.PlutusData {
 
 func (a UpdateCommitteeGovAction) isGovAction() {}
 
+// NewUpdateCommitteeGovAction builds an update committee governance action.
+// actionId is optional (nil means no parent action). credentials are the
+// members to remove and credEpochs maps members to add to their expiration
+// epoch.
+func NewUpdateCommitteeGovAction(
+	actionId *GovActionId,
+	credentials []Credential,
+	credEpochs map[*Credential]uint,
+	quorum cbor.Rat,
+) (*UpdateCommitteeGovAction, error) {
+	return &UpdateCommitteeGovAction{
+		Type:        uint(GovActionTypeUpdateCommittee),
+		ActionId:    actionId,
+		Credentials: credentials,
+		CredEpochs:  credEpochs,
+		Quorum:      quorum,
+	}, nil
+}
+
 type NewConstitutionGovAction struct {
 	cbor.StructAsArray
 	Type         uint
@@ -738,6 +838,30 @@ func (a *NewConstitutionGovAction) ToPlutusData() data.PlutusData {
 
 func (a NewConstitutionGovAction) isGovAction() {}
 
+// NewNewConstitutionGovAction builds a new constitution governance action.
+// actionId is optional (nil means no parent action). scriptHash is optional,
+// but when provided must be a 28-byte guardrail script hash.
+func NewNewConstitutionGovAction(
+	actionId *GovActionId,
+	anchor GovAnchor,
+	scriptHash []byte,
+) (*NewConstitutionGovAction, error) {
+	if len(scriptHash) != 0 && len(scriptHash) != Blake2b224Size {
+		return nil, fmt.Errorf(
+			"invalid script hash length: expected %d bytes, got %d",
+			Blake2b224Size,
+			len(scriptHash),
+		)
+	}
+	a := &NewConstitutionGovAction{
+		Type:     uint(GovActionTypeNewConstitution),
+		ActionId: actionId,
+	}
+	a.Constitution.Anchor = anchor
+	a.Constitution.ScriptHash = scriptHash
+	return a, nil
+}
+
 type InfoGovAction struct {
 	cbor.StructAsArray
 	Type uint
@@ -748,3 +872,10 @@ func (a *InfoGovAction) ToPlutusData() data.PlutusData {
 }
 
 func (a InfoGovAction) isGovAction() {}
+
+// NewInfoGovAction builds an info governance action.
+func NewInfoGovAction() (*InfoGovAction, error) {
+	return &InfoGovAction{
+		Type: uint(GovActionTypeInfo),
+	}, nil
+}

--- a/ledger/common/gov.go
+++ b/ledger/common/gov.go
@@ -692,6 +692,14 @@ func NewTreasuryWithdrawalGovAction(
 			"treasury withdrawal requires at least one withdrawal",
 		)
 	}
+	// Nil address keys panic when the action is rendered to PlutusData.
+	for addr := range withdrawals {
+		if addr == nil {
+			return nil, errors.New(
+				"treasury withdrawal contains a nil address",
+			)
+		}
+	}
 	if len(policyHash) != 0 && len(policyHash) != Blake2b224Size {
 		return nil, fmt.Errorf(
 			"invalid policy hash length: expected %d bytes, got %d",
@@ -796,6 +804,19 @@ func NewUpdateCommitteeGovAction(
 	credEpochs map[*Credential]uint,
 	quorum cbor.Rat,
 ) (*UpdateCommitteeGovAction, error) {
+	// A zero-value cbor.Rat has a nil inner *big.Rat and panics when CBOR
+	// encoded, so require a populated quorum.
+	if quorum.Rat == nil {
+		return nil, errors.New("update committee requires a quorum")
+	}
+	// Nil credential keys panic when the action is rendered to PlutusData.
+	for cred := range credEpochs {
+		if cred == nil {
+			return nil, errors.New(
+				"update committee contains a nil credential",
+			)
+		}
+	}
 	return &UpdateCommitteeGovAction{
 		Type:        uint(GovActionTypeUpdateCommittee),
 		ActionId:    actionId,

--- a/ledger/common/gov_constructors_test.go
+++ b/ledger/common/gov_constructors_test.go
@@ -1,0 +1,214 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewGovAnchor(t *testing.T) {
+	dataHash := make([]byte, 32)
+	for i := range dataHash {
+		dataHash[i] = byte(i)
+	}
+	anchor, err := NewGovAnchor("https://example.com/proposal.json", dataHash)
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com/proposal.json", anchor.Url)
+	assert.Equal(t, [32]byte(dataHash), anchor.DataHash)
+
+	// Negative: wrong-length data hash
+	_, err = NewGovAnchor("https://example.com", make([]byte, 31))
+	require.Error(t, err)
+	_, err = NewGovAnchor("https://example.com", make([]byte, 33))
+	require.Error(t, err)
+}
+
+func TestNewGovActionId(t *testing.T) {
+	txId := make([]byte, 32)
+	for i := range txId {
+		txId[i] = byte(i)
+	}
+	id, err := NewGovActionId(txId, 3)
+	require.NoError(t, err)
+	assert.Equal(t, [32]byte(txId), id.TransactionId)
+	assert.Equal(t, uint32(3), id.GovActionIdx)
+
+	// Negative: wrong-length transaction id
+	_, err = NewGovActionId(make([]byte, 16), 0)
+	require.Error(t, err)
+}
+
+func TestNewHardForkInitiationGovAction(t *testing.T) {
+	action, err := NewHardForkInitiationGovAction(nil, 10, 1)
+	require.NoError(t, err)
+	assert.Equal(t, uint(GovActionTypeHardForkInitiation), action.Type)
+	assert.Nil(t, action.ActionId)
+	assert.Equal(t, uint(10), action.ProtocolVersion.Major)
+	assert.Equal(t, uint(1), action.ProtocolVersion.Minor)
+
+	// CBOR round-trip preserves the discriminant and version
+	cborData, err := cbor.Encode(action)
+	require.NoError(t, err)
+	assert.NotEmpty(t, cborData)
+	var decoded HardForkInitiationGovAction
+	_, err = cbor.Decode(cborData, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, uint(GovActionTypeHardForkInitiation), decoded.Type)
+	assert.Equal(t, uint(10), decoded.ProtocolVersion.Major)
+	assert.Equal(t, uint(1), decoded.ProtocolVersion.Minor)
+
+	// Optional parent action id is carried through
+	actionId := &GovActionId{GovActionIdx: 7}
+	withParent, err := NewHardForkInitiationGovAction(actionId, 11, 0)
+	require.NoError(t, err)
+	assert.Equal(t, actionId, withParent.ActionId)
+}
+
+func TestNewTreasuryWithdrawalGovAction(t *testing.T) {
+	addr, err := NewAddress(
+		"addr1vx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers66hrl8",
+	)
+	require.NoError(t, err)
+	withdrawals := map[*Address]uint64{&addr: 5_000_000}
+	policyHash := make([]byte, Blake2b224Size)
+
+	action, err := NewTreasuryWithdrawalGovAction(withdrawals, policyHash)
+	require.NoError(t, err)
+	assert.Equal(t, uint(GovActionTypeTreasuryWithdrawal), action.Type)
+
+	// CBOR round-trip preserves the discriminant and withdrawals
+	cborData, err := cbor.Encode(action)
+	require.NoError(t, err)
+	var decoded TreasuryWithdrawalGovAction
+	_, err = cbor.Decode(cborData, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, uint(GovActionTypeTreasuryWithdrawal), decoded.Type)
+	assert.Len(t, decoded.Withdrawals, 1)
+
+	// Empty policy hash is valid (optional field)
+	noPolicy, err := NewTreasuryWithdrawalGovAction(withdrawals, nil)
+	require.NoError(t, err)
+	assert.Empty(t, noPolicy.PolicyHash)
+
+	// Negative: at least one withdrawal is required
+	_, err = NewTreasuryWithdrawalGovAction(nil, policyHash)
+	require.Error(t, err)
+	// Negative: non-empty policy hash must be 28 bytes
+	_, err = NewTreasuryWithdrawalGovAction(withdrawals, []byte{1, 2})
+	require.Error(t, err)
+}
+
+func TestNewNoConfidenceGovAction(t *testing.T) {
+	action, err := NewNoConfidenceGovAction(nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint(GovActionTypeNoConfidence), action.Type)
+	assert.Nil(t, action.ActionId)
+
+	cborData, err := cbor.Encode(action)
+	require.NoError(t, err)
+	var decoded NoConfidenceGovAction
+	_, err = cbor.Decode(cborData, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, uint(GovActionTypeNoConfidence), decoded.Type)
+
+	// Optional parent action id is carried through
+	actionId := &GovActionId{GovActionIdx: 4}
+	withParent, err := NewNoConfidenceGovAction(actionId)
+	require.NoError(t, err)
+	assert.Equal(t, actionId, withParent.ActionId)
+}
+
+func TestNewUpdateCommitteeGovAction(t *testing.T) {
+	cred := Credential{
+		CredType:   CredentialTypeAddrKeyHash,
+		Credential: NewBlake2b224([]byte("test")),
+	}
+	creds := []Credential{cred}
+	credEpochs := map[*Credential]uint{&cred: 42}
+
+	// Zero-value Rat is accepted by the constructor (it is not CBOR-encoded
+	// here because an empty cbor.Rat has no inner value to marshal).
+	zeroQuorum, err := NewUpdateCommitteeGovAction(
+		nil, creds, credEpochs, cbor.Rat{},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint(GovActionTypeUpdateCommittee), zeroQuorum.Type)
+
+	// Populated Rat: full CBOR round-trip
+	action, err := NewUpdateCommitteeGovAction(
+		&GovActionId{},
+		creds,
+		credEpochs,
+		cbor.Rat{Rat: big.NewRat(2, 3)},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, uint(GovActionTypeUpdateCommittee), action.Type)
+
+	cborData, err := cbor.Encode(action)
+	require.NoError(t, err)
+	var decoded UpdateCommitteeGovAction
+	_, err = cbor.Decode(cborData, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, uint(GovActionTypeUpdateCommittee), decoded.Type)
+	assert.Len(t, decoded.Credentials, 1)
+}
+
+func TestNewNewConstitutionGovAction(t *testing.T) {
+	dataHash := make([]byte, 32)
+	anchor, err := NewGovAnchor("https://example.com/constitution.json", dataHash)
+	require.NoError(t, err)
+	scriptHash := make([]byte, Blake2b224Size)
+
+	action, err := NewNewConstitutionGovAction(nil, anchor, scriptHash)
+	require.NoError(t, err)
+	assert.Equal(t, uint(GovActionTypeNewConstitution), action.Type)
+	assert.Equal(t, anchor, action.Constitution.Anchor)
+	assert.Equal(t, scriptHash, action.Constitution.ScriptHash)
+
+	// CBOR round-trip preserves the discriminant
+	cborData, err := cbor.Encode(action)
+	require.NoError(t, err)
+	var decoded NewConstitutionGovAction
+	_, err = cbor.Decode(cborData, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, uint(GovActionTypeNewConstitution), decoded.Type)
+
+	// Empty script hash is valid (optional guardrail script)
+	noScript, err := NewNewConstitutionGovAction(nil, anchor, nil)
+	require.NoError(t, err)
+	assert.Empty(t, noScript.Constitution.ScriptHash)
+
+	// Negative: non-empty script hash must be 28 bytes
+	_, err = NewNewConstitutionGovAction(nil, anchor, []byte{1, 2})
+	require.Error(t, err)
+}
+
+func TestNewInfoGovAction(t *testing.T) {
+	action, err := NewInfoGovAction()
+	require.NoError(t, err)
+	assert.Equal(t, uint(GovActionTypeInfo), action.Type)
+
+	cborData, err := cbor.Encode(action)
+	require.NoError(t, err)
+	var decoded InfoGovAction
+	_, err = cbor.Decode(cborData, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, uint(GovActionTypeInfo), decoded.Type)
+}

--- a/ledger/common/gov_constructors_test.go
+++ b/ledger/common/gov_constructors_test.go
@@ -113,6 +113,12 @@ func TestNewTreasuryWithdrawalGovAction(t *testing.T) {
 	// Negative: non-empty policy hash must be 28 bytes
 	_, err = NewTreasuryWithdrawalGovAction(withdrawals, []byte{1, 2})
 	require.Error(t, err)
+	// Negative: a nil address key would panic in ToPlutusData
+	_, err = NewTreasuryWithdrawalGovAction(
+		map[*Address]uint64{nil: 5_000_000},
+		nil,
+	)
+	require.Error(t, err)
 }
 
 func TestNewNoConfidenceGovAction(t *testing.T) {
@@ -143,13 +149,12 @@ func TestNewUpdateCommitteeGovAction(t *testing.T) {
 	creds := []Credential{cred}
 	credEpochs := map[*Credential]uint{&cred: 42}
 
-	// Zero-value Rat is accepted by the constructor (it is not CBOR-encoded
-	// here because an empty cbor.Rat has no inner value to marshal).
-	zeroQuorum, err := NewUpdateCommitteeGovAction(
+	// Negative: a zero-value Rat has a nil inner value and panics when CBOR
+	// encoded, so the constructor must reject it up front.
+	_, err := NewUpdateCommitteeGovAction(
 		nil, creds, credEpochs, cbor.Rat{},
 	)
-	require.NoError(t, err)
-	assert.Equal(t, uint(GovActionTypeUpdateCommittee), zeroQuorum.Type)
+	require.Error(t, err)
 
 	// Populated Rat: full CBOR round-trip
 	action, err := NewUpdateCommitteeGovAction(
@@ -168,6 +173,15 @@ func TestNewUpdateCommitteeGovAction(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint(GovActionTypeUpdateCommittee), decoded.Type)
 	assert.Len(t, decoded.Credentials, 1)
+
+	// Negative: a nil credential key would panic in ToPlutusData
+	_, err = NewUpdateCommitteeGovAction(
+		nil,
+		creds,
+		map[*Credential]uint{nil: 1},
+		cbor.Rat{Rat: big.NewRat(2, 3)},
+	)
+	require.Error(t, err)
 }
 
 func TestNewNewConstitutionGovAction(t *testing.T) {

--- a/ledger/conway/gov.go
+++ b/ledger/conway/gov.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"reflect"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
@@ -184,6 +185,16 @@ func NewConwayGovAction(action common.GovAction) (ConwayGovAction, error) {
 // silently defaulting to discriminant 0, which would be indistinguishable from a
 // valid parameter change action.
 func conwayGovActionType(action common.GovAction) (uint, error) {
+	if action == nil {
+		return 0, errors.New("governance action cannot be nil")
+	}
+	// A typed-nil pointer would otherwise match its concrete case below and wrap
+	// a nil action that encodes to CBOR null or panics in ToPlutusData; reject
+	// it before the type switch.
+	if rv := reflect.ValueOf(action); rv.Kind() == reflect.Pointer &&
+		rv.IsNil() {
+		return 0, errors.New("governance action cannot be nil")
+	}
 	switch action.(type) {
 	case *ConwayParameterChangeGovAction:
 		return uint(common.GovActionTypeParameterChange), nil
@@ -199,8 +210,6 @@ func conwayGovActionType(action common.GovAction) (uint, error) {
 		return uint(common.GovActionTypeNewConstitution), nil
 	case *common.InfoGovAction:
 		return uint(common.GovActionTypeInfo), nil
-	case nil:
-		return 0, errors.New("governance action cannot be nil")
 	default:
 		return 0, fmt.Errorf("unsupported governance action type: %T", action)
 	}

--- a/ledger/conway/gov.go
+++ b/ledger/conway/gov.go
@@ -139,3 +139,80 @@ func (a *ConwayParameterChangeGovAction) ToPlutusData() data.PlutusData {
 func (a *ConwayParameterChangeGovAction) GetPolicyHash() []byte {
 	return a.PolicyHash
 }
+
+// NewConwayParameterChangeGovAction builds a parameter change governance
+// action. actionId is optional (nil means no parent action). policyHash is
+// optional, but when provided must be a 28-byte script hash.
+func NewConwayParameterChangeGovAction(
+	actionId *common.GovActionId,
+	paramUpdate ConwayProtocolParameterUpdate,
+	policyHash []byte,
+) (*ConwayParameterChangeGovAction, error) {
+	if len(policyHash) != 0 && len(policyHash) != common.Blake2b224Size {
+		return nil, fmt.Errorf(
+			"invalid policy hash length: expected %d bytes, got %d",
+			common.Blake2b224Size,
+			len(policyHash),
+		)
+	}
+	return &ConwayParameterChangeGovAction{
+		Type:        uint(common.GovActionTypeParameterChange),
+		ActionId:    actionId,
+		ParamUpdate: paramUpdate,
+		PolicyHash:  policyHash,
+	}, nil
+}
+
+// NewConwayGovAction wraps a governance action and sets the (non-serialized)
+// discriminant Type for in-memory consistency.
+func NewConwayGovAction(action common.GovAction) (ConwayGovAction, error) {
+	return ConwayGovAction{
+		Type:   conwayGovActionType(action),
+		Action: action,
+	}, nil
+}
+
+// conwayGovActionType maps a concrete governance action to its discriminant.
+// The returned value is only used for the in-memory ConwayGovAction.Type field,
+// which is not serialized.
+func conwayGovActionType(action common.GovAction) uint {
+	switch action.(type) {
+	case *ConwayParameterChangeGovAction:
+		return uint(common.GovActionTypeParameterChange)
+	case *common.HardForkInitiationGovAction:
+		return uint(common.GovActionTypeHardForkInitiation)
+	case *common.TreasuryWithdrawalGovAction:
+		return uint(common.GovActionTypeTreasuryWithdrawal)
+	case *common.NoConfidenceGovAction:
+		return uint(common.GovActionTypeNoConfidence)
+	case *common.UpdateCommitteeGovAction:
+		return uint(common.GovActionTypeUpdateCommittee)
+	case *common.NewConstitutionGovAction:
+		return uint(common.GovActionTypeNewConstitution)
+	case *common.InfoGovAction:
+		return uint(common.GovActionTypeInfo)
+	default:
+		// Unknown/foreign action: leave Type as the zero-value default.
+		return 0
+	}
+}
+
+// NewConwayProposalProcedure builds a Conway proposal procedure from a deposit,
+// reward account, governance action, and anchor.
+func NewConwayProposalProcedure(
+	deposit uint64,
+	rewardAccount common.Address,
+	action common.GovAction,
+	anchor common.GovAnchor,
+) (*ConwayProposalProcedure, error) {
+	govAction, err := NewConwayGovAction(action)
+	if err != nil {
+		return nil, err
+	}
+	return &ConwayProposalProcedure{
+		PPDeposit:       deposit,
+		PPRewardAccount: rewardAccount,
+		PPGovAction:     govAction,
+		PPAnchor:        anchor,
+	}, nil
+}

--- a/ledger/conway/gov.go
+++ b/ledger/conway/gov.go
@@ -15,6 +15,7 @@
 package conway
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -164,36 +165,44 @@ func NewConwayParameterChangeGovAction(
 }
 
 // NewConwayGovAction wraps a governance action and sets the (non-serialized)
-// discriminant Type for in-memory consistency.
+// discriminant Type for in-memory consistency. A nil or unsupported action
+// returns an error.
 func NewConwayGovAction(action common.GovAction) (ConwayGovAction, error) {
+	actionType, err := conwayGovActionType(action)
+	if err != nil {
+		return ConwayGovAction{}, err
+	}
 	return ConwayGovAction{
-		Type:   conwayGovActionType(action),
+		Type:   actionType,
 		Action: action,
 	}, nil
 }
 
 // conwayGovActionType maps a concrete governance action to its discriminant.
 // The returned value is only used for the in-memory ConwayGovAction.Type field,
-// which is not serialized.
-func conwayGovActionType(action common.GovAction) uint {
+// which is not serialized. An unknown or nil action returns an error rather than
+// silently defaulting to discriminant 0, which would be indistinguishable from a
+// valid parameter change action.
+func conwayGovActionType(action common.GovAction) (uint, error) {
 	switch action.(type) {
 	case *ConwayParameterChangeGovAction:
-		return uint(common.GovActionTypeParameterChange)
+		return uint(common.GovActionTypeParameterChange), nil
 	case *common.HardForkInitiationGovAction:
-		return uint(common.GovActionTypeHardForkInitiation)
+		return uint(common.GovActionTypeHardForkInitiation), nil
 	case *common.TreasuryWithdrawalGovAction:
-		return uint(common.GovActionTypeTreasuryWithdrawal)
+		return uint(common.GovActionTypeTreasuryWithdrawal), nil
 	case *common.NoConfidenceGovAction:
-		return uint(common.GovActionTypeNoConfidence)
+		return uint(common.GovActionTypeNoConfidence), nil
 	case *common.UpdateCommitteeGovAction:
-		return uint(common.GovActionTypeUpdateCommittee)
+		return uint(common.GovActionTypeUpdateCommittee), nil
 	case *common.NewConstitutionGovAction:
-		return uint(common.GovActionTypeNewConstitution)
+		return uint(common.GovActionTypeNewConstitution), nil
 	case *common.InfoGovAction:
-		return uint(common.GovActionTypeInfo)
+		return uint(common.GovActionTypeInfo), nil
+	case nil:
+		return 0, errors.New("governance action cannot be nil")
 	default:
-		// Unknown/foreign action: leave Type as the zero-value default.
-		return 0
+		return 0, fmt.Errorf("unsupported governance action type: %T", action)
 	}
 }
 

--- a/ledger/conway/gov_constructors_test.go
+++ b/ledger/conway/gov_constructors_test.go
@@ -135,6 +135,13 @@ func TestNewConwayGovActionRejectsInvalid(t *testing.T) {
 	_, err = NewConwayGovAction(unsupportedGovAction{})
 	require.Error(t, err)
 
+	// A typed-nil pointer must be rejected rather than matching its concrete
+	// case and wrapping a nil action, for both known and unsupported types.
+	_, err = NewConwayGovAction((*common.InfoGovAction)(nil))
+	require.Error(t, err)
+	_, err = NewConwayGovAction((*unsupportedGovAction)(nil))
+	require.Error(t, err)
+
 	// NewConwayProposalProcedure propagates the error instead of producing a
 	// procedure that encodes a CBOR-null governance action.
 	addr, err := common.NewAddress(

--- a/ledger/conway/gov_constructors_test.go
+++ b/ledger/conway/gov_constructors_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conway
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewConwayParameterChangeGovAction(t *testing.T) {
+	minFeeA := uint(44)
+	paramUpdate := ConwayProtocolParameterUpdate{MinFeeA: &minFeeA}
+	policyHash := make([]byte, common.Blake2b224Size)
+
+	action, err := NewConwayParameterChangeGovAction(nil, paramUpdate, policyHash)
+	require.NoError(t, err)
+	assert.Equal(t, uint(common.GovActionTypeParameterChange), action.Type)
+	assert.Nil(t, action.ActionId)
+
+	// CBOR round-trip through the ConwayGovAction wrapper preserves the
+	// concrete type and discriminant.
+	ga, err := NewConwayGovAction(action)
+	require.NoError(t, err)
+	cborData, err := ga.MarshalCBOR()
+	require.NoError(t, err)
+	var decoded ConwayGovAction
+	require.NoError(t, decoded.UnmarshalCBOR(cborData))
+	decodedAction, ok := decoded.Action.(*ConwayParameterChangeGovAction)
+	require.True(t, ok, "expected *ConwayParameterChangeGovAction")
+	assert.Equal(
+		t,
+		uint(common.GovActionTypeParameterChange),
+		decodedAction.Type,
+	)
+
+	// Empty policy hash is valid (optional field)
+	noPolicy, err := NewConwayParameterChangeGovAction(nil, paramUpdate, nil)
+	require.NoError(t, err)
+	assert.Empty(t, noPolicy.PolicyHash)
+
+	// Negative: non-empty policy hash must be 28 bytes
+	_, err = NewConwayParameterChangeGovAction(nil, paramUpdate, []byte{1, 2})
+	require.Error(t, err)
+}
+
+func TestNewConwayGovActionType(t *testing.T) {
+	testCases := []struct {
+		name     string
+		action   common.GovAction
+		expected common.GovActionType
+	}{
+		{
+			name:     "ParameterChange",
+			action:   &ConwayParameterChangeGovAction{},
+			expected: common.GovActionTypeParameterChange,
+		},
+		{
+			name:     "HardForkInitiation",
+			action:   &common.HardForkInitiationGovAction{},
+			expected: common.GovActionTypeHardForkInitiation,
+		},
+		{
+			name:     "TreasuryWithdrawal",
+			action:   &common.TreasuryWithdrawalGovAction{},
+			expected: common.GovActionTypeTreasuryWithdrawal,
+		},
+		{
+			name:     "NoConfidence",
+			action:   &common.NoConfidenceGovAction{},
+			expected: common.GovActionTypeNoConfidence,
+		},
+		{
+			name:     "UpdateCommittee",
+			action:   &common.UpdateCommitteeGovAction{},
+			expected: common.GovActionTypeUpdateCommittee,
+		},
+		{
+			name:     "NewConstitution",
+			action:   &common.NewConstitutionGovAction{},
+			expected: common.GovActionTypeNewConstitution,
+		},
+		{
+			name:     "Info",
+			action:   &common.InfoGovAction{},
+			expected: common.GovActionTypeInfo,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ga, err := NewConwayGovAction(tc.action)
+			require.NoError(t, err)
+			assert.Equal(t, uint(tc.expected), ga.Type)
+			assert.Equal(t, tc.action, ga.Action)
+		})
+	}
+}
+
+func TestNewConwayProposalProcedure(t *testing.T) {
+	addr, err := common.NewAddress(
+		"addr1vx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers66hrl8",
+	)
+	require.NoError(t, err)
+	anchor, err := common.NewGovAnchor(
+		"https://example.com/proposal.json",
+		make([]byte, 32),
+	)
+	require.NoError(t, err)
+	action, err := common.NewInfoGovAction()
+	require.NoError(t, err)
+
+	pp, err := NewConwayProposalProcedure(1_000_000, addr, action, anchor)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1_000_000), pp.PPDeposit)
+	// The wrapper discriminant is set from the action
+	assert.Equal(t, uint(common.GovActionTypeInfo), pp.PPGovAction.Type)
+
+	// CBOR round-trip
+	cborData, err := cbor.Encode(pp)
+	require.NoError(t, err)
+	var decoded ConwayProposalProcedure
+	_, err = cbor.Decode(cborData, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, pp.PPDeposit, decoded.PPDeposit)
+	assert.Equal(t, pp.PPRewardAccount.String(), decoded.PPRewardAccount.String())
+	decodedAction, ok := decoded.PPGovAction.Action.(*common.InfoGovAction)
+	require.True(t, ok, "expected *common.InfoGovAction")
+	assert.Equal(t, uint(common.GovActionTypeInfo), decodedAction.Type)
+}

--- a/ledger/conway/gov_constructors_test.go
+++ b/ledger/conway/gov_constructors_test.go
@@ -19,9 +19,22 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/plutigo/data"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// unsupportedGovAction satisfies common.GovAction (via the embedded
+// GovActionBase) but is not one of the known Conway action types, so
+// NewConwayGovAction must reject it rather than silently coerce it to
+// discriminant 0.
+type unsupportedGovAction struct {
+	common.GovActionBase
+}
+
+func (unsupportedGovAction) ToPlutusData() data.PlutusData {
+	return data.NewConstr(0)
+}
 
 func TestNewConwayParameterChangeGovAction(t *testing.T) {
 	minFeeA := uint(44)
@@ -109,6 +122,32 @@ func TestNewConwayGovActionType(t *testing.T) {
 			assert.Equal(t, tc.action, ga.Action)
 		})
 	}
+}
+
+func TestNewConwayGovActionRejectsInvalid(t *testing.T) {
+	// A nil action must be rejected rather than wrapped with a CBOR-null
+	// governance action.
+	_, err := NewConwayGovAction(nil)
+	require.Error(t, err)
+
+	// An action that satisfies common.GovAction but is not a known Conway type
+	// must be rejected rather than silently coerced to discriminant 0.
+	_, err = NewConwayGovAction(unsupportedGovAction{})
+	require.Error(t, err)
+
+	// NewConwayProposalProcedure propagates the error instead of producing a
+	// procedure that encodes a CBOR-null governance action.
+	addr, err := common.NewAddress(
+		"addr1vx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers66hrl8",
+	)
+	require.NoError(t, err)
+	anchor, err := common.NewGovAnchor(
+		"https://example.com/proposal.json",
+		make([]byte, 32),
+	)
+	require.NoError(t, err)
+	_, err = NewConwayProposalProcedure(1_000_000, addr, nil, anchor)
+	require.Error(t, err)
 }
 
 func TestNewConwayProposalProcedure(t *testing.T) {


### PR DESCRIPTION
## Summary

Building a Conway proposal procedure or governance action previously required populating concrete structs by hand, including the `Type` discriminant field that must exactly match the action's place in the `GovActionType` enum. This PR adds constructors that auto-set the discriminant and validate required fields, so callers no longer assign discriminant constants manually.

Closes #1802.

## What's added

`ledger/common/gov.go`:
- `NewGovAnchor(url, dataHash)` — validates the 32-byte data hash
- `NewGovActionId(txId, idx)` — validates the 32-byte transaction id
- Constructors for the six common governance actions: `NewHardForkInitiationGovAction`, `NewTreasuryWithdrawalGovAction`, `NewNoConfidenceGovAction`, `NewUpdateCommitteeGovAction`, `NewNewConstitutionGovAction`, `NewInfoGovAction`

`ledger/conway/gov.go`:
- `NewConwayParameterChangeGovAction` — the Conway-specific action (references the Conway param-update type)
- `NewConwayGovAction` — wraps a `common.GovAction` and sets the wrapper discriminant via a type switch
- `NewConwayProposalProcedure` — composes deposit, reward account, action, and anchor end-to-end

Each governance-action constructor returns `(*T, error)`, auto-sets `Type`, and validates required fields:
- policy/script hashes must be 28 bytes when non-empty (empty is the valid "no policy/guardrail" case)
- treasury withdrawals require at least one entry
- anchor data hash and gov action transaction id must be 32 bytes

Reward accounts reuse the existing `common.NewAddress` / `common.NewAddressFromBytes`; no redundant helper was added.

## Acceptance criteria

- [x] Callers can build each proposal/action without manually assigning discriminant constants
- [x] Tests cover CBOR encoding for all action constructors and reject invalid required-field combinations
- [x] Existing exported structs and encoding behavior remain backward compatible (change is purely additive — no existing struct, field order, CBOR tag, or Marshal/Unmarshal code is touched)

## Tests

New `gov_constructors_test.go` in both `ledger/common` and `ledger/conway`:
- per-constructor discriminant assertions and CBOR round-trips
- negative tests for invalid required-field combinations (wrong hash length, empty withdrawals)
- a table test asserting the wrapper discriminant for all seven action types
- an end-to-end `NewConwayProposalProcedure` build → encode → decode round-trip

`make format`, `make lint` (0 issues), `go vet`, and `go test ./...` all pass.

## Follow-up (not in this PR)

`ledger/dijkstra/gov.go` is a near-identical clone of the Conway governance types. This issue is scoped to Conway, so Dijkstra is intentionally untouched; an identical additive set of constructors there would be a sensible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds constructors for Conway governance actions and proposal procedures that auto-set discriminants and validate inputs to fail fast. This removes manual struct wiring and prevents mismatched Type values, bad hash lengths, nil map keys, typed-nil actions, and unsupported actions.

- **New Features**
  - `ledger/common`: `NewGovAnchor`, `NewGovActionId`, and constructors for `HardForkInitiation`, `TreasuryWithdrawal`, `NoConfidence`, `UpdateCommittee`, `NewConstitution`, `Info`.
  - `ledger/conway`: `NewConwayParameterChangeGovAction`, `NewConwayGovAction` (wraps and sets type), `NewConwayProposalProcedure`.
  - Validation:
    - 32-byte anchor data hash and action tx id; 28-byte policy/script hashes when provided.
    - Treasury withdrawals require at least one entry and no nil address keys.
    - `UpdateCommittee` requires a non-nil quorum and no nil credential keys.
    - `NewConwayGovAction` rejects nil, typed-nil, or unsupported actions.

- **Migration**
  - Switch to the constructors instead of manual struct initialization.
  - No breaking changes; existing types and encoding remain unchanged.

<sup>Written for commit ef70ac46246eede56ad0893ff747b63bd5b825b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added constructor functions for governance actions with built-in input validation for anchors, action IDs, treasury withdrawals, constitutional updates, and other governance operations.

* **Tests**
  * Added comprehensive test coverage for governance constructors, including validation testing and CBOR encoding/decoding verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->