### PR TITLE
feat(dijkstra): Enforce Dijkstra reference script size limits

### DIFF
--- a/ledger/common/errors.go
+++ b/ledger/common/errors.go
@@ -176,3 +176,43 @@ var ErrMalformedReferenceScripts = errors.New("malformed reference scripts")
 func (MalformedReferenceScriptsError) Is(target error) bool {
 	return target == ErrMalformedReferenceScripts
 }
+
+// RefScriptSizePerTxTooLargeError indicates the total reference-script size in a
+// transaction's outputs exceeds the per-transaction limit.
+type RefScriptSizePerTxTooLargeError struct {
+	TxSize  uint64
+	MaxSize uint64
+}
+
+func (e RefScriptSizePerTxTooLargeError) Error() string {
+	return fmt.Sprintf(
+		"reference-script size per transaction too large: %d > %d",
+		e.TxSize, e.MaxSize,
+	)
+}
+
+var ErrRefScriptSizePerTxTooLarge = errors.New("reference-script size per transaction too large")
+
+func (RefScriptSizePerTxTooLargeError) Is(target error) bool {
+	return target == ErrRefScriptSizePerTxTooLarge
+}
+
+// RefScriptSizePerBlockTooLargeError indicates the total reference-script size
+// in a block's transaction outputs exceeds the per-block limit.
+type RefScriptSizePerBlockTooLargeError struct {
+	BlockSize uint64
+	MaxSize   uint64
+}
+
+func (e RefScriptSizePerBlockTooLargeError) Error() string {
+	return fmt.Sprintf(
+		"reference-script size per block too large: %d > %d",
+		e.BlockSize, e.MaxSize,
+	)
+}
+
+var ErrRefScriptSizePerBlockTooLarge = errors.New("reference-script size per block too large")
+
+func (RefScriptSizePerBlockTooLargeError) Is(target error) bool {
+	return target == ErrRefScriptSizePerBlockTooLarge
+}

--- a/ledger/dijkstra/pparams.go
+++ b/ledger/dijkstra/pparams.go
@@ -26,7 +26,6 @@ import (
 
 type DijkstraProtocolParameters struct {
 	conway.ConwayProtocolParameters
-	// TODO: Wire reference-script size limits into Dijkstra validation rules.
 	MaxRefScriptSizePerBlock uint32
 	MaxRefScriptSizePerTx    uint32
 	RefScriptCostStride      uint32

--- a/ledger/dijkstra/rules.go
+++ b/ledger/dijkstra/rules.go
@@ -82,6 +82,15 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	conway.UtxoValidateCommitteeCertificates,
 	UtxoValidateCCVotingRestrictions,
 	UtxoValidateMalformedReferenceScripts,
+	UtxoValidateRefScriptSizePerTx,
+}
+
+func dijkstraPparams(pp common.ProtocolParameters) (*DijkstraProtocolParameters, error) {
+	p, ok := pp.(*DijkstraProtocolParameters)
+	if !ok {
+		return nil, errors.New("pparams are not DijkstraProtocolParameters")
+	}
+	return p, nil
 }
 
 func conwayPparams(
@@ -1625,4 +1634,65 @@ func UtxoValidateMalformedReferenceScripts(
 		}
 	}
 	return nil
+}
+
+func UtxoValidateRefScriptSizePerTx(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	tmpPparams, err := dijkstraPparams(pp)
+	if err != nil {
+		return err
+	}
+	maxSize := tmpPparams.MaxRefScriptSizePerTx
+	if maxSize == 0 {
+		return nil
+	}
+	totalSize := refScriptSize(tx)
+	if totalSize > uint64(maxSize) {
+		return common.RefScriptSizePerTxTooLargeError{
+			TxSize:  totalSize,
+			MaxSize: uint64(maxSize),
+		}
+	}
+	return nil
+}
+
+func ValidateRefScriptSizePerBlock(
+	block *DijkstraBlock,
+	pp common.ProtocolParameters,
+) error {
+	tmpPparams, err := dijkstraPparams(pp)
+	if err != nil {
+		return err
+	}
+	maxSize := tmpPparams.MaxRefScriptSizePerBlock
+	if maxSize == 0 {
+		return nil
+	}
+	var totalSize uint64
+	for _, tx := range block.Transactions() {
+		totalSize += refScriptSize(tx)
+	}
+	if totalSize > uint64(maxSize) {
+		return common.RefScriptSizePerBlockTooLargeError{
+			BlockSize: totalSize,
+			MaxSize:   uint64(maxSize),
+		}
+	}
+	return nil
+}
+
+func refScriptSize(tx common.Transaction) uint64 {
+	var totalSize uint64
+	for _, output := range tx.Outputs() {
+		scriptRef := output.ScriptRef()
+		if scriptRef == nil {
+			continue
+		}
+		totalSize += uint64(len(scriptRef.RawScriptBytes()))
+	}
+	return totalSize
 }

