### PR TITLE
fix: parse genesis staking pool vrf/owners/metadata fields

### DIFF
--- a/ledger/common/certs.go
+++ b/ledger/common/certs.go
@@ -525,12 +525,41 @@ func (p *PoolRegistrationCertificate) UnmarshalJSON(data []byte) error {
 			Hostname *string `json:"hostname,omitempty"`
 		} `json:"relays"`
 		PoolMetadata *PoolMetadata `json:"poolMetadata,omitempty"`
+
+		// Shelley genesis staking.pools uses different field names than the
+		// on-chain / API representation above for the same values. Accept both
+		// so pools declared in genesis parse correctly — otherwise a genesis
+		// pool's VRF key hash is dropped and reads as all-zeros, which breaks
+		// header VRF-key validation for that pool's blocks.
+		PublicKey string        `json:"publicKey"`
+		Vrf       string        `json:"vrf"`
+		Owners    []string      `json:"owners"`
+		Metadata  *PoolMetadata `json:"metadata,omitempty"`
 	}
 
 	var tmp tempPool
 	//nolint:musttag
 	if err := json.Unmarshal(data, &tmp); err != nil {
 		return fmt.Errorf("failed to unmarshal pool registration: %w", err)
+	}
+
+	// Resolve fields that have distinct genesis-staking names, preferring the
+	// on-chain/API name when both are present.
+	operator := tmp.Operator
+	if operator == "" {
+		operator = tmp.PublicKey
+	}
+	vrfKeyHash := tmp.VrfKeyHash
+	if vrfKeyHash == "" {
+		vrfKeyHash = tmp.Vrf
+	}
+	poolOwners := tmp.PoolOwners
+	if len(poolOwners) == 0 {
+		poolOwners = tmp.Owners
+	}
+	poolMetadata := tmp.PoolMetadata
+	if poolMetadata == nil {
+		poolMetadata = tmp.Metadata
 	}
 
 	p.Pledge = tmp.Pledge
@@ -545,7 +574,7 @@ func (p *PoolRegistrationCertificate) UnmarshalJSON(data []byte) error {
 			Hostname: relay.Hostname,
 		}
 	}
-	p.PoolMetadata = tmp.PoolMetadata
+	p.PoolMetadata = poolMetadata
 
 	// Handle margin field
 	if len(tmp.Margin) > 0 {
@@ -585,8 +614,8 @@ func (p *PoolRegistrationCertificate) UnmarshalJSON(data []byte) error {
 	}
 
 	// Convert operator key
-	if tmp.Operator != "" {
-		opBytes, err := hex.DecodeString(tmp.Operator)
+	if operator != "" {
+		opBytes, err := hex.DecodeString(operator)
 		if err != nil {
 			return fmt.Errorf("invalid operator key: %w", err)
 		}
@@ -594,8 +623,8 @@ func (p *PoolRegistrationCertificate) UnmarshalJSON(data []byte) error {
 	}
 
 	// Convert VRF key hash
-	if tmp.VrfKeyHash != "" {
-		vrfBytes, err := hex.DecodeString(tmp.VrfKeyHash)
+	if vrfKeyHash != "" {
+		vrfBytes, err := hex.DecodeString(vrfKeyHash)
 		if err != nil {
 			return fmt.Errorf("invalid VRF key hash: %w", err)
 		}
@@ -603,9 +632,9 @@ func (p *PoolRegistrationCertificate) UnmarshalJSON(data []byte) error {
 	}
 
 	// Convert pool owners
-	if len(tmp.PoolOwners) > 0 {
-		owners := make([]AddrKeyHash, len(tmp.PoolOwners))
-		for i, owner := range tmp.PoolOwners {
+	if len(poolOwners) > 0 {
+		owners := make([]AddrKeyHash, len(poolOwners))
+		for i, owner := range poolOwners {
 			ownerBytes, err := hex.DecodeString(owner)
 			if err != nil {
 				return fmt.Errorf("invalid pool owner key: %w", err)

--- a/ledger/shelley/genesis_test.go
+++ b/ledger/shelley/genesis_test.go
@@ -320,6 +320,18 @@ func TestGenesisStaking(t *testing.T) {
 			t.Errorf("Expected pool cost 340000000, got %d", pool.Cost)
 		}
 
+		// The VRF key hash must be parsed from the genesis "vrf" field.
+		// If it is dropped it reads as all-zeros, which breaks consensus
+		// header VRF-key validation for this pool's blocks.
+		expectedVrf := "eb53a17fbad9b7ea0bcf1e1ea89355305600d593b426dfc3084a924d8877d47e"
+		if got := hex.EncodeToString(pool.VrfKeyHash[:]); got != expectedVrf {
+			t.Errorf(
+				"Expected pool VRF key hash %s, got %s",
+				expectedVrf,
+				got,
+			)
+		}
+
 		// Test delegators
 		if len(delegators) != 1 {
 			t.Errorf("Expected 1 delegator mapping, got %d", len(delegators))
@@ -367,6 +379,18 @@ func TestGenesisStaking(t *testing.T) {
 		// Test pool data
 		if pool.Cost != 340000000 {
 			t.Errorf("Expected pool cost 340000000, got %d", pool.Cost)
+		}
+
+		// The VRF key hash must be parsed from the genesis "vrf" field.
+		// If it is dropped it reads as all-zeros, which breaks consensus
+		// header VRF-key validation for this pool's blocks.
+		expectedVrf := "eb53a17fbad9b7ea0bcf1e1ea89355305600d593b426dfc3084a924d8877d47e"
+		if got := hex.EncodeToString(pool.VrfKeyHash[:]); got != expectedVrf {
+			t.Errorf(
+				"Expected pool VRF key hash %s, got %s",
+				expectedVrf,
+				got,
+			)
 		}
 
 		// Test delegators


### PR DESCRIPTION
## Problem

`PoolRegistrationCertificate.UnmarshalJSON` reads only the on-chain / API field names:

```
operator, vrfKeyHash, poolOwners, poolMetadata
```

But Shelley genesis `staking.pools` (the cardano-node genesis format, and the only place this JSON is unmarshaled) uses different names for the same values:

```
publicKey, vrf, owners, metadata
```

So a pool declared in genesis parses with an **all-zeros VRF key hash** (and dropped owners/metadata). The operator survives only because `InitialPools()` sets it from the map key.

This went unnoticed because `TestInitialPools`/`TestPoolById` only asserted `cost`, never the VRF key hash — and the genesis fixtures already use `"vrf"`.

## Impact (consensus)

A zero registered VRF key hash breaks header VRF-key validation in downstream consumers: a genesis pool's blocks are rejected because their real VRF key does not match the zero "registered" value. This was found in a downstream node (dingo), whose devnet stalled — it rejected the reference `cardano-node` producer's valid blocks with `VRF key does not match registered VRF key (... registered 0000…0000)` for a genesis-declared pool.

## Fix

Accept both name sets in `UnmarshalJSON`, preferring the on-chain/API name when both are present (`vrf`→`VrfKeyHash`, `owners`→`PoolOwners`, `metadata`→`PoolMetadata`, `publicKey`→`Operator`). Assert the parsed VRF key hash in the `InitialPools`/`PoolById` tests.

## Verification

- `go test -race ./ledger/common/... ./ledger/shelley/...` passes; the new VRF assertion fails without the fix (previously parsed as all-zeros).
- `gofmt` clean; `golangci-lint run` 0 issues.
- End-to-end: with this change pulled into dingo (via a `replace`), its devnet no longer rejects the `cardano-node` producer's genesis-pool blocks — the chain grows and reaches consensus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix genesis staking pool parsing so `publicKey`, `vrf`, `owners`, and `metadata` in Shelley genesis are read correctly, preventing zero VRF key hashes and block validation failures.

- **Bug Fixes**
  - `PoolRegistrationCertificate.UnmarshalJSON` now accepts both on-chain/API and genesis field names, preferring on-chain names when both exist.
  - Field mapping: `publicKey`→operator, `vrf`→VRF key hash, `owners`→owners, `metadata`→pool metadata.
  - Tests updated to assert the parsed VRF key hash in genesis pool loading.

<sup>Written for commit 05dc4aa881123cf4407598b5ce011dc4d657ba60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded support for stake pool registration data to handle additional JSON field names, improving compatibility with more genesis staking pool exports.

* **Bug Fixes**
  * Improved pool parsing so key details like operator key, VRF key hash, owners, and metadata are resolved correctly when field names vary.
  * Strengthened validation to ensure VRF key hashes are read correctly from genesis data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->