### PR TITLE
fix(ledger): dijkstra redeemers

### DIFF
--- a/ledger/dijkstra/dijkstra.go
+++ b/ledger/dijkstra/dijkstra.go
@@ -1195,7 +1195,7 @@ func (r *DijkstraRedeemers) UnmarshalCBOR(cborData []byte) error {
 		return errors.New("dijkstra redeemers must use map encoding")
 	}
 	var redeemers map[common.RedeemerKey]common.RedeemerValue
-	if err := cbor.DecodeGeneric(cborData, &redeemers); err != nil {
+	if _, err := cbor.Decode(cborData, &redeemers); err != nil {
 		return err
 	}
 	if len(redeemers) == 0 {

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -328,6 +328,7 @@ func TestDijkstraBlockRoundTripWithBodyHash(t *testing.T) {
 }
 
 func TestDijkstraBlockDecodesRedeemerWitnessMap(t *testing.T) {
+	expectedRedeemerData := data.NewInteger(big.NewInt(42))
 	blockBody := DijkstraBlockBody{
 		TransactionBodies: []DijkstraTransactionBody{
 			{TxFee: 1},
@@ -338,7 +339,7 @@ func TestDijkstraBlockDecodesRedeemerWitnessMap(t *testing.T) {
 					Redeemers: map[common.RedeemerKey]common.RedeemerValue{
 						{Tag: common.RedeemerTagGuarding, Index: 0}: {
 							Data: common.Datum{
-								Data: data.NewInteger(big.NewInt(42)),
+								Data: expectedRedeemerData,
 							},
 							ExUnits: common.ExUnits{
 								Memory: 11,
@@ -385,6 +386,14 @@ func TestDijkstraBlockDecodesRedeemerWitnessMap(t *testing.T) {
 	redeemers := decoded.BlockBody.TransactionWitnessSets[0].WsRedeemers
 	require.Equal(t, 1, redeemers.Len())
 	redeemer := redeemers.Value(0, common.RedeemerTagGuarding)
+	require.NotNil(t, redeemer.Data.Data)
+	require.True(
+		t,
+		expectedRedeemerData.Equal(redeemer.Data.Data),
+		"redeemer data mismatch: got %s, want %s",
+		redeemer.Data.Data,
+		expectedRedeemerData,
+	)
 	require.Equal(t, int64(11), redeemer.ExUnits.Memory)
 	require.Equal(t, int64(22), redeemer.ExUnits.Steps)
 	require.Equal(t, blockBody.Hash(), decoded.BlockBodyHash())

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/plutigo/data"
 	"github.com/stretchr/testify/require"
 )
 
@@ -324,6 +325,69 @@ func TestDijkstraBlockRoundTripWithBodyHash(t *testing.T) {
 	require.NotEmpty(t, raw)
 	require.NotEmpty(t, decoded.BlockHeader.Cbor())
 	require.Equal(t, []byte(raw[0]), decoded.BlockHeader.Cbor())
+}
+
+func TestDijkstraBlockDecodesRedeemerWitnessMap(t *testing.T) {
+	blockBody := DijkstraBlockBody{
+		TransactionBodies: []DijkstraTransactionBody{
+			{TxFee: 1},
+		},
+		TransactionWitnessSets: []DijkstraTransactionWitnessSet{
+			{
+				WsRedeemers: DijkstraRedeemers{
+					Redeemers: map[common.RedeemerKey]common.RedeemerValue{
+						{Tag: common.RedeemerTagGuarding, Index: 0}: {
+							Data: common.Datum{
+								Data: data.NewInteger(big.NewInt(42)),
+							},
+							ExUnits: common.ExUnits{
+								Memory: 11,
+								Steps:  22,
+							},
+						},
+					},
+				},
+			},
+		},
+		InvalidTransactions: []uint{},
+	}
+	block := DijkstraBlock{
+		BlockHeader: &DijkstraBlockHeader{
+			BabbageBlockHeader: babbage.BabbageBlockHeader{
+				Body: babbage.BabbageBlockHeaderBody{
+					BlockBodyHash: blockBody.Hash(),
+					VrfKey:        make([]byte, 32),
+					VrfResult: common.VrfResult{
+						Output: []byte{},
+						Proof:  make([]byte, 80),
+					},
+					OpCert: babbage.BabbageOpCert{
+						HotVkey:   make([]byte, 32),
+						Signature: make([]byte, 64),
+					},
+					ProtoVersion: babbage.BabbageProtoVersion{
+						Major: MinProtocolVersionDijkstra,
+					},
+				},
+				Signature: make([]byte, 448),
+			},
+		},
+		BlockBody: blockBody,
+	}
+
+	blockCbor, err := block.MarshalCBOR()
+	require.NoError(t, err)
+
+	decoded, err := NewDijkstraBlockFromCbor(blockCbor)
+	require.NoError(t, err)
+	require.Len(t, decoded.BlockBody.TransactionWitnessSets, 1)
+
+	redeemers := decoded.BlockBody.TransactionWitnessSets[0].WsRedeemers
+	require.Equal(t, 1, redeemers.Len())
+	redeemer := redeemers.Value(0, common.RedeemerTagGuarding)
+	require.Equal(t, int64(11), redeemer.ExUnits.Memory)
+	require.Equal(t, int64(22), redeemer.ExUnits.Steps)
+	require.Equal(t, blockBody.Hash(), decoded.BlockBodyHash())
 }
 
 func TestIsCborNullOnlyAcceptsEncodedNull(t *testing.T) {


### PR DESCRIPTION
Closes #1842 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CBOR decoding of Dijkstra redeemers so map-encoded witnesses parse correctly and keep data/ex-units. Prevents empty or missing redeemers during block decode.

- **Bug Fixes**
  - Use `cbor.Decode` in `DijkstraRedeemers.UnmarshalCBOR` to decode `map[common.RedeemerKey]common.RedeemerValue`.
  - Added `TestDijkstraBlockDecodesRedeemerWitnessMap` to verify redeemer datum/ex-units and block body hash; fixed assertion to compare Plutus data values.

<sup>Written for commit 7309740162218653c7b31354e1cf5d67db801f0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decoding of redeemer witness data during block parsing.
  * Preserved validation for invalid or empty redeemer data, while ensuring encoded values are read back correctly.
  * Added coverage to verify redeemer witness details and block body integrity are decoded as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->