### PR TITLE
fix(ledger): tolerate tag-258 set duplicates in Conway witness fields

### DIFF
--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -438,17 +438,22 @@ func (w *ConwayTransactionWitnessSet) UnmarshalCBOR(cborData []byte) error {
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
 		return err
 	}
-	// Reject duplicate members in any tag-258 witness set field.
-	// Untagged array fields are left unchecked so pre-Conway encodings remain valid.
+	// Conway (protocol versions 9-11) tolerates duplicate members in the
+	// witness-set sets that cardano-ledger decodes via Set/Map.fromList: vkey
+	// witnesses, bootstrap witnesses, native scripts, and plutus data all
+	// silently deduplicate at decode and only begin rejecting duplicates at
+	// protocol version 12 (Dijkstra, handled by DijkstraTransactionWitnessSet).
+	// Plutus script sets, by contrast, reject duplicates from version 9
+	// (cardano-ledger scriptDecoderV9 / decodeMapLikeEnforceNoDuplicates), like
+	// the tx-body sets. Only enforce the fields cardano-ledger enforces in
+	// Conway; enforcing the tolerated fields rejects valid historical blocks at
+	// decode (issue #1853). Untagged array fields are left unchecked so
+	// pre-Conway encodings remain valid.
 	type duplicateChecker interface {
 		CheckForDuplicates() error
 	}
 	for _, c := range []duplicateChecker{
-		&tmp.VkeyWitnesses,
-		&tmp.WsNativeScripts,
-		&tmp.BootstrapWitnesses,
 		&tmp.WsPlutusV1Scripts,
-		&tmp.WsPlutusData,
 		&tmp.WsPlutusV2Scripts,
 		&tmp.WsPlutusV3Scripts,
 	} {

--- a/ledger/conway/conway_test.go
+++ b/ledger/conway/conway_test.go
@@ -306,7 +306,11 @@ func TestConwayTransactionBodyRejectsDuplicateTaggedSetFields(t *testing.T) {
 	}
 }
 
-func TestConwayWitnessSetRejectsDuplicateTaggedVkeyWitness(t *testing.T) {
+// Conway (protocol versions 9-11) tolerates duplicate vkey witnesses:
+// cardano-ledger decodes them via Set.fromList and only begins rejecting
+// duplicates at protocol version 12 (Dijkstra). Rejecting at decode in Conway
+// wrongly rejects valid historical blocks (issue #1853).
+func TestConwayWitnessSetToleratesDuplicateTaggedVkeyWitness(t *testing.T) {
 	dupCbor := []byte{
 		0xa1,             // map(1)
 		0x00,             // key: 0  (VkeyWitnesses field)
@@ -318,7 +322,96 @@ func TestConwayWitnessSetRejectsDuplicateTaggedVkeyWitness(t *testing.T) {
 
 	var ws ConwayTransactionWitnessSet
 	err := ws.UnmarshalCBOR(dupCbor)
+	assert.NoError(t, err,
+		"Conway must tolerate duplicate vkey witnesses (dedup at decode, matching cardano-ledger pv 9-11)")
+}
+
+func TestConwayWitnessSetToleratesDuplicateTaggedWitnessSetFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		field  byte
+		member []byte
+	}{
+		{
+			name:  "bootstrap witnesses",
+			field: 0x02,
+			member: []byte{
+				0x84,                   // BootstrapWitness
+				0x41, 0x01, 0x41, 0x02, // public key, signature
+				0x41, 0x03, 0x41, 0x04, // chain code, attributes
+			},
+		},
+		{
+			name:   "native scripts",
+			field:  0x01,
+			member: []byte{0x82, 0x00, 0x41, 0x01}, // pubkey script
+		},
+		{
+			name:   "plutus data",
+			field:  0x04,
+			member: []byte{0x00}, // integer datum
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ws ConwayTransactionWitnessSet
+			err := ws.UnmarshalCBOR(
+				duplicateTaggedWitnessSetFieldCbor(tt.field, tt.member),
+			)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// Plutus script sets reject duplicates from protocol version 9 (cardano-ledger
+// scriptDecoderV9), so Conway must still reject them at decode.
+func TestConwayWitnessSetRejectsDuplicateTaggedPlutusV1Script(t *testing.T) {
+	dupCbor := []byte{
+		0xa1,             // map(1)
+		0x03,             // key: 3  (WsPlutusV1Scripts field)
+		0xd9, 0x01, 0x02, // tag(258) - CBOR set
+		0x82,       // array(2)
+		0x41, 0x01, // PlutusV1Script [0x01]
+		0x41, 0x01, // duplicate
+	}
+
+	var ws ConwayTransactionWitnessSet
+	err := ws.UnmarshalCBOR(dupCbor)
 	assert.ErrorContains(t, err, "duplicate member in set")
+}
+
+func TestConwayWitnessSetRejectsDuplicateTaggedPlutusV2AndV3Scripts(t *testing.T) {
+	tests := []struct {
+		name  string
+		field byte
+	}{
+		{name: "Plutus V2", field: 0x06},
+		{name: "Plutus V3", field: 0x07},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ws ConwayTransactionWitnessSet
+			err := ws.UnmarshalCBOR(
+				duplicateTaggedWitnessSetFieldCbor(
+					tt.field,
+					[]byte{0x41, 0x01},
+				),
+			)
+			assert.ErrorContains(t, err, "duplicate member in set")
+		})
+	}
+}
+
+func duplicateTaggedWitnessSetFieldCbor(field byte, member []byte) []byte {
+	ret := []byte{
+		0xa1,             // map(1)
+		field,            // witness set field key
+		0xd9, 0x01, 0x02, // tag(258) - CBOR set
+		0x82, // array(2)
+	}
+	ret = append(ret, member...)
+	ret = append(ret, member...)
+	return ret
 }
 
 func testConwayShelleyInput() shelley.ShelleyTransactionInput {


### PR DESCRIPTION
Fixes #1853

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tolerate tag-258 set duplicates in Conway witness-set fields (pv 9–11) to match cardano-ledger and avoid decode failures of valid historical blocks (Fixes #1853). Plutus script sets remain strict; vkey, bootstrap, native scripts, and Plutus data dedupe at decode.

- **Bug Fixes**
  - Only enforce no-duplicate on `WsPlutusV1Scripts`, `WsPlutusV2Scripts`, `WsPlutusV3Scripts`; stop enforcing on vkey witnesses, bootstrap witnesses, native scripts, and Plutus data in `ConwayTransactionWitnessSet.UnmarshalCBOR`.
  - Tests cover tolerating duplicates for vkey, bootstrap, native scripts, and Plutus data; and rejecting duplicates for Plutus V1/V2/V3 scripts. pv12 remains strict via `DijkstraTransactionWitnessSet`.

<sup>Written for commit 79081a96011ec8e0088b61ce30381e27cef2c847. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conway witness-set decoding now allows duplicate entries for vkey, native script, bootstrap witness, and Plutus data sets where duplicates are handled during decoding.
  * Duplicate entries in Plutus script sets still trigger a validation error, preserving strict checks where needed.

* **Tests**
  * Updated coverage to reflect the new duplicate-handling behavior.
  * Added validation to ensure duplicate Plutus V1 script entries continue to be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->