### PR TITLE
fix: sync with leios-prototype

### DIFF
--- a/ledger/common/leios_endorser_block.go
+++ b/ledger/common/leios_endorser_block.go
@@ -40,24 +40,48 @@ type LeiosTransactionReference struct {
 }
 
 func (b *LeiosEndorserBlock) UnmarshalCBOR(cborData []byte) error {
-	var items []cbor.RawMessage
-	bytesRead, err := cbor.Decode(cborData, &items)
-	if err != nil {
-		return err
+	if len(cborData) == 0 {
+		return errors.New("empty leios endorser block")
 	}
-	if bytesRead != len(cborData) {
+	// The endorser block is carried in two wire shapes depending on the peer:
+	//
+	//   - CIP-0164 / dingo: [ transaction_references ] — the references map
+	//     wrapped in a single-element array (major type 4).
+	//   - IOG Leios prototype: { hash => size } — a bare references map
+	//     (major type 5), with no array wrapper.
+	//
+	// Accept both so dingo can fetch endorser blocks from the prototype relays
+	// while still round-tripping its own array-wrapped form.
+	var refsRaw cbor.RawMessage
+	switch majorType := cborData[0] >> 5; majorType {
+	case 4: // CBOR array: array-wrapped references
+		var items []cbor.RawMessage
+		bytesRead, err := cbor.Decode(cborData, &items)
+		if err != nil {
+			return err
+		}
+		if bytesRead != len(cborData) {
+			return fmt.Errorf(
+				"trailing bytes after leios endorser block: %d",
+				len(cborData)-bytesRead,
+			)
+		}
+		if len(items) != 1 {
+			return fmt.Errorf(
+				"invalid leios endorser block: expected 1 component, got %d",
+				len(items),
+			)
+		}
+		refsRaw = items[0]
+	case 5: // CBOR map: bare references map (prototype)
+		refsRaw = cborData
+	default:
 		return fmt.Errorf(
-			"trailing bytes after leios endorser block: %d",
-			len(cborData)-bytesRead,
+			"invalid leios endorser block: expected CBOR array or map, got major type %d",
+			majorType,
 		)
 	}
-	if len(items) != 1 {
-		return fmt.Errorf(
-			"invalid leios endorser block: expected 1 component, got %d",
-			len(items),
-		)
-	}
-	refs, err := decodeLeiosTransactionReferences(items[0])
+	refs, err := decodeLeiosTransactionReferences(refsRaw)
 	if err != nil {
 		return err
 	}

--- a/ledger/dijkstra/dijkstra.go
+++ b/ledger/dijkstra/dijkstra.go
@@ -709,6 +709,36 @@ func (h *DijkstraBlockHeader) Era() common.Era {
 	return EraDijkstra
 }
 
+// LeiosEndorserBlockRef returns the endorser block referenced by this ranking
+// block via its Leios header extension. The extension's first element is the
+// endorser-block announcement [eb_hash, eb_size] (the same shape leios-notify
+// uses), identifying the endorser block whose transactions this ranking block
+// endorses. ok is false for pre-Leios-extension Dijkstra headers (which carry
+// no extension) or if the extension is not the expected [hash32, uint] shape.
+func (h *DijkstraBlockHeader) LeiosEndorserBlockRef() (
+	hash common.Blake2b256,
+	size uint64,
+	ok bool,
+) {
+	if len(h.LeiosHeaderExtension) == 0 {
+		return common.Blake2b256{}, 0, false
+	}
+	var pair []cbor.RawMessage
+	if _, err := cbor.Decode(h.LeiosHeaderExtension[0], &pair); err != nil ||
+		len(pair) != 2 {
+		return common.Blake2b256{}, 0, false
+	}
+	var hashBytes []byte
+	if _, err := cbor.Decode(pair[0], &hashBytes); err != nil ||
+		len(hashBytes) != common.Blake2b256Size {
+		return common.Blake2b256{}, 0, false
+	}
+	if _, err := cbor.Decode(pair[1], &size); err != nil {
+		return common.Blake2b256{}, 0, false
+	}
+	return common.NewBlake2b256(hashBytes), size, true
+}
+
 type DijkstraTransactionOutput struct {
 	cbor.DecodeStoreCbor
 	Output common.TransactionOutput

--- a/protocol/leiosfetch/messages.go
+++ b/protocol/leiosfetch/messages.go
@@ -126,9 +126,61 @@ func NewMsgBlockTxsRequest(
 	return m
 }
 
+// MarshalCBOR encodes the request as [msgType, point, bitmaps], where bitmaps
+// is an indefinite-length CBOR map (0xbf ... 0xff). The IOG Leios prototype
+// emits and expects the bitmaps map in indefinite-length form; encoding it as
+// a definite-length map causes the prototype relay to reject the request and
+// reset the connection.
+func (m *MsgBlockTxsRequest) MarshalCBOR() ([]byte, error) {
+	if raw := m.Cbor(); len(raw) > 0 {
+		return raw, nil
+	}
+	bitmaps, err := encodeBlockTxBitmaps(m.Bitmaps)
+	if err != nil {
+		return nil, err
+	}
+	return cbor.Encode(
+		[]any{m.MessageType, m.Point, cbor.RawMessage(bitmaps)},
+	)
+}
+
+func encodeBlockTxBitmaps(bitmaps map[uint16]uint64) ([]byte, error) {
+	keys := make([]uint16, 0, len(bitmaps))
+	for k := range bitmaps {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	ret := []byte{0xbf} // indefinite-length map header
+	for _, k := range keys {
+		kc, err := cbor.Encode(k)
+		if err != nil {
+			return nil, err
+		}
+		vc, err := cbor.Encode(bitmaps[k])
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, kc...)
+		ret = append(ret, vc...)
+	}
+	ret = append(ret, 0xff) // break
+	return ret, nil
+}
+
+// MsgBlockTxs carries the transactions of an endorser block. Two wire shapes
+// are accepted for prototype interop:
+//
+//   - dingo: [tx_list] — just the transactions (2-element message).
+//   - IOG Leios prototype: [point, bitmaps, tx_list] — echoes the request's
+//     point and bitmaps alongside the transactions (4-element message).
+//
+// Point/Bitmaps are populated only when decoding the prototype form; encoding
+// emits the prototype form when Bitmaps is non-nil, otherwise the dingo form.
 type MsgBlockTxs struct {
 	protocol.MessageBase
-	TxsRaw []cbor.RawMessage
+	Point   pcommon.Point
+	Bitmaps map[uint16]uint64
+	TxsRaw  []cbor.RawMessage
 }
 
 func NewMsgBlockTxs(txs []cbor.RawMessage) *MsgBlockTxs {
@@ -139,6 +191,88 @@ func NewMsgBlockTxs(txs []cbor.RawMessage) *MsgBlockTxs {
 		TxsRaw: slices.Clone(txs),
 	}
 	return m
+}
+
+// NewMsgBlockTxsFull builds the prototype's 4-element block-txs response,
+// echoing the requested point and bitmaps alongside the transactions.
+func NewMsgBlockTxsFull(
+	point pcommon.Point,
+	bitmaps map[uint16]uint64,
+	txs []cbor.RawMessage,
+) *MsgBlockTxs {
+	m := &MsgBlockTxs{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeBlockTxs,
+		},
+		Point:   point,
+		Bitmaps: maps.Clone(bitmaps),
+		TxsRaw:  slices.Clone(txs),
+	}
+	return m
+}
+
+func (m *MsgBlockTxs) MarshalCBOR() ([]byte, error) {
+	if raw := m.Cbor(); len(raw) > 0 {
+		return raw, nil
+	}
+	if m.Bitmaps != nil {
+		bitmaps, err := encodeBlockTxBitmaps(m.Bitmaps)
+		if err != nil {
+			return nil, err
+		}
+		return cbor.Encode(
+			[]any{
+				m.MessageType,
+				m.Point,
+				cbor.RawMessage(bitmaps),
+				m.TxsRaw,
+			},
+		)
+	}
+	return cbor.Encode([]any{m.MessageType, m.TxsRaw})
+}
+
+func (m *MsgBlockTxs) UnmarshalCBOR(data []byte) error {
+	var elems []cbor.RawMessage
+	if _, err := cbor.Decode(data, &elems); err != nil {
+		return err
+	}
+	switch len(elems) {
+	case 2: // [msgType, tx_list] — dingo form
+		var env struct {
+			cbor.StructAsArray
+			MessageType uint8
+			TxsRaw      []cbor.RawMessage
+		}
+		if _, err := cbor.Decode(data, &env); err != nil {
+			return err
+		}
+		m.MessageType = env.MessageType
+		m.TxsRaw = env.TxsRaw
+	case 4: // [msgType, point, bitmaps, tx_list] — prototype form
+		var env struct {
+			cbor.StructAsArray
+			MessageType uint8
+			Point       pcommon.Point
+			Bitmaps     map[uint16]uint64
+			TxsRaw      []cbor.RawMessage
+		}
+		if _, err := cbor.Decode(data, &env); err != nil {
+			return err
+		}
+		m.MessageType = env.MessageType
+		m.Point = env.Point
+		m.Bitmaps = env.Bitmaps
+		m.TxsRaw = env.TxsRaw
+	default:
+		return fmt.Errorf(
+			"%s: block txs: unexpected element count %d",
+			ProtocolName,
+			len(elems),
+		)
+	}
+	m.SetCbor(data)
+	return nil
 }
 
 type MsgVotesRequest struct {

--- a/protocol/leiosfetch/messages_test.go
+++ b/protocol/leiosfetch/messages_test.go
@@ -251,6 +251,47 @@ func TestMsgBlockTxs(t *testing.T) {
 	assert.Equal(t, txs, msg.TxsRaw)
 }
 
+func TestMsgBlockTxsFullUsesRequestBitmapEncoding(t *testing.T) {
+	point := pcommon.NewPoint(123, []byte{0x01, 0x02})
+	bitmaps := map[uint16]uint64{
+		0:  1,
+		64: 0x00ff000000000000,
+	}
+
+	requestEncoded, err := cbor.Encode(
+		NewMsgBlockTxsRequest(point, bitmaps),
+	)
+	require.NoError(t, err)
+
+	responseEncoded, err := cbor.Encode(
+		NewMsgBlockTxsFull(
+			point,
+			bitmaps,
+			[]cbor.RawMessage{[]byte{0x82, 0x01, 0x02}},
+		),
+	)
+	require.NoError(t, err)
+
+	var requestElems []cbor.RawMessage
+	_, err = cbor.Decode(requestEncoded, &requestElems)
+	require.NoError(t, err)
+
+	var responseElems []cbor.RawMessage
+	_, err = cbor.Decode(responseEncoded, &responseElems)
+	require.NoError(t, err)
+
+	require.Len(t, requestElems, 3)
+	require.Len(t, responseElems, 4)
+	require.NotEmpty(t, responseElems[2])
+	assert.Equal(t, requestElems[2], responseElems[2])
+	assert.Equal(t, byte(0xbf), responseElems[2][0])
+	assert.Equal(t, byte(0xff), responseElems[2][len(responseElems[2])-1])
+
+	decoded, err := NewMsgFromCbor(MessageTypeBlockTxs, responseEncoded)
+	require.NoError(t, err)
+	assert.Equal(t, bitmaps, decoded.(*MsgBlockTxs).Bitmaps)
+}
+
 func TestMsgVotesRequest(t *testing.T) {
 	voteIds := []MsgVotesRequestVoteId{
 		{SlotNo: 100, VoterId: 1},
@@ -355,11 +396,12 @@ func TestMsgDone(t *testing.T) {
 }
 
 func TestNewMsgFromCborUnknownType(t *testing.T) {
-	// Test with unknown message type - the NewMsgFromCbor function tries to decode
-	// into a nil pointer, which results in an error
+	// Test with unknown message type - the NewMsgFromCbor function tries to
+	// decode into a nil pointer, which results in an error
 	data := []byte{0x80} // empty array
 	msg, err := NewMsgFromCbor(999, data)
-	// When the message type is unknown, ret is nil, and cbor.Decode(data, nil) returns an error
+	// When the message type is unknown, ret is nil, and
+	// cbor.Decode(data, nil) returns an error
 	assert.Error(t, err)
 	assert.Nil(t, msg)
 }

--- a/protocol/leiosnotify/messages.go
+++ b/protocol/leiosnotify/messages.go
@@ -121,9 +121,22 @@ func NewMsgBlockTxsOffer(point pcommon.Point) *MsgBlockTxsOffer {
 	return m
 }
 
+// MsgVotesOffer carries vote information over leios-notify (tag 4). It is
+// lenient about the per-vote element shape so dingo can interoperate with the
+// IOG Leios prototype, which diffuses vote data inline over this message
+// rather than over a standalone leios-votes mini-protocol:
+//
+//   - Votes holds vote IDs ([slot, voter_id], 2 elements) when the peer offers
+//     IDs to be fetched (dingo's offer-and-fetch design).
+//   - FullVotes holds complete votes ([slot, eb_hash, voter_id, signature], 4
+//     elements) when the peer pushes votes directly (the prototype dialect).
+//
+// After decoding, exactly one of Votes / FullVotes is populated depending on
+// the per-vote CBOR array length. Encoding prefers FullVotes when present.
 type MsgVotesOffer struct {
 	protocol.MessageBase
-	Votes []MsgVotesOfferVote
+	Votes     []MsgVotesOfferVote
+	FullVotes []lcommon.LeiosVote
 }
 
 type MsgVotesOfferVote = lcommon.LeiosVoteId
@@ -136,6 +149,92 @@ func NewMsgVotesOffer(votes []MsgVotesOfferVote) *MsgVotesOffer {
 		Votes: votes,
 	}
 	return m
+}
+
+// NewMsgVotesOfferFull builds a votes offer carrying full pushed votes, as the
+// Leios prototype diffuses them inline over leios-notify.
+func NewMsgVotesOfferFull(votes []lcommon.LeiosVote) *MsgVotesOffer {
+	m := &MsgVotesOffer{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeVotesOffer,
+		},
+		FullVotes: votes,
+	}
+	return m
+}
+
+func (m *MsgVotesOffer) MarshalCBOR() ([]byte, error) {
+	if raw := m.Cbor(); len(raw) > 0 {
+		return raw, nil
+	}
+	if len(m.FullVotes) > 0 {
+		return cbor.Encode([]any{m.MessageType, m.FullVotes})
+	}
+	return cbor.Encode([]any{m.MessageType, m.Votes})
+}
+
+func (m *MsgVotesOffer) UnmarshalCBOR(data []byte) error {
+	// Decode the outer [msgType, [vote, ...]] envelope, capturing each vote
+	// as raw CBOR so we can branch on its element count without committing to
+	// a single per-vote shape.
+	var envelope struct {
+		cbor.StructAsArray
+		MessageType uint8
+		Votes       []cbor.RawMessage
+	}
+	if _, err := cbor.Decode(data, &envelope); err != nil {
+		return err
+	}
+	m.MessageType = envelope.MessageType
+	m.Votes = nil
+	m.FullVotes = nil
+	for idx, voteRaw := range envelope.Votes {
+		// Peek at the element count to distinguish a vote ID
+		// ([slot, voter_id]) from a full vote
+		// ([slot, eb_hash, voter_id, signature]).
+		var elems []cbor.RawMessage
+		if _, err := cbor.Decode(voteRaw, &elems); err != nil {
+			return fmt.Errorf(
+				"%s: votes offer: decode vote %d: %w",
+				ProtocolName,
+				idx,
+				err,
+			)
+		}
+		switch len(elems) {
+		case 2:
+			var id MsgVotesOfferVote
+			if _, err := cbor.Decode(voteRaw, &id); err != nil {
+				return fmt.Errorf(
+					"%s: votes offer: decode vote id %d: %w",
+					ProtocolName,
+					idx,
+					err,
+				)
+			}
+			m.Votes = append(m.Votes, id)
+		case 4:
+			var vote lcommon.LeiosVote
+			if _, err := cbor.Decode(voteRaw, &vote); err != nil {
+				return fmt.Errorf(
+					"%s: votes offer: decode full vote %d: %w",
+					ProtocolName,
+					idx,
+					err,
+				)
+			}
+			m.FullVotes = append(m.FullVotes, vote)
+		default:
+			return fmt.Errorf(
+				"%s: votes offer: vote %d has unexpected element count %d",
+				ProtocolName,
+				idx,
+				len(elems),
+			)
+		}
+	}
+	m.SetCbor(data)
+	return nil
 }
 
 type MsgDone struct {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Leios prototype compatibility so dingo can fetch endorser blocks, block txs, and votes without disconnects. Accepts prototype CBOR shapes and emits the encodings the prototype expects, including indefinite-length bitmap maps and inline votes.

- **Bug Fixes**
  - `ledger/common`: Endorser block decoding now accepts array-wrapped or bare-map CBOR; rejects empty input.
  - `ledger/dijkstra`: Added `LeiosEndorserBlockRef()` to read `[eb_hash, eb_size]` from the Leios header extension.
  - `protocol/leiosfetch`: `MsgBlockTxsRequest` encodes bitmaps as an indefinite-length CBOR map; `MsgBlockTxs` now supports both dingo `[tx_list]` and prototype `[point, bitmaps, tx_list]` forms with `Point`/`Bitmaps` fields and a `NewMsgBlockTxsFull` helper.
  - `protocol/leiosnotify`: `MsgVotesOffer` accepts either vote IDs or full votes (prototype push), decoding by per-vote arity; adds `NewMsgVotesOfferFull` and prefers encoding full votes when present.

<sup>Written for commit 79088f48fc7c7daa1318a24b15d13d9636543fd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple CBOR wire format shapes (array-wrapped and bare maps) to improve protocol compatibility.
  * Introduced ability to extract endorser block references from block headers.

* **Improvements**
  * Enhanced block transaction and vote message handling to support both CIP-0164/dingo and IOG Leios prototype wire formats.
  * Improved validation of message components and trailing bytes for better interoperability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->