### PR TITLE
fix(localstatequery): encode DRepState as cardano-node's 4-element record

### DIFF
--- a/protocol/localstatequery/drep_state_test.go
+++ b/protocol/localstatequery/drep_state_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localstatequery
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// drepCredHash is the DRep key hash captured from a real cardano-node
+// GetDRepState reply on a Conway devnet (cardano-cli 11.0.0.0).
+const drepCredHash = "f857c5ebc4c4c6d8683c8b83a87de825f436acc2fddc48b4f0bae474"
+
+// TestDRepStateResultWireBytes pins the GetDRepState value encoding to the
+// exact bytes a real cardano-node sends, so the 4-element shape
+// [ expiry, anchor, deposit, delegators ] cannot silently regress to the
+// 3-element form that made cardano-cli fail with
+// "Size mismatch when decoding Record RecD. Expected 3, but found 4."
+func TestDRepStateResultWireBytes(t *testing.T) {
+	var hash ledger.Blake2b224
+	raw, err := hex.DecodeString(drepCredHash)
+	if err != nil {
+		t.Fatalf("decode hash: %s", err)
+	}
+	copy(hash[:], raw)
+	cred := StakeCredential{Tag: 0, Bytes: hash}
+
+	result := DRepStateResult{
+		cred: DRepStateEntry{
+			Expiry:  22,
+			Anchor:  nil, // StrictMaybe SNothing -> empty list 0x80
+			Deposit: 500_000_000,
+			// no delegators -> empty set 0xd9010280
+		},
+	}
+	data, err := cbor.Encode(result)
+	if err != nil {
+		t.Fatalf("encode: %s", err)
+	}
+	// map(1) { [0, hash] : [22, [], 500000000, set()] }
+	//   a1 8200 581c <28 hash> 84 16 80 1a1dcd6500 d9010280
+	want := "a18200581c" + drepCredHash + "8416801a1dcd6500d9010280"
+	if got := hex.EncodeToString(data); got != want {
+		t.Fatalf("DRepState wire mismatch (no anchor/delegators):\n  got:  %s\n  want: %s", got, want)
+	}
+}
+
+// TestDRepStateResultRoundTrip exercises the populated case: an anchor present
+// (StrictMaybe SJust -> [anchor]) and a non-empty delegators set, and verifies
+// encode/decode round-trips through the gouroboros client type.
+func TestDRepStateResultRoundTrip(t *testing.T) {
+	var drepHash ledger.Blake2b224
+	copy(drepHash[:], mustHex(t, drepCredHash))
+	cred := StakeCredential{Tag: 0, Bytes: drepHash}
+
+	var delegHash ledger.Blake2b224
+	copy(delegHash[:], mustHex(t, "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c"))
+	deleg := StakeCredential{Tag: 1, Bytes: delegHash}
+
+	anchor := lcommon.GovAnchor{Url: "https://drep.example.com"}
+	copy(anchor.DataHash[:], mustHex(t,
+		"aabbcc00000000000000000000000000000000000000000000000000000000ff"))
+
+	want := DRepStateResult{
+		cred: DRepStateEntry{
+			Expiry:     100,
+			Anchor:     &anchor,
+			Deposit:    500_000_000,
+			Delegators: []StakeCredential{deleg},
+		},
+	}
+	data, err := cbor.Encode(want)
+	if err != nil {
+		t.Fatalf("encode: %s", err)
+	}
+	var got DRepStateResult
+	if _, err := cbor.Decode(data, &got); err != nil {
+		t.Fatalf("decode: %s", err)
+	}
+	entry, ok := got[cred]
+	if !ok {
+		t.Fatalf("credential key missing after round-trip")
+	}
+	if entry.Expiry != 100 || entry.Deposit != 500_000_000 {
+		t.Fatalf("scalar fields wrong: %+v", entry)
+	}
+	if entry.Anchor == nil || entry.Anchor.Url != anchor.Url ||
+		entry.Anchor.DataHash != anchor.DataHash {
+		t.Fatalf("anchor wrong after round-trip: %+v", entry.Anchor)
+	}
+	if len(entry.Delegators) != 1 || entry.Delegators[0] != deleg {
+		t.Fatalf("delegators wrong after round-trip: %+v", entry.Delegators)
+	}
+}
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("decode hex %q: %s", s, err)
+	}
+	return b
+}

--- a/protocol/localstatequery/queries.go
+++ b/protocol/localstatequery/queries.go
@@ -1121,12 +1121,64 @@ func (g *GovStateResult) DecodeCommittee() (*Committee, error) {
 	}
 }
 
