### PR TITLE
feat(leiosnotify): report response delivery result

### DIFF
--- a/muxer/muxer.go
+++ b/muxer/muxer.go
@@ -223,7 +223,9 @@ func (m *Muxer) RegisterProtocol(
 				if !ok {
 					return
 				}
-				if err := m.Send(msg); err != nil {
+				err := m.Send(msg)
+				msg.reportDelivery(err)
+				if err != nil {
 					m.sendError(err)
 					return
 				}

--- a/muxer/muxer_test.go
+++ b/muxer/muxer_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/gouroboros/muxer"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
 
@@ -36,6 +37,14 @@ type mockConn struct {
 	writeBuf *bytes.Buffer
 	closed   bool
 	mu       sync.Mutex
+}
+
+type failingWriteConn struct {
+	*mockConn
+}
+
+func (*failingWriteConn) Write([]byte) (int, error) {
+	return 0, errors.New("test: forced write failure")
 }
 
 func newMockConn() *mockConn {
@@ -405,6 +414,54 @@ func TestMuxerSendReceive(t *testing.T) {
 	// Check payload
 	if !bytes.Equal(written[8:], payload) {
 		t.Errorf("expected payload %v, got %v", payload, written[8:])
+	}
+}
+
+func TestMuxerReportsSegmentDelivery(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	tests := []struct {
+		name      string
+		conn      net.Conn
+		wantError bool
+	}{
+		{
+			name: "success",
+			conn: newMockConn(),
+		},
+		{
+			name:      "write failure",
+			conn:      &failingWriteConn{mockConn: newMockConn()},
+			wantError: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := muxer.New(test.conn)
+			defer m.Stop()
+			sendChan, _, _ := m.RegisterProtocol(
+				0x01,
+				muxer.ProtocolRoleInitiator,
+			)
+			m.Start()
+
+			deliveryChan := make(chan error, 1)
+			segment := muxer.NewSegment(0x01, []byte("test"), false)
+			require.NotNil(t, segment)
+			segment.SetDeliveryChan(deliveryChan)
+			sendChan <- segment
+
+			select {
+			case err := <-deliveryChan:
+				if test.wantError {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for segment delivery result")
+			}
+		})
 	}
 }
 

--- a/muxer/segment.go
+++ b/muxer/segment.go
@@ -40,7 +40,25 @@ type SegmentHeader struct {
 // the actual payload
 type Segment struct {
 	SegmentHeader
-	Payload []byte
+	Payload      []byte
+	deliveryChan chan<- error
+}
+
+// SetDeliveryChan registers a channel that receives the result of writing the
+// segment to the underlying connection. The channel must be buffered so muxer
+// shutdown cannot block on an abandoned receiver.
+func (s *Segment) SetDeliveryChan(deliveryChan chan<- error) {
+	s.deliveryChan = deliveryChan
+}
+
+func (s *Segment) reportDelivery(err error) {
+	if s.deliveryChan == nil {
+		return
+	}
+	select {
+	case s.deliveryChan <- err:
+	default:
+	}
 }
 
 // NewSegment returns a new Segment given a protocol ID, payload bytes, and whether the segment

--- a/protocol/leiosnotify/client_test.go
+++ b/protocol/leiosnotify/client_test.go
@@ -204,6 +204,7 @@ func TestConfig(t *testing.T) {
 
 	// Test config with options
 	requestNextCalled := false
+	responseSentCalled := false
 
 	cfg = NewConfig(
 		WithTimeout(120*time.Second),
@@ -211,14 +212,24 @@ func TestConfig(t *testing.T) {
 			requestNextCalled = true
 			return nil, nil
 		}),
+		WithResponseSentFunc(func(
+			CallbackContext,
+			protocol.Message,
+			error,
+		) {
+			responseSentCalled = true
+		}),
 	)
 
 	assert.Equal(t, 120*time.Second, cfg.Timeout)
 	assert.NotNil(t, cfg.RequestNextFunc)
+	assert.NotNil(t, cfg.ResponseSentFunc)
 
 	// Test that callback can be invoked
 	_, _ = cfg.RequestNextFunc(CallbackContext{})
 	assert.True(t, requestNextCalled)
+	cfg.ResponseSentFunc(CallbackContext{}, nil, nil)
+	assert.True(t, responseSentCalled)
 }
 
 func TestProtocolConstants(t *testing.T) {

--- a/protocol/leiosnotify/leiosnotify.go
+++ b/protocol/leiosnotify/leiosnotify.go
@@ -81,6 +81,7 @@ type LeiosNotify struct {
 type Config struct {
 	NotificationFunc NotificationFunc
 	PipelineLimit    int
+	ResponseSentFunc ResponseSentFunc
 	RequestNextFunc  RequestNextFunc
 	Timeout          time.Duration
 }
@@ -100,6 +101,7 @@ type CallbackContext struct {
 // Callback function types
 type (
 	RequestNextFunc  func(CallbackContext) (protocol.Message, error)
+	ResponseSentFunc func(CallbackContext, protocol.Message, error)
 	NotificationFunc func(CallbackContext, protocol.Message) error
 )
 
@@ -186,6 +188,18 @@ func WithRequestNextFunc(
 ) LeiosNotifyOptionFunc {
 	return func(c *Config) {
 		c.RequestNextFunc = requestNextFunc
+	}
+}
+
+// WithResponseSentFunc registers a callback invoked after the server attempts
+// to send a response returned by RequestNextFunc. The callback receives the
+// send result so notification sources can commit or release delivery
+// reservations without advancing them before transport delivery.
+func WithResponseSentFunc(
+	responseSentFunc ResponseSentFunc,
+) LeiosNotifyOptionFunc {
+	return func(c *Config) {
+		c.ResponseSentFunc = responseSentFunc
 	}
 }
 

--- a/protocol/leiosnotify/server.go
+++ b/protocol/leiosnotify/server.go
@@ -119,10 +119,11 @@ func (s *Server) handleRequestNext() error {
 			"received leios-notify NotificationRequestNext message but callback returned nil",
 		)
 	}
-	if err := s.SendMessage(resp); err != nil {
-		return err
+	sendErr := s.SendMessageAndWait(resp)
+	if s.config.ResponseSentFunc != nil {
+		s.config.ResponseSentFunc(s.callbackContext, resp, sendErr)
 	}
-	return nil
+	return sendErr
 }
 
 func (s *Server) handleDone() {

--- a/protocol/leiosnotify/server_test.go
+++ b/protocol/leiosnotify/server_test.go
@@ -66,6 +66,18 @@ func writeLeiosNotifyTestSegment(
 	require.NoError(t, err)
 }
 
+type leiosNotifyFailWriteConn struct {
+	net.Conn
+}
+
+var errLeiosNotifyTestWrite = errors.New(
+	"test: forced transport write failure",
+)
+
+func (leiosNotifyFailWriteConn) Write([]byte) (int, error) {
+	return 0, errLeiosNotifyTestWrite
+}
+
 func TestNewServer(t *testing.T) {
 	connId := connection.ConnectionId{
 		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
@@ -110,6 +122,169 @@ func TestHandleRequestNext_CallbackIsCalled(t *testing.T) {
 	// Error is expected because we return an error from the callback
 	assert.Error(t, err)
 	assert.True(t, called, "expected RequestNextFunc to be called")
+}
+
+func TestHandleRequestNextReportsSuccessfulSend(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	connA, connB := net.Pipe()
+	defer connA.Close()
+	defer connB.Close()
+	m := muxer.New(connA)
+	defer m.Stop()
+
+	response := NewMsgBlockAnnouncement(cbor.RawMessage{0x82, 0x01, 0x02})
+	type sendResult struct {
+		msg protocol.Message
+		err error
+	}
+	resultCh := make(chan sendResult, 1)
+	cfg := NewConfig(
+		WithRequestNextFunc(func(CallbackContext) (protocol.Message, error) {
+			return response, nil
+		}),
+		WithResponseSentFunc(func(
+			_ CallbackContext,
+			msg protocol.Message,
+			err error,
+		) {
+			resultCh <- sendResult{msg: msg, err: err}
+		}),
+	)
+	server := NewServer(protocol.ProtocolOptions{
+		ConnectionId: connId,
+		Muxer:        m,
+	}, &cfg)
+	server.Start()
+	defer server.Protocol.Stop()
+	m.Start()
+
+	requestData, err := cbor.Encode(NewMsgNotificationRequestNext())
+	require.NoError(t, err)
+	writeLeiosNotifyTestSegment(
+		t,
+		connB,
+		muxer.NewSegment(ProtocolId, requestData, false),
+	)
+	require.NoError(t, connB.SetReadDeadline(time.Now().Add(time.Second)))
+	_, err = readLeiosNotifyTestSegment(t, connB)
+	require.NoError(t, err)
+
+	select {
+	case result := <-resultCh:
+		require.Same(t, response, result.msg)
+		require.NoError(t, result.err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for response send callback")
+	}
+}
+
+func TestHandleRequestNextReportsFailedSend(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	resultCh := make(chan error, 1)
+	connA, connB := net.Pipe()
+	defer connA.Close()
+	defer connB.Close()
+	m := muxer.New(leiosNotifyFailWriteConn{Conn: connA})
+	defer m.Stop()
+	cfg := NewConfig(
+		WithRequestNextFunc(func(CallbackContext) (protocol.Message, error) {
+			return NewMsgBlockAnnouncement(cbor.RawMessage{0x81, 0x01}), nil
+		}),
+		WithResponseSentFunc(func(
+			_ CallbackContext,
+			_ protocol.Message,
+			err error,
+		) {
+			resultCh <- err
+		}),
+	)
+	server := NewServer(protocol.ProtocolOptions{
+		ConnectionId: connId,
+		Muxer:        m,
+	}, &cfg)
+	server.Start()
+	defer server.Protocol.Stop()
+	m.Start()
+
+	requestData, err := cbor.Encode(NewMsgNotificationRequestNext())
+	require.NoError(t, err)
+	writeLeiosNotifyTestSegment(
+		t,
+		connB,
+		muxer.NewSegment(ProtocolId, requestData, false),
+	)
+
+	select {
+	case sendErr := <-resultCh:
+		require.ErrorIs(t, sendErr, errLeiosNotifyTestWrite)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for failed response send callback")
+	}
+}
+
+func TestHandleRequestNextReportsShutdownBeforeDelivery(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	connA, connB := net.Pipe()
+	defer connA.Close()
+	defer connB.Close()
+	m := muxer.New(connA)
+	defer m.Stop()
+
+	requestCalled := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	resultCh := make(chan error, 1)
+	cfg := NewConfig(
+		WithRequestNextFunc(func(CallbackContext) (protocol.Message, error) {
+			close(requestCalled)
+			// Keep the response from being queued until shutdown is observable.
+			<-releaseRequest
+			return NewMsgBlockAnnouncement(cbor.RawMessage{0x81, 0x01}), nil
+		}),
+		WithResponseSentFunc(func(
+			_ CallbackContext,
+			_ protocol.Message,
+			err error,
+		) {
+			resultCh <- err
+		}),
+	)
+	server := NewServer(protocol.ProtocolOptions{
+		ConnectionId: connId,
+		Muxer:        m,
+	}, &cfg)
+	server.Start()
+	m.Start()
+
+	requestData, err := cbor.Encode(NewMsgNotificationRequestNext())
+	require.NoError(t, err)
+	writeLeiosNotifyTestSegment(
+		t,
+		connB,
+		muxer.NewSegment(ProtocolId, requestData, false),
+	)
+	select {
+	case <-requestCalled:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for request callback")
+	}
+	server.Protocol.Stop()
+	close(releaseRequest)
+
+	select {
+	case sendErr := <-resultCh:
+		require.ErrorIs(t, sendErr, protocol.ErrProtocolShuttingDown)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for shutdown delivery callback")
+	}
 }
 
 func TestHandleRequestNext_NilCallback(t *testing.T) {

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -50,7 +50,7 @@ type Protocol struct {
 	muxerSendChan       chan *muxer.Segment
 	muxerRecvChan       chan *muxer.Segment
 	muxerDoneChan       chan bool
-	sendQueueChan       chan Message
+	sendQueueChan       chan outboundMessage
 	recvDoneChan        chan struct{}
 	recvQueueChan       chan Message
 	recvReadyChan       chan bool
@@ -121,6 +121,11 @@ type protocolStateTransition struct {
 	errorChan chan<- error
 }
 
+type outboundMessage struct {
+	message      Message
+	deliveryChan chan error
+}
+
 // MessageHandlerFunc represents a function that handles an incoming message
 type MessageHandlerFunc func(Message) error
 
@@ -168,7 +173,7 @@ func (p *Protocol) Start() {
 		}
 
 		// Create channels
-		p.sendQueueChan = make(chan Message, 80)
+		p.sendQueueChan = make(chan outboundMessage, 80)
 		p.recvQueueChan = make(chan Message, p.config.RecvQueueSize)
 		p.recvReadyChan = make(chan bool, 1)
 		p.sendReadyChan = make(chan bool, 1)
@@ -313,11 +318,56 @@ func (p *Protocol) getCurrentState() State {
 
 // SendMessage appends a message to the send queue
 func (p *Protocol) SendMessage(msg Message) error {
+	return p.enqueueMessage(msg, nil)
+}
+
+// SendMessageAndWait queues a message and waits until its final muxer segment
+// is written to the underlying connection. It returns an error if the write
+// fails or the protocol shuts down before delivery completes.
+func (p *Protocol) SendMessageAndWait(msg Message) error {
+	deliveryChan := make(chan error, 1)
+	if err := p.enqueueMessage(msg, deliveryChan); err != nil {
+		return err
+	}
+	return p.waitForMessageDelivery(deliveryChan)
+}
+
+func (p *Protocol) waitForMessageDelivery(deliveryChan <-chan error) error {
+	select {
+	case err := <-deliveryChan:
+		return err
+	case <-p.stopChan:
+		return deliveryResultOrShutdown(deliveryChan)
+	case <-p.doneChan:
+		return deliveryResultOrShutdown(deliveryChan)
+	case <-p.muxerDoneChan:
+		return deliveryResultOrShutdown(deliveryChan)
+	}
+}
+
+// deliveryResultOrShutdown preserves a delivery result that was reported
+// immediately before its corresponding shutdown signal became observable.
+func deliveryResultOrShutdown(deliveryChan <-chan error) error {
+	select {
+	case err := <-deliveryChan:
+		return err
+	default:
+		return ErrProtocolShuttingDown
+	}
+}
+
+func (p *Protocol) enqueueMessage(msg Message, deliveryChan chan error) error {
 	// Immediately return if we're already shutting down
 	select {
 	case <-p.stopChan:
 		return ErrProtocolShuttingDown
 	case <-p.doneChan:
+		return ErrProtocolShuttingDown
+	case <-p.muxerDoneChan:
+		return ErrProtocolShuttingDown
+	case <-p.recvDoneChan:
+		return ErrProtocolShuttingDown
+	case <-p.sendDoneChan:
 		return ErrProtocolShuttingDown
 	default:
 	}
@@ -350,8 +400,25 @@ func (p *Protocol) SendMessage(msg Message) error {
 	}
 	p.pendingSendBytes += msgLen
 	p.pendingBytesMu.Unlock()
-	p.sendQueueChan <- msg
-	return nil
+	outbound := outboundMessage{
+		message:      msg,
+		deliveryChan: deliveryChan,
+	}
+	select {
+	case p.sendQueueChan <- outbound:
+		return nil
+	case <-p.stopChan:
+	case <-p.doneChan:
+	case <-p.muxerDoneChan:
+	case <-p.recvDoneChan:
+	case <-p.sendDoneChan:
+	}
+
+	// The message was accounted for above but never reached the queue.
+	p.pendingBytesMu.Lock()
+	p.pendingSendBytes -= msgLen
+	p.pendingBytesMu.Unlock()
+	return ErrProtocolShuttingDown
 }
 
 // SendError sends an error to the handler in the Ouroboros object and stops the protocol.
@@ -428,6 +495,7 @@ waitSendReadyChan:
 		payloadBuf := bytes.NewBuffer(nil)
 		msgCount := 0
 		queueTransition := false
+		var deliveryChan chan error
 	readSendQueueLoop:
 		for {
 			// Get next message from send queue
@@ -437,11 +505,12 @@ waitSendReadyChan:
 			case <-p.recvDoneChan:
 				// Break out of send loop if we're shutting down
 				return
-			case msg, ok := <-p.sendQueueChan:
+			case outbound, ok := <-p.sendQueueChan:
 				if !ok {
 					// We're shutting down
 					return
 				}
+				msg := outbound.message
 				msgCount = msgCount + 1
 
 				// Get raw CBOR from message
@@ -489,6 +558,10 @@ waitSendReadyChan:
 					// Queue any state transitions after the initial one for this message batch
 					queueTransition = true
 				}
+				if outbound.deliveryChan != nil {
+					deliveryChan = outbound.deliveryChan
+					break readSendQueueLoop
+				}
 
 				// We don't want more than maxMessagesPerSegment messages in a segment
 				if msgCount >= maxMessagesPerSegment {
@@ -520,6 +593,18 @@ waitSendReadyChan:
 				segmentPayload,
 				isResponse,
 			)
+			if segment == nil {
+				p.SendError(
+					fmt.Errorf(
+						"%s: failed to create muxer segment",
+						p.config.Name,
+					),
+				)
+				return
+			}
+			if deliveryChan != nil && segmentPayloadLength == payloadBuf.Len() {
+				segment.SetDeliveryChan(deliveryChan)
+			}
 			select {
 			case <-p.stopChan:
 				return

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -15,10 +15,153 @@
 package protocol
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestEnqueueMessageReturnsWhenFullQueueShutsDown(t *testing.T) {
+	tests := []struct {
+		name     string
+		shutdown func(*Protocol)
+	}{
+		{
+			name: "protocol stop",
+			shutdown: func(p *Protocol) {
+				close(p.stopChan)
+			},
+		},
+		{
+			name: "protocol done",
+			shutdown: func(p *Protocol) {
+				close(p.doneChan)
+			},
+		},
+		{
+			name: "muxer done",
+			shutdown: func(p *Protocol) {
+				close(p.muxerDoneChan)
+			},
+		},
+		{
+			name: "receive loop done",
+			shutdown: func(p *Protocol) {
+				close(p.recvDoneChan)
+			},
+		},
+		{
+			name: "send loop done",
+			shutdown: func(p *Protocol) {
+				close(p.sendDoneChan)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p := &Protocol{
+				stopChan:      make(chan struct{}),
+				doneChan:      make(chan struct{}),
+				muxerDoneChan: make(chan bool),
+				recvDoneChan:  make(chan struct{}),
+				sendDoneChan:  make(chan struct{}),
+				sendQueueChan: make(chan outboundMessage, 1),
+			}
+			p.sendQueueChan <- outboundMessage{}
+
+			msg := &MessageBase{}
+			msg.SetCbor([]byte{0x80})
+			resultChan := make(chan error, 1)
+			go func() {
+				resultChan <- p.enqueueMessage(msg, nil)
+			}()
+
+			require.Eventually(t, func() bool {
+				p.pendingBytesMu.Lock()
+				defer p.pendingBytesMu.Unlock()
+				return p.pendingSendBytes == 1
+			}, time.Second, time.Millisecond)
+
+			test.shutdown(p)
+			select {
+			case err := <-resultChan:
+				require.ErrorIs(t, err, ErrProtocolShuttingDown)
+			case <-time.After(time.Second):
+				t.Fatal("enqueueMessage remained blocked during shutdown")
+			}
+
+			p.pendingBytesMu.Lock()
+			defer p.pendingBytesMu.Unlock()
+			require.Zero(t, p.pendingSendBytes)
+		})
+	}
+}
+
+func TestWaitForMessageDeliveryPrefersReportedResult(t *testing.T) {
+	deliveryErr := errors.New("write failed")
+
+	tests := []struct {
+		name     string
+		shutdown func(*Protocol)
+	}{
+		{
+			name: "protocol stop",
+			shutdown: func(p *Protocol) {
+				close(p.stopChan)
+			},
+		},
+		{
+			name: "protocol done",
+			shutdown: func(p *Protocol) {
+				close(p.doneChan)
+			},
+		},
+		{
+			name: "muxer done",
+			shutdown: func(p *Protocol) {
+				close(p.muxerDoneChan)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for range 100 {
+				deliveryChan := make(chan error, 1)
+				deliveryChan <- deliveryErr
+				p := &Protocol{
+					stopChan:      make(chan struct{}),
+					doneChan:      make(chan struct{}),
+					muxerDoneChan: make(chan bool),
+				}
+				test.shutdown(p)
+
+				require.ErrorIs(
+					t,
+					p.waitForMessageDelivery(deliveryChan),
+					deliveryErr,
+				)
+			}
+		})
+	}
+}
+
+func TestWaitForMessageDeliveryReportsShutdownWithoutResult(t *testing.T) {
+	p := &Protocol{
+		stopChan:      make(chan struct{}),
+		doneChan:      make(chan struct{}),
+		muxerDoneChan: make(chan bool),
+	}
+	close(p.stopChan)
+
+	require.ErrorIs(
+		t,
+		p.waitForMessageDelivery(make(chan error, 1)),
+		ErrProtocolShuttingDown,
+	)
+}
 
 func TestIsDone(t *testing.T) {
 	stateIdle := NewState(1, "Idle")


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Report delivery results for `leiosnotify` responses so producers can commit only after transport delivery. Plumbs delivery reporting from `muxer` through `protocol` to the `leiosnotify` server.

- **New Features**
  - `leiosnotify.Config`: add `WithResponseSentFunc` callback, invoked after the server attempts to send a `RequestNextFunc` response with `(context, message, error)`.
  - `protocol.Protocol`: add `SendMessageAndWait` to queue a message and wait until its final segment is written (or shutdown); returns the send error or `ErrProtocolShuttingDown`, with shutdown races handled safely.
  - `muxer`: segments can carry a buffered delivery channel via `Segment.SetDeliveryChan`; `Muxer` reports the write result back to the segment immediately after `Send`.
  - `leiosnotify.Server`: uses `SendMessageAndWait` and calls `ResponseSentFunc` with the delivery result (success, transport error, or shutdown).

<sup>Written for commit 2e4ff00b114a9aa82ad5d434037e8e70d335f394. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

