### PR TITLE
chore(examples): mod tidy

### DIFF
--- a/examples/block-fetch/go.sum
+++ b/examples/block-fetch/go.sum
@@ -4,8 +4,8 @@ github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/ouroboros-mock v0.12.0 h1:ihiS/G/Rd01+gzarCWHxjBarhz9uyW2Pi8whe7zxoRo=
-github.com/blinklabs-io/ouroboros-mock v0.12.0/go.mod h1:2jimY85PkKl/J1pmSwy9+G2xof2OtUI2czhUGYP1QMo=
+github.com/blinklabs-io/ouroboros-mock v0.13.0 h1:7lavNgWzqPe4FcsDLuA/B1m2jOtlZ7nlKcImnKc3aY4=
+github.com/blinklabs-io/ouroboros-mock v0.13.0/go.mod h1:9jNLVTUagJ04l6fFzzN44ElqJrr0ndv9bGo/UTnfDbc=
 github.com/blinklabs-io/plutigo v0.1.15 h1:I2PS/byq30lH3cfq8cNxLb6iF5N7RTpokCtNE4sTLqk=
 github.com/blinklabs-io/plutigo v0.1.15/go.mod h1:vn7QgZc7d1LimRn9SCKSBnwf5JeEZI46Jqz2UGk3Zag=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=

--- a/examples/chain-sync/go.sum
+++ b/examples/chain-sync/go.sum
@@ -4,8 +4,8 @@ github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/ouroboros-mock v0.12.0 h1:ihiS/G/Rd01+gzarCWHxjBarhz9uyW2Pi8whe7zxoRo=
-github.com/blinklabs-io/ouroboros-mock v0.12.0/go.mod h1:2jimY85PkKl/J1pmSwy9+G2xof2OtUI2czhUGYP1QMo=
+github.com/blinklabs-io/ouroboros-mock v0.13.0 h1:7lavNgWzqPe4FcsDLuA/B1m2jOtlZ7nlKcImnKc3aY4=
+github.com/blinklabs-io/ouroboros-mock v0.13.0/go.mod h1:9jNLVTUagJ04l6fFzzN44ElqJrr0ndv9bGo/UTnfDbc=
 github.com/blinklabs-io/plutigo v0.1.15 h1:I2PS/byq30lH3cfq8cNxLb6iF5N7RTpokCtNE4sTLqk=
 github.com/blinklabs-io/plutigo v0.1.15/go.mod h1:vn7QgZc7d1LimRn9SCKSBnwf5JeEZI46Jqz2UGk3Zag=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=

--- a/examples/chain-tip/go.sum
+++ b/examples/chain-tip/go.sum
@@ -4,8 +4,8 @@ github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/ouroboros-mock v0.12.0 h1:ihiS/G/Rd01+gzarCWHxjBarhz9uyW2Pi8whe7zxoRo=
-github.com/blinklabs-io/ouroboros-mock v0.12.0/go.mod h1:2jimY85PkKl/J1pmSwy9+G2xof2OtUI2czhUGYP1QMo=
+github.com/blinklabs-io/ouroboros-mock v0.13.0 h1:7lavNgWzqPe4FcsDLuA/B1m2jOtlZ7nlKcImnKc3aY4=
+github.com/blinklabs-io/ouroboros-mock v0.13.0/go.mod h1:9jNLVTUagJ04l6fFzzN44ElqJrr0ndv9bGo/UTnfDbc=
 github.com/blinklabs-io/plutigo v0.1.15 h1:I2PS/byq30lH3cfq8cNxLb6iF5N7RTpokCtNE4sTLqk=
 github.com/blinklabs-io/plutigo v0.1.15/go.mod h1:vn7QgZc7d1LimRn9SCKSBnwf5JeEZI46Jqz2UGk3Zag=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=

--- a/examples/peer-sharing/go.sum
+++ b/examples/peer-sharing/go.sum
@@ -4,8 +4,8 @@ github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/ouroboros-mock v0.12.0 h1:ihiS/G/Rd01+gzarCWHxjBarhz9uyW2Pi8whe7zxoRo=
-github.com/blinklabs-io/ouroboros-mock v0.12.0/go.mod h1:2jimY85PkKl/J1pmSwy9+G2xof2OtUI2czhUGYP1QMo=
+github.com/blinklabs-io/ouroboros-mock v0.13.0 h1:7lavNgWzqPe4FcsDLuA/B1m2jOtlZ7nlKcImnKc3aY4=
+github.com/blinklabs-io/ouroboros-mock v0.13.0/go.mod h1:9jNLVTUagJ04l6fFzzN44ElqJrr0ndv9bGo/UTnfDbc=
 github.com/blinklabs-io/plutigo v0.1.15 h1:I2PS/byq30lH3cfq8cNxLb6iF5N7RTpokCtNE4sTLqk=
 github.com/blinklabs-io/plutigo v0.1.15/go.mod h1:vn7QgZc7d1LimRn9SCKSBnwf5JeEZI46Jqz2UGk3Zag=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=

