### PR TITLE
fix(dijkstra): Added negative fixtures for duplicate witness and redeemer encodings

### DIFF
--- a/cbor/tags.go
+++ b/cbor/tags.go
@@ -263,7 +263,7 @@ func (t *SetType[T]) CheckForDuplicates() error {
 		}
 		key := string(encoded)
 		if _, exists := seen[key]; exists {
-			return errors.New("duplicate member in witness set")
+			return errors.New("duplicate member in set")
 		}
 		seen[key] = struct{}{}
 	}

--- a/cbor/tags.go
+++ b/cbor/tags.go
@@ -248,6 +248,28 @@ func (t *SetType[T]) Items() []T {
 	return ret
 }
 
+// CheckForDuplicates returns an error if the set was decoded from a CBOR tag-258
+// set and contains duplicate members (compared by CBOR encoding).
+// Untagged arrays are not checked so that pre-Dijkstra eras are unaffected.
+func (t *SetType[T]) CheckForDuplicates() error {
+	if !t.useTag {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(t.items))
+	for _, item := range t.items {
+		encoded, err := Encode(item)
+		if err != nil {
+			return err
+		}
+		key := string(encoded)
+		if _, exists := seen[key]; exists {
+			return errors.New("duplicate member in witness set")
+		}
+		seen[key] = struct{}{}
+	}
+	return nil
+}
+
 func (t SetType[T]) MarshalJSON() ([]byte, error) {
 	if t.items == nil {
 		return []byte("[]"), nil

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -493,6 +493,7 @@ func (s *ConwayTransactionInputSet) UnmarshalCBOR(data []byte) error {
 	// Check if the set is wrapped in a CBOR tag
 	// This is mostly needed so we can remember whether it was Set-wrapped for CBOR encoding
 	var tmpTag cbor.RawTag
+	s.useSet = false
 	if _, err := cbor.Decode(data, &tmpTag); err == nil {
 		if tmpTag.Number != cbor.CborTagSet {
 			return errors.New("unexpected tag type")
@@ -505,6 +506,25 @@ func (s *ConwayTransactionInputSet) UnmarshalCBOR(data []byte) error {
 		return err
 	}
 	s.items = tmpData
+	return nil
+}
+
+func (s *ConwayTransactionInputSet) CheckForDuplicates() error {
+	if !s.useSet {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(s.items))
+	for _, item := range s.items {
+		encoded, err := cbor.Encode(item)
+		if err != nil {
+			return err
+		}
+		key := string(encoded)
+		if _, exists := seen[key]; exists {
+			return errors.New("duplicate member in set")
+		}
+		seen[key] = struct{}{}
+	}
 	return nil
 }
 

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -438,6 +438,24 @@ func (w *ConwayTransactionWitnessSet) UnmarshalCBOR(cborData []byte) error {
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
 		return err
 	}
+	// Reject duplicate members in any tag-258 witness set field.
+	// Untagged array fields are left unchecked so pre-Conway encodings remain valid.
+	type duplicateChecker interface {
+		CheckForDuplicates() error
+	}
+	for _, c := range []duplicateChecker{
+		&tmp.VkeyWitnesses,
+		&tmp.WsNativeScripts,
+		&tmp.BootstrapWitnesses,
+		&tmp.WsPlutusV1Scripts,
+		&tmp.WsPlutusData,
+		&tmp.WsPlutusV2Scripts,
+		&tmp.WsPlutusV3Scripts,
+	} {
+		if err := c.CheckForDuplicates(); err != nil {
+			return err
+		}
+	}
 	*w = ConwayTransactionWitnessSet(tmp)
 	w.SetCbor(cborData)
 	return nil
@@ -587,6 +605,20 @@ func (b *ConwayTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	var tmp tConwayTransactionBody
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
 		return err
+	}
+	// Reject duplicate members in any tag-258 set field on the transaction body.
+	type duplicateChecker interface {
+		CheckForDuplicates() error
+	}
+	for _, c := range []duplicateChecker{
+		&tmp.TxInputs,
+		&tmp.TxCollateral,
+		&tmp.TxRequiredSigners,
+		&tmp.TxReferenceInputs,
+	} {
+		if err := c.CheckForDuplicates(); err != nil {
+			return err
+		}
 	}
 	*b = ConwayTransactionBody(tmp)
 	b.SetCborReference(cborData)

--- a/ledger/conway/conway_test.go
+++ b/ledger/conway/conway_test.go
@@ -210,6 +210,87 @@ func TestConwayTx_Utxorpc(t *testing.T) {
 	}
 }
 
+func TestConwayTransactionBodyRejectsDuplicateTaggedInputs(t *testing.T) {
+	input := testConwayShelleyInput()
+	bodyCbor, err := cbor.Encode(map[uint]any{
+		0: cbor.NewSetType([]shelley.ShelleyTransactionInput{input, input}, true),
+	})
+	assert.NoError(t, err)
+
+	var body ConwayTransactionBody
+	err = body.UnmarshalCBOR(bodyCbor)
+	assert.ErrorContains(t, err, "duplicate member in set")
+}
+
+func TestConwayTransactionBodyRejectsDuplicateTaggedSetFields(t *testing.T) {
+	input := testConwayShelleyInput()
+	var signer common.Blake2b224
+	signer[0] = 1
+	tests := []struct {
+		name  string
+		field uint
+		value any
+	}{
+		{
+			name:  "collateral",
+			field: 13,
+			value: cbor.NewSetType(
+				[]shelley.ShelleyTransactionInput{input, input},
+				true,
+			),
+		},
+		{
+			name:  "required signers",
+			field: 14,
+			value: cbor.NewSetType([]common.Blake2b224{signer, signer}, true),
+		},
+		{
+			name:  "reference inputs",
+			field: 18,
+			value: cbor.NewSetType(
+				[]shelley.ShelleyTransactionInput{input, input},
+				true,
+			),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bodyCbor, err := cbor.Encode(map[uint]any{
+				tt.field: tt.value,
+			})
+			assert.NoError(t, err)
+
+			var body ConwayTransactionBody
+			err = body.UnmarshalCBOR(bodyCbor)
+			assert.ErrorContains(t, err, "duplicate member in set")
+		})
+	}
+}
+
+func TestConwayWitnessSetRejectsDuplicateTaggedVkeyWitness(t *testing.T) {
+	dupCbor := []byte{
+		0xa1,             // map(1)
+		0x00,             // key: 0  (VkeyWitnesses field)
+		0xd9, 0x01, 0x02, // tag(258) - CBOR set
+		0x82,                         // array(2)
+		0x82, 0x41, 0x01, 0x41, 0x02, // VkeyWitness{[0x01], [0x02]}
+		0x82, 0x41, 0x01, 0x41, 0x02, // duplicate
+	}
+
+	var ws ConwayTransactionWitnessSet
+	err := ws.UnmarshalCBOR(dupCbor)
+	assert.ErrorContains(t, err, "duplicate member in set")
+}
+
+func testConwayShelleyInput() shelley.ShelleyTransactionInput {
+	var txId common.Blake2b256
+	txId[0] = 1
+	return shelley.ShelleyTransactionInput{
+		TxId:        txId,
+		OutputIndex: 0,
+	}
+}
+
 func TestConwayTx_WithReferenceInputs_CborRoundTrip(t *testing.T) {
 	// Test CBOR round-trip for transactions with reference inputs (CIP-0031)
 

--- a/ledger/dijkstra/dijkstra.go
+++ b/ledger/dijkstra/dijkstra.go
@@ -907,6 +907,19 @@ func (b *DijkstraTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
 		return err
 	}
+	// Reject duplicate members in any tag-258 set field on the transaction body.
+	type duplicateChecker interface {
+		CheckForDuplicates() error
+	}
+	for _, c := range []duplicateChecker{
+		&tmp.TxCollateral,
+		&tmp.TxReferenceInputs,
+		&tmp.TxSubTransactions,
+	} {
+		if err := c.CheckForDuplicates(); err != nil {
+			return err
+		}
+	}
 	*b = DijkstraTransactionBody(tmp)
 	b.SetCborReference(cborData)
 	return nil
@@ -1269,6 +1282,25 @@ func (w *DijkstraTransactionWitnessSet) UnmarshalCBOR(cborData []byte) error {
 	var tmp tDijkstraTransactionWitnessSet
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
 		return err
+	}
+	// Reject duplicate members in any tag-258 witness set field.
+	// Untagged array fields are left unchecked so pre-Dijkstra encodings remain valid.
+	type duplicateChecker interface {
+		CheckForDuplicates() error
+	}
+	for _, c := range []duplicateChecker{
+		&tmp.VkeyWitnesses,
+		&tmp.WsNativeScripts,
+		&tmp.BootstrapWitnesses,
+		&tmp.WsPlutusV1Scripts,
+		&tmp.WsPlutusData,
+		&tmp.WsPlutusV2Scripts,
+		&tmp.WsPlutusV3Scripts,
+		&tmp.WsPlutusV4Scripts,
+	} {
+		if err := c.CheckForDuplicates(); err != nil {
+			return err
+		}
 	}
 	*w = DijkstraTransactionWitnessSet(tmp)
 	w.SetCbor(cborData)

--- a/ledger/dijkstra/dijkstra.go
+++ b/ledger/dijkstra/dijkstra.go
@@ -829,6 +829,9 @@ func (g *DijkstraGuards) UnmarshalCBOR(cborData []byte) error {
 	g.SetCbor(cborData)
 	var credentials cbor.SetType[common.Credential]
 	if _, err := cbor.Decode(cborData, &credentials); err == nil {
+		if err := credentials.CheckForDuplicates(); err != nil {
+			return err
+		}
 		if len(credentials.Items()) == 0 {
 			return errors.New("dijkstra guards must not be empty")
 		}
@@ -838,6 +841,9 @@ func (g *DijkstraGuards) UnmarshalCBOR(cborData []byte) error {
 	}
 	var keyHashes cbor.SetType[common.Blake2b224]
 	if _, err := cbor.Decode(cborData, &keyHashes); err != nil {
+		return err
+	}
+	if err := keyHashes.CheckForDuplicates(); err != nil {
 		return err
 	}
 	if len(keyHashes.Items()) == 0 {
@@ -912,6 +918,7 @@ func (b *DijkstraTransactionBody) UnmarshalCBOR(cborData []byte) error {
 		CheckForDuplicates() error
 	}
 	for _, c := range []duplicateChecker{
+		&tmp.TxInputs,
 		&tmp.TxCollateral,
 		&tmp.TxReferenceInputs,
 		&tmp.TxSubTransactions,
@@ -1123,6 +1130,12 @@ func (b *DijkstraSubTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	type tDijkstraSubTransactionBody DijkstraSubTransactionBody
 	var tmp tDijkstraSubTransactionBody
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	if err := tmp.TxInputs.CheckForDuplicates(); err != nil {
+		return err
+	}
+	if err := tmp.TxReferenceInputs.CheckForDuplicates(); err != nil {
 		return err
 	}
 	*b = DijkstraSubTransactionBody(tmp)

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/blinklabs-io/plutigo/data"
 	"github.com/stretchr/testify/require"
 )
@@ -337,10 +338,10 @@ func TestDijkstraRedeemersRejectsDuplicateMapKey(t *testing.T) {
 	// RedeemerValue{Datum(int 1), ExUnits{1,1}} encodes as [1,[1,1]] = 82 01 82 01 01.
 	// DupMapKeyEnforcedAPF on the shared decode mode must reject this before rule evaluation.
 	dupCbor := []byte{
-		0xa2,                          // map(2)
-		0x82, 0x00, 0x00,              // key:   [0, 0]
+		0xa2,             // map(2)
+		0x82, 0x00, 0x00, // key:   [0, 0]
 		0x82, 0x01, 0x82, 0x01, 0x01, // value: [1, [1, 1]]
-		0x82, 0x00, 0x00,              // key:   [0, 0]  -- duplicate
+		0x82, 0x00, 0x00, // key:   [0, 0]  -- duplicate
 		0x82, 0x02, 0x82, 0x02, 0x02, // value: [2, [2, 2]]
 	}
 	var r DijkstraRedeemers
@@ -354,9 +355,9 @@ func TestDijkstraWitnessSetRejectsDuplicateTaggedVkeyWitness(t *testing.T) {
 	// VkeyWitness{Vkey:[0x01], Signature:[0x02]} = 82 41 01 41 02.
 	// The Dijkstra guard introduced in UnmarshalCBOR must reject this.
 	dupCbor := []byte{
-		0xa1,                         // map(1)
-		0x00,                         // key: 0  (VkeyWitnesses field)
-		0xd9, 0x01, 0x02,             // tag(258) — CBOR set
+		0xa1,             // map(1)
+		0x00,             // key: 0  (VkeyWitnesses field)
+		0xd9, 0x01, 0x02, // tag(258) — CBOR set
 		0x82,                         // array(2)
 		0x82, 0x41, 0x01, 0x41, 0x02, // VkeyWitness{[0x01], [0x02]}
 		0x82, 0x41, 0x01, 0x41, 0x02, // duplicate
@@ -371,15 +372,108 @@ func TestDijkstraTransactionBodyRejectsDuplicateSubTransaction(t *testing.T) {
 	// containing two identical minimal sub-transactions.
 	// Minimal sub-transaction = [empty-body, empty-witness, null] = 83 a0 a0 f6.
 	dupCbor := []byte{
-		0xa1,                         // map(1)
-		0x17,                         // key: 23 (TxSubTransactions field)
-		0xd9, 0x01, 0x02,             // tag(258) — CBOR set
-		0x82,                         // array(2)
-		0x83, 0xa0, 0xa0, 0xf6,       // sub-tx: [empty-body, empty-witness, null]
-		0x83, 0xa0, 0xa0, 0xf6,       // duplicate
+		0xa1,             // map(1)
+		0x17,             // key: 23 (TxSubTransactions field)
+		0xd9, 0x01, 0x02, // tag(258) — CBOR set
+		0x82,                   // array(2)
+		0x83, 0xa0, 0xa0, 0xf6, // sub-tx: [empty-body, empty-witness, null]
+		0x83, 0xa0, 0xa0, 0xf6, // duplicate
 	}
 	var body DijkstraTransactionBody
 	err := body.UnmarshalCBOR(dupCbor)
+	require.ErrorContains(t, err, "duplicate member in set")
+}
+
+func TestDijkstraTransactionBodyRejectsDuplicateTaggedInputs(t *testing.T) {
+	input := testShelleyInput()
+	bodyCbor, err := cbor.Encode(map[uint]any{
+		0: cbor.NewSetType([]shelley.ShelleyTransactionInput{input, input}, true),
+	})
+	require.NoError(t, err)
+
+	var body DijkstraTransactionBody
+	err = body.UnmarshalCBOR(bodyCbor)
+	require.ErrorContains(t, err, "duplicate member in set")
+}
+
+func TestDijkstraTransactionBodyRejectsDuplicateSubTransactionInputs(t *testing.T) {
+	input := testShelleyInput()
+	subTx := []any{
+		map[uint]any{
+			0: cbor.NewSetType(
+				[]shelley.ShelleyTransactionInput{input, input},
+				true,
+			),
+		},
+		map[uint]any{},
+		nil,
+	}
+	bodyCbor, err := cbor.Encode(map[uint]any{
+		23: cbor.NewSetType([]any{subTx}, true),
+	})
+	require.NoError(t, err)
+
+	var body DijkstraTransactionBody
+	err = body.UnmarshalCBOR(bodyCbor)
+	require.ErrorContains(t, err, "duplicate member in set")
+}
+
+func TestDijkstraTransactionBodyRejectsDuplicateSubTransactionReferenceInputs(t *testing.T) {
+	refInput := testShelleyInput()
+	subTx := DijkstraSubTransaction{
+		Body: DijkstraSubTransactionBody{
+			TxReferenceInputs: cbor.NewSetType(
+				[]shelley.ShelleyTransactionInput{refInput, refInput},
+				true,
+			),
+		},
+	}
+	bodyCbor, err := cbor.Encode(map[uint]any{
+		23: cbor.NewSetType([]DijkstraSubTransaction{subTx}, true),
+	})
+	require.NoError(t, err)
+
+	var body DijkstraTransactionBody
+	err = body.UnmarshalCBOR(bodyCbor)
+	require.ErrorContains(t, err, "duplicate member in set")
+}
+
+func testShelleyInput() shelley.ShelleyTransactionInput {
+	var txId common.Blake2b256
+	txId[0] = 1
+	return shelley.ShelleyTransactionInput{
+		TxId:        txId,
+		OutputIndex: 0,
+	}
+}
+
+func TestDijkstraTransactionBodyRejectsDuplicateCredentialGuards(t *testing.T) {
+	var hash common.Blake2b224
+	hash[0] = 1
+	guard := common.Credential{
+		CredType:   common.CredentialTypeAddrKeyHash,
+		Credential: hash,
+	}
+	bodyCbor, err := cbor.Encode(map[uint]any{
+		14: cbor.NewSetType([]common.Credential{guard, guard}, true),
+	})
+	require.NoError(t, err)
+
+	var body DijkstraTransactionBody
+	err = body.UnmarshalCBOR(bodyCbor)
+	require.ErrorContains(t, err, "duplicate member in set")
+}
+
+func TestDijkstraTransactionBodyRejectsDuplicateKeyHashGuards(t *testing.T) {
+	var hash common.Blake2b224
+	hash[0] = 1
+	bodyCbor, err := cbor.Encode(map[uint]any{
+		14: cbor.NewSetType([]common.Blake2b224{hash, hash}, true),
+	})
+	require.NoError(t, err)
+
+	var body DijkstraTransactionBody
+	err = body.UnmarshalCBOR(bodyCbor)
 	require.ErrorContains(t, err, "duplicate member in set")
 }
 
@@ -387,8 +481,8 @@ func TestDijkstraWitnessSetAllowsDuplicateUntaggedVkeyWitness(t *testing.T) {
 	// Untagged arrays (no tag 258) are not checked for duplicates so that
 	// pre-Dijkstra encodings decoded via this path remain accepted.
 	dupCbor := []byte{
-		0xa1,                         // map(1)
-		0x00,                         // key: 0  (VkeyWitnesses field)
+		0xa1, // map(1)
+		0x00, // key: 0  (VkeyWitnesses field)
 		// plain array — no tag 258
 		0x82,                         // array(2)
 		0x82, 0x41, 0x01, 0x41, 0x02, // VkeyWitness{[0x01], [0x02]}

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -363,7 +363,7 @@ func TestDijkstraWitnessSetRejectsDuplicateTaggedVkeyWitness(t *testing.T) {
 	}
 	var ws DijkstraTransactionWitnessSet
 	err := ws.UnmarshalCBOR(dupCbor)
-	require.ErrorContains(t, err, "duplicate member in witness set")
+	require.ErrorContains(t, err, "duplicate member in set")
 }
 
 func TestDijkstraTransactionBodyRejectsDuplicateSubTransaction(t *testing.T) {
@@ -380,7 +380,7 @@ func TestDijkstraTransactionBodyRejectsDuplicateSubTransaction(t *testing.T) {
 	}
 	var body DijkstraTransactionBody
 	err := body.UnmarshalCBOR(dupCbor)
-	require.ErrorContains(t, err, "duplicate member in witness set")
+	require.ErrorContains(t, err, "duplicate member in set")
 }
 
 func TestDijkstraWitnessSetAllowsDuplicateUntaggedVkeyWitness(t *testing.T) {

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -331,6 +331,73 @@ func TestDijkstraBlockRoundTripWithBodyHash(t *testing.T) {
 	require.Equal(t, []byte(raw[0]), decoded.BlockHeader.Cbor())
 }
 
+func TestDijkstraRedeemersRejectsDuplicateMapKey(t *testing.T) {
+	// Craft a raw CBOR map with two identical RedeemerKey entries.
+	// RedeemerKey{Tag:0, Index:0} encodes as StructAsArray [0,0] = 82 00 00.
+	// RedeemerValue{Datum(int 1), ExUnits{1,1}} encodes as [1,[1,1]] = 82 01 82 01 01.
+	// DupMapKeyEnforcedAPF on the shared decode mode must reject this before rule evaluation.
+	dupCbor := []byte{
+		0xa2,                          // map(2)
+		0x82, 0x00, 0x00,              // key:   [0, 0]
+		0x82, 0x01, 0x82, 0x01, 0x01, // value: [1, [1, 1]]
+		0x82, 0x00, 0x00,              // key:   [0, 0]  -- duplicate
+		0x82, 0x02, 0x82, 0x02, 0x02, // value: [2, [2, 2]]
+	}
+	var r DijkstraRedeemers
+	err := r.UnmarshalCBOR(dupCbor)
+	require.Error(t, err)
+}
+
+func TestDijkstraWitnessSetRejectsDuplicateTaggedVkeyWitness(t *testing.T) {
+	// Craft a witness set CBOR where field 0 (vkey witnesses) is a tag-258 set
+	// containing two identical VkeyWitness entries.
+	// VkeyWitness{Vkey:[0x01], Signature:[0x02]} = 82 41 01 41 02.
+	// The Dijkstra guard introduced in UnmarshalCBOR must reject this.
+	dupCbor := []byte{
+		0xa1,                         // map(1)
+		0x00,                         // key: 0  (VkeyWitnesses field)
+		0xd9, 0x01, 0x02,             // tag(258) — CBOR set
+		0x82,                         // array(2)
+		0x82, 0x41, 0x01, 0x41, 0x02, // VkeyWitness{[0x01], [0x02]}
+		0x82, 0x41, 0x01, 0x41, 0x02, // duplicate
+	}
+	var ws DijkstraTransactionWitnessSet
+	err := ws.UnmarshalCBOR(dupCbor)
+	require.ErrorContains(t, err, "duplicate member in witness set")
+}
+
+func TestDijkstraTransactionBodyRejectsDuplicateSubTransaction(t *testing.T) {
+	// Craft a transaction body where field 23 (TxSubTransactions) is a tag-258 set
+	// containing two identical minimal sub-transactions.
+	// Minimal sub-transaction = [empty-body, empty-witness, null] = 83 a0 a0 f6.
+	dupCbor := []byte{
+		0xa1,                         // map(1)
+		0x17,                         // key: 23 (TxSubTransactions field)
+		0xd9, 0x01, 0x02,             // tag(258) — CBOR set
+		0x82,                         // array(2)
+		0x83, 0xa0, 0xa0, 0xf6,       // sub-tx: [empty-body, empty-witness, null]
+		0x83, 0xa0, 0xa0, 0xf6,       // duplicate
+	}
+	var body DijkstraTransactionBody
+	err := body.UnmarshalCBOR(dupCbor)
+	require.ErrorContains(t, err, "duplicate member in witness set")
+}
+
+func TestDijkstraWitnessSetAllowsDuplicateUntaggedVkeyWitness(t *testing.T) {
+	// Untagged arrays (no tag 258) are not checked for duplicates so that
+	// pre-Dijkstra encodings decoded via this path remain accepted.
+	dupCbor := []byte{
+		0xa1,                         // map(1)
+		0x00,                         // key: 0  (VkeyWitnesses field)
+		// plain array — no tag 258
+		0x82,                         // array(2)
+		0x82, 0x41, 0x01, 0x41, 0x02, // VkeyWitness{[0x01], [0x02]}
+		0x82, 0x41, 0x01, 0x41, 0x02, // duplicate — must NOT be rejected
+	}
+	var ws DijkstraTransactionWitnessSet
+	require.NoError(t, ws.UnmarshalCBOR(dupCbor))
+}
+
 func TestDijkstraBlockDecodesRedeemerWitnessMap(t *testing.T) {
 	expectedRedeemerData := data.NewInteger(big.NewInt(42))
 	blockBody := DijkstraBlockBody{


### PR DESCRIPTION
1. Added `CheckForDuplicates()` error to `cbor.SetType[T]` — encodes each item to CBOR bytes and checks for byte-level duplicates; no-ops on untagged arrays so pre-Dijkstra encodings are unaffected
2. Extended `DijkstraTransactionWitnessSet.UnmarshalCBOR `to call the check for duplicates on all eight witness-set fields (`vkeys, native scripts, bootstrap witnesses, Plutus V1–V4 scripts, datums`)
3. Extended `DijkstraTransactionBody.UnmarshalCBOR` to call the check for duplicates on the three SetType body fields (`TxCollateral, TxReferenceInputs, TxSubTransactions`)
4. Added four negative tests covering duplicate redeemer map key (existing `DupMapKeyEnforcedAPF`), duplicate tagged vkey witness, duplicate tagged sub-transaction, and duplicate untagged vkey witness.
5. Wired duplicate-member validation into Conway transaction body decoding for tagged `TxInputs`, since Dijkstra reuses `ConwayTransactionInputSet` for its input set decode path.

Closes #1799 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject duplicate members in tag-258 CBOR sets across Dijkstra and Conway witness sets, transaction bodies, guards, and nested sub-transactions. Untagged arrays remain unchanged. Fulfills #1799.

- **Bug Fixes**
  - Added `CheckForDuplicates()` to `cbor.SetType[T]` and `ConwayTransactionInputSet`; tagged sets only; returns "duplicate member in set".
  - Enforced duplicate rejection on decode in Dijkstra and Conway: `DijkstraTransactionWitnessSet.UnmarshalCBOR`, `DijkstraTransactionBody.UnmarshalCBOR`, `DijkstraSubTransactionBody.UnmarshalCBOR`, `DijkstraGuards.UnmarshalCBOR`, plus `ConwayTransactionWitnessSet.UnmarshalCBOR` and `ConwayTransactionBody.UnmarshalCBOR` for witness fields and body sets (`TxInputs`, `TxCollateral`, `TxRequiredSigners`, `TxReferenceInputs`, and `TxSubTransactions` where applicable).
  - Expanded tests to cover duplicate tagged vkeys, inputs, body sets, sub-transactions and nested sub-tx inputs/reference inputs, guards, and redeemer map keys; confirmed untagged arrays remain allowed.

<sup>Written for commit ddc411766a475a801a44b7e5f67edef2dbbbce5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when decoding certain transaction and witness data, now rejecting duplicate members in tagged set fields.
  * Duplicate map keys in redeemer data are now detected and rejected.
  * Untagged list-based encodings continue to be accepted for compatibility.

* **Tests**
  * Added coverage for duplicate-member rejection and compatibility with untagged encodings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->