### PR TITLE
fix(cbor): handle null and undefined map keys in Value decoding

### DIFF
--- a/cbor/value.go
+++ b/cbor/value.go
@@ -147,9 +147,14 @@ func (v *Value) processMap(data []byte) (err error) {
 	// Extract actual value from each child value
 	newValue := map[any]any{}
 	for key, value := range tmpValue {
-		keyValue := key.Value()
+		// CBOR null/undefined map keys decode to a nil *Value, which is
+		// represented as a nil map key
+		var keyValue any
+		if key != nil {
+			keyValue = key.Value()
+		}
 		// Use a pointer for unhashable key types
-		if !reflect.TypeOf(keyValue).Comparable() {
+		if keyValue != nil && !reflect.TypeOf(keyValue).Comparable() {
 			keyValue = &keyValue
 		}
 		newValue[keyValue] = value.Value()

--- a/cbor/value_test.go
+++ b/cbor/value_test.go
@@ -215,18 +215,66 @@ func TestValueDecodeMapWithUnhashableKeyIsWrapped(t *testing.T) {
 	}
 }
 
-func TestValueDecodeMapUnexpectedPanicIsNotSwallowed(t *testing.T) {
-	// { null: 1 }
-	cborData := test.DecodeHexString("a1f601")
+func TestValueDecodeMapWithNullKey(t *testing.T) {
+	testDefs := []struct {
+		name    string
+		cborHex string
+	}{
+		// { null: 1 }
+		{name: "NullKey", cborHex: "a1f601"},
+		// { undefined: 1 }
+		{name: "UndefinedKey", cborHex: "a1f701"},
+	}
+	for _, testDef := range testDefs {
+		t.Run(testDef.name, func(t *testing.T) {
+			cborData := test.DecodeHexString(testDef.cborHex)
+			var tmpValue cbor.Value
+			if _, err := cbor.Decode(cborData, &tmpValue); err != nil {
+				t.Fatalf("failed to decode CBOR map with null key: %s", err)
+			}
+			valueMap, ok := tmpValue.Value().(map[any]any)
+			if !ok {
+				t.Fatalf("expected map[any]any, got: %T", tmpValue.Value())
+			}
+			if len(valueMap) != 1 {
+				t.Fatalf("expected one map item, got: %d", len(valueMap))
+			}
+			value, ok := valueMap[nil]
+			if !ok {
+				t.Fatal("expected map entry with nil key")
+			}
+			if value != uint64(1) {
+				t.Fatalf("unexpected map value: %#v", value)
+			}
+		})
+	}
+}
 
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("expected unexpected panic to be re-panicked")
-		}
-	}()
+func TestValueDecodeMapWithNullKeyInNestedMapKey(t *testing.T) {
+	// { {null: 1}: 100 } -- a map key that is itself a map with a null key,
+	// matching the shape found by FuzzNewBlockFromCbor via tx metadata
+	cborData := test.DecodeHexString("a1a1f6011864")
 
 	var tmpValue cbor.Value
-	_, _ = cbor.Decode(cborData, &tmpValue)
+	if _, err := cbor.Decode(cborData, &tmpValue); err != nil {
+		t.Fatalf("failed to decode CBOR map with nested null key: %s", err)
+	}
+	valueMap, ok := tmpValue.Value().(map[any]any)
+	if !ok {
+		t.Fatalf("expected map[any]any, got: %T", tmpValue.Value())
+	}
+	if len(valueMap) != 1 {
+		t.Fatalf("expected one map item, got: %d", len(valueMap))
+	}
+	for key, value := range valueMap {
+		// The unhashable map key is wrapped as a pointer
+		if reflect.TypeOf(key).Kind() != reflect.Ptr {
+			t.Fatalf("expected unhashable key to be wrapped as pointer, got: %T", key)
+		}
+		if value != uint64(100) {
+			t.Fatalf("unexpected map value: %#v", value)
+		}
+	}
 }
 
 func TestValueMarshalJSON(t *testing.T) {

--- a/ledger/common/testdata/fuzz/FuzzValue/698b8eab961f741b
+++ b/ledger/common/testdata/fuzz/FuzzValue/698b8eab961f741b
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("\xa1\xf70")

--- a/ledger/testdata/fuzz/FuzzNewBlockFromCbor/cc5a5bc93d2b2445
+++ b/ledger/testdata/fuzz/FuzzNewBlockFromCbor/cc5a5bc93d2b2445
@@ -1,0 +1,3 @@
+go test fuzz v1
+uint(2)
+[]byte("\x84000\xa1\x02\xa1\xa1\xf600")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes CBOR map decoding in `cbor.Value` to handle `null` and `undefined` keys safely. Prevents panics and decodes these keys as a `nil` map key, including in nested map keys.

- **Bug Fixes**
  - Treat `null`/`undefined` map keys as `nil` and guard `reflect.TypeOf` calls.
  - Preserve pointer-wrapping for unhashable keys, including nested maps.
  - Added tests for `null`/`undefined` keys and nested cases, plus fuzz seeds in `ledger/...` to reproduce the issue.

<sup>Written for commit 11c7fc76295fe27f33d7ff23068e2038dd00579c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CBOR map decoding to properly handle maps with null or undefined keys.

* **Tests**
  * Added comprehensive test coverage for null key handling in CBOR map decoding.
  * Expanded fuzzing test data to improve edge case detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->