### PR TITLE
fix(ledger): serialize cost models in dijkstra pparam update

### DIFF
--- a/ledger/common/pparams.go
+++ b/ledger/common/pparams.go
@@ -16,8 +16,12 @@ package common
 
 import (
 	"log/slog"
+	"maps"
+	"math/big"
+	"slices"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/plutigo/data"
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
 
@@ -62,4 +66,26 @@ func ConvertToUtxorpcCardanoCostModels(
 		}
 	}
 	return costModels
+}
+
+// CostModelsToPlutusData converts ledger cost-model updates to a PlutusData map.
+func CostModelsToPlutusData(models map[uint][]int64) data.PlutusData {
+	keys := slices.Collect(maps.Keys(models))
+	slices.Sort(keys)
+	pairs := make([][2]data.PlutusData, 0, len(keys))
+	for _, key := range keys {
+		values := models[key]
+		valueItems := make([]data.PlutusData, len(values))
+		for i, value := range values {
+			valueItems[i] = data.NewInteger(big.NewInt(value))
+		}
+		pairs = append(
+			pairs,
+			[2]data.PlutusData{
+				data.NewInteger(new(big.Int).SetUint64(uint64(key))),
+				data.NewList(valueItems...),
+			},
+		)
+	}
+	return data.NewMap(pairs)
 }

--- a/ledger/conway/pparams.go
+++ b/ledger/conway/pparams.go
@@ -563,7 +563,9 @@ func (u ConwayProtocolParameterUpdate) ToPlutusData() data.PlutusData {
 			data.NewInteger(new(big.Int).SetUint64(uint64(*u.AdaPerUtxoByte))),
 		)
 	}
-	// TODO(enhancement): Add CostModels serialization for Plutus data conversion
+	if u.CostModels != nil {
+		push(18, common.CostModelsToPlutusData(u.CostModels))
+	}
 	if u.ExecutionCosts != nil {
 		push(19,
 			data.NewList(

--- a/ledger/conway/pparams_test.go
+++ b/ledger/conway/pparams_test.go
@@ -27,9 +27,14 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/blinklabs-io/plutigo/data"
 	"github.com/stretchr/testify/assert"
 	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
+
+func testPlutusInteger(v int64) data.PlutusData {
+	return data.NewInteger(big.NewInt(v))
+}
 
 func TestConwayProtocolParamsUpdate(t *testing.T) {
 	testDefs := []struct {
@@ -1112,6 +1117,40 @@ func TestConwayProtocolParameters_CborRoundTrip(t *testing.T) {
 		params.MinFeeRefScriptCostPerByte.Rat.RatString(),
 		decoded.MinFeeRefScriptCostPerByte.Rat.RatString(),
 	)
+}
+
+func TestConwayProtocolParameterUpdateToPlutusDataCostModels(t *testing.T) {
+	update := conway.ConwayProtocolParameterUpdate{
+		CostModels: map[uint][]int64{
+			2: {8, 7},
+			0: {1, 2, 3},
+		},
+	}
+	expected := data.NewMap([][2]data.PlutusData{
+		{
+			testPlutusInteger(18),
+			data.NewMap([][2]data.PlutusData{
+				{
+					testPlutusInteger(0),
+					data.NewList(
+						testPlutusInteger(1),
+						testPlutusInteger(2),
+						testPlutusInteger(3),
+					),
+				},
+				{
+					testPlutusInteger(2),
+					data.NewList(
+						testPlutusInteger(8),
+						testPlutusInteger(7),
+					),
+				},
+			}),
+		},
+	})
+
+	result := update.ToPlutusData()
+	assert.True(t, expected.Equal(result), "got %#v", result)
 }
 
 func TestConwayProtocolParameterUpdate_BootstrapRestrictedFields(t *testing.T) {

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -24,8 +24,13 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/plutigo/data"
 	"github.com/stretchr/testify/require"
 )
+
+func testPlutusInteger(v int64) data.PlutusData {
+	return data.NewInteger(big.NewInt(v))
+}
 
 func minimalTxBody() map[uint]any {
 	return map[uint]any{
@@ -601,6 +606,50 @@ func TestDijkstraProtocolParametersUpdatePreservesLeiosStakeInvariant(t *testing
 		pparams.CommitteeStakeCoverage.Cmp(big.NewRat(99, 100)),
 	)
 	require.Equal(t, 0, pparams.QuorumStakeThreshold.Cmp(big.NewRat(4, 5)))
+}
+
+func TestDijkstraProtocolParameterUpdateToPlutusDataCostModels(t *testing.T) {
+	maxRefScriptSizePerBlock := uint32(1234)
+	maxRefScriptSizePerTx := uint32(4321)
+	refScriptCostStride := uint32(64)
+	update := DijkstraProtocolParameterUpdate{
+		CostModels: map[uint][]int64{
+			3: {9, 8},
+			1: {7},
+		},
+		MaxRefScriptSizePerBlock: &maxRefScriptSizePerBlock,
+		MaxRefScriptSizePerTx:    &maxRefScriptSizePerTx,
+		RefScriptCostStride:      &refScriptCostStride,
+		RefScriptCostMultiplier:  &cbor.Rat{Rat: big.NewRat(5, 2)},
+	}
+	expected := data.NewMap([][2]data.PlutusData{
+		{
+			testPlutusInteger(18),
+			data.NewMap([][2]data.PlutusData{
+				{
+					testPlutusInteger(1),
+					data.NewList(testPlutusInteger(7)),
+				},
+				{
+					testPlutusInteger(3),
+					data.NewList(
+						testPlutusInteger(9),
+						testPlutusInteger(8),
+					),
+				},
+			}),
+		},
+		{testPlutusInteger(34), testPlutusInteger(1234)},
+		{testPlutusInteger(35), testPlutusInteger(4321)},
+		{testPlutusInteger(36), testPlutusInteger(64)},
+		{
+			testPlutusInteger(37),
+			data.NewList(testPlutusInteger(5), testPlutusInteger(2)),
+		},
+	})
+
+	result := update.ToPlutusData()
+	require.True(t, expected.Equal(result), "got %#v", result)
 }
 
 func TestDijkstraParameterChangeGovActionDecodesDijkstraUpdateFields(t *testing.T) {

--- a/ledger/dijkstra/pparams.go
+++ b/ledger/dijkstra/pparams.go
@@ -570,7 +570,9 @@ func (u DijkstraProtocolParameterUpdate) ToPlutusData() data.PlutusData {
 			data.NewInteger(new(big.Int).SetUint64(uint64(*u.AdaPerUtxoByte))),
 		)
 	}
-	// TODO(enhancement): Add CostModels serialization for Plutus data conversion.
+	if u.CostModels != nil {
+		push(18, common.CostModelsToPlutusData(u.CostModels))
+	}
 	if u.ExecutionCosts != nil {
 		push(19,
 			data.NewList(


### PR DESCRIPTION
Closes #1798 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Serialize cost models into PlutusData for Conway and Dijkstra protocol parameter updates, fixing missing encoding so governance actions can include cost model updates. Adds a shared helper and tests to ensure stable, ordered encoding. Aligns with Linear issue 1798.

- **Bug Fixes**
  - Implemented cost model serialization (key 18) in `ToPlutusData()` for `ConwayProtocolParameterUpdate` and `DijkstraProtocolParameterUpdate`.
  - Added `common.CostModelsToPlutusData` to produce deterministic map/list encoding.
  - Added unit tests for Conway and Dijkstra to verify encoding and ordering.

<sup>Written for commit 1449c2e56a36839fc8ca3110c24264eafc6adfe9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