--- a/examples/ping/go.sum
+++ b/examples/ping/go.sum
@@ -4,8 +4,8 @@ github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/ouroboros-mock v0.12.0 h1:ihiS/G/Rd01+gzarCWHxjBarhz9uyW2Pi8whe7zxoRo=
-github.com/blinklabs-io/ouroboros-mock v0.12.0/go.mod h1:2jimY85PkKl/J1pmSwy9+G2xof2OtUI2czhUGYP1QMo=
+github.com/blinklabs-io/ouroboros-mock v0.13.0 h1:7lavNgWzqPe4FcsDLuA/B1m2jOtlZ7nlKcImnKc3aY4=
+github.com/blinklabs-io/ouroboros-mock v0.13.0/go.mod h1:9jNLVTUagJ04l6fFzzN44ElqJrr0ndv9bGo/UTnfDbc=
 github.com/blinklabs-io/plutigo v0.1.15 h1:I2PS/byq30lH3cfq8cNxLb6iF5N7RTpokCtNE4sTLqk=
 github.com/blinklabs-io/plutigo v0.1.15/go.mod h1:vn7QgZc7d1LimRn9SCKSBnwf5JeEZI46Jqz2UGk3Zag=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=

--- a/examples/state-query/go.sum
+++ b/examples/state-query/go.sum
@@ -4,8 +4,8 @@ github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/ouroboros-mock v0.12.0 h1:ihiS/G/Rd01+gzarCWHxjBarhz9uyW2Pi8whe7zxoRo=
-github.com/blinklabs-io/ouroboros-mock v0.12.0/go.mod h1:2jimY85PkKl/J1pmSwy9+G2xof2OtUI2czhUGYP1QMo=
+github.com/blinklabs-io/ouroboros-mock v0.13.0 h1:7lavNgWzqPe4FcsDLuA/B1m2jOtlZ7nlKcImnKc3aY4=
+github.com/blinklabs-io/ouroboros-mock v0.13.0/go.mod h1:9jNLVTUagJ04l6fFzzN44ElqJrr0ndv9bGo/UTnfDbc=
 github.com/blinklabs-io/plutigo v0.1.15 h1:I2PS/byq30lH3cfq8cNxLb6iF5N7RTpokCtNE4sTLqk=
 github.com/blinklabs-io/plutigo v0.1.15/go.mod h1:vn7QgZc7d1LimRn9SCKSBnwf5JeEZI46Jqz2UGk3Zag=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=

--- a/examples/tx-monitor/go.sum
+++ b/examples/tx-monitor/go.sum
@@ -4,8 +4,8 @@ github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/ouroboros-mock v0.12.0 h1:ihiS/G/Rd01+gzarCWHxjBarhz9uyW2Pi8whe7zxoRo=
-github.com/blinklabs-io/ouroboros-mock v0.12.0/go.mod h1:2jimY85PkKl/J1pmSwy9+G2xof2OtUI2czhUGYP1QMo=
+github.com/blinklabs-io/ouroboros-mock v0.13.0 h1:7lavNgWzqPe4FcsDLuA/B1m2jOtlZ7nlKcImnKc3aY4=
+github.com/blinklabs-io/ouroboros-mock v0.13.0/go.mod h1:9jNLVTUagJ04l6fFzzN44ElqJrr0ndv9bGo/UTnfDbc=
 github.com/blinklabs-io/plutigo v0.1.15 h1:I2PS/byq30lH3cfq8cNxLb6iF5N7RTpokCtNE4sTLqk=
 github.com/blinklabs-io/plutigo v0.1.15/go.mod h1:vn7QgZc7d1LimRn9SCKSBnwf5JeEZI46Jqz2UGk3Zag=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=

--- a/examples/tx-submission/go.sum
+++ b/examples/tx-submission/go.sum
@@ -4,8 +4,8 @@ github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/ouroboros-mock v0.12.0 h1:ihiS/G/Rd01+gzarCWHxjBarhz9uyW2Pi8whe7zxoRo=
-github.com/blinklabs-io/ouroboros-mock v0.12.0/go.mod h1:2jimY85PkKl/J1pmSwy9+G2xof2OtUI2czhUGYP1QMo=
+github.com/blinklabs-io/ouroboros-mock v0.13.0 h1:7lavNgWzqPe4FcsDLuA/B1m2jOtlZ7nlKcImnKc3aY4=
+github.com/blinklabs-io/ouroboros-mock v0.13.0/go.mod h1:9jNLVTUagJ04l6fFzzN44ElqJrr0ndv9bGo/UTnfDbc=
 github.com/blinklabs-io/plutigo v0.1.15 h1:I2PS/byq30lH3cfq8cNxLb6iF5N7RTpokCtNE4sTLqk=
 github.com/blinklabs-io/plutigo v0.1.15/go.mod h1:vn7QgZc7d1LimRn9SCKSBnwf5JeEZI46Jqz2UGk3Zag=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ran `go mod tidy` in example modules and bumped `github.com/blinklabs-io/ouroboros-mock` from v0.12.0 to v0.13.0. Updates `go.sum` across all examples to keep checksums consistent and dependencies current.

<sup>Written for commit 7e881786a072e6f57c59cb34853c628d20f5d5dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

