### PR TITLE
fix(leios): fix vote message

### DIFF
--- a/protocol/leiosnotify/messages.go
+++ b/protocol/leiosnotify/messages.go
@@ -48,14 +48,14 @@ func NewMsgFromCbor(msgType uint, data []byte) (protocol.Message, error) {
 		ret = &MsgVotesOffer{}
 	case MessageTypeDone:
 		ret = &MsgDone{}
+	default:
+		return nil, fmt.Errorf("%s: unknown message type %d", ProtocolName, msgType)
 	}
 	if _, err := cbor.Decode(data, ret); err != nil {
 		return nil, fmt.Errorf("%s: decode error: %w", ProtocolName, err)
 	}
-	if ret != nil {
-		// Store the raw message CBOR
-		ret.SetCbor(data)
-	}
+	// Store the raw message CBOR
+	ret.SetCbor(data)
 	return ret, nil
 }
 
@@ -132,7 +132,8 @@ func NewMsgBlockTxsOffer(point pcommon.Point) *MsgBlockTxsOffer {
 //     elements) when the peer pushes votes directly (the prototype dialect).
 //
 // After decoding, exactly one of Votes / FullVotes is populated depending on
-// the per-vote CBOR array length. Encoding prefers FullVotes when present.
+// the known per-vote CBOR array length. Encoding prefers FullVotes when
+// present.
 type MsgVotesOffer struct {
 	protocol.MessageBase
 	Votes     []MsgVotesOfferVote
@@ -224,9 +225,54 @@ func (m *MsgVotesOffer) UnmarshalCBOR(data []byte) error {
 				)
 			}
 			m.FullVotes = append(m.FullVotes, vote)
+		case 3:
+			// prototype-2026w27 (the deployed musashi relay) diffuses a vote as
+			// a 3-element array [endorser_block_hash (hash32), voter_id (uint),
+			// signature (bytes .size 48)] — the 4-element full vote with the
+			// leading slot field dropped. Verified against live captures from
+			// leios-node.play.dev.cardano.org:3001 (network magic 164). Decode
+			// the three fields; SlotNo is left zero because the wire omits it.
+			var ebHash []byte
+			if _, err := cbor.Decode(elems[0], &ebHash); err != nil {
+				return fmt.Errorf(
+					"%s: votes offer: decode vote %d endorser block hash: %w",
+					ProtocolName, idx, err,
+				)
+			}
+			if len(ebHash) != lcommon.Blake2b256Size {
+				return fmt.Errorf(
+					"%s: votes offer: vote %d endorser block hash is %d bytes, expected %d",
+					ProtocolName, idx, len(ebHash), lcommon.Blake2b256Size,
+				)
+			}
+			var voterId uint64
+			if _, err := cbor.Decode(elems[1], &voterId); err != nil {
+				return fmt.Errorf(
+					"%s: votes offer: decode vote %d voter id: %w",
+					ProtocolName, idx, err,
+				)
+			}
+			var sig []byte
+			if _, err := cbor.Decode(elems[2], &sig); err != nil {
+				return fmt.Errorf(
+					"%s: votes offer: decode vote %d signature: %w",
+					ProtocolName, idx, err,
+				)
+			}
+			if len(sig) != lcommon.LeiosBlsSignatureSize {
+				return fmt.Errorf(
+					"%s: votes offer: vote %d signature is %d bytes, expected %d",
+					ProtocolName, idx, len(sig), lcommon.LeiosBlsSignatureSize,
+				)
+			}
+			m.FullVotes = append(m.FullVotes, lcommon.LeiosVote{
+				EndorserBlockHash: lcommon.NewBlake2b256(ebHash),
+				VoterId:           voterId,
+				VoteSignature:     sig,
+			})
 		default:
 			return fmt.Errorf(
-				"%s: votes offer: vote %d has unexpected element count %d",
+				"%s: votes offer: vote %d unexpected element count %d",
 				ProtocolName,
 				idx,
 				len(elems),

--- a/protocol/leiosnotify/messages_test.go
+++ b/protocol/leiosnotify/messages_test.go
@@ -15,10 +15,12 @@
 package leiosnotify
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
@@ -198,13 +200,11 @@ func TestMsgDone(t *testing.T) {
 }
 
 func TestNewMsgFromCborUnknownType(t *testing.T) {
-	// Test with unknown message type - the NewMsgFromCbor function tries to decode
-	// into a nil pointer, which results in an error
 	data := []byte{0x80} // empty array
 	msg, err := NewMsgFromCbor(999, data)
-	// When the message type is unknown, ret is nil, and cbor.Decode(data, nil) returns an error
-	assert.Error(t, err)
-	assert.Nil(t, msg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown message type 999")
+	require.Nil(t, msg)
 }
 
 func TestMsgVotesOfferEmpty(t *testing.T) {
@@ -234,4 +234,58 @@ func TestMsgBlockAnnouncementEmpty(t *testing.T) {
 	// After CBOR round-trip, empty RawMessage may decode differently
 	// so we just check it's not nil
 	assert.NotNil(t, decodedMsg)
+}
+
+// TestMsgVotesOfferThreeElementVote verifies decoding the prototype-2026w27
+// deployed vote shape: a 3-element array [endorser_block_hash (hash32),
+// voter_id (uint), signature (bytes .size 48)] — the full LeiosVote with the
+// leading slot dropped. Shape confirmed from live musashi captures.
+func TestMsgVotesOfferThreeElementVote(t *testing.T) {
+	ebHash := bytes.Repeat([]byte{0xAB}, lcommon.Blake2b256Size)
+	sig := bytes.Repeat([]byte{0xCD}, lcommon.LeiosBlsSignatureSize)
+	voteCbor, err := cbor.Encode([]any{ebHash, uint64(7), sig})
+	require.NoError(t, err)
+	msgCbor, err := cbor.Encode([]any{
+		uint(MessageTypeVotesOffer),
+		[]cbor.RawMessage{cbor.RawMessage(voteCbor)},
+	})
+	require.NoError(t, err)
+
+	var m MsgVotesOffer
+	require.NoError(t, m.UnmarshalCBOR(msgCbor))
+	require.Len(t, m.FullVotes, 1)
+	require.Empty(t, m.Votes)
+	v := m.FullVotes[0]
+	assert.Equal(t, uint64(0), v.SlotNo, "3-element vote omits slot")
+	assert.Equal(t, ebHash, v.EndorserBlockHash.Bytes())
+	assert.Equal(t, uint64(7), v.VoterId)
+	assert.Equal(t, sig, v.VoteSignature)
+
+	// A 3-element vote with a wrong-length signature is rejected.
+	badCbor, err := cbor.Encode([]any{ebHash, uint64(7), []byte{0x01, 0x02}})
+	require.NoError(t, err)
+	badMsg, err := cbor.Encode([]any{
+		uint(MessageTypeVotesOffer),
+		[]cbor.RawMessage{cbor.RawMessage(badCbor)},
+	})
+	require.NoError(t, err)
+	var m2 MsgVotesOffer
+	require.ErrorContains(t, m2.UnmarshalCBOR(badMsg), "signature is 2 bytes")
+}
+
+func TestMsgVotesOfferUnknownVoteShape(t *testing.T) {
+	voteCbor, err := cbor.Encode([]any{uint64(100)})
+	require.NoError(t, err)
+	msgCbor, err := cbor.Encode([]any{
+		uint(MessageTypeVotesOffer),
+		[]cbor.RawMessage{cbor.RawMessage(voteCbor)},
+	})
+	require.NoError(t, err)
+
+	var m MsgVotesOffer
+	require.ErrorContains(
+		t,
+		m.UnmarshalCBOR(msgCbor),
+		"votes offer: vote 0 unexpected element count 1",
+	)
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add support for the Musashi relay’s 3-field vote format in `MsgVotesOffer` and improve message decoding errors. Also return a clear error for unknown message types and always store the raw CBOR.

- **Bug Fixes**
  - Decode 3-element votes `[endorser_block_hash, voter_id, signature]` and populate `FullVotes` with `SlotNo` set to 0. Validate hash (32 bytes) and signature (48 bytes). Improve error messages.
  - In `NewMsgFromCbor`, return an explicit “unknown message type” error and always call `SetCbor`.
  - Add tests for the 3-element vote, bad signature length, unknown vote shape, and unknown message type.

<sup>Written for commit e30d8535ae1acdb39bc53dd03db3576433bf8b79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

