### PR TITLE
ci(fuzz): use exact package paths for targets

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -14,20 +14,23 @@ jobs:
     strategy:
       matrix:
         target:
-          - {package: "./cbor/...", fuzz: "FuzzDecode$"}
-          - {package: "./cbor/...", fuzz: "FuzzDecodeStruct$"}
-          - {package: "./ledger/...", fuzz: "FuzzNewBlockFromCbor"}
-          - {package: "./ledger/...", fuzz: "FuzzNewTransactionFromCbor"}
-          - {package: "./ledger/common/...", fuzz: "FuzzMultiAsset"}
-          - {package: "./ledger/common/...", fuzz: "FuzzValue"}
-          - {package: "./ledger/common/...", fuzz: "FuzzNewAddressFromBytes"}
-          - {package: "./ledger/common/...", fuzz: "FuzzNewAddress$"}
-          - {package: "./ledger/common/...", fuzz: "FuzzNewScriptHashFromBech32"}
-          - {package: "./kes/...", fuzz: "FuzzVerifySignedKES"}
-          - {package: "./kes/...", fuzz: "FuzzNewSumKesFromBytes"}
-          - {package: "./vrf/...", fuzz: "FuzzVerify$"}
-          - {package: "./vrf/...", fuzz: "FuzzVerifyAndHash$"}
-          - {package: "./vrf/...", fuzz: "FuzzProofToHash"}
+          # go test rejects -fuzz when the package pattern matches more than
+          # one package, so each entry must name the exact package containing
+          # the fuzz target (no /... wildcards).
+          - {package: "./cbor", fuzz: "FuzzDecode$"}
+          - {package: "./cbor", fuzz: "FuzzDecodeStruct$"}
+          - {package: "./ledger", fuzz: "FuzzNewBlockFromCbor"}
+          - {package: "./ledger", fuzz: "FuzzNewTransactionFromCbor"}
+          - {package: "./ledger/common", fuzz: "FuzzMultiAsset"}
+          - {package: "./ledger/common", fuzz: "FuzzValue"}
+          - {package: "./ledger/common", fuzz: "FuzzNewAddressFromBytes"}
+          - {package: "./ledger/common", fuzz: "FuzzNewAddress$"}
+          - {package: "./ledger/common", fuzz: "FuzzNewScriptHashFromBech32"}
+          - {package: "./kes", fuzz: "FuzzVerifySignedKES"}
+          - {package: "./kes", fuzz: "FuzzNewSumKesFromBytes"}
+          - {package: "./vrf", fuzz: "FuzzVerify$"}
+          - {package: "./vrf", fuzz: "FuzzVerifyAndHash$"}
+          - {package: "./vrf", fuzz: "FuzzProofToHash"}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update fuzz CI workflow to use exact package paths for each target, removing /... wildcards. This fixes go test -fuzz rejections when patterns match multiple packages and restores reliable fuzz runs in CI.

<sup>Written for commit 030b8857bef81fb11204775d7d56937d0571760f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

