### PR TITLE
feat(localstatequery): add GetAccountState query

### DIFF
--- a/protocol/localstatequery/account_state_test.go
+++ b/protocol/localstatequery/account_state_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localstatequery
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+)
+
+// TestShelleyAccountStateQueryBuildShelleyQuery verifies the GetAccountState
+// (sub-query 29) leaf wraps through buildShelleyQuery into the full
+// BlockQuery -> ShelleyQuery -> era -> [29] envelope cardano-node sends.
+func TestShelleyAccountStateQueryBuildShelleyQuery(t *testing.T) {
+	const era = 6 // Conway
+	q := buildShelleyQuery(era, QueryTypeShelleyAccountState)
+	data, err := cbor.Encode(q)
+	if err != nil {
+		t.Fatalf("encode: %s", err)
+	}
+	// [0, [0, [6, [29]]]]  =>  82 00 82 00 82 06 81 18 1d
+	want := "82008200820681181d"
+	if got := hex.EncodeToString(data); got != want {
+		t.Fatalf("built query mismatch:\n  got:  %s\n  want: %s", got, want)
+	}
+}
+
+// TestAccountStateResultRoundTrip verifies the [ [treasury, reserves] ] wire
+// shape, including a negative reserves value (Coin is signed; a misconfigured
+// network can drive reserves below zero, as seen against a real cardano-node).
+func TestAccountStateResultRoundTrip(t *testing.T) {
+	want := AccountStateResult{
+		State: AccountState{Treasury: 500_000_000, Reserves: -1234},
+	}
+	data, err := cbor.Encode(want)
+	if err != nil {
+		t.Fatalf("encode: %s", err)
+	}
+	var got AccountStateResult
+	if _, err := cbor.Decode(data, &got); err != nil {
+		t.Fatalf("decode: %s", err)
+	}
+	if got != want {
+		t.Fatalf("round-trip mismatch:\n  got:  %#v\n  want: %#v", got, want)
+	}
+}

--- a/protocol/localstatequery/client.go
+++ b/protocol/localstatequery/client.go
@@ -729,6 +729,31 @@ func (c *Client) GetStakePools() (*StakePoolsResult, error) {
 	return &result, nil
 }
 
