### PR TITLE
test(bench): expect proof verification failure in block VRF benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -72,7 +72,10 @@ jobs:
           go-version: '1.26'
 
       - name: Run benchmarks
-        run: go test -run='^$' -bench=. -benchmem -count=3 -timeout=30m ./... 2>&1 | tee benchmark.txt
+        # pipefail so a benchmark failure is not masked by tee's exit code
+        run: |
+          set -o pipefail
+          go test -run='^$' -bench=. -benchmem -count=3 -timeout=30m ./... 2>&1 | tee benchmark.txt
 
       - name: Upload benchmark results
         if: github.event_name == 'issue_comment'

--- a/internal/bench/block_bench_test.go
+++ b/internal/bench/block_bench_test.go
@@ -15,6 +15,7 @@
 package bench
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -357,9 +358,11 @@ func BenchmarkBlockVRFVerification(b *testing.B) {
 	}
 
 	// Create test eta0 (32 bytes of zeros). This intentionally does not
-	// match the real epoch nonce, so VRF verification will fail. We use
-	// a fixed all-zero value because this benchmark isolates VRF
-	// cryptographic performance (Verify call cost), not correctness.
+	// match the real epoch nonce, so VRF verification fails with
+	// ErrProofVerificationFailed after performing the full cryptographic
+	// computation. We use a fixed all-zero value because this benchmark
+	// isolates VRF cryptographic performance (Verify call cost), not
+	// correctness.
 	eta0 := make([]byte, 32)
 
 	for _, vd := range vrfDataList {
@@ -374,7 +377,10 @@ func BenchmarkBlockVRFVerification(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				valid, err := vrf.Verify(vd.vrfKey, vd.proof, vd.output, vrfMsg)
-				if err != nil {
+				// The mismatched eta0 makes ErrProofVerificationFailed the
+				// expected outcome; any other error is a real failure
+				if err != nil &&
+					!errors.Is(err, vrf.ErrProofVerificationFailed) {
 					b.Fatalf("VRF verify failed: %v", err)
 				}
 				benchSink = valid

--- a/vrf/vrf.go
+++ b/vrf/vrf.go
@@ -76,6 +76,11 @@ const (
 	PublicKeySize = 32
 )
 
+// ErrProofVerificationFailed is returned when a VRF proof fails
+// cryptographic verification against the provided message. It allows
+// callers to distinguish an invalid proof from malformed inputs.
+var ErrProofVerificationFailed = errors.New("issue verifying proof")
+
 // KeyGen generates a new VRF keypair from a 32-byte seed.
 // Returns (publicKey, secretKey) where secretKey is the original seed.
 //
@@ -221,7 +226,7 @@ func VerifyAndHash(publicKey []byte, proof []byte, msg []byte) ([]byte, error) {
 		return nil, err
 	}
 	if !ok {
-		return nil, errors.New("issue verifying proof")
+		return nil, ErrProofVerificationFailed
 	}
 	// proof to hash
 	return ProofToHash(proof)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the block VRF benchmark expect a verification failure so it measures the full Verify path without relying on a real epoch nonce. Introduce a typed error in `vrf` to cleanly distinguish invalid proofs, and ensure CI surfaces benchmark failures.

- **New Features**
  - Added `vrf.ErrProofVerificationFailed` to indicate a cryptographic proof verification failure.
  - `vrf.VerifyAndHash` now returns `ErrProofVerificationFailed` when verification fails.

- **Refactors**
  - Updated block VRF benchmark to use a zeroed `eta0` and treat `ErrProofVerificationFailed` as the expected outcome; any other error fails the test.
  - CI: set `-o pipefail` in the benchmark workflow so `go test` failures are not masked by `tee`.

<sup>Written for commit 13ddd99dc12ea15480147582fee806ad2c0a02ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