-// DRepStateEntry represents the state of a single DRep
+// DRepStateEntry represents the state of a single DRep.
+//
+// On the wire it is the cardano-node GetDRepState value: a 4-element array
+//
+//	[ expiry, anchor, deposit, delegators ]
+//
+// where anchor is a StrictMaybe encoded as a list ([] for none, [anchor] for
+// some — not a CBOR null), and delegators is a CBOR set (tag 258) of the stake
+// credentials currently delegating their voting power to this DRep. cardano
+// clients (cardano-cli) decode this exact shape; emitting a 3-element array (no
+// delegators) or a CBOR null anchor makes them fail with a size mismatch.
 type DRepStateEntry struct {
-	cbor.StructAsArray
-	Expiry  uint64             // Epoch when DRep expires
-	Anchor  *lcommon.GovAnchor // Optional metadata anchor
-	Deposit uint64             // Deposit amount
+	Expiry     uint64             // Epoch when DRep expires
+	Anchor     *lcommon.GovAnchor // Optional metadata anchor
+	Deposit    uint64             // Deposit amount
+	Delegators []StakeCredential  // Stake credentials delegating to this DRep
+}
+
+func (e DRepStateEntry) MarshalCBOR() ([]byte, error) {
+	// StrictMaybe Anchor: SNothing -> [], SJust -> [anchor].
+	anchor := []any{}
+	if e.Anchor != nil {
+		anchor = []any{*e.Anchor}
+	}
+	// Delegators as a CBOR set (tag 258); empty when the DRep has none.
+	delegators := make(cbor.Set, len(e.Delegators))
+	for i := range e.Delegators {
+		delegators[i] = e.Delegators[i]
+	}
+	return cbor.Encode([]any{
+		e.Expiry,
+		anchor,
+		e.Deposit,
+		delegators,
+	})
+}
+
+func (e *DRepStateEntry) UnmarshalCBOR(data []byte) error {
+	var raw struct {
+		cbor.StructAsArray
+		Expiry     uint64
+		Anchor     []lcommon.GovAnchor
+		Deposit    uint64
+		Delegators []StakeCredential
+	}
+	if _, err := cbor.Decode(data, &raw); err != nil {
+		return err
+	}
+	e.Expiry = raw.Expiry
+	if len(raw.Anchor) > 0 {
+		anchor := raw.Anchor[0]
+		e.Anchor = &anchor
+	} else {
+		e.Anchor = nil
+	}
+	e.Deposit = raw.Deposit
+	e.Delegators = raw.Delegators
+	return nil
 }
 
 // DRepStateResult represents the DRep state query result.


### PR DESCRIPTION
## Summary

`cardano-cli` tears down a balancing transaction against a node that uses
gOuroboros for `GetDRepState` with:

```
DecoderFailure ... (DeserialiseFailure 37 "Size mismatch when decoding
Record RecD.\nExpected 3, but found 4.")
```

Root cause: `DRepStateEntry` encoded each DRep value as a **3-element** array
`[expiry, anchor, deposit]` with the anchor as a CBOR **null** (`0xf6`). A real
`cardano-node` emits a **4-element** record `[expiry, anchor, deposit, delegators]`:

- `anchor` is a `StrictMaybe` encoded as a **list** — `[]` (`0x80`) for none,
  `[anchor]` (`0x81 …`) for some — **not** a CBOR null.
- `delegators` is a CBOR **set** (tag 258) of the stake credentials delegating
  their voting power to the DRep (empty = `0xd9010280`).

This never surfaced before because an empty `GetDRepState` result is just `[]`,
so no value record is ever decoded. The type was only round-tripped through its
own codec, which cannot catch a wire-shape mismatch.

## Byte diff (same DRep, captured from the wire)

| Source | `DRepState` value |
|---|---|
| **cardano-node (correct)** | `84 16 80 1a1dcd6500 d9010280` |
| **before (broken)** | `83 00 f6 1a1dcd6500` |
| **after (this PR)** | `84 16 80 1a1dcd6500 d9010280` |

## Changes

- Replace `DRepStateEntry`'s `StructAsArray` with explicit `MarshalCBOR` /
  `UnmarshalCBOR` producing the 4-element shape, and add a `Delegators` field.
- Add `drep_state_test.go` pinning the encoding to cardano-node's captured bytes
  (`TestDRepStateResultWireBytes`) plus a populated round-trip with an anchor and
  a non-empty delegators set.

## Verification

`go build ./...`, `go vet`, `gofmt`, `golangci-lint` (0 issues), and
`go test ./protocol/localstatequery/...` all pass. Reproduced and verified
end-to-end on a Conway devnet with `cardano-cli 11.0.0.0`: `query drep-state`
and `transaction build` now decode against the node once a DRep is registered.

## Downstream

Fixes the Dingo report blinklabs-io/dingo#2636. A Dingo PR that populates the
`delegators` set from its account table depends on this; it will bump `go.mod`
once this merges and a tag is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `GetDRepState` encoding to match cardano-node by emitting a 4-element record [expiry, anchor, deposit, delegators]. This removes the cardano-cli decode error when any DRep exists and adds wire-accurate tests.

- **Bug Fixes**
  - Encode `DRepStateEntry` with explicit CBOR marshal/unmarshal: anchor as StrictMaybe list ([] or [anchor]) and delegators as CBOR set (tag 258).
  - Add `Delegators []StakeCredential` and tests that pin exact node bytes plus a populated round-trip.
  - Verified on Conway devnet: `query drep-state` and `transaction build` now decode correctly.

<sup>Written for commit 529c476eb6f81ea3b8e97f390205cc4755d62b24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with network state data by preserving the expected 4-part structure during encoding and decoding.
  * Fixed handling of missing anchors and empty delegator lists so round-tripping data stays reliable.

* **Tests**
  * Added coverage to verify encoding output and ensure state data can be decoded back without losing information.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->