+func (c *Client) GetAccountState() (*AccountStateResult, error) {
+	c.Protocol.Logger().
+		Debug("calling GetAccountState()",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "client",
+			"connection_id", c.callbackContext.ConnectionId.String(),
+		)
+	c.busyMutex.Lock()
+	defer c.busyMutex.Unlock()
+	currentEra, err := c.getCurrentEra()
+	if err != nil {
+		return nil, err
+	}
+	query := buildShelleyQuery(
+		currentEra,
+		QueryTypeShelleyAccountState,
+	)
+	var result AccountStateResult
+	if err := c.runQuery(query, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 func (c *Client) GetStakePoolParams(
 	poolIds []ledger.PoolId,
 ) (*StakePoolParamsResult, error) {

--- a/protocol/localstatequery/client.go
+++ b/protocol/localstatequery/client.go
@@ -743,6 +743,12 @@ func (c *Client) GetAccountState() (*AccountStateResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	if currentEra < ledger.EraIdConway {
+		return nil, fmt.Errorf(
+			"GetAccountState requires Conway era or later (current era: %d)",
+			currentEra,
+		)
+	}
 	query := buildShelleyQuery(
 		currentEra,
 		QueryTypeShelleyAccountState,

--- a/protocol/localstatequery/queries.go
+++ b/protocol/localstatequery/queries.go
@@ -71,6 +71,7 @@ const (
 	QueryTypeShelleyDRepStakeDistr         = 26
 	QueryTypeShelleyCommitteeMembersState  = 27
 	QueryTypeShelleyFilteredVoteDelegatees = 28
+	QueryTypeShelleyAccountState           = 29
 	QueryTypeShelleySPOStakeDistr          = 30
 	QueryTypeShelleyGetProposals           = 31
 	QueryTypeShelleyGetRatifyState         = 32
@@ -232,6 +233,7 @@ func (q *ShelleyQuery) UnmarshalCBOR(data []byte) error {
 			QueryTypeShelleyDRepStakeDistr:         &ShelleyDRepStakeDistrQuery{},
 			QueryTypeShelleyCommitteeMembersState:  &ShelleyCommitteeMembersStateQuery{},
 			QueryTypeShelleyFilteredVoteDelegatees: &ShelleyFilteredVoteDelegateesQuery{},
+			QueryTypeShelleyAccountState:           &ShelleyAccountStateQuery{},
 			QueryTypeShelleySPOStakeDistr:          &ShelleySPOStakeDistrQuery{},
 			QueryTypeShelleyGetProposals:           &ShelleyGetProposalsQuery{},
 			QueryTypeShelleyGetRatifyState:         &ShelleyGetRatifyStateQuery{},
@@ -795,6 +797,23 @@ type StakePoolsResult struct {
 	Results []ledger.PoolId
 }
 
+// AccountState is the chain's treasury and reserves pots. Both are signed
+// because Coin is an Integer in the ledger (a misconfigured network can drive
+// reserves negative).
+type AccountState struct {
+	cbor.StructAsArray
+	Treasury int64
+	Reserves int64
+}
+
+// AccountStateResult is the result of GetAccountState. The account state is
+// wrapped in the single-element result array, so on the wire it is
+// [ [treasury, reserves] ].
+type AccountStateResult struct {
+	cbor.StructAsArray
+	State AccountState
+}
+
 type StakePoolParamsResult struct {
 	cbor.StructAsArray
 	Results map[ledger.PoolId]struct {
@@ -987,6 +1006,10 @@ type ShelleySPOStakeDistrQuery struct {
 	cbor.StructAsArray
 	Type    int
 	PoolIds cbor.SetType[ledger.PoolId]
+}
+
+type ShelleyAccountStateQuery struct {
+	simpleQueryBase
 }
 
 type ShelleyGetProposalsQuery struct {


### PR DESCRIPTION
## Summary

`GetAccountState` (Shelley/Conway block sub-query **29**) was a gap in the local-state-query registry — indices 22, 29 and 33 were unregistered. Because the server-side decoder couldn't map sub-query 29, any client that issued it had its `LedgerStateQuery` connection torn down. `cardano-cli` issues `GetAccountState` while balancing a transaction (`transaction build`), so this gap broke that flow for any node built on gOuroboros (e.g. Dingo).

## Changes

- Add `QueryTypeShelleyAccountState = 29` and the `ShelleyAccountStateQuery` type (a no-arg `simpleQueryBase`).
- Register it in the block sub-query decode map so the server can decode it.
- Add the result types `AccountState` (`{treasury, reserves}`) and `AccountStateResult`, plus a `Client.GetAccountState()` method.

## Wire format

The result is the account-state pots wrapped in the single-element result array — on the wire `[ [treasury, reserves] ]`. Both values are **signed**, since `Coin` is an `Integer` in the ledger; a misconfigured network can drive reserves negative (observed on the devnet's cardano-node). This was confirmed by capturing cardano-node's actual `GetAccountState` reply on a Conway devnet and matching it byte-for-byte.

## Tests

`TestShelleyAccountStateQueryBuildShelleyQuery` (query envelope encoding) and `TestAccountStateResultRoundTrip` (result round-trip incl. negative reserves). `go test ./protocol/localstatequery/...`, `gofmt`, `go vet` all pass.

This unblocks `cardano-cli transaction build` against gOuroboros-based nodes — verified end-to-end with Dingo: the build now completes and produces a valid `Tx ConwayEra` (see the companion Dingo change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `GetAccountState` (Shelley/Conway sub-query 29) to the local-state-query registry and client, fixing connection drops when `cardano-cli` requests account state during `transaction build`. The client now gates this query to Conway era and returns a clear error on pre-Conway chains.

- **New Features**
  - Register `QueryTypeShelleyAccountState = 29` and `ShelleyAccountStateQuery` in the decode map.
  - Add result types: `AccountState` (signed `treasury`, `reserves`) and `AccountStateResult`.
  - Add `Client.GetAccountState()` with a Conway-era guard.
  - Wire format: result is `[ [treasury, reserves] ]`.

<sup>Written for commit 4e9a47121bfec5b1c36d1b463818377a865e0ad5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new account state query method to the LocalStateQuery client API for Shelley-era queries.
  * Enables retrieval of current treasury and reserves information for governance operations.

* **Tests**
  * Added test coverage validating CBOR encoding/decoding of account state queries and results.
  * Includes round-trip serialization testing with edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->