### PR TITLE
fix(pipeline): differentiate between validation enabled/ran

### DIFF
--- a/pipeline/apply_stage.go
+++ b/pipeline/apply_stage.go
@@ -24,6 +24,13 @@ import (
 // ErrPendingLimitExceeded is returned when the apply stage's pending buffer is full.
 var ErrPendingLimitExceeded = errors.New("pipeline: pending block limit exceeded")
 
+// ErrBlockNotValidated is returned when the apply stage requires validation
+// but receives a block that was never validated. This guards against blocks
+// reaching apply without passing through the validate stage.
+var ErrBlockNotValidated = errors.New(
+	"pipeline: block reached apply stage without validation",
+)
+
 // ApplyFunc is a function that applies a block to some state.
 // It is called in sequence order (by SequenceNumber).
 type ApplyFunc func(*BlockItem) error
@@ -34,9 +41,13 @@ type ApplyFunc func(*BlockItem) error
 // ProcessWithStatus must be called from a single goroutine to guarantee ordered
 // execution of ApplyFunc. The ApplyStageRunner provides this guarantee.
 type ApplyStage struct {
-	applyFunc  ApplyFunc
-	maxPending int
-	mu         sync.Mutex
+	applyFunc ApplyFunc
+	// requireValidation requires items to have passed validation (IsValid)
+	// before applying. ValidationError alone cannot distinguish "validation
+	// passed" from "validation never ran" (both are nil).
+	requireValidation bool
+	maxPending        int
+	mu                sync.Mutex
 	// pending holds out-of-order items waiting to be applied
 	pending map[uint64]*BlockItem
 	// nextSequence is the next sequence number to apply
@@ -54,6 +65,16 @@ func NewApplyStage(applyFunc ApplyFunc, maxPending int) *ApplyStage {
 		pending:      make(map[uint64]*BlockItem),
 		nextSequence: 0,
 	}
+}
+
+// SetRequireValidation sets whether items must have passed validation before
+// being applied. When enabled, an unvalidated item is not applied and its
+// apply error is set to ErrBlockNotValidated. Enable this whenever the
+// pipeline runs with validation so that blocks which bypass the validate
+// stage cannot be applied. Must be called before processing begins to avoid
+// data races.
+func (s *ApplyStage) SetRequireValidation(require bool) {
+	s.requireValidation = require
 }
 
 // Name returns the stage name.
@@ -89,10 +110,7 @@ func (s *ApplyStage) ProcessWithStatus(ctx context.Context, item *BlockItem) ([]
 	if item.SequenceNumber() == s.nextSequence {
 		s.nextSequence++
 		s.mu.Unlock()
-		// Apply if valid (no decode or validation errors)
-		if item.DecodeError() == nil && item.ValidationError() == nil {
-			s.applyItem(ctx, item)
-		}
+		s.maybeApply(ctx, item)
 		// Try to apply any buffered items that are now in order
 		buffered := s.applyPending(ctx)
 		// Return the input item plus any buffered items
@@ -113,6 +131,21 @@ func (s *ApplyStage) ProcessWithStatus(ctx context.Context, item *BlockItem) ([]
 		return nil, ErrPendingLimitExceeded
 	}
 	return nil, nil
+}
+
+// maybeApply applies the item if it passed all preceding stages: no decode or
+// validation errors, and (when validation is required) validation actually ran
+// and passed. Items failing the validation requirement are marked with
+// ErrBlockNotValidated so the skip is observable downstream.
+func (s *ApplyStage) maybeApply(ctx context.Context, item *BlockItem) {
+	if item.DecodeError() != nil || item.ValidationError() != nil {
+		return
+	}
+	if s.requireValidation && !item.IsValid() {
+		item.SetApplied(false, ErrBlockNotValidated, 0)
+		return
+	}
+	s.applyItem(ctx, item)
 }
 
 // applyItem applies a single item without holding the lock.
@@ -170,9 +203,7 @@ func (s *ApplyStage) applyPending(ctx context.Context) []*BlockItem {
 		s.mu.Unlock()
 
 		// Apply if valid, otherwise just advance (sequence already incremented)
-		if item.DecodeError() == nil && item.ValidationError() == nil {
-			s.applyItem(ctx, item)
-		}
+		s.maybeApply(ctx, item)
 
 		processed = append(processed, item)
 	}

--- a/pipeline/options.go
+++ b/pipeline/options.go
@@ -106,6 +106,9 @@ func WithDecodeWorkers(n int) PipelineOption {
 
 // WithValidateWorkers sets the number of validate workers.
 // Set to 0 to disable validation entirely (useful for trusted block sources).
+// When validation is enabled (n > 0), the apply stage refuses to apply any
+// block that has not actually passed validation, reporting
+// ErrBlockNotValidated on the errors channel.
 func WithValidateWorkers(n int) PipelineOption {
 	return func(c *PipelineConfig) {
 		if n >= 0 {

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -137,6 +137,10 @@ func (p *BlockPipeline) Start(ctx context.Context) error {
 	// Create decode stage
 	p.decodeStage = NewDecodeStage(p.config.SkipBodyHashValidation)
 	p.applyStage = NewApplyStage(p.config.ApplyFunc, p.config.MaxPendingBlocks)
+	// When validation is enabled, require items to have actually passed
+	// validation before apply; ValidationError alone cannot distinguish
+	// "passed" from "never ran"
+	p.applyStage.SetRequireValidation(validationEnabled)
 
 	// Create decode worker pool
 	p.decodePool = NewStageWorkerPool(StageWorkerPoolConfig{

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -705,6 +705,141 @@ func TestApplyStageOrdering_SkipsInvalidItems(t *testing.T) {
 	assert.Equal(t, []uint64{0, 2, 4}, appliedSeqs)
 }
 
+// newDecodedTestItem creates a decoded BlockItem that has NOT been validated
+// (SetValidation never called), so ValidationError() is nil despite no
+// validation having run.
+func newDecodedTestItem(t *testing.T, seq uint64) *BlockItem {
+	t.Helper()
+	rawCbor := getValidBlockCbor(t)
+	tip := createTestTip(1000+seq, 500+seq)
+	item := NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, seq)
+	block, err := ledger.NewBlockFromCbor(
+		uint(ledger.BlockTypeConway),
+		rawCbor,
+		common.VerifyConfig{SkipBodyHashValidation: true},
+	)
+	require.NoError(t, err)
+	item.SetBlock(block, time.Millisecond)
+	return item
+}
+
+func TestApplyStage_RequireValidation_SkipsUnvalidatedItems(t *testing.T) {
+	var appliedSeqs []uint64
+	var mu sync.Mutex
+
+	applyFunc := func(item *BlockItem) error {
+		mu.Lock()
+		appliedSeqs = append(appliedSeqs, item.SequenceNumber())
+		mu.Unlock()
+		return nil
+	}
+
+	applyStage := NewApplyStage(applyFunc, 0)
+	applyStage.SetRequireValidation(true)
+
+	item := newDecodedTestItem(t, 0)
+
+	err := applyStage.Process(context.Background(), item)
+	require.NoError(t, err)
+
+	// The unvalidated item must not be applied, and the skip must be loud
+	assert.Empty(t, appliedSeqs)
+	assert.False(t, item.IsApplied())
+	assert.ErrorIs(t, item.ApplyError(), ErrBlockNotValidated)
+}
+
+func TestApplyStage_RequireValidation_AppliesValidatedItems(t *testing.T) {
+	var appliedSeqs []uint64
+	var mu sync.Mutex
+
+	applyFunc := func(item *BlockItem) error {
+		mu.Lock()
+		appliedSeqs = append(appliedSeqs, item.SequenceNumber())
+		mu.Unlock()
+		return nil
+	}
+
+	applyStage := NewApplyStage(applyFunc, 0)
+	applyStage.SetRequireValidation(true)
+
+	item := newDecodedTestItem(t, 0)
+	item.SetValidation(true, "vrf", nil, time.Millisecond)
+
+	err := applyStage.Process(context.Background(), item)
+	require.NoError(t, err)
+
+	assert.Equal(t, []uint64{0}, appliedSeqs)
+	assert.True(t, item.IsApplied())
+	assert.NoError(t, item.ApplyError())
+}
+
+func TestApplyStage_RequireValidation_BufferedUnvalidatedItemsSkipped(t *testing.T) {
+	var appliedSeqs []uint64
+	var mu sync.Mutex
+
+	applyFunc := func(item *BlockItem) error {
+		mu.Lock()
+		appliedSeqs = append(appliedSeqs, item.SequenceNumber())
+		mu.Unlock()
+		return nil
+	}
+
+	applyStage := NewApplyStage(applyFunc, 0)
+	applyStage.SetRequireValidation(true)
+
+	// Item 1 is unvalidated and arrives first, so it is buffered and later
+	// released via the pending path; item 0 is validated
+	item1 := newDecodedTestItem(t, 1)
+	item0 := newDecodedTestItem(t, 0)
+	item0.SetValidation(true, "vrf", nil, time.Millisecond)
+
+	require.NoError(t, applyStage.Process(context.Background(), item1))
+	require.NoError(t, applyStage.Process(context.Background(), item0))
+
+	// Only the validated item is applied; the buffered unvalidated item is
+	// skipped with an explicit error
+	assert.Equal(t, []uint64{0}, appliedSeqs)
+	assert.False(t, item1.IsApplied())
+	assert.ErrorIs(t, item1.ApplyError(), ErrBlockNotValidated)
+}
+
+func TestApplyStage_NoRequireValidation_AppliesUnvalidatedItems(t *testing.T) {
+	var appliedSeqs []uint64
+	var mu sync.Mutex
+
+	applyFunc := func(item *BlockItem) error {
+		mu.Lock()
+		appliedSeqs = append(appliedSeqs, item.SequenceNumber())
+		mu.Unlock()
+		return nil
+	}
+
+	// Default behavior (validation disabled / trusted source) is unchanged
+	applyStage := NewApplyStage(applyFunc, 0)
+
+	item := newDecodedTestItem(t, 0)
+
+	err := applyStage.Process(context.Background(), item)
+	require.NoError(t, err)
+
+	assert.Equal(t, []uint64{0}, appliedSeqs)
+	assert.True(t, item.IsApplied())
+}
+
+func TestBlockPipeline_Start_WiresRequireValidation(t *testing.T) {
+	// Validation enabled -> apply stage must require validated items
+	p := NewBlockPipeline(WithValidateWorkers(1), WithEta0("00"))
+	require.NoError(t, p.Start(context.Background()))
+	defer p.Stop()
+	assert.True(t, p.applyStage.requireValidation)
+
+	// Validation disabled (default) -> apply stage accepts unvalidated items
+	p2 := NewBlockPipeline()
+	require.NoError(t, p2.Start(context.Background()))
+	defer p2.Stop()
+	assert.False(t, p2.applyStage.requireValidation)
+}
+
 func TestApplyStage_PendingCount(t *testing.T) {
 	rawCbor := getValidBlockCbor(t)
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure the apply stage only applies blocks that actually ran validation when validation is enabled. Prevents unvalidated blocks from sneaking past apply and returns a clear error.

- **Bug Fixes**
  - Added `ErrBlockNotValidated` and `ApplyStage.maybeApply` to block unvalidated items when required.
  - Introduced `ApplyStage.SetRequireValidation` and wired it in `BlockPipeline.Start` based on `WithValidateWorkers(n)`.
  - Apply behavior unchanged when validation is disabled (`n == 0`); unvalidated items are allowed.
  - Updated `WithValidateWorkers` docs and added tests to cover both validated and unvalidated paths.

<sup>Written for commit 49d6254518a4ea4c2bdc593230728847a85e594f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

