### PR TITLE
refactor: rename leios testnet to musashi

### DIFF
--- a/networks.go
+++ b/networks.go
@@ -70,9 +70,9 @@ var (
 			},
 		},
 	}
-	NetworkCardanoLeios = Network{
+	NetworkCardanoMusashi = Network{
 		Id:           common.AddressNetworkTestnet,
-		Name:         "leios",
+		Name:         "musashi",
 		NetworkMagic: 164,
 		BootstrapPeers: []NetworkBootstrapPeer{
 			{
@@ -150,7 +150,7 @@ var networks = []Network{
 	NetworkCardanoPreprod,
 	NetworkCardanoPreview,
 	NetworkCardanoSancho,
-	NetworkCardanoLeios,
+	NetworkCardanoMusashi,
 	NetworkPrimeMainnet,
 	NetworkPrimeTestnet,
 	NetworkDevnet,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the Cardano testnet from "leios" to "musashi" by updating the exported symbol and network name. Behavior, network magic (164), and bootstrap peers are unchanged.

- **Migration**
  - Replace `NetworkCardanoLeios` with `NetworkCardanoMusashi`.
  - Update any configs/env that refer to "leios" to "musashi".

<sup>Written for commit d02a617eb3932895800f298759d54704ddfe88cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

