### PR TITLE
fix(leios): support prototype vote wire format

### DIFF
--- a/ledger/common/leios.go
+++ b/ledger/common/leios.go
@@ -37,6 +37,36 @@ type LeiosVote struct {
 	VoteSignature     []byte
 }
 
+// LeiosPrototypeVote is the current prototype vote wire shape. Its signed
+// message is AnnouncingRbHash. Slot and endorser-block identity are resolved
+// from the announcing ranking block by the consumer.
+type LeiosPrototypeVote struct {
+	cbor.StructAsArray
+	AnnouncingRbHash Blake2b256
+	VoterId          uint64
+	VoteSignature    []byte
+}
+
+func (v *LeiosPrototypeVote) UnmarshalCBOR(cborData []byte) error {
+	type tLeiosPrototypeVote LeiosPrototypeVote
+	var tmp tLeiosPrototypeVote
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	if err := LeiosPrototypeVote(tmp).Validate(); err != nil {
+		return err
+	}
+	*v = LeiosPrototypeVote(tmp)
+	return nil
+}
+
+func (v LeiosPrototypeVote) Validate() error {
+	return ValidateLeiosSignature(
+		"LeiosPrototypeVote: VoteSignature",
+		v.VoteSignature,
+	)
+}
+
 func (v LeiosVote) MarshalCBOR() ([]byte, error) {
 	if raw := v.Cbor(); len(raw) > 0 {
 		return raw, nil

--- a/ledger/common/leios_test.go
+++ b/ledger/common/leios_test.go
@@ -102,6 +102,20 @@ func TestLeiosVoteRejectsInvalidSignatureLength(t *testing.T) {
 	assert.Contains(t, err.Error(), "VoteSignature")
 }
 
+func TestLeiosPrototypeVoteRejectsInvalidSignatureLength(t *testing.T) {
+	encoded, err := cbor.Encode([]any{
+		NewBlake2b256([]byte{0x01}),
+		uint64(42),
+		[]byte{0xaa},
+	})
+	require.NoError(t, err)
+
+	var decoded LeiosPrototypeVote
+	_, err = cbor.Decode(encoded, &decoded)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "VoteSignature")
+}
+
 func TestLeiosEbCertificateCborRoundTrip(t *testing.T) {
 	cert := LeiosEbCertificate{
 		SlotNo:              99,

--- a/protocol/leiosnotify/messages.go
+++ b/protocol/leiosnotify/messages.go
@@ -128,17 +128,22 @@ func NewMsgBlockTxsOffer(point pcommon.Point) *MsgBlockTxsOffer {
 //
 //   - Votes holds vote IDs ([slot, voter_id], 2 elements) when the peer offers
 //     IDs to be fetched (dingo's offer-and-fetch design).
-//   - FullVotes holds complete votes ([slot, eb_hash, voter_id, signature], 4
-//     elements) when the peer pushes votes directly (the prototype dialect).
+//   - FullVotes holds legacy complete votes
+//     ([slot, eb_hash, voter_id, signature], 4 elements).
+//   - PrototypeVotes holds current prototype votes
+//     ([announcing_rb_hash, voter_id, signature], 3 elements).
 //
-// After decoding, exactly one of Votes / FullVotes is populated depending on
-// the known per-vote CBOR array length. Encoding prefers FullVotes when
-// present.
+// After decoding, exactly one of Votes, FullVotes, or PrototypeVotes is
+// populated depending on the known per-vote CBOR array length. Encoding
+// prefers PrototypeVotes, then FullVotes, when present.
 type MsgVotesOffer struct {
 	protocol.MessageBase
-	Votes     []MsgVotesOfferVote
-	FullVotes []lcommon.LeiosVote
+	Votes          []MsgVotesOfferVote
+	FullVotes      []lcommon.LeiosVote
+	PrototypeVotes []lcommon.LeiosPrototypeVote
 }
+
+type PrototypeVote = lcommon.LeiosPrototypeVote
 
 type MsgVotesOfferVote = lcommon.LeiosVoteId
 
@@ -164,9 +169,20 @@ func NewMsgVotesOfferFull(votes []lcommon.LeiosVote) *MsgVotesOffer {
 	return m
 }
 
+// NewMsgVotesOfferPrototype builds a current-prototype pushed vote offer.
+func NewMsgVotesOfferPrototype(votes []PrototypeVote) *MsgVotesOffer {
+	return &MsgVotesOffer{
+		MessageBase:    protocol.MessageBase{MessageType: MessageTypeVotesOffer},
+		PrototypeVotes: votes,
+	}
+}
+
 func (m *MsgVotesOffer) MarshalCBOR() ([]byte, error) {
 	if raw := m.Cbor(); len(raw) > 0 {
 		return raw, nil
+	}
+	if len(m.PrototypeVotes) > 0 {
+		return cbor.Encode([]any{m.MessageType, m.PrototypeVotes})
 	}
 	if len(m.FullVotes) > 0 {
 		return cbor.Encode([]any{m.MessageType, m.FullVotes})
@@ -189,6 +205,7 @@ func (m *MsgVotesOffer) UnmarshalCBOR(data []byte) error {
 	m.MessageType = envelope.MessageType
 	m.Votes = nil
 	m.FullVotes = nil
+	m.PrototypeVotes = nil
 	for idx, voteRaw := range envelope.Votes {
 		// Peek at the element count to distinguish a vote ID
 		// ([slot, voter_id]) from a full vote
@@ -226,23 +243,19 @@ func (m *MsgVotesOffer) UnmarshalCBOR(data []byte) error {
 			}
 			m.FullVotes = append(m.FullVotes, vote)
 		case 3:
-			// prototype-2026w27 (the deployed musashi relay) diffuses a vote as
-			// a 3-element array [endorser_block_hash (hash32), voter_id (uint),
-			// signature (bytes .size 48)] — the 4-element full vote with the
-			// leading slot field dropped. Verified against live captures from
-			// leios-node.play.dev.cardano.org:3001 (network magic 164). Decode
-			// the three fields; SlotNo is left zero because the wire omits it.
-			var ebHash []byte
-			if _, err := cbor.Decode(elems[0], &ebHash); err != nil {
+			// The current prototype signs and diffuses the announcing ranking
+			// block hash, not the endorser-block point.
+			var rbHash []byte
+			if _, err := cbor.Decode(elems[0], &rbHash); err != nil {
 				return fmt.Errorf(
-					"%s: votes offer: decode vote %d endorser block hash: %w",
+					"%s: votes offer: decode vote %d announcing RB hash: %w",
 					ProtocolName, idx, err,
 				)
 			}
-			if len(ebHash) != lcommon.Blake2b256Size {
+			if len(rbHash) != lcommon.Blake2b256Size {
 				return fmt.Errorf(
-					"%s: votes offer: vote %d endorser block hash is %d bytes, expected %d",
-					ProtocolName, idx, len(ebHash), lcommon.Blake2b256Size,
+					"%s: votes offer: vote %d announcing RB hash is %d bytes, expected %d",
+					ProtocolName, idx, len(rbHash), lcommon.Blake2b256Size,
 				)
 			}
 			var voterId uint64
@@ -265,10 +278,10 @@ func (m *MsgVotesOffer) UnmarshalCBOR(data []byte) error {
 					ProtocolName, idx, len(sig), lcommon.LeiosBlsSignatureSize,
 				)
 			}
-			m.FullVotes = append(m.FullVotes, lcommon.LeiosVote{
-				EndorserBlockHash: lcommon.NewBlake2b256(ebHash),
-				VoterId:           voterId,
-				VoteSignature:     sig,
+			m.PrototypeVotes = append(m.PrototypeVotes, PrototypeVote{
+				AnnouncingRbHash: lcommon.NewBlake2b256(rbHash),
+				VoterId:          voterId,
+				VoteSignature:    sig,
 			})
 		default:
 			return fmt.Errorf(

--- a/protocol/leiosnotify/messages_test.go
+++ b/protocol/leiosnotify/messages_test.go
@@ -236,10 +236,8 @@ func TestMsgBlockAnnouncementEmpty(t *testing.T) {
 	assert.NotNil(t, decodedMsg)
 }
 
-// TestMsgVotesOfferThreeElementVote verifies decoding the prototype-2026w27
-// deployed vote shape: a 3-element array [endorser_block_hash (hash32),
-// voter_id (uint), signature (bytes .size 48)] — the full LeiosVote with the
-// leading slot dropped. Shape confirmed from live musashi captures.
+// TestMsgVotesOfferThreeElementVote verifies the current prototype vote shape:
+// [announcing_rb_hash, voter_id, signature].
 func TestMsgVotesOfferThreeElementVote(t *testing.T) {
 	ebHash := bytes.Repeat([]byte{0xAB}, lcommon.Blake2b256Size)
 	sig := bytes.Repeat([]byte{0xCD}, lcommon.LeiosBlsSignatureSize)
@@ -253,11 +251,11 @@ func TestMsgVotesOfferThreeElementVote(t *testing.T) {
 
 	var m MsgVotesOffer
 	require.NoError(t, m.UnmarshalCBOR(msgCbor))
-	require.Len(t, m.FullVotes, 1)
+	require.Len(t, m.PrototypeVotes, 1)
 	require.Empty(t, m.Votes)
-	v := m.FullVotes[0]
-	assert.Equal(t, uint64(0), v.SlotNo, "3-element vote omits slot")
-	assert.Equal(t, ebHash, v.EndorserBlockHash.Bytes())
+	require.Empty(t, m.FullVotes)
+	v := m.PrototypeVotes[0]
+	assert.Equal(t, ebHash, v.AnnouncingRbHash.Bytes())
 	assert.Equal(t, uint64(7), v.VoterId)
 	assert.Equal(t, sig, v.VoteSignature)
 
@@ -271,6 +269,19 @@ func TestMsgVotesOfferThreeElementVote(t *testing.T) {
 	require.NoError(t, err)
 	var m2 MsgVotesOffer
 	require.ErrorContains(t, m2.UnmarshalCBOR(badMsg), "signature is 2 bytes")
+}
+
+func TestMsgVotesOfferPrototypeRoundTrip(t *testing.T) {
+	vote := PrototypeVote{
+		AnnouncingRbHash: lcommon.NewBlake2b256(bytes.Repeat([]byte{0xAB}, 32)),
+		VoterId:          7,
+		VoteSignature:    bytes.Repeat([]byte{0xCD}, lcommon.LeiosBlsSignatureSize),
+	}
+	raw, err := NewMsgVotesOfferPrototype([]PrototypeVote{vote}).MarshalCBOR()
+	require.NoError(t, err)
+	var decoded MsgVotesOffer
+	require.NoError(t, decoded.UnmarshalCBOR(raw))
+	require.Equal(t, []PrototypeVote{vote}, decoded.PrototypeVotes)
 }
 
 func TestMsgVotesOfferUnknownVoteShape(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds support for the prototype Leios vote wire format and makes it the preferred encoding. We now handle 3-element votes [announcing_rb_hash, voter_id, signature] while keeping legacy 2- and 4-element shapes.

- **New Features**
  - Added `LeiosPrototypeVote` in `ledger/common` with strict `UnmarshalCBOR` and signature validation.
  - Extended `MsgVotesOffer` in `protocol/leiosnotify` with `PrototypeVotes`; encoder prefers it, decoder sets exactly one of `Votes`/`FullVotes`/`PrototypeVotes`.
  - Added `NewMsgVotesOfferPrototype(...)` and updated tests (round-trip and invalid signature cases).

<sup>Written for commit 3d94b8d176edffc94d3ae88519e025557c47c39a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

