### PR TITLE
fix(conway): tolerate duplicate redeemer key

### DIFF
--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -290,8 +290,25 @@ func (r *ConwayRedeemers) UnmarshalCBOR(cborData []byte) error {
 		// Modern map form — clear any stale legacy state
 		r.legacy = false
 		r.legacyRedeemers = alonzo.AlonzoRedeemers{}
-		_, err := cbor.Decode(cborData, &(r.Redeemers))
-		return err
+		if _, err := cbor.Decode(cborData, &(r.Redeemers)); err != nil {
+			if !cbor.IsDuplicateMapKeyError(err) {
+				return err
+			}
+			// A Redeemers map with a duplicate (tag, index) key. cardano-ledger
+			// decodes this map last-wins and cardano-node accepts such blocks,
+			// so they appear on canonical chains (gouroboros #1860: a preview
+			// block carries a duplicate (Spend, 0) redeemer that cardano-node
+			// accepts). Reject-on-duplicate poisons every peer serving the block
+			// and stalls sync, so decode leniently (last-wins) to match
+			// consensus. Hash-safe: redeemer/tx/block hashes are computed over
+			// the stored raw CBOR (SetCbor above), so lenient struct decoding
+			// never changes them.
+			r.Redeemers = nil
+			if _, err := cbor.DecodeLenient(cborData, &(r.Redeemers)); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 	// Legacy array form — clear any stale map state
 	r.Redeemers = nil

--- a/ledger/conway/conway_test.go
+++ b/ledger/conway/conway_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConwayRedeemersIter(t *testing.T) {
@@ -597,5 +598,45 @@ func TestConwayTx_WithReferenceScripts_CborRoundTrip(t *testing.T) {
 		cborData,
 		reEncoded,
 		"CBOR round-trip should be byte-identical",
+	)
+}
+
+// TestConwayRedeemersDuplicateKeyLenient verifies that a Redeemers map carrying
+// a duplicate (tag, index) key — which cardano-node accepts and strict decoding
+// rejects — is decoded leniently (last-wins) instead of failing the block.
+// See gouroboros #1860.
+func TestConwayRedeemersDuplicateKeyLenient(t *testing.T) {
+	// Redeemers map with two entries under the same key [Spend(0), index 0]:
+	//   { [0,0]: [0,[1,2]], [0,0]: [0,[3,4]] }
+	// Plutus data is the bare integer 0; the value's second element is
+	// ExUnits [mem, steps].
+	dupCbor := []byte{
+		0xA2,             // map(2)
+		0x82, 0x00, 0x00, // key [Spend, 0]
+		0x82, 0x00, 0x82, 0x01, 0x02, // value [datum=0, exUnits=[1,2]]
+		0x82, 0x00, 0x00, // key [Spend, 0] (duplicate)
+		0x82, 0x00, 0x82, 0x03, 0x04, // value [datum=0, exUnits=[3,4]]
+	}
+	// Strict decode rejects the duplicate key (the pre-fix behavior that
+	// wedged preview sync).
+	var strict map[common.RedeemerKey]common.RedeemerValue
+	_, strictErr := cbor.Decode(dupCbor, &strict)
+	assert.Error(t, strictErr)
+	assert.True(
+		t,
+		cbor.IsDuplicateMapKeyError(strictErr),
+		"expected a duplicate-map-key error, got %v",
+		strictErr,
+	)
+	// ConwayRedeemers decodes it, keeping the last value for the duplicate key.
+	var r ConwayRedeemers
+	require.NoError(t, r.UnmarshalCBOR(dupCbor))
+	key := common.RedeemerKey{Tag: common.RedeemerTagSpend, Index: 0}
+	assert.Len(t, r.Redeemers, 1)
+	assert.Equal(
+		t,
+		common.ExUnits{Memory: 3, Steps: 4},
+		r.Redeemers[key].ExUnits,
+		"duplicate key should resolve last-wins",
 	)
 }


### PR DESCRIPTION
Closes #1860 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes decoding of Conway redeemers when the CBOR map contains a duplicate (tag, index) key by using last-wins decoding, matching `cardano-node`/`cardano-ledger` and preventing sync stalls on canonical blocks. Hashes remain unchanged because we still hash the raw CBOR.

- **Bug Fixes**
  - In `UnmarshalCBOR`, try strict decode; on duplicate-map-key, retry with `cbor.DecodeLenient` and keep the last value.
  - Added a unit test covering the duplicate-key case and last-wins outcome.

<sup>Written for commit 6e6e86270239954554df0e7493ce915f0182bb10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decoding of redeemer data when duplicate entries are present, so valid data is now handled more gracefully.
  * Duplicate redeemer keys now resolve predictably using the latest value instead of failing outright.
* **Tests**
  * Added coverage for duplicate-key decoding behavior to confirm the updated handling works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->