### PR TITLE
feat: leios/dijkstra block header

### DIFF
--- a/cbor/cardano_diagnostic.go
+++ b/cbor/cardano_diagnostic.go
@@ -590,7 +590,7 @@ func (w *cardanoWriter) writePlutusData(n *DiagnosticNode, depth int) {
 		w.writeRange(n)
 		w.b.WriteString("\n")
 		pairs := len(n.Children) / 2
-		for i := 0; i < pairs; i++ {
+		for i := range pairs {
 			w.b.WriteString(w.indent(depth + 1))
 			w.writePlutusData(&n.Children[i*2], depth+1)
 			w.b.WriteString(": ")

--- a/cbor/debug_test.go
+++ b/cbor/debug_test.go
@@ -52,7 +52,7 @@ func TestDumpCborStructureMaxDepthNoPanic(t *testing.T) {
 func deeplyNestedArrayCbor(depth int) []byte {
 	// Repeating [ (0x81) around a final empty array [] (0x80)
 	ret := make([]byte, depth+1)
-	for i := 0; i < depth; i++ {
+	for i := range depth {
 		ret[i] = 0x81
 	}
 	ret[len(ret)-1] = 0x80

--- a/cbor/decode.go
+++ b/cbor/decode.go
@@ -550,7 +550,7 @@ func (d *StreamDecoder) SkipN(n int) (int, int, error) {
 	}
 
 	start := d.consumed + d.dec.NumBytesRead()
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if err := d.dec.Skip(); err != nil {
 			return 0, 0, fmt.Errorf("skip item %d: %w", i, err)
 		}

--- a/cbor/diagnostic.go
+++ b/cbor/diagnostic.go
@@ -187,7 +187,7 @@ func parseArrayDiagnosticNode(
 			children = append(children, *child)
 		}
 	} else {
-		for idx := 0; idx < length; idx++ {
+		for range length {
 			child, err := parseDiagnosticNode(dec, depth+1)
 			if err != nil {
 				return nil, err
@@ -250,7 +250,7 @@ func parseMapDiagnosticNode(
 			pairs = append(pairs, [2]any{keyNode.Value, valNode.Value})
 		}
 	} else {
-		for idx := 0; idx < length; idx++ {
+		for range length {
 			keyNode, err := parseDiagnosticNode(dec, depth+1)
 			if err != nil {
 				return nil, err
@@ -635,10 +635,7 @@ func (n *DiagnosticNode) writeHexDump(
 		return
 	}
 
-	headerLen := n.cborHeaderLen()
-	if headerLen > len(n.RawBytes) {
-		headerLen = len(n.RawBytes)
-	}
+	headerLen := min(n.cborHeaderLen(), len(n.RawBytes))
 	headerBytes := n.RawBytes[:headerLen]
 
 	label := n.structureLabel()
@@ -810,7 +807,7 @@ func formatHexBytes(data []byte, maxBytes int) string {
 		return strings.Join(parts, " ")
 	}
 	parts := make([]string, maxBytes)
-	for i := 0; i < maxBytes; i++ {
+	for i := range maxBytes {
 		parts[i] = fmt.Sprintf("%02x", data[i])
 	}
 	return strings.Join(parts, " ") + fmt.Sprintf(" ... (%d bytes)", len(data))

--- a/cbor/diagnostic_api_test.go
+++ b/cbor/diagnostic_api_test.go
@@ -484,7 +484,7 @@ func TestRoundTrip(t *testing.T) {
 			assert.Equal(t, r1.Statistics, r2.Statistics)
 
 			// Path lookup is offset-stable across parses.
-			for off := 0; off < len(data); off++ {
+			for off := range data {
 				p1 := r1.Root.GetPathToOffset(off)
 				p2 := r2.Root.GetPathToOffset(off)
 				assert.Equal(t, p1, p2, "path mismatch at offset %d", off)

--- a/cbor/diagnostic_test.go
+++ b/cbor/diagnostic_test.go
@@ -193,7 +193,7 @@ func TestParseDiagnosticIndefiniteTextString(t *testing.T) {
 
 func TestParseDiagnosticMaxNestedLevels(t *testing.T) {
 	data := make([]byte, 0, 260)
-	for i := 0; i < 257; i++ {
+	for range 257 {
 		data = append(data, 0x81)
 	}
 	data = append(data, 0x00)

--- a/cbor/errors.go
+++ b/cbor/errors.go
@@ -48,10 +48,7 @@ func NewDecodeError(
 ) *DecodeError {
 	var raw []byte
 	if len(rawBytes) > 0 {
-		n := len(rawBytes)
-		if n > maxRawBytesPreview {
-			n = maxRawBytesPreview
-		}
+		n := min(len(rawBytes), maxRawBytesPreview)
 		raw = make([]byte, n)
 		copy(raw, rawBytes[:n])
 	}
@@ -128,10 +125,7 @@ func (e *DecodeError) WithDiagnostic(data []byte, opts DiagnosticOptions) string
 	}
 	raw := e.RawBytes
 	if len(raw) == 0 && len(data) > 0 && e.Offset >= 0 && e.Offset < len(data) {
-		end := e.Offset + maxRawBytesPreview
-		if end > len(data) {
-			end = len(data)
-		}
+		end := min(e.Offset+maxRawBytesPreview, len(data))
 		raw = data[e.Offset:end]
 	}
 	if len(raw) > 0 {

--- a/connection.go
+++ b/connection.go
@@ -470,9 +470,7 @@ func (c *Connection) setupConnection() error {
 	// Create muxer instance
 	c.muxer = muxer.New(c.conn)
 	// Start Goroutine to pass along errors from the muxer
-	c.waitGroup.Add(1)
-	go func() {
-		defer c.waitGroup.Done()
+	c.waitGroup.Go(func() {
 		select {
 		case <-c.doneChan:
 			return
@@ -502,7 +500,7 @@ func (c *Connection) setupConnection() error {
 			// Close connection on muxer errors
 			c.Close()
 		}
-	}()
+	})
 	protoOptions := protocol.ProtocolOptions{
 		ConnectionId: c.id,
 		Muxer:        c.muxer,
@@ -592,9 +590,7 @@ func (c *Connection) setupConnection() error {
 	// Provide the negotiated protocol version to the various mini-protocols
 	protoOptions.Version = c.handshakeVersion
 	// Start Goroutine to pass along errors from the mini-protocols
-	c.waitGroup.Add(1)
-	go func() {
-		defer c.waitGroup.Done()
+	c.waitGroup.Go(func() {
 		select {
 		case <-c.doneChan:
 			// Return if we're shutting down
@@ -608,7 +604,7 @@ func (c *Connection) setupConnection() error {
 			// Close connection on mini-protocol errors
 			c.Close()
 		}
-	}()
+	})
 	// Configure the relevant mini-protocols
 	if c.useNodeToNodeProto {
 		versionNtN := protocol.GetProtocolVersion(c.handshakeVersion)

--- a/consensus/byron/validate_test.go
+++ b/consensus/byron/validate_test.go
@@ -470,7 +470,7 @@ func TestValidateSlotLeader(t *testing.T) {
 	// Generate 3 test keys to simulate genesis delegates
 	keys := make([]ed25519.PublicKey, 3)
 	keyHashes := make([][]byte, 3)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		pubKey, _, err := ed25519.GenerateKey(nil)
 		if err != nil {
 			t.Fatalf("ed25519.GenerateKey failed: %v", err)
@@ -576,7 +576,7 @@ func TestValidateSlotLeader(t *testing.T) {
 func TestSlotLeader(t *testing.T) {
 	// Generate 5 test key hashes
 	keyHashes := make([][]byte, 5)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		keyHashes[i] = make([]byte, 28) // Blake2b224 hash size
 		keyHashes[i][0] = byte(i)       // Make each unique
 	}
@@ -1257,7 +1257,7 @@ func TestNewByronConfigFromGenesis(t *testing.T) {
 	}
 
 	// Verify slot leader calculation works
-	for slot := uint64(0); slot < 6; slot++ {
+	for slot := range uint64(6) {
 		expectedIndex := int(slot % 3)
 		index, keyHash := config.SlotLeader(slot)
 		if index != expectedIndex {

--- a/consensus/threshold_test.go
+++ b/consensus/threshold_test.go
@@ -836,7 +836,7 @@ func TestCPRAOSHighStakeIncreasesEligibility(t *testing.T) {
 	highStakeEligible := 0
 	numSamples := 100
 
-	for i := 0; i < numSamples; i++ {
+	for i := range numSamples {
 		vrfOutput := make([]byte, 64)
 		// Deterministic pseudo-random data based on index
 		for j := range vrfOutput {

--- a/internal/bench/consensus_bench_test.go
+++ b/internal/bench/consensus_bench_test.go
@@ -63,7 +63,7 @@ func init() {
 }
 
 // consensusSink prevents compiler dead-code elimination in benchmarks.
-var consensusSink interface{}
+var consensusSink any
 
 // consensusParallelSink is an atomic sink for use in RunParallel benchmarks
 // to avoid data races when multiple goroutines store results concurrently.

--- a/internal/bench/script_bench_test.go
+++ b/internal/bench/script_bench_test.go
@@ -48,7 +48,7 @@ var (
 
 // marshalNativeScript encodes a native script struct to CBOR and unmarshals it
 // back into a NativeScript. Panics on encode/unmarshal errors.
-func marshalNativeScript(script interface{}) common.NativeScript {
+func marshalNativeScript(script any) common.NativeScript {
 	data, err := cbor.Encode(script)
 	if err != nil {
 		panic("failed to encode native script: " + err.Error())

--- a/internal/bench/tx_bench_test.go
+++ b/internal/bench/tx_bench_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 // benchSink prevents compiler dead-code elimination in benchmarks.
-var benchSink interface{}
+var benchSink any
 
 // BenchmarkTxDecode benchmarks transaction CBOR decoding by era.
 func BenchmarkTxDecode(b *testing.B) {

--- a/kes/benchmark_test.go
+++ b/kes/benchmark_test.go
@@ -78,7 +78,7 @@ func BenchmarkSignAtDifferentPeriods(b *testing.B) {
 			}
 
 			// Update key to desired period
-			for p := uint64(0); p < period; p++ {
+			for range period {
 				sk, err = Update(sk)
 				if err != nil {
 					b.Fatal(err)
@@ -139,7 +139,7 @@ func BenchmarkUpdateMultiplePeriods(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				for j := 0; j < numUpdates; j++ {
+				for range numUpdates {
 					sk, err = Update(sk)
 					if err != nil {
 						b.Fatal(err)
@@ -160,7 +160,7 @@ func BenchmarkUpdateAtBoundary(b *testing.B) {
 			b.Fatal(err)
 		}
 		// Evolve to period 31
-		for p := 0; p < 31; p++ {
+		for range 31 {
 			sk, err = Update(sk)
 			if err != nil {
 				b.Fatal(err)
@@ -251,7 +251,7 @@ func BenchmarkVerifyAtDifferentPeriods(b *testing.B) {
 			}
 
 			// Update key to desired period
-			for p := uint64(0); p < period; p++ {
+			for range period {
 				sk, err = Update(sk)
 				if err != nil {
 					b.Fatal(err)

--- a/ledger/alonzo/pparams.go
+++ b/ledger/alonzo/pparams.go
@@ -17,6 +17,7 @@ package alonzo
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"math/big"
 
@@ -157,9 +158,7 @@ func (p *AlonzoProtocolParameters) Update(
 		if p.CostModels == nil {
 			p.CostModels = make(map[uint][]int64)
 		}
-		for key, model := range paramUpdate.CostModels {
-			p.CostModels[key] = model
-		}
+		maps.Copy(p.CostModels, paramUpdate.CostModels)
 	}
 	if paramUpdate.ExecutionCosts != nil {
 		p.ExecutionCosts = *paramUpdate.ExecutionCosts

--- a/ledger/babbage/pparams.go
+++ b/ledger/babbage/pparams.go
@@ -16,6 +16,7 @@ package babbage
 
 import (
 	"errors"
+	"maps"
 	"math"
 	"math/big"
 
@@ -126,9 +127,7 @@ func (p *BabbageProtocolParameters) Update(
 		if p.CostModels == nil {
 			p.CostModels = make(map[uint][]int64)
 		}
-		for key, model := range paramUpdate.CostModels {
-			p.CostModels[key] = model
-		}
+		maps.Copy(p.CostModels, paramUpdate.CostModels)
 	}
 	if paramUpdate.ExecutionCosts != nil {
 		p.ExecutionCosts = *paramUpdate.ExecutionCosts

--- a/ledger/common/address_test.go
+++ b/ledger/common/address_test.go
@@ -824,7 +824,7 @@ func TestCIP0019_AllAddressTypes(t *testing.T) {
 	// Create valid test data for each address type
 	paymentHash := make([]byte, 28)
 	stakingHash := make([]byte, 28)
-	for i := 0; i < 28; i++ {
+	for i := range 28 {
 		paymentHash[i] = byte(i)
 		stakingHash[i] = byte(i + 28)
 	}

--- a/ledger/common/leios_endorser_block.go
+++ b/ledger/common/leios_endorser_block.go
@@ -166,7 +166,7 @@ func decodeLeiosTransactionReferences(
 	}
 	refs := make([]LeiosTransactionReference, 0, count)
 	seen := make(map[Blake2b256]struct{}, count)
-	for idx := 0; idx < count; idx++ {
+	for idx := range count {
 		var hashBytes cbor.ByteString
 		if _, _, err := dec.Decode(&hashBytes); err != nil {
 			return nil, fmt.Errorf(

--- a/ledger/common/metadata.go
+++ b/ledger/common/metadata.go
@@ -262,7 +262,7 @@ func mapFirstKeyType(b []byte) byte {
 			return 0xff
 		}
 		empty := true
-		for i := 0; i < 8; i++ {
+		for i := range 8 {
 			if b[offset+i] != 0 {
 				empty = false
 				break

--- a/ledger/conway/pparams.go
+++ b/ledger/conway/pparams.go
@@ -16,6 +16,7 @@ package conway
 
 import (
 	"errors"
+	"maps"
 	"math"
 	"math/big"
 
@@ -240,9 +241,7 @@ func (p *ConwayProtocolParameters) Update(
 		if p.CostModels == nil {
 			p.CostModels = make(map[uint][]int64)
 		}
-		for key, model := range paramUpdate.CostModels {
-			p.CostModels[key] = model
-		}
+		maps.Copy(p.CostModels, paramUpdate.CostModels)
 	}
 	if paramUpdate.ExecutionCosts != nil {
 		p.ExecutionCosts = *paramUpdate.ExecutionCosts

--- a/ledger/dijkstra/dijkstra.go
+++ b/ledger/dijkstra/dijkstra.go
@@ -613,18 +613,96 @@ func decodeDijkstraPerasCertificate(
 	return &cert, nil
 }
 
+// babbageHeaderBodyFieldCount is the number of fields in a Babbage block
+// header body (block_number, slot, prev_hash, issuer_vkey, vrf_vkey,
+// vrf_result, block_body_size, block_body_hash, operational_cert,
+// protocol_version).
+const babbageHeaderBodyFieldCount = 10
+
 type DijkstraBlockHeader struct {
 	babbage.BabbageBlockHeader
+	// LeiosHeaderExtension holds the Dijkstra/Leios block-header fields that
+	// follow Babbage's protocol_version field. The leios-prototype testnet
+	// began emitting an extra trailing element (a [hash, uint] pair) once the
+	// Leios header extension activated mid-Dijkstra; earlier Dijkstra blocks
+	// carry the plain 10-field Babbage header body, for which this is nil. The
+	// elements are retained verbatim so the header round-trips and hashes
+	// identically to the bytes received on the wire.
+	LeiosHeaderExtension []cbor.RawMessage
 }
 
 func (h *DijkstraBlockHeader) UnmarshalCBOR(cborData []byte) error {
+	// Fast path: legacy Dijkstra headers are byte-for-byte Babbage headers
+	// with a 10-field body.
 	var tmp babbage.BabbageBlockHeader
-	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+	if _, err := cbor.Decode(cborData, &tmp); err == nil {
+		h.BabbageBlockHeader = tmp
+		h.LeiosHeaderExtension = nil
+		h.SetCbor(cborData)
+		return nil
+	}
+	// Leios-extended header: the header body array carries extra trailing
+	// fields after protocol_version. Decode the leading Babbage fields and
+	// retain the remainder verbatim. The full original header CBOR is stored
+	// for hashing, so the trailing fields never need typed interpretation to
+	// follow the chain.
+	var top []cbor.RawMessage
+	if _, err := cbor.Decode(cborData, &top); err != nil {
 		return err
 	}
-	h.BabbageBlockHeader = tmp
+	if len(top) != 2 {
+		return fmt.Errorf(
+			"unexpected Dijkstra block header: expected 2 elements, got %d",
+			len(top),
+		)
+	}
+	var bodyElems []cbor.RawMessage
+	if _, err := cbor.Decode(top[0], &bodyElems); err != nil {
+		return err
+	}
+	if len(bodyElems) < babbageHeaderBodyFieldCount {
+		return fmt.Errorf(
+			"unexpected Dijkstra block header body: expected at least %d fields, got %d",
+			babbageHeaderBodyFieldCount,
+			len(bodyElems),
+		)
+	}
+	babbageBodyCbor, err := cbor.Encode(bodyElems[:babbageHeaderBodyFieldCount])
+	if err != nil {
+		return err
+	}
+	var body babbage.BabbageBlockHeaderBody
+	if _, err := cbor.Decode(babbageBodyCbor, &body); err != nil {
+		return err
+	}
+	// The leading-10-field re-encoding above is only used to populate the
+	// typed Babbage fields. The body's stored CBOR must remain the ORIGINAL
+	// body bytes (the full Leios-extended array), because KES signature
+	// verification is computed over the original header-body encoding -- see
+	// ledger.extractOriginalBodyCbor. Using the re-encoded 10-field bytes here
+	// makes KES verification fail on Leios-extended headers near the tip.
+	body.SetCbor([]byte(top[0]))
+	var signature []byte
+	if _, err := cbor.Decode(top[1], &signature); err != nil {
+		return err
+	}
+	h.Body = body
+	h.Signature = signature
+	h.LeiosHeaderExtension = bodyElems[babbageHeaderBodyFieldCount:]
 	h.SetCbor(cborData)
 	return nil
+}
+
+func (h *DijkstraBlockHeader) MarshalCBOR() ([]byte, error) {
+	// Decoded headers retain their original wire bytes (including any Leios
+	// extension), which must be reproduced verbatim so the header hash is
+	// stable.
+	if cborData := h.Cbor(); cborData != nil {
+		return cborData, nil
+	}
+	// Headers constructed in-process (no stored CBOR) have no Leios extension
+	// to preserve; fall back to the Babbage encoding.
+	return cbor.Encode(&h.BabbageBlockHeader)
 }
 
 func (h *DijkstraBlockHeader) Era() common.Era {

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -15,6 +15,7 @@
 package dijkstra
 
 import (
+	"encoding/hex"
 	"math/big"
 	"strings"
 	"testing"
@@ -167,6 +168,87 @@ func TestDijkstraBlockMarshalUsesSevenItemEnvelope(t *testing.T) {
 	require.Equal(t, []byte{0x80}, []byte(raw[4]))
 	require.Equal(t, []byte{0x80}, []byte(raw[5]))
 	require.Equal(t, []byte{0x80}, []byte(raw[6]))
+}
+
+// leiosExtendedHeaderHex is a real Dijkstra block header captured from the
+// Leios prototype testnet (network magic 164) at slot 1309596. After the
+// Leios header extension activated mid-Dijkstra, the header body carries an
+// 11th element (a [hash, uint] pair) following protocol_version, which a plain
+// Babbage header decoder rejects.
+const leiosExtendedHeaderHex = "828b19ff661a0013fb9c582017f18b18364e406fdf68a72845f9b005119425ddd344d171a7d5dd005df8b7f058200c058acd8105777ffee584b5bc3e7507fe1615179bb2d291f83b089e7733de5f582017658451b63aa1614b7a93c12533a9d73032a599a411533cf5e88f9fb98343c58258405231c2bde7d989ef9df5f31dd636ad8bb6773ef1d3b1e54f35e9c2ebac647aa525b6a9219763b3a9e285a5f7acd8d1cf8c5c3ed2fc780a9f4b9f1f063a7346a05850d58cc6245cad4d434f6b17fc5af1d9d56df46f7d483af40b134f817903f0061ce3cac58fda15cfe085fa42407d03b40d207dad9d2255791f1c000bfebd36a3017aa274cbb138e6768199574e0466f8091a000151c158206f351bafba4758062454b2125a57419c3599e62be312ed0677411d4ad05c0f6184582022cead0f99f08fb8002d88ce78ec2b8bc2657b0b9e4b96f68b01dcc249e71671000058403f56eec6cb0cb526154a6fd0dcc27fe1efcbeabac244bc49c2c1ac304db52bd5d40da6960c6331a808307340c285b1abc94ea69a947ef64980f0015f1f77a607820c00825820a2dcb7c0d77a9ab7396d734665d5b25f7ead1ee0595704a90f9825c6b533925019567f5901c0103d6a7191e176f98c0dd438ba9fb84f665d17728eb659e26096fee55f9493f8d3914ebd42204b6d1ca0c93d0edab06235e7e44b5458c3ab676763dd1306d60388573c0fd8f581c24f0bbeb91eae9379d175fd6c532120acd570e3b83db66b03dade4cdfa86f4fc857c3c3580eeb14d5eb7922b2c83531aea1c725d9a296ee51a24b6006c0c0b4f0842ed247536aafe86b983252566d869ae04a3bab013ff55a116b7a220285cce2e49355b2e9aa316f3e4f71c4e1ffc880462bc49e39e064c783ce40c166b39673407fea92ed55a9721fdf9d3c06d38ec0edd2278effc70b9c985ec7c776edc22234f7659e4c085821c27756713ad2243080e1e32d28a635ff9f45309b537c142f880ff07898aa4cf5b2f26356e267a2c8fb425b324653c991d0c9138a27891be8d5d8a427446cce884e3cb4b3d9d9b3a8d551a3e0471091a4dffb3ef2868c9982a9fafcc6ef22ba750bf9a38c821e1c496511b98ee90e43b01f088e3a96e2ddb0be9309b63ca34c317e708d0a739f69e979f9b9a97cd608e1a64266877574542014af4f55223c6ff56eaa98730bde2ad7bef8d164b5a4d0a729e746714501986f1d97c69e5645befd8771bf628a3fdf6011bf8e438aaadc35"
+
+// TestDijkstraBlockHeaderDecodesLeiosExtension verifies that the Leios-extended
+// Dijkstra block header (11-field body) decodes, exposes the standard Babbage
+// fields, retains the extra Leios field, and round-trips byte-for-byte so the
+// header hash is stable.
+func TestDijkstraBlockHeaderDecodesLeiosExtension(t *testing.T) {
+	raw, err := hex.DecodeString(leiosExtendedHeaderHex)
+	require.NoError(t, err)
+
+	var header DijkstraBlockHeader
+	_, err = cbor.Decode(raw, &header)
+	require.NoError(t, err)
+
+	// Standard Babbage header fields decode positionally.
+	require.Equal(t, uint64(65382), header.BlockNumber())
+	require.Equal(t, uint64(1309596), header.SlotNumber())
+
+	// The 11th body element is retained verbatim.
+	require.Len(t, header.LeiosHeaderExtension, 1)
+
+	// The body's stored CBOR must be the ORIGINAL (Leios-extended) body bytes,
+	// not a re-encoding of the leading Babbage fields: KES signature
+	// verification (ledger.extractOriginalBodyCbor) is computed over the
+	// original header-body encoding.
+	var top []cbor.RawMessage
+	_, err = cbor.Decode(raw, &top)
+	require.NoError(t, err)
+	if len(top) == 0 {
+		t.Fatal("expected header CBOR to contain a body")
+	}
+	require.Equal(t, []byte(top[0]), header.Body.Cbor())
+
+	// Round-trips byte-for-byte so the header hash matches the wire bytes.
+	out, err := header.MarshalCBOR()
+	require.NoError(t, err)
+	require.Equal(t, raw, out)
+	require.Equal(t, common.Blake2b256Hash(raw), header.Hash())
+}
+
+// TestDijkstraBlockHeaderDecodesLegacyBabbageBody verifies that a plain
+// 10-field Babbage-shaped Dijkstra header (pre-Leios-extension) still decodes
+// with no Leios extension captured.
+func TestDijkstraBlockHeaderDecodesLegacyBabbageBody(t *testing.T) {
+	// Re-encode the captured header with only the first 10 body fields to
+	// model a legacy Dijkstra header.
+	full, err := hex.DecodeString(leiosExtendedHeaderHex)
+	require.NoError(t, err)
+	var top []cbor.RawMessage
+	_, err = cbor.Decode(full, &top)
+	require.NoError(t, err)
+	if len(top) < 2 {
+		t.Fatal("expected header CBOR to contain body and signature")
+	}
+	var bodyElems []cbor.RawMessage
+	_, err = cbor.Decode(top[0], &bodyElems)
+	require.NoError(t, err)
+	if len(bodyElems) < 10 {
+		t.Fatal("expected at least 10 header body fields")
+	}
+	legacyBody, err := cbor.Encode(bodyElems[:10])
+	require.NoError(t, err)
+	legacyHeader, err := cbor.Encode([]cbor.RawMessage{
+		cbor.RawMessage(legacyBody),
+		top[1],
+	})
+	require.NoError(t, err)
+
+	var header DijkstraBlockHeader
+	_, err = cbor.Decode(legacyHeader, &header)
+	require.NoError(t, err)
+	require.Nil(t, header.LeiosHeaderExtension)
+	require.Equal(t, uint64(65382), header.BlockNumber())
+	require.Equal(t, uint64(1309596), header.SlotNumber())
 }
 
 func TestDijkstraBlockBodyHashIncludesLeiosAndPerasCertSlots(t *testing.T) {

--- a/ledger/error_test.go
+++ b/ledger/error_test.go
@@ -833,7 +833,7 @@ func TestUtxowFailure_EraAwareDecoding_Conway(t *testing.T) {
 
 func TestUtxowFailure_InvalidMetadata_Conway(t *testing.T) {
 	// Test InvalidMetadata (tag 8) which has no payload
-	cborData, err := cbor.Encode([]interface{}{
+	cborData, err := cbor.Encode([]any{
 		uint(8), // Tag 8 = InvalidMetadata in Conway
 	})
 	require.NoError(t, err)
@@ -851,7 +851,7 @@ func TestUtxowFailure_InvalidMetadata_Conway(t *testing.T) {
 
 func TestConwayUtxowFailure_AllTags(t *testing.T) {
 	// Test that ConwayUtxowFailure can handle InvalidMetadata (tag 8, no payload)
-	cborData, err := cbor.Encode([]interface{}{uint(8)})
+	cborData, err := cbor.Encode([]any{uint(8)})
 	require.NoError(t, err)
 
 	conwayErr := &ConwayUtxowFailure{}
@@ -1033,7 +1033,7 @@ func TestShelleyUtxowFailure_Error(t *testing.T) {
 
 func TestUtxowFailure_EraAwareDecoding_Shelley(t *testing.T) {
 	// Test Shelley era decoding (tag 8 = InvalidMetadata)
-	cborData, err := cbor.Encode([]interface{}{uint(ShelleyUtxowInvalidMetadata)})
+	cborData, err := cbor.Encode([]any{uint(ShelleyUtxowInvalidMetadata)})
 	require.NoError(t, err)
 
 	utxowErr := &UtxowFailure{}
@@ -1047,7 +1047,7 @@ func TestUtxowFailure_EraAwareDecoding_Shelley(t *testing.T) {
 
 func TestUtxowFailure_EraAwareDecoding_Allegra(t *testing.T) {
 	// Test Allegra era uses same tags as Shelley (tag 8 = InvalidMetadata)
-	cborData, err := cbor.Encode([]interface{}{uint(ShelleyUtxowInvalidMetadata)})
+	cborData, err := cbor.Encode([]any{uint(ShelleyUtxowInvalidMetadata)})
 	require.NoError(t, err)
 
 	utxowErr := &UtxowFailure{}
@@ -1061,7 +1061,7 @@ func TestUtxowFailure_EraAwareDecoding_Allegra(t *testing.T) {
 
 func TestUtxowFailure_EraAwareDecoding_Mary(t *testing.T) {
 	// Test Mary era uses same tags as Shelley (tag 8 = InvalidMetadata)
-	cborData, err := cbor.Encode([]interface{}{uint(ShelleyUtxowInvalidMetadata)})
+	cborData, err := cbor.Encode([]any{uint(ShelleyUtxowInvalidMetadata)})
 	require.NoError(t, err)
 
 	utxowErr := &UtxowFailure{}
@@ -1084,7 +1084,7 @@ func TestUtxowFailure_EraAwareDecoding_Alonzo(t *testing.T) {
 
 func TestShelleyUtxowFailure_UnmarshalCBOR_InvalidMetadata(t *testing.T) {
 	// Test ShelleyUtxowFailure can decode InvalidMetadata (no payload)
-	cborData, err := cbor.Encode([]interface{}{uint(ShelleyUtxowInvalidMetadata)})
+	cborData, err := cbor.Encode([]any{uint(ShelleyUtxowInvalidMetadata)})
 	require.NoError(t, err)
 
 	shelleyErr := &ShelleyUtxowFailure{}

--- a/ledger/fuzz_test.go
+++ b/ledger/fuzz_test.go
@@ -19,6 +19,7 @@ package ledger
 
 import (
 	"encoding/hex"
+	"slices"
 	"testing"
 )
 
@@ -80,13 +81,7 @@ func FuzzNewBlockFromCbor(f *testing.F) {
 	f.Fuzz(func(t *testing.T, blockType uint, data []byte) {
 		// Only test valid block types to avoid noise from invalid types
 		validTypes := []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
-		isValid := false
-		for _, vt := range validTypes {
-			if blockType == vt {
-				isValid = true
-				break
-			}
-		}
+		isValid := slices.Contains(validTypes, blockType)
 		if !isValid {
 			return
 		}
@@ -143,13 +138,7 @@ func FuzzNewBlockHeaderFromCbor(f *testing.F) {
 	f.Fuzz(func(t *testing.T, blockType uint, data []byte) {
 		// Only test valid block types to avoid noise from invalid types
 		validTypes := []uint{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
-		isValid := false
-		for _, vt := range validTypes {
-			if blockType == vt {
-				isValid = true
-				break
-			}
-		}
+		isValid := slices.Contains(validTypes, blockType)
 		if !isValid {
 			return
 		}
@@ -185,13 +174,7 @@ func FuzzNewTransactionFromCbor(f *testing.F) {
 	f.Fuzz(func(t *testing.T, txType uint, data []byte) {
 		// Only test valid tx types to avoid noise from invalid types
 		validTypes := []uint{0, 1, 2, 3, 4, 5, 6, 7}
-		isValid := false
-		for _, vt := range validTypes {
-			if txType == vt {
-				isValid = true
-				break
-			}
-		}
+		isValid := slices.Contains(validTypes, txType)
 		if !isValid {
 			return
 		}

--- a/muxer/muxer.go
+++ b/muxer/muxer.go
@@ -211,9 +211,7 @@ func (m *Muxer) RegisterProtocol(
 	m.protocolReceivers[protocolId][protocolRole] = receiverChan
 	m.protocolReceiversMutex.Unlock()
 	// Start Goroutine to handle outbound messages
-	m.waitGroup.Add(1)
-	go func() {
-		defer m.waitGroup.Done()
+	m.waitGroup.Go(func() {
 		for {
 			select {
 			case _, ok := <-m.doneChan:
@@ -231,7 +229,7 @@ func (m *Muxer) RegisterProtocol(
 				}
 			}
 		}
-	}()
+	})
 	return senderChan, receiver, m.doneChan
 }
 

--- a/pipeline/benchmark_test.go
+++ b/pipeline/benchmark_test.go
@@ -91,8 +91,7 @@ func BenchmarkStageWorkerPool(b *testing.B) {
 			// b.SetBytes expects bytes per operation; use average block size
 			b.SetBytes(totalBytes / int64(len(blocks)))
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := b.Context()
 
 			// Use fixed-size buffers to avoid OOM when b.N is large
 			const bufferSize = 100
@@ -116,9 +115,7 @@ func BenchmarkStageWorkerPool(b *testing.B) {
 
 			// Feeder goroutine to avoid blocking on full channel
 			var wg sync.WaitGroup
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				for i := 0; i < b.N; i++ {
 					block := blocks[i%len(blocks)]
 					item := pipeline.NewBlockItem(block.BlockType, block.Cbor, pcommon.Tip{}, uint64(i))
@@ -129,7 +126,7 @@ func BenchmarkStageWorkerPool(b *testing.B) {
 					}
 				}
 				close(input)
-			}()
+			})
 
 			// Drain output
 			received := 0
@@ -173,8 +170,7 @@ func BenchmarkBlockPipeline(b *testing.B) {
 		}
 		b.SetBytes(totalBytes / int64(len(blocks)))
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := b.Context()
 
 		// Create full pipeline (decode + apply, no validation for benchmark)
 		p := pipeline.NewBlockPipeline(
@@ -194,9 +190,7 @@ func BenchmarkBlockPipeline(b *testing.B) {
 
 		// Submit blocks
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for i := 0; i < b.N; i++ {
 				blk := blocks[i%len(blocks)]
 				tip := pcommon.Tip{BlockNumber: uint64(i)}
@@ -204,7 +198,7 @@ func BenchmarkBlockPipeline(b *testing.B) {
 					return
 				}
 			}
-		}()
+		})
 
 		// Receive results
 		received := 0

--- a/pipeline/options.go
+++ b/pipeline/options.go
@@ -61,10 +61,7 @@ func DefaultPipelineConfig() PipelineConfig {
 	numCPU := runtime.NumCPU()
 
 	// Scale decode workers with CPU count (decode is faster than validate)
-	decodeWorkers := numCPU / 4
-	if decodeWorkers < 2 {
-		decodeWorkers = 2
-	}
+	decodeWorkers := max(numCPU/4, 2)
 
 	return PipelineConfig{
 		DecodeWorkers:      decodeWorkers,

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -75,7 +75,7 @@ type BlockPipeline struct {
 	metrics *PipelineMetrics
 
 	// State
-	sequenceCounter uint64
+	sequenceCounter atomic.Uint64
 	ctx             context.Context
 	cancel          context.CancelFunc
 	started         atomic.Bool
@@ -228,7 +228,7 @@ func (p *BlockPipeline) Submit(ctx context.Context, blockType uint, rawCbor []by
 	// Allocate sequence number only once, then send.
 	// We use a single blocking select to avoid sequence gaps that would occur
 	// if we allocated in a non-blocking attempt that failed.
-	item := NewBlockItem(blockType, rawCbor, tip, atomic.AddUint64(&p.sequenceCounter, 1)-1)
+	item := NewBlockItem(blockType, rawCbor, tip, p.sequenceCounter.Add(1)-1)
 
 	select {
 	case p.submitChan <- item:

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -177,30 +177,30 @@ func TestBlockItem_ThreadSafety(t *testing.T) {
 	wg.Add(numGoroutines * 4) // 4 groups of concurrent operations
 
 	// Concurrent writers for SetBlock
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		go func() {
 			defer wg.Done()
-			for j := 0; j < numIterations; j++ {
+			for j := range numIterations {
 				item.SetBlock(block, time.Duration(j)*time.Millisecond)
 			}
 		}()
 	}
 
 	// Concurrent writers for SetValidation
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		go func() {
 			defer wg.Done()
-			for j := 0; j < numIterations; j++ {
+			for j := range numIterations {
 				item.SetValidation(true, "test", nil, time.Duration(j)*time.Millisecond)
 			}
 		}()
 	}
 
 	// Concurrent readers
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		go func() {
 			defer wg.Done()
-			for j := 0; j < numIterations; j++ {
+			for range numIterations {
 				_ = item.Block()
 				_ = item.IsDecoded()
 				_ = item.IsValid()
@@ -209,10 +209,10 @@ func TestBlockItem_ThreadSafety(t *testing.T) {
 	}
 
 	// Concurrent writers for SetApplied
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		go func() {
 			defer wg.Done()
-			for j := 0; j < numIterations; j++ {
+			for j := range numIterations {
 				item.SetApplied(true, nil, time.Duration(j)*time.Millisecond)
 			}
 		}()
@@ -302,7 +302,7 @@ func TestDecodeStageWorkerPool_MultipleWorkers(t *testing.T) {
 	errors := make(chan error, numItems)
 
 	// Populate input channel
-	for i := 0; i < numItems; i++ {
+	for i := range numItems {
 		tip := createTestTip(uint64(1000+i), uint64(500+i))
 		item := NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, uint64(i))
 		input <- item
@@ -343,7 +343,7 @@ func TestDecodeStageWorkerPool_ItemsFlowThrough(t *testing.T) {
 
 	// Create items with specific sequence numbers
 	expectedSeqs := make(map[uint64]bool)
-	for i := 0; i < numItems; i++ {
+	for i := range numItems {
 		seq := uint64(100 + i)
 		expectedSeqs[seq] = false
 		tip := createTestTip(1000, 500)
@@ -634,7 +634,7 @@ func TestApplyStageOrdering_OutOfOrderReordering(t *testing.T) {
 
 	// Create items with sequence numbers
 	items := make([]*BlockItem, 5)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		tip := createTestTip(1000+uint64(i), 500+uint64(i))
 		items[i] = NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, uint64(i))
 		// Decode and validate them
@@ -675,7 +675,7 @@ func TestApplyStageOrdering_SkipsInvalidItems(t *testing.T) {
 
 	// Create items - some valid, some invalid
 	items := make([]*BlockItem, 5)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		tip := createTestTip(1000+uint64(i), 500+uint64(i))
 		items[i] = NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, uint64(i))
 
@@ -1054,9 +1054,7 @@ func TestBlockPipeline_SubmitAndResults(t *testing.T) {
 
 	// Decode worker
 	decoded := make(chan *BlockItem, numBlocks)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		defer close(decoded)
 		stage := NewDecodeStage(true)
 		for item := range input {
@@ -1067,13 +1065,11 @@ func TestBlockPipeline_SubmitAndResults(t *testing.T) {
 				statsMu.Unlock()
 			}
 		}
-	}()
+	})
 
 	// Validate worker (mock)
 	validated := make(chan *BlockItem, numBlocks)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		defer close(validated)
 		for item := range decoded {
 			if item.IsDecoded() {
@@ -1084,12 +1080,10 @@ func TestBlockPipeline_SubmitAndResults(t *testing.T) {
 			}
 			validated <- item
 		}
-	}()
+	})
 
 	// Apply worker
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		defer close(results)
 		for item := range validated {
 			if item.IsValid() {
@@ -1100,10 +1094,10 @@ func TestBlockPipeline_SubmitAndResults(t *testing.T) {
 			}
 			results <- item
 		}
-	}()
+	})
 
 	// Submit blocks
-	for i := 0; i < numBlocks; i++ {
+	for i := range numBlocks {
 		tip := createTestTip(uint64(1000+i), uint64(i))
 		item := NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, uint64(i))
 		input <- item
@@ -1133,7 +1127,7 @@ func TestBlockPipeline_StatsUpdated(t *testing.T) {
 	rawCbor := getValidBlockCbor(t)
 
 	// Simple stats tracking
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		submitted.Add(1)
 
 		tip := createTestTip(uint64(1000+i), uint64(i))
@@ -1171,7 +1165,7 @@ func TestPipelineBackpressure_SlowConsumer(t *testing.T) {
 
 	// Producer
 	go func() {
-		for i := 0; i < numBlocks; i++ {
+		for i := range numBlocks {
 			tip := createTestTip(uint64(i), uint64(i))
 			item := NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, uint64(i))
 			select {
@@ -1229,7 +1223,7 @@ func TestPipelineBackpressure_PrefetchBufferFillsUp(t *testing.T) {
 	input := make(chan *BlockItem, bufferSize)
 
 	// Fill buffer
-	for i := 0; i < bufferSize; i++ {
+	for i := range bufferSize {
 		tip := createTestTip(uint64(i), uint64(i))
 		item := NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, uint64(i))
 		select {
@@ -1296,7 +1290,7 @@ func TestPipelineGracefulShutdown_InFlightItemsComplete(t *testing.T) {
 	}()
 
 	// Submit items
-	for i := 0; i < numItems; i++ {
+	for i := range numItems {
 		tip := createTestTip(uint64(i), uint64(i))
 		item := NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, uint64(i))
 		input <- item
@@ -1524,7 +1518,7 @@ func TestBlockPipeline_SubmitStopRaceCondition(t *testing.T) {
 	tip := createTestTip(1000, 500)
 
 	// Run multiple iterations to increase likelihood of hitting the race
-	for iteration := 0; iteration < 100; iteration++ {
+	for iteration := range 100 {
 		p := NewBlockPipeline(
 			WithSkipBodyHashValidation(true),
 			WithValidateWorkers(1),
@@ -1551,7 +1545,7 @@ func TestBlockPipeline_SubmitStopRaceCondition(t *testing.T) {
 		// Goroutine 1: Rapidly submit items
 		go func(ctx context.Context) {
 			defer wg.Done()
-			for i := 0; i < 10; i++ {
+			for range 10 {
 				err := p.Submit(ctx, uint(ledger.BlockTypeConway), rawCbor, tip)
 				// Either no error, ErrPipelineStopped, or context.Canceled is acceptable.
 				// context.Canceled occurs when Stop() cancels the context before Submit
@@ -1607,7 +1601,7 @@ func TestApplyStageRunner_OutOfOrderItemsForwarded(t *testing.T) {
 
 	// Create 5 items with sequence numbers 0-4
 	items := make([]*BlockItem, 5)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		tip := createTestTip(1000+uint64(i), 500+uint64(i))
 		items[i] = NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, uint64(i))
 
@@ -1691,7 +1685,7 @@ func TestApplyStageRunner_OutOfOrderErrorItemsForwardedOnce(t *testing.T) {
 	// Create 5 items with sequence numbers 0-4
 	// Items 1 and 3 will have validation errors
 	items := make([]*BlockItem, 5)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		tip := createTestTip(1000+uint64(i), 500+uint64(i))
 		items[i] = NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, uint64(i))
 
@@ -1809,7 +1803,7 @@ func TestBlockPipeline_ValidationDisabled(t *testing.T) {
 	require.NoError(t, err)
 
 	// Submit blocks
-	for i := 0; i < numBlocks; i++ {
+	for i := range numBlocks {
 		tip := createTestTip(uint64(1000+i), uint64(i))
 		err := pipeline.Submit(ctx, uint(ledger.BlockTypeConway), rawCbor, tip)
 		require.NoError(t, err)
@@ -1889,7 +1883,7 @@ func TestBlockPipeline_MetricsRecorded(t *testing.T) {
 	require.NoError(t, err)
 
 	// Submit blocks
-	for i := 0; i < numBlocks; i++ {
+	for i := range numBlocks {
 		tip := createTestTip(uint64(1000+i), uint64(i))
 		err := pipeline.Submit(ctx, uint(ledger.BlockTypeConway), rawCbor, tip)
 		require.NoError(t, err)

--- a/protocol/blockfetch/client_test.go
+++ b/protocol/blockfetch/client_test.go
@@ -335,7 +335,7 @@ func TestStopAfterConnectionClose(t *testing.T) {
 func TestStopAfterConnectionCloseStress(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		t.Run(fmt.Sprintf("iteration_%02d", i), func(t *testing.T) {
 			conversation := []ouroboros_mock.ConversationEntry{
 				ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
@@ -380,7 +380,7 @@ func TestStopAfterConnectionCloseStress(t *testing.T) {
 				require.Fail(t, "connection did not close within timeout")
 			}
 
-			for stopAttempt := 0; stopAttempt < 3; stopAttempt++ {
+			for range 3 {
 				require.NoError(t, client.Stop())
 			}
 			require.True(t, client.IsDone())

--- a/protocol/chainsync/client_test.go
+++ b/protocol/chainsync/client_test.go
@@ -433,7 +433,7 @@ func TestSyncPipelining(t *testing.T) {
 	// Create test blocks
 	testBlocks := make([]ledger.BabbageBlock, totalBlocks)
 	blockCbors := make([][]byte, totalBlocks)
-	for i := 0; i < totalBlocks; i++ {
+	for i := range totalBlocks {
 		testBlocks[i] = ledger.BabbageBlock{
 			BlockHeader: &ledger.BabbageBlockHeader{},
 		}
@@ -587,7 +587,7 @@ func TestSyncPipelining(t *testing.T) {
 			if len(receivedBlocks) != totalBlocks {
 				t.Fatalf("expected %d blocks, received %d", totalBlocks, len(receivedBlocks))
 			}
-			for i := 0; i < totalBlocks; i++ {
+			for i := range totalBlocks {
 				expectedSlot := uint64(1000 + i)
 				if receivedBlocks[i] != expectedSlot {
 					t.Fatalf("block %d: expected slot %d, got %d", i, expectedSlot, receivedBlocks[i])

--- a/protocol/leiosnotify/client_test.go
+++ b/protocol/leiosnotify/client_test.go
@@ -414,7 +414,7 @@ func TestNotificationLoopDrainsOnStop(t *testing.T) {
 	client.notificationChan <- NewMsgBlockAnnouncement([]byte{0x01})
 
 	// Send 3 remaining pipelined messages (should be drained without calling NotificationFunc)
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		select {
 		case client.notificationChan <- NewMsgBlockAnnouncement([]byte{byte(i + 2)}):
 		case <-time.After(time.Second):

--- a/protocol/leiosnotify/server.go
+++ b/protocol/leiosnotify/server.go
@@ -96,9 +96,17 @@ func (s *Server) handleRequestNext() error {
 			"connection_id", s.callbackContext.ConnectionId.String(),
 		)
 	if s.config == nil || s.config.RequestNextFunc == nil {
-		return errors.New(
-			"received leios-notify NotificationRequestNext message but no callback function is defined",
-		)
+		// No notification source is wired. This happens when a node negotiates
+		// an N2N version that includes the Leios mini-protocols but does not
+		// actively serve Leios notifications (e.g. a node following the chain
+		// over chainsync/blockfetch without participating in Leios diffusion).
+		// Leave the request pending in the Busy state instead of erroring:
+		// leios-notify has no response timeout and no await message, so a
+		// server with nothing to announce legitimately holds agency until it
+		// has a notification. Erroring here would tear down the whole
+		// connection -- including chainsync/blockfetch -- over an unanswered
+		// notification request.
+		return nil
 	}
 	resp, err := s.config.RequestNextFunc(
 		s.callbackContext,

--- a/protocol/leiosnotify/server_test.go
+++ b/protocol/leiosnotify/server_test.go
@@ -15,17 +15,56 @@
 package leiosnotify
 
 import (
+	"bytes"
+	"encoding/binary"
 	"errors"
+	"io"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/muxer"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func readLeiosNotifyTestSegment(
+	t *testing.T,
+	conn net.Conn,
+) (*muxer.Segment, error) {
+	t.Helper()
+	header := muxer.SegmentHeader{}
+	if err := binary.Read(conn, binary.BigEndian, &header); err != nil {
+		return nil, err
+	}
+	payload := make([]byte, header.PayloadLength)
+	if _, err := io.ReadFull(conn, payload); err != nil {
+		return nil, err
+	}
+	return &muxer.Segment{
+		SegmentHeader: header,
+		Payload:       payload,
+	}, nil
+}
+
+func writeLeiosNotifyTestSegment(
+	t *testing.T,
+	conn net.Conn,
+	segment *muxer.Segment,
+) {
+	t.Helper()
+	require.NotNil(t, segment)
+	buf := &bytes.Buffer{}
+	require.NoError(t, binary.Write(buf, binary.BigEndian, segment.SegmentHeader))
+	_, err := buf.Write(segment.Payload)
+	require.NoError(t, err)
+	_, err = conn.Write(buf.Bytes())
+	require.NoError(t, err)
+}
 
 func TestNewServer(t *testing.T) {
 	connId := connection.ConnectionId{
@@ -88,8 +127,70 @@ func TestHandleRequestNext_NilCallback(t *testing.T) {
 
 	err := server.handleRequestNext()
 
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "no callback function is defined")
+	// With no callback wired, the request is left pending (the server holds
+	// agency until it has a notification) rather than tearing down the
+	// connection. leios-notify has no response timeout or await message, so
+	// this is valid protocol behavior for a node that does not serve
+	// notifications.
+	assert.NoError(t, err)
+	assert.False(t, server.IsDone(), "nil callback must not stop the protocol")
+	assert.Equal(t, connId, server.callbackContext.ConnectionId)
+}
+
+func TestNilCallbackRequestStaysPendingAndConnectionUsable(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+
+	connA, connB := net.Pipe()
+	defer connA.Close()
+	defer connB.Close()
+
+	m := muxer.New(connA)
+	defer m.Stop()
+
+	cfg := NewConfig()
+	server := NewServer(
+		protocol.ProtocolOptions{
+			ConnectionId: connId,
+			Muxer:        m,
+		},
+		&cfg,
+	)
+	server.Start()
+	defer server.Protocol.Stop()
+	m.Start()
+
+	requestData, err := cbor.Encode(NewMsgNotificationRequestNext())
+	require.NoError(t, err)
+	writeLeiosNotifyTestSegment(
+		t,
+		connB,
+		muxer.NewSegment(ProtocolId, requestData, false),
+	)
+
+	require.Eventually(t, func() bool {
+		return !server.IsInTerminalOrIdleState()
+	}, time.Second, 10*time.Millisecond, "server should remain in Busy")
+	assert.False(t, server.IsDone(), "pending request must not close protocol")
+	assert.Equal(t, connId, server.callbackContext.ConnectionId)
+	assert.Equal(t, server, server.callbackContext.Server)
+
+	response := NewMsgBlockAnnouncement(cbor.RawMessage{0x82, 0x01, 0x02})
+	require.NoError(t, server.SendMessage(response))
+	require.NoError(t, connB.SetReadDeadline(time.Now().Add(time.Second)))
+	segment, err := readLeiosNotifyTestSegment(t, connB)
+	require.NoError(t, err)
+	assert.True(t, segment.IsResponse())
+	assert.Equal(t, ProtocolId, segment.GetProtocolId())
+
+	msg, err := NewMsgFromCbor(MessageTypeBlockAnnouncement, segment.Payload)
+	require.NoError(t, err)
+	if msg == nil {
+		t.Fatal("expected block announcement message")
+	}
+	assert.Equal(t, response.Type(), msg.Type())
 }
 
 func TestHandleRequestNext_NilConfig(t *testing.T) {
@@ -106,8 +207,8 @@ func TestHandleRequestNext_NilConfig(t *testing.T) {
 
 	err := server.handleRequestNext()
 
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "no callback function is defined")
+	// A nil config likewise leaves the request pending rather than erroring.
+	assert.NoError(t, err)
 }
 
 func TestHandleRequestNext_CallbackError(t *testing.T) {

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -109,7 +109,7 @@ func TestIsDone(t *testing.T) {
 
 		close(doneChan)
 
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			require.True(t, p.IsDone(), "IsDone() call %d should return true", i+1)
 		}
 	})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for Leios-extended Dijkstra block headers and preserves original header/body CBOR to keep hashes and KES verification stable. Also updates the `leios-notify` server to keep requests pending when no callback is configured so connections stay open.

- **New Features**
  - `ledger/dijkstra`: Decode Leios-extended headers; trailing body fields are retained in `LeiosHeaderExtension`.
  - `ledger/dijkstra`: Preserve original header/body CBOR and reproduce it in `MarshalCBOR` for byte-for-byte round-trips.
  - Tests cover extended and legacy headers, including a real Leios testnet header.

- **Bug Fixes**
  - `ledger/dijkstra`: Ensure KES verification uses the original body CBOR (no re-encode of the first 10 fields).
  - `protocol/leiosnotify`: Leave `NotificationRequestNext` pending when no `RequestNextFunc`/config is wired; add tests to verify the protocol stays usable and can still send announcements.

<sup>Written for commit e27b81d4ab7bf6e28c4e045c19b087ffbf3ce933. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for extended block headers with additional trailing fields while maintaining backward compatibility with legacy header formats.

* **Bug Fixes**
  * Improved notification server request handling to keep requests pending when callbacks are unavailable, rather than terminating the connection with an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->