### PR TITLE
perf(cbor): shard cache locks

### DIFF
--- a/cbor/decode.go
+++ b/cbor/decode.go
@@ -196,29 +196,23 @@ func DecodeById(
 	return ret, nil
 }
 
-var (
-	decodeGenericTypeCache      = map[reflect.Type]reflect.Type{}
-	decodeGenericTypeCacheMutex sync.RWMutex
-)
+var decodeGenericTypeCache = newGenericTypeCache()
 
 // DecodeGeneric decodes the specified CBOR into the destination object without using the
 // destination object's UnmarshalCBOR() function
 func DecodeGeneric(cborData []byte, dest any) error {
 	// Get destination type
 	valueDest := reflect.ValueOf(dest)
+	if valueDest.Kind() != reflect.Pointer ||
+		valueDest.IsNil() ||
+		valueDest.Elem().Kind() != reflect.Struct {
+		return errors.New("destination must be a pointer to a struct")
+	}
 	typeDest := valueDest.Elem().Type()
-	// Check type cache
-	decodeGenericTypeCacheMutex.RLock()
-	tmpTypeDest, ok := decodeGenericTypeCache[typeDest]
-	decodeGenericTypeCacheMutex.RUnlock()
-	if !ok {
+	tmpTypeDest, err := decodeGenericTypeCache.getOrCreate(typeDest, func() (reflect.Type, error) {
 		// Create a duplicate(-ish) struct from the destination
 		// We do this so that we can bypass any custom UnmarshalCBOR() function on the
 		// destination object
-		if valueDest.Kind() != reflect.Pointer ||
-			valueDest.Elem().Kind() != reflect.Struct {
-			return errors.New("destination must be a pointer to a struct")
-		}
 		destTypeFields := []reflect.StructField{}
 		for i := range typeDest.NumField() {
 			tmpField := typeDest.Field(i)
@@ -226,11 +220,10 @@ func DecodeGeneric(cborData []byte, dest any) error {
 				destTypeFields = append(destTypeFields, tmpField)
 			}
 		}
-		tmpTypeDest = reflect.StructOf(destTypeFields)
-		// Populate cache
-		decodeGenericTypeCacheMutex.Lock()
-		decodeGenericTypeCache[typeDest] = tmpTypeDest
-		decodeGenericTypeCacheMutex.Unlock()
+		return reflect.StructOf(destTypeFields), nil
+	})
+	if err != nil {
+		return err
 	}
 	// Create temporary object with the type created above
 	tmpDest := reflect.New(tmpTypeDest)

--- a/cbor/decode_test.go
+++ b/cbor/decode_test.go
@@ -361,6 +361,35 @@ func TestDecodeGeneric(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "destination must be a pointer to a struct")
 	})
+
+	cborData, _ := hex.DecodeString(validCborHex)
+	for _, test := range []struct {
+		name string
+		dest any
+	}{
+		{
+			name: "non-pointer struct",
+			dest: decodeGenericTestStruct{},
+		},
+		{
+			name: "nil interface",
+			dest: nil,
+		},
+		{
+			name: "typed nil pointer",
+			dest: (*decodeGenericTestStruct)(nil),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := cbor.DecodeGeneric(cborData, test.dest)
+			require.Error(t, err)
+			assert.Contains(
+				t,
+				err.Error(),
+				"destination must be a pointer to a struct",
+			)
+		})
+	}
 }
 
 func TestDecodeGenericTypeCache(t *testing.T) {

--- a/cbor/encode.go
+++ b/cbor/encode.go
@@ -60,29 +60,23 @@ func Encode(data any) ([]byte, error) {
 	return buf.Bytes(), err
 }
 
-var (
-	encodeGenericTypeCache      = map[reflect.Type]reflect.Type{}
-	encodeGenericTypeCacheMutex sync.RWMutex
-)
+var encodeGenericTypeCache = newGenericTypeCache()
 
 // EncodeGeneric encodes the specified object to CBOR without using the source object's
 // MarshalCBOR() function
 func EncodeGeneric(src any) ([]byte, error) {
 	// Get source type
 	valueSrc := reflect.ValueOf(src)
+	if valueSrc.Kind() != reflect.Pointer ||
+		valueSrc.IsNil() ||
+		valueSrc.Elem().Kind() != reflect.Struct {
+		return nil, errors.New("source must be a pointer to a struct")
+	}
 	typeSrc := valueSrc.Elem().Type()
-	// Check type cache
-	encodeGenericTypeCacheMutex.RLock()
-	tmpTypeSrc, ok := encodeGenericTypeCache[typeSrc]
-	encodeGenericTypeCacheMutex.RUnlock()
-	if !ok {
+	tmpTypeSrc, err := encodeGenericTypeCache.getOrCreate(typeSrc, func() (reflect.Type, error) {
 		// Create a duplicate(-ish) struct from the destination
 		// We do this so that we can bypass any custom MarshalCBOR() function on the
 		// source object
-		if valueSrc.Kind() != reflect.Pointer ||
-			valueSrc.Elem().Kind() != reflect.Struct {
-			return nil, errors.New("source must be a pointer to a struct")
-		}
 		srcTypeFields := []reflect.StructField{}
 		for i := range typeSrc.NumField() {
 			tmpField := typeSrc.Field(i)
@@ -90,11 +84,10 @@ func EncodeGeneric(src any) ([]byte, error) {
 				srcTypeFields = append(srcTypeFields, tmpField)
 			}
 		}
-		tmpTypeSrc = reflect.StructOf(srcTypeFields)
-		// Populate cache
-		encodeGenericTypeCacheMutex.Lock()
-		encodeGenericTypeCache[typeSrc] = tmpTypeSrc
-		encodeGenericTypeCacheMutex.Unlock()
+		return reflect.StructOf(srcTypeFields), nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	// Create temporary object with the type created above
 	tmpSrc := reflect.New(tmpTypeSrc)

--- a/cbor/encode_test.go
+++ b/cbor/encode_test.go
@@ -140,6 +140,30 @@ func TestEncodeGeneric(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "source must be a pointer to a struct")
 	})
+
+	for _, test := range []struct {
+		name string
+		src  any
+	}{
+		{
+			name: "non-pointer struct",
+			src:  encodeGenericTestStruct{},
+		},
+		{
+			name: "nil interface",
+			src:  nil,
+		},
+		{
+			name: "typed nil pointer",
+			src:  (*encodeGenericTestStruct)(nil),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := cbor.EncodeGeneric(test.src)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "source must be a pointer to a struct")
+		})
+	}
 }
 
 func TestEncodeGenericRoundTrip(t *testing.T) {

--- a/cbor/generic_cache_test.go
+++ b/cbor/generic_cache_test.go
@@ -1,0 +1,169 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cbor_test
+
+import (
+	"encoding/hex"
+	"sync"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeGenericTypeCacheConcurrent(t *testing.T) {
+	src := &encodeGenericTestStruct{Foo: 5, Bar: "ba"}
+	expected, err := cbor.EncodeGeneric(src)
+	require.NoError(t, err)
+
+	const goroutines = 32
+	const iterations = 100
+
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+	results := make(chan []byte, goroutines*iterations)
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				result, err := cbor.EncodeGeneric(src)
+				if err != nil {
+					errs <- err
+					return
+				}
+				results <- result
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	close(results)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	for result := range results {
+		assert.Equal(t, expected, result)
+	}
+}
+
+func TestDecodeGenericTypeCacheConcurrent(t *testing.T) {
+	cborData, err := hex.DecodeString("a26342617262626163466f6f05")
+	require.NoError(t, err)
+	expected := &decodeGenericTestStruct{Foo: 5, Bar: "ba"}
+
+	const goroutines = 32
+	const iterations = 100
+
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+	results := make(chan *decodeGenericTestStruct, goroutines*iterations)
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				dest := &decodeGenericTestStruct{}
+				if err := cbor.DecodeGeneric(cborData, dest); err != nil {
+					errs <- err
+					return
+				}
+				results <- dest
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	close(results)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	for result := range results {
+		assert.Equal(t, expected, result)
+	}
+}
+
+func BenchmarkEncodeGenericCached(b *testing.B) {
+	src := &encodeGenericTestStruct{Foo: 5, Bar: "ba"}
+	if _, err := cbor.EncodeGeneric(src); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := cbor.EncodeGeneric(src); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkEncodeGenericCachedParallel(b *testing.B) {
+	src := &encodeGenericTestStruct{Foo: 5, Bar: "ba"}
+	if _, err := cbor.EncodeGeneric(src); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, err := cbor.EncodeGeneric(src); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkDecodeGenericCached(b *testing.B) {
+	cborData, err := hex.DecodeString("a26342617262626163466f6f05")
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := cbor.DecodeGeneric(cborData, &decodeGenericTestStruct{}); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if err := cbor.DecodeGeneric(cborData, &decodeGenericTestStruct{}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDecodeGenericCachedParallel(b *testing.B) {
+	cborData, err := hex.DecodeString("a26342617262626163466f6f05")
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := cbor.DecodeGeneric(cborData, &decodeGenericTestStruct{}); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if err := cbor.DecodeGeneric(cborData, &decodeGenericTestStruct{}); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/cbor/type_cache.go
+++ b/cbor/type_cache.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cbor
+
+import (
+	"reflect"
+	"sync"
+	"sync/atomic"
+)
+
+type genericTypeCache struct {
+	mu    sync.Mutex
+	types atomic.Pointer[map[reflect.Type]reflect.Type]
+}
+
+func newGenericTypeCache() *genericTypeCache {
+	cache := &genericTypeCache{}
+	types := make(map[reflect.Type]reflect.Type)
+	cache.types.Store(&types)
+	return cache
+}
+
+func (c *genericTypeCache) getOrCreate(
+	srcType reflect.Type,
+	create func() (reflect.Type, error),
+) (reflect.Type, error) {
+	if cachedType, ok := c.get(srcType); ok {
+		return cachedType, nil
+	}
+
+	createdType, err := create()
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Publish a fresh map on misses so cache hits can read without a lock.
+	currentTypes := *c.types.Load()
+	if cachedType, ok := currentTypes[srcType]; ok {
+		return cachedType, nil
+	}
+
+	nextTypes := make(map[reflect.Type]reflect.Type, len(currentTypes)+1)
+	for cachedSrcType, cachedType := range currentTypes {
+		nextTypes[cachedSrcType] = cachedType
+	}
+	nextTypes[srcType] = createdType
+	c.types.Store(&nextTypes)
+	return createdType, nil
+}
+
+func (c *genericTypeCache) get(srcType reflect.Type) (reflect.Type, bool) {
+	cachedType, ok := (*c.types.Load())[srcType]
+	return cachedType, ok
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made CBOR generic type caches lock‑free on reads to reduce contention in `EncodeGeneric` and `DecodeGeneric`, and added input validation to avoid panics on nil or non‑pointer inputs. No public API changes.

- **Refactors**
  - Replaced RWMutex maps with a copy‑on‑write `genericTypeCache` using `atomic.Pointer`; hits are lock‑free, misses take a short mutex and publish a fresh map.
  - Centralized temporary struct type creation with a shared `getOrCreate`; new cache lives in `type_cache.go`.
  - Added concurrency tests and parallel benchmarks to validate thread safety and throughput.

- **Bug Fixes**
  - Validate inputs in `EncodeGeneric`/`DecodeGeneric`: require a non‑nil pointer to a struct; return clear errors instead of panicking (e.g., typed nil pointers, nil interfaces, non‑pointer structs).
  - Added tests covering these error cases.

<sup>Written for commit bf41a5f9973547e650eb971c9be7bc872c4873e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal caching mechanism for generic type operations with enhanced concurrency support.

* **Tests**
  * Added concurrency tests verifying thread-safe behavior of generic encoding and decoding.
  * Added performance benchmarks measuring cached operation efficiency in single-threaded and parallel scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->