### PR TITLE
fix(leios): block encoding for prototype-2026w27

### DIFF
--- a/ledger/dijkstra/dijkstra.go
+++ b/ledger/dijkstra/dijkstra.go
@@ -192,30 +192,67 @@ func (b *DijkstraBlock) CalculatedBlockBodyHash() common.Blake2b256 {
 	return b.BlockBody.Hash()
 }
 
-// DijkstraLeiosCertificate matches the generated Dijkstra CDDL in
-// IntersectMBO/cardano-ledger at c47305fcf47bd77437b837d0dfb9cb4181bfbc77:
+// DijkstraLeiosCertificate is the in-body Leios certificate added in the
+// ouroboros-leios prototype-2026w27 release (IntersectMBO/cardano-ledger #5872):
 //
-//	block = [..., leios_cert : leios_cert / nil, peras_cert : peras_cert / nil]
-//	leios_cert = []
-//	peras_cert = []
+//	block_body = [..., leios_certificate : leios_certificate / nil, peras_certificate : peras_certificate / nil]
+//	leios_certificate = [ signers : bytes ; committee signer bitfield
+//	                    , aggregated_signature : leios_signature ]
+//	leios_signature = bytes .size 48
 //
-// The Leios and Peras slots are always present and nullable. When non-null,
-// the current Dijkstra CDDL placeholder is an empty CBOR list, not the CIP-0164
-// stake-committee EB certificate payload.
+// It certifies the endorser block announced by an earlier ranking block; the
+// ranking block whose header sets leios_certified carries it in its body. Per
+// CIP-0164 a block that carries a Leios certificate carries no Dijkstra-era
+// transactions.
 type DijkstraLeiosCertificate struct {
 	cbor.DecodeStoreCbor
+	Signers             []byte
+	AggregatedSignature []byte
 }
 
 func (c *DijkstraLeiosCertificate) UnmarshalCBOR(cborData []byte) error {
-	return decodeDijkstraEmptyCertificate(
-		cborData,
-		"Dijkstra Leios certificate",
-		&c.DecodeStoreCbor,
-	)
+	var items []cbor.RawMessage
+	if _, err := cbor.Decode(cborData, &items); err != nil {
+		return fmt.Errorf("decode Dijkstra Leios certificate: %w", err)
+	}
+	if len(items) != 2 {
+		return fmt.Errorf(
+			"dijkstra Leios certificate must have 2 fields, got %d",
+			len(items),
+		)
+	}
+	var signers []byte
+	if _, err := cbor.Decode(items[0], &signers); err != nil {
+		return fmt.Errorf(
+			"decode Dijkstra Leios certificate signers: %w",
+			err,
+		)
+	}
+	var aggSig []byte
+	if _, err := cbor.Decode(items[1], &aggSig); err != nil {
+		return fmt.Errorf(
+			"decode Dijkstra Leios certificate aggregated signature: %w",
+			err,
+		)
+	}
+	if len(aggSig) != common.LeiosBlsSignatureSize {
+		return fmt.Errorf(
+			"invalid Dijkstra Leios certificate aggregated signature length: expected %d, got %d",
+			common.LeiosBlsSignatureSize,
+			len(aggSig),
+		)
+	}
+	c.Signers = signers
+	c.AggregatedSignature = aggSig
+	c.SetCbor(cborData)
+	return nil
 }
 
 func (c DijkstraLeiosCertificate) MarshalCBOR() ([]byte, error) {
-	return marshalDijkstraEmptyCertificate(c.DecodeStoreCbor)
+	if raw := c.Cbor(); len(raw) > 0 {
+		return raw, nil
+	}
+	return cbor.Encode([]any{c.Signers, c.AggregatedSignature})
 }
 
 type DijkstraPerasCertificate struct {
@@ -622,12 +659,14 @@ const babbageHeaderBodyFieldCount = 10
 type DijkstraBlockHeader struct {
 	babbage.BabbageBlockHeader
 	// LeiosHeaderExtension holds the Dijkstra/Leios block-header fields that
-	// follow Babbage's protocol_version field. The leios-prototype testnet
-	// began emitting an extra trailing element (a [hash, uint] pair) once the
-	// Leios header extension activated mid-Dijkstra; earlier Dijkstra blocks
-	// carry the plain 10-field Babbage header body, for which this is nil. The
-	// elements are retained verbatim so the header round-trips and hashes
-	// identically to the bytes received on the wire.
+	// follow Babbage's protocol_version field. As of the ouroboros-leios
+	// prototype-2026w27 release (IntersectMBO/cardano-ledger #5889) these are
+	// two fields: leios_certified (bool) and leios_announcement
+	// ([announced_eb : hash32, announced_eb_size : uint .size 4] / nil). Earlier
+	// Dijkstra blocks carry the plain 10-field Babbage header body, for which
+	// this is nil. The elements are retained verbatim so the header round-trips
+	// and hashes identically to the bytes received on the wire; use
+	// LeiosCertified and LeiosAnnouncement for typed access.
 	LeiosHeaderExtension []cbor.RawMessage
 }
 
@@ -709,22 +748,42 @@ func (h *DijkstraBlockHeader) Era() common.Era {
 	return EraDijkstra
 }
 
-// LeiosEndorserBlockRef returns the endorser block referenced by this ranking
-// block via its Leios header extension. The extension's first element is the
-// endorser-block announcement [eb_hash, eb_size] (the same shape leios-notify
-// uses), identifying the endorser block whose transactions this ranking block
-// endorses. ok is false for pre-Leios-extension Dijkstra headers (which carry
-// no extension) or if the extension is not the expected [hash32, uint] shape.
-func (h *DijkstraBlockHeader) LeiosEndorserBlockRef() (
+// LeiosCertified reports whether this ranking block certifies the endorser
+// block announced by an earlier ranking block. It is the leios_certified header
+// field added in the ouroboros-leios prototype-2026w27 release
+// (IntersectMBO/cardano-ledger #5889); when true, the block body carries the
+// leios_certificate. present is false for pre-Leios-extension Dijkstra headers,
+// which carry no extension.
+func (h *DijkstraBlockHeader) LeiosCertified() (certified bool, present bool) {
+	if len(h.LeiosHeaderExtension) == 0 {
+		return false, false
+	}
+	if _, err := cbor.Decode(h.LeiosHeaderExtension[0], &certified); err != nil {
+		return false, false
+	}
+	return certified, true
+}
+
+// LeiosAnnouncement returns the endorser block this ranking block announces via
+// its Leios header extension. It is the leios_announcement header field added in
+// the ouroboros-leios prototype-2026w27 release (IntersectMBO/cardano-ledger
+// #5889):
+//
+//	leios_announcement = [announced_eb : hash32, announced_eb_size : uint .size 4]
+//
+// ok is false when the block announces no endorser block (leios_announcement is
+// nil), for pre-Leios-extension Dijkstra headers, or if the field is not the
+// expected [hash32, uint] shape.
+func (h *DijkstraBlockHeader) LeiosAnnouncement() (
 	hash common.Blake2b256,
 	size uint64,
 	ok bool,
 ) {
-	if len(h.LeiosHeaderExtension) == 0 {
+	if len(h.LeiosHeaderExtension) < 2 {
 		return common.Blake2b256{}, 0, false
 	}
 	var pair []cbor.RawMessage
-	if _, err := cbor.Decode(h.LeiosHeaderExtension[0], &pair); err != nil ||
+	if _, err := cbor.Decode(h.LeiosHeaderExtension[1], &pair); err != nil ||
 		len(pair) != 2 {
 		return common.Blake2b256{}, 0, false
 	}

--- a/ledger/dijkstra/dijkstra_leios_w27_test.go
+++ b/ledger/dijkstra/dijkstra_leios_w27_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dijkstra
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// prototype-2026w27 (IntersectMBO/cardano-ledger #5872, #5889):
+//
+//	leios_certificate  = [ signers : bytes, aggregated_signature : bytes .size 48 ]
+//	leios_announcement = [ announced_eb : hash32, announced_eb_size : uint .size 4 ]
+//	header extension   = [ leios_certified : bool, leios_announcement / nil ]
+
+func TestDijkstraLeiosCertificateRoundTrip(t *testing.T) {
+	signers := []byte{0xf0, 0x0f}
+	sig := make([]byte, common.LeiosBlsSignatureSize)
+	for i := range sig {
+		sig[i] = byte(i)
+	}
+	certCbor, err := cbor.Encode([]any{signers, sig})
+	require.NoError(t, err)
+	var cert DijkstraLeiosCertificate
+	_, err = cbor.Decode(certCbor, &cert)
+	require.NoError(t, err)
+	assert.Equal(t, signers, cert.Signers)
+	assert.Equal(t, sig, cert.AggregatedSignature)
+	out, err := cert.MarshalCBOR()
+	require.NoError(t, err)
+	assert.Equal(t, certCbor, out)
+}
+
+func TestDijkstraLeiosCertificateRejectsBadSignatureLength(t *testing.T) {
+	shortSig := make([]byte, common.LeiosBlsSignatureSize-1)
+	certCbor, err := cbor.Encode([]any{[]byte{0x01}, shortSig})
+	require.NoError(t, err)
+	var cert DijkstraLeiosCertificate
+	_, err = cbor.Decode(certCbor, &cert)
+	require.Error(t, err)
+}
+
+func TestDijkstraLeiosCertificateRejectsWrongFieldCount(t *testing.T) {
+	sig := make([]byte, common.LeiosBlsSignatureSize)
+	certCbor, err := cbor.Encode([]any{[]byte{0x01}, sig, uint64(3)})
+	require.NoError(t, err)
+	var cert DijkstraLeiosCertificate
+	_, err = cbor.Decode(certCbor, &cert)
+	require.Error(t, err)
+}
+
+func encodeAnnouncement(t *testing.T, hash []byte, size uint64) cbor.RawMessage {
+	t.Helper()
+	raw, err := cbor.Encode([]any{hash, size})
+	require.NoError(t, err)
+	return cbor.RawMessage(raw)
+}
+
+func encodeBool(t *testing.T, v bool) cbor.RawMessage {
+	t.Helper()
+	raw, err := cbor.Encode(v)
+	require.NoError(t, err)
+	return cbor.RawMessage(raw)
+}
+
+func TestDijkstraLeiosHeaderExtensionAccessors(t *testing.T) {
+	hash := make([]byte, common.Blake2b256Size)
+	for i := range hash {
+		hash[i] = byte(0xa0 + i%16)
+	}
+	const size = uint64(4096)
+
+	// Certified block that also announces an endorser block.
+	h := &DijkstraBlockHeader{
+		LeiosHeaderExtension: []cbor.RawMessage{
+			encodeBool(t, true),
+			encodeAnnouncement(t, hash, size),
+		},
+	}
+	certified, present := h.LeiosCertified()
+	assert.True(t, present)
+	assert.True(t, certified)
+	gotHash, gotSize, ok := h.LeiosAnnouncement()
+	assert.True(t, ok)
+	assert.Equal(t, hash, gotHash.Bytes())
+	assert.Equal(t, size, gotSize)
+
+	// Not certified, no announcement (leios_announcement = nil).
+	hNil := &DijkstraBlockHeader{
+		LeiosHeaderExtension: []cbor.RawMessage{
+			encodeBool(t, false),
+			cbor.RawMessage([]byte{0xf6}), // CBOR null
+		},
+	}
+	certified, present = hNil.LeiosCertified()
+	assert.True(t, present)
+	assert.False(t, certified)
+	_, _, ok = hNil.LeiosAnnouncement()
+	assert.False(t, ok)
+
+	// Pre-Leios-extension header: no extension at all.
+	hLegacy := &DijkstraBlockHeader{}
+	_, present = hLegacy.LeiosCertified()
+	assert.False(t, present)
+	_, _, ok = hLegacy.LeiosAnnouncement()
+	assert.False(t, ok)
+}

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -184,6 +184,11 @@ func TestDijkstraBlockBodyRejectsInvalidTransactionIndexOutOfRange(t *testing.T)
 }
 
 func TestDijkstraBlockMarshalUsesSevenItemEnvelope(t *testing.T) {
+	sig := make([]byte, common.LeiosBlsSignatureSize)
+	leiosCert := &DijkstraLeiosCertificate{
+		Signers:             []byte{0x01},
+		AggregatedSignature: sig,
+	}
 	block := DijkstraBlock{
 		BlockBody: DijkstraBlockBody{
 			TransactionBodies: []DijkstraTransactionBody{
@@ -191,7 +196,7 @@ func TestDijkstraBlockMarshalUsesSevenItemEnvelope(t *testing.T) {
 			},
 			TransactionWitnessSets: []DijkstraTransactionWitnessSet{{}},
 			InvalidTransactions:    []uint{},
-			LeiosCertificate:       &DijkstraLeiosCertificate{},
+			LeiosCertificate:       leiosCert,
 			PerasCertificate:       &DijkstraPerasCertificate{},
 		},
 	}
@@ -203,13 +208,17 @@ func TestDijkstraBlockMarshalUsesSevenItemEnvelope(t *testing.T) {
 	_, err = cbor.Decode(blockCbor, &raw)
 	require.NoError(t, err)
 	require.Len(t, raw, 7)
-	// When a Leios cert is present, the prototype encodes empty transaction
-	// components and resolves the EB closure through LeiosDB.
+	// Per CIP-0164 a block that carries a Leios certificate carries no
+	// Dijkstra-era transactions, so the transaction components encode empty.
 	require.Equal(t, []byte{0x80}, []byte(raw[1]))
 	require.Equal(t, []byte{0x80}, []byte(raw[2]))
 	require.Equal(t, []byte{0xa0}, []byte(raw[3]))
 	require.Equal(t, []byte{0x80}, []byte(raw[4]))
-	require.Equal(t, []byte{0x80}, []byte(raw[5]))
+	// raw[5] is the real Leios certificate [signers, aggregated_signature].
+	expectedCert, err := cbor.Encode([]any{[]byte{0x01}, sig})
+	require.NoError(t, err)
+	require.Equal(t, expectedCert, []byte(raw[5]))
+	// raw[6] is the Peras certificate placeholder (empty list).
 	require.Equal(t, []byte{0x80}, []byte(raw[6]))
 }
 
@@ -304,23 +313,24 @@ func TestDijkstraBlockBodyHashIncludesLeiosAndPerasCertSlots(t *testing.T) {
 	require.NotEqual(t, withoutCerts.Hash(), withCerts.Hash())
 }
 
-func TestDijkstraLeiosCertificateMatchesCddlPlaceholder(t *testing.T) {
-	raw, err := cbor.Encode([]any{})
+// prototype-2026w27 replaced the empty-list leios_cert placeholder with a real
+// two-field certificate (IntersectMBO/cardano-ledger #5872); the old empty-list
+// form is no longer valid. Full round-trip coverage is in
+// dijkstra_leios_w27_test.go.
+func TestDijkstraLeiosCertificateRejectsEmptyPlaceholder(t *testing.T) {
+	empty, err := cbor.Encode([]any{})
 	require.NoError(t, err)
-	require.Equal(t, []byte{0x80}, raw)
+	require.Equal(t, []byte{0x80}, empty)
 
 	var cert DijkstraLeiosCertificate
-	require.NoError(t, cert.UnmarshalCBOR(raw))
-	require.Equal(t, raw, cert.Cbor())
+	require.Error(t, cert.UnmarshalCBOR(empty))
 
-	encoded, err := cbor.Encode(&cert)
+	sig := make([]byte, common.LeiosBlsSignatureSize)
+	realCert, err := cbor.Encode([]any{[]byte{0x03}, sig})
 	require.NoError(t, err)
-	require.Equal(t, raw, encoded)
-
-	nonEmpty, err := cbor.Encode([]any{uint64(99)})
-	require.NoError(t, err)
-	err = cert.UnmarshalCBOR(nonEmpty)
-	require.ErrorContains(t, err, "empty list")
+	require.NoError(t, cert.UnmarshalCBOR(realCert))
+	require.Equal(t, []byte{0x03}, cert.Signers)
+	require.Len(t, cert.AggregatedSignature, common.LeiosBlsSignatureSize)
 }
 
 func TestDijkstraBlockRoundTripWithBodyHash(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Dijkstra/Leios block encoding to match `prototype-2026w27`. Adds the real in-body Leios certificate and the new header fields `leios_certified` and `leios_announcement`; blocks with a Leios certificate now encode empty tx components per CIP-0164.

- **Migration**
  - Replace `LeiosEndorserBlockRef()` with `LeiosCertified()` and `LeiosAnnouncement()` (announcement may be nil).
  - Use `DijkstraLeiosCertificate{ Signers, AggregatedSignature }`; the empty-list placeholder is rejected and `AggregatedSignature` must be 48 bytes.

<sup>Written for commit b32ad82e231ac692f85f8a6394d45b502b8c0cd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reading and writing Leios certificates in block data.
  * Exposed block header accessors for Leios certification status and the announced block reference.

* **Bug Fixes**
  * Fixed certificate handling so empty placeholder values are now rejected.
  * Improved validation of certificate structure and signature length to prevent malformed data from being accepted.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->