--- a/ledger/dijkstra/rules.go
+++ b/ledger/dijkstra/rules.go
@@ -86,11 +86,16 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 }
 
 func dijkstraPparams(pp common.ProtocolParameters) (*DijkstraProtocolParameters, error) {
-	p, ok := pp.(*DijkstraProtocolParameters)
-	if !ok {
-		return nil, errors.New("pparams are not DijkstraProtocolParameters")
+	switch p := pp.(type) {
+	case *DijkstraProtocolParameters:
+		return p, nil
+	case *conway.ConwayProtocolParameters:
+		return &DijkstraProtocolParameters{
+			ConwayProtocolParameters: *p,
+		}, nil
+	default:
+		return nil, errors.New("pparams are not expected type")
 	}
-	return p, nil
 }
 
 func conwayPparams(

--- a/ledger/dijkstra/rules_test.go
+++ b/ledger/dijkstra/rules_test.go
@@ -513,11 +513,28 @@ func TestUtxoValidateRefScriptSizePerTxZeroLimitSkipped(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// Verifies Conway protocol params do not fail Dijkstra per-tx validation.
+func TestUtxoValidateRefScriptSizePerTxConwayParams(t *testing.T) {
+	pp := &conway.ConwayProtocolParameters{}
+	err := UtxoValidateRefScriptSizePerTx(txWithRefScripts(99999), 0, nil, pp)
+	require.NoError(t, err)
+}
+
 // Verifies a block with reference scripts below the per-block limit passes.
 func TestValidateRefScriptSizePerBlockBelowLimit(t *testing.T) {
 	pp := &DijkstraProtocolParameters{MaxRefScriptSizePerBlock: 300}
 	err := ValidateRefScriptSizePerBlock(
 		blockWithRefScripts([]int{100}, []int{100}),
+		pp,
+	)
+	require.NoError(t, err)
+}
+
+// Verifies Conway protocol params do not fail Dijkstra per-block validation.
+func TestValidateRefScriptSizePerBlockConwayParams(t *testing.T) {
+	pp := &conway.ConwayProtocolParameters{}
+	err := ValidateRefScriptSizePerBlock(
+		blockWithRefScripts([]int{99999}, []int{99999}),
 		pp,
 	)
 	require.NoError(t, err)

--- a/ledger/dijkstra/rules_test.go
+++ b/ledger/dijkstra/rules_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
@@ -455,4 +456,99 @@ func TestUtxoValidatePlutusScriptsGuardingRedeemer(t *testing.T) {
 		&DijkstraProtocolParameters{},
 	)
 	require.ErrorAs(t, err, &common.MissingScriptWitnessesError{})
+}
+
+func txWithRefScripts(sizes ...int) *DijkstraTransaction {
+	outputs := make([]DijkstraTransactionOutput, len(sizes))
+	for i, size := range sizes {
+		script := make(common.PlutusV4Script, size)
+		outputs[i] = DijkstraTransactionOutput{
+			Output: babbage.BabbageTransactionOutput{
+				TxOutScriptRef: &common.ScriptRef{
+					Script: script,
+				},
+			},
+		}
+	}
+	return &DijkstraTransaction{
+		Body: DijkstraTransactionBody{TxOutputs: outputs},
+	}
+}
+
+func blockWithRefScripts(txScriptSizes ...[]int) *DijkstraBlock {
+	txs := make([]DijkstraTransaction, len(txScriptSizes))
+	for i, sizes := range txScriptSizes {
+		txs[i] = *txWithRefScripts(sizes...)
+	}
+	return &DijkstraBlock{
+		BlockBody: DijkstraBlockBody{Transactions: txs},
+	}
+}
+
+// Verifies a transaction with reference scripts below the per-tx limit passes.
+func TestUtxoValidateRefScriptSizePerTxBelowLimit(t *testing.T) {
+	pp := &DijkstraProtocolParameters{MaxRefScriptSizePerTx: 200}
+	err := UtxoValidateRefScriptSizePerTx(txWithRefScripts(100), 0, nil, pp)
+	require.NoError(t, err)
+}
+
+// Verifies a transaction with reference scripts exactly at the per-tx limit passes.
+func TestUtxoValidateRefScriptSizePerTxAtLimit(t *testing.T) {
+	pp := &DijkstraProtocolParameters{MaxRefScriptSizePerTx: 100}
+	err := UtxoValidateRefScriptSizePerTx(txWithRefScripts(100), 0, nil, pp)
+	require.NoError(t, err)
+}
+
+// Verifies a transaction exceeding the per-tx reference-script limit fails.
+func TestUtxoValidateRefScriptSizePerTxExceedsLimit(t *testing.T) {
+	pp := &DijkstraProtocolParameters{MaxRefScriptSizePerTx: 100}
+	err := UtxoValidateRefScriptSizePerTx(txWithRefScripts(60, 60), 0, nil, pp)
+	require.ErrorAs(t, err, &common.RefScriptSizePerTxTooLargeError{})
+}
+
+// Verifies a zero per-tx reference-script limit skips size validation.
+func TestUtxoValidateRefScriptSizePerTxZeroLimitSkipped(t *testing.T) {
+	pp := &DijkstraProtocolParameters{MaxRefScriptSizePerTx: 0}
+	err := UtxoValidateRefScriptSizePerTx(txWithRefScripts(99999), 0, nil, pp)
+	require.NoError(t, err)
+}
+
+// Verifies a block with reference scripts below the per-block limit passes.
+func TestValidateRefScriptSizePerBlockBelowLimit(t *testing.T) {
+	pp := &DijkstraProtocolParameters{MaxRefScriptSizePerBlock: 300}
+	err := ValidateRefScriptSizePerBlock(
+		blockWithRefScripts([]int{100}, []int{100}),
+		pp,
+	)
+	require.NoError(t, err)
+}
+
+// Verifies a block with reference scripts exactly at the per-block limit passes.
+func TestValidateRefScriptSizePerBlockAtLimit(t *testing.T) {
+	pp := &DijkstraProtocolParameters{MaxRefScriptSizePerBlock: 200}
+	err := ValidateRefScriptSizePerBlock(
+		blockWithRefScripts([]int{100}, []int{50, 50}),
+		pp,
+	)
+	require.NoError(t, err)
+}
+
+// Verifies a block exceeding the per-block reference-script limit fails.
+func TestValidateRefScriptSizePerBlockExceedsLimit(t *testing.T) {
+	pp := &DijkstraProtocolParameters{MaxRefScriptSizePerBlock: 200}
+	err := ValidateRefScriptSizePerBlock(
+		blockWithRefScripts([]int{100}, []int{60, 60}),
+		pp,
+	)
+	require.ErrorAs(t, err, &common.RefScriptSizePerBlockTooLargeError{})
+}
+
+// Verifies a zero per-block reference-script limit skips size validation.
+func TestValidateRefScriptSizePerBlockZeroLimitSkipped(t *testing.T) {
+	pp := &DijkstraProtocolParameters{MaxRefScriptSizePerBlock: 0}
+	err := ValidateRefScriptSizePerBlock(
+		blockWithRefScripts([]int{99999}, []int{99999}),
+		pp,
+	)
+	require.NoError(t, err)
 }

--- a/ledger/verify_block.go
+++ b/ledger/verify_block.go
@@ -558,6 +558,20 @@ func VerifyBlock(
 				)
 			}
 		}
+		if dijkstraBlock, ok := block.(*dijkstra.DijkstraBlock); ok {
+			if err := dijkstra.ValidateRefScriptSizePerBlock(dijkstraBlock, config.ProtocolParameters); err != nil {
+				return false, "", 0, 0, common.NewValidationError(
+					common.ValidationErrorTypeTransaction,
+					"block reference-script size validation failed",
+					map[string]any{
+						"block_slot":   slot,
+						"block_number": blockNo,
+						"era":          era,
+					},
+					err,
+				)
+			}
+		}
 	}
 
 	// Verify stake pool registration (can be skipped via config)


### PR DESCRIPTION
1. Made changes to enforce Dijkstra reference-script size limits at both transaction and block level.
2. Enforced `MaxRefScriptSizePerTx` for Dijkstra transactions by adding `UtxoValidateRefScriptSizePerTx`.
3. Enforced `MaxRefScriptSizePerBlock` for Dijkstra blocks by adding block-level aggregate validation.
4. Made changes to wire block-level reference-script validation into `VerifyBlock` for Dijkstra blocks.
5. Added typed errors for per-transaction and per-block reference-script size violations.
6. Counted reference-script bytes from produced transaction outputs using raw script bytes.
7. Registered the new per-transaction rule in `Dijkstra` UTxO validation rules.
8. Added tests for per-tx below-limit, exact-limit, over-limit, and zero-limit behavior.
9. Added tests for per-block below-limit, exact-limit, over-limit, and zero-limit behavior.
10. Added helpers for building test transactions and blocks with known reference-script sizes.

Closes #1797 





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces Dijkstra reference-script size limits per transaction and per block, counting raw script bytes from outputs. Violations now return typed errors, and per-block checks run during `VerifyBlock` (meets #1797).

- **New Features**
  - Adds `UtxoValidateRefScriptSizePerTx` to enforce `MaxRefScriptSizePerTx` in Dijkstra UTxO rules.
  - Adds `ValidateRefScriptSizePerBlock` and wires it into `VerifyBlock` to enforce `MaxRefScriptSizePerBlock`.
  - Introduces typed errors: `RefScriptSizePerTxTooLargeError` and `RefScriptSizePerBlockTooLargeError`.
  - Skips checks when limits are zero; supports both `DijkstraProtocolParameters` and `conway.ConwayProtocolParameters`.
  - Adds focused tests for below/at/over/zero limits and helpers for size-controlled txs/blocks.

<sup>Written for commit 46f233e96389133630a35b6dd797d2cecb281ea1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for reference-script size limits at both the transaction and block level.
  * Blocks and transactions now report clearer errors when reference-script sizes exceed configured limits.

* **Bug Fixes**
  * Block verification now rejects Dijkstra-era blocks that exceed reference-script size limits.
  * Validation correctly skips checks when the relevant limit is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->