### PR TITLE
feat(leiosfetch): add MsgNoBlock/MsgNoBlockTxs not-found responses

### DIFF
--- a/protocol/leiosfetch/README.md
+++ b/protocol/leiosfetch/README.md
@@ -20,14 +20,14 @@ The LeiosFetch protocol retrieves Leios-specific data including blocks, block tr
          │  Idle  │                  │ Block │
          └────┬───┘                  └───┬───┘
               │                          │
-              │ BlockTxsRequest          │ Block
+              │ BlockTxsRequest          │ Block / NoBlock
               │                          │
               ▼                          ▼
          ┌──────────┐               ┌──────┐
          │ BlockTxs │               │ Idle │
          └────┬─────┘               └──────┘
               │
-              │ BlockTxs
+              │ BlockTxs / NoBlockTxs
               ▼
          ┌──────┐
          │ Idle │
@@ -87,6 +87,12 @@ The LeiosFetch protocol retrieves Leios-specific data including blocks, block tr
 | `LastBlockAndTxsInRange` | 7 | Server → Client | Last block in range |
 | `NextBlockAndTxsInRange` | 8 | Server → Client | Next block in range |
 | `Done` | 9 | Client → Server | Terminate protocol |
+| `NoBlock` | 10 | Server → Client | Requested block not available |
+| `NoBlockTxs` | 11 | Server → Client | Requested block transactions not available |
+
+> **Note:** Type IDs `10` and `11` are placeholders pending confirmation against
+> the Leios protocol spec (CIP-0164 or equivalent), consistent with the other
+> IDs in this experimental protocol.
 
 ## State Transitions
 
@@ -103,11 +109,13 @@ The LeiosFetch protocol retrieves Leios-specific data including blocks, block tr
 | Message | New State |
 |---------|-----------|
 | `Block` | Idle |
+| `NoBlock` | Idle |
 
 ### From BlockTxs (Server Agency)
 | Message | New State |
 |---------|-----------|
 | `BlockTxs` | Idle |
+| `NoBlockTxs` | Idle |
 
 ### From Votes (Server Agency)
 | Message | New State |
@@ -161,6 +169,22 @@ for _, block := range blocks {
     // Process each block
 }
 ```
+
+## Not-found responses
+
+A server that cannot serve a requested endorser block (for example, an
+already-synced relay whose in-memory cache has expired) responds with `NoBlock`
+or `NoBlockTxs` instead of returning an error. This lets the server decline
+gracefully rather than triggering a protocol violation that tears down the
+whole node-to-node connection.
+
+- A `BlockRequestFunc` / `BlockTxsRequestFunc` callback signals not-found by
+  returning `ErrBlockNotFound` / `ErrBlockTxsNotFound` (directly or wrapped
+  with `fmt.Errorf("...: %w", ...)`). Any other error is still treated as a
+  protocol violation.
+- The client's `BlockRequest` / `BlockTxsRequest` returns the matching sentinel
+  error to the caller, who can distinguish "not available" from a real protocol
+  error with `errors.Is`.
 
 ## Notes
 

--- a/protocol/leiosfetch/client.go
+++ b/protocol/leiosfetch/client.go
@@ -133,6 +133,10 @@ func (c *Client) BlockRequest(
 	if !ok {
 		return nil, protocol.ErrProtocolShuttingDown
 	}
+	// The server reported the endorser block as not available
+	if _, ok := resp.(*MsgNoBlock); ok {
+		return nil, ErrBlockNotFound
+	}
 	return resp, nil
 }
 
@@ -148,6 +152,10 @@ func (c *Client) BlockTxsRequest(
 	resp, ok := <-c.blockTxsResultChan
 	if !ok {
 		return nil, protocol.ErrProtocolShuttingDown
+	}
+	// The server reported the endorser block transactions as not available
+	if _, ok := resp.(*MsgNoBlockTxs); ok {
+		return nil, ErrBlockTxsNotFound
 	}
 	return resp, nil
 }
@@ -196,8 +204,12 @@ func (c *Client) messageHandler(msg protocol.Message) error {
 	switch msg.Type() {
 	case MessageTypeBlock:
 		c.handleBlock(msg)
+	case MessageTypeNoBlock:
+		c.handleNoBlock(msg)
 	case MessageTypeBlockTxs:
 		c.handleBlockTxs(msg)
+	case MessageTypeNoBlockTxs:
+		c.handleNoBlockTxs(msg)
 	case MessageTypeVotes:
 		c.handleVotes(msg)
 	case MessageTypeNextBlockAndTxsInRange:
@@ -218,7 +230,29 @@ func (c *Client) handleBlock(msg protocol.Message) {
 	c.blockResultChan <- msg
 }
 
+func (c *Client) handleNoBlock(msg protocol.Message) {
+	c.Protocol.Logger().
+		Debug("endorser block not available",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "client",
+			"connection_id", c.callbackContext.ConnectionId.String(),
+		)
+	c.blockResultChan <- msg
+}
+
 func (c *Client) handleBlockTxs(msg protocol.Message) {
+	c.blockTxsResultChan <- msg
+}
+
+func (c *Client) handleNoBlockTxs(msg protocol.Message) {
+	c.Protocol.Logger().
+		Debug("endorser block transactions not available",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "client",
+			"connection_id", c.callbackContext.ConnectionId.String(),
+		)
 	c.blockTxsResultChan <- msg
 }
 

--- a/protocol/leiosfetch/client_test.go
+++ b/protocol/leiosfetch/client_test.go
@@ -81,8 +81,18 @@ func TestClientMessageHandler(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:        "NoBlock message",
+			msg:         NewMsgNoBlock(),
+			expectError: false,
+		},
+		{
 			name:        "BlockTxs message",
 			msg:         NewMsgBlockTxs(nil),
+			expectError: false,
+		},
+		{
+			name:        "NoBlockTxs message",
+			msg:         NewMsgNoBlockTxs(),
 			expectError: false,
 		},
 		{
@@ -110,9 +120,9 @@ func TestClientMessageHandler(t *testing.T) {
 			go func() {
 				defer close(done)
 				switch tc.msg.Type() {
-				case MessageTypeBlock:
+				case MessageTypeBlock, MessageTypeNoBlock:
 					<-client.blockResultChan
-				case MessageTypeBlockTxs:
+				case MessageTypeBlockTxs, MessageTypeNoBlockTxs:
 					<-client.blockTxsResultChan
 				case MessageTypeVotes:
 					<-client.votesResultChan
@@ -203,11 +213,25 @@ func TestStateTransitions(t *testing.T) {
 		assert.Equal(t, expected, trans.NewState)
 	}
 
-	// Test transitions from Block state
+	// Test transitions from Block state: both Block and NoBlock return to Idle
 	blockEntry := StateMap[StateBlock]
-	require.Len(t, blockEntry.Transitions, 1)
-	assert.Equal(t, uint8(MessageTypeBlock), blockEntry.Transitions[0].MsgType)
-	assert.Equal(t, StateIdle, blockEntry.Transitions[0].NewState)
+	require.Len(t, blockEntry.Transitions, 2)
+	blockTransitions := map[uint8]protocol.State{}
+	for _, trans := range blockEntry.Transitions {
+		blockTransitions[trans.MsgType] = trans.NewState
+	}
+	assert.Equal(t, StateIdle, blockTransitions[MessageTypeBlock])
+	assert.Equal(t, StateIdle, blockTransitions[MessageTypeNoBlock])
+
+	// Test transitions from BlockTxs state: both BlockTxs and NoBlockTxs return to Idle
+	blockTxsEntry := StateMap[StateBlockTxs]
+	require.Len(t, blockTxsEntry.Transitions, 2)
+	blockTxsTransitions := map[uint8]protocol.State{}
+	for _, trans := range blockTxsEntry.Transitions {
+		blockTxsTransitions[trans.MsgType] = trans.NewState
+	}
+	assert.Equal(t, StateIdle, blockTxsTransitions[MessageTypeBlockTxs])
+	assert.Equal(t, StateIdle, blockTxsTransitions[MessageTypeNoBlockTxs])
 
 	// Test transitions from BlockRange state
 	blockRangeEntry := StateMap[StateBlockRange]

--- a/protocol/leiosfetch/error.go
+++ b/protocol/leiosfetch/error.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leiosfetch
+
+import "errors"
+
+// ErrBlockNotFound signals that a requested endorser block is not available.
+// A BlockRequestFunc callback returns it (directly or wrapped) to make the
+// server respond with MsgNoBlock instead of tearing down the connection; the
+// client's BlockRequest returns it to the caller when the server sends
+// MsgNoBlock. Callers can test for it with errors.Is.
+var ErrBlockNotFound = errors.New(
+	"leios-fetch: endorser block not available",
+)
+
+// ErrBlockTxsNotFound signals that the requested endorser block transactions
+// are not available. A BlockTxsRequestFunc callback returns it (directly or
+// wrapped) to make the server respond with MsgNoBlockTxs instead of tearing
+// down the connection; the client's BlockTxsRequest returns it to the caller
+// when the server sends MsgNoBlockTxs. Callers can test for it with errors.Is.
+var ErrBlockTxsNotFound = errors.New(
+	"leios-fetch: endorser block transactions not available",
+)

--- a/protocol/leiosfetch/error.go
+++ b/protocol/leiosfetch/error.go
@@ -22,7 +22,7 @@ import "errors"
 // client's BlockRequest returns it to the caller when the server sends
 // MsgNoBlock. Callers can test for it with errors.Is.
 var ErrBlockNotFound = errors.New(
-	"leios-fetch: endorser block not available",
+	"endorser block not available",
 )
 
 // ErrBlockTxsNotFound signals that the requested endorser block transactions
@@ -31,5 +31,5 @@ var ErrBlockNotFound = errors.New(
 // down the connection; the client's BlockTxsRequest returns it to the caller
 // when the server sends MsgNoBlockTxs. Callers can test for it with errors.Is.
 var ErrBlockTxsNotFound = errors.New(
-	"leios-fetch: endorser block transactions not available",
+	"endorser block transactions not available",
 )

--- a/protocol/leiosfetch/leiosfetch.go
+++ b/protocol/leiosfetch/leiosfetch.go
@@ -69,6 +69,10 @@ var StateMap = protocol.StateMap{
 				MsgType:  MessageTypeBlock,
 				NewState: StateIdle,
 			},
+			{
+				MsgType:  MessageTypeNoBlock,
+				NewState: StateIdle,
+			},
 		},
 	},
 	StateBlockTxs: protocol.StateMapEntry{
@@ -76,6 +80,10 @@ var StateMap = protocol.StateMap{
 		Transitions: []protocol.StateTransition{
 			{
 				MsgType:  MessageTypeBlockTxs,
+				NewState: StateIdle,
+			},
+			{
+				MsgType:  MessageTypeNoBlockTxs,
 				NewState: StateIdle,
 			},
 		},
@@ -128,6 +136,12 @@ type CallbackContext struct {
 }
 
 // Callback function types
+//
+// BlockRequestFunc and BlockTxsRequestFunc may return ErrBlockNotFound /
+// ErrBlockTxsNotFound (directly or wrapped) to signal that the requested data
+// is not available. The server then responds with MsgNoBlock / MsgNoBlockTxs
+// rather than propagating the error and tearing down the connection. Any other
+// error is treated as a protocol violation.
 type (
 	BlockRequestFunc      func(CallbackContext, pcommon.Point) (protocol.Message, error)
 	BlockTxsRequestFunc   func(CallbackContext, pcommon.Point, map[uint16]uint64) (protocol.Message, error)

--- a/protocol/leiosfetch/leiosfetch_test.go
+++ b/protocol/leiosfetch/leiosfetch_test.go
@@ -1,0 +1,172 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leiosfetch_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/blinklabs-io/gouroboros/protocol/leiosfetch"
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+type testInnerFunc func(*testing.T, *ouroboros.Connection)
+
+func runTest(
+	t *testing.T,
+	conversation []ouroboros_mock.ConversationEntry,
+	innerFunc testInnerFunc,
+) {
+	defer goleak.VerifyNone(t)
+	mockConn := ouroboros_mock.NewConnection(
+		ouroboros_mock.ProtocolRoleClient,
+		conversation,
+	)
+	// Async mock connection error handler
+	asyncErrChan := make(chan error, 1)
+	go func() {
+		err := <-mockConn.(*ouroboros_mock.Connection).ErrorChan()
+		if err != nil {
+			asyncErrChan <- fmt.Errorf("received unexpected error: %w", err)
+		}
+		close(asyncErrChan)
+	}()
+	oConn, err := ouroboros.New(
+		ouroboros.WithConnection(mockConn),
+		ouroboros.WithNetworkMagic(ouroboros_mock.MockNetworkMagic),
+		ouroboros.WithNodeToNode(true),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error when creating Ouroboros object: %s", err)
+	}
+	// Async error handler
+	go func() {
+		err, ok := <-oConn.ErrorChan()
+		if !ok {
+			return
+		}
+		// We can't call t.Fatalf() from a different Goroutine, so we panic instead
+		panic(fmt.Sprintf("unexpected Ouroboros error: %s", err))
+	}()
+	// Run test inner function
+	innerFunc(t, oConn)
+	// Wait for mock connection shutdown
+	select {
+	case err, ok := <-asyncErrChan:
+		if ok {
+			t.Fatal(err.Error())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("did not complete within timeout")
+	}
+	// Close Ouroboros connection
+	if err := oConn.Close(); err != nil {
+		t.Fatalf("unexpected error when closing Ouroboros object: %s", err)
+	}
+	// Wait for connection shutdown
+	select {
+	case <-oConn.ErrorChan():
+	case <-time.After(10 * time.Second):
+		t.Errorf("did not shutdown within timeout")
+	}
+}
+
+var conversationHandshake = []ouroboros_mock.ConversationEntry{
+	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+	ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+}
+
+// TestBlockRequestNoBlock verifies that when the server responds to a
+// BlockRequest with MsgNoBlock, the client's BlockRequest returns the typed
+// ErrBlockNotFound sentinel rather than a protocol error, and the connection
+// stays usable.
+func TestBlockRequestNoBlock(t *testing.T) {
+	conversation := append(
+		conversationHandshake,
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  leiosfetch.ProtocolId,
+			MessageType: leiosfetch.MessageTypeBlockRequest,
+		},
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: leiosfetch.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				leiosfetch.NewMsgNoBlock(),
+			},
+		},
+	)
+	runTest(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			resp, err := oConn.LeiosFetch().Client.BlockRequest(
+				pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+			)
+			require.Error(t, err)
+			assert.True(
+				t,
+				errors.Is(err, leiosfetch.ErrBlockNotFound),
+				"expected ErrBlockNotFound, got: %v",
+				err,
+			)
+			assert.Nil(t, resp)
+		},
+	)
+}
+
+// TestBlockTxsRequestNoBlockTxs verifies the equivalent behavior for
+// BlockTxsRequest / MsgNoBlockTxs.
+func TestBlockTxsRequestNoBlockTxs(t *testing.T) {
+	conversation := append(
+		conversationHandshake,
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  leiosfetch.ProtocolId,
+			MessageType: leiosfetch.MessageTypeBlockTxsRequest,
+		},
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: leiosfetch.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				leiosfetch.NewMsgNoBlockTxs(),
+			},
+		},
+	)
+	runTest(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			resp, err := oConn.LeiosFetch().Client.BlockTxsRequest(
+				pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+				map[uint16]uint64{0: 0xff00000000000000},
+			)
+			require.Error(t, err)
+			assert.True(
+				t,
+				errors.Is(err, leiosfetch.ErrBlockTxsNotFound),
+				"expected ErrBlockTxsNotFound, got: %v",
+				err,
+			)
+			assert.Nil(t, resp)
+		},
+	)
+}

--- a/protocol/leiosfetch/leiosfetch_test.go
+++ b/protocol/leiosfetch/leiosfetch_test.go
@@ -15,7 +15,6 @@
 package leiosfetch_test
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -123,12 +122,7 @@ func TestBlockRequestNoBlock(t *testing.T) {
 				pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}),
 			)
 			require.Error(t, err)
-			assert.True(
-				t,
-				errors.Is(err, leiosfetch.ErrBlockNotFound),
-				"expected ErrBlockNotFound, got: %v",
-				err,
-			)
+			assert.ErrorIs(t, err, leiosfetch.ErrBlockNotFound)
 			assert.Nil(t, resp)
 		},
 	)
@@ -160,12 +154,7 @@ func TestBlockTxsRequestNoBlockTxs(t *testing.T) {
 				map[uint16]uint64{0: 0xff00000000000000},
 			)
 			require.Error(t, err)
-			assert.True(
-				t,
-				errors.Is(err, leiosfetch.ErrBlockTxsNotFound),
-				"expected ErrBlockTxsNotFound, got: %v",
-				err,
-			)
+			assert.ErrorIs(t, err, leiosfetch.ErrBlockTxsNotFound)
 			assert.Nil(t, resp)
 		},
 	)

--- a/protocol/leiosfetch/messages.go
+++ b/protocol/leiosfetch/messages.go
@@ -26,6 +26,11 @@ import (
 )
 
 // NOTE: these are dummy message IDs and will probably need to be changed
+//
+// NOTE: MessageTypeNoBlock and MessageTypeNoBlockTxs (10 and 11) are
+// placeholder IDs. They must be confirmed against the Leios protocol spec
+// (CIP-0164 or equivalent) before they can be relied on for wire interop with
+// the IOG prototype relay.
 const (
 	MessageTypeBlockRequest           = 0
 	MessageTypeBlock                  = 1
@@ -37,6 +42,8 @@ const (
 	MessageTypeLastBlockAndTxsInRange = 7
 	MessageTypeNextBlockAndTxsInRange = 8
 	MessageTypeDone                   = 9
+	MessageTypeNoBlock                = 10
+	MessageTypeNoBlockTxs             = 11
 )
 
 func NewMsgFromCbor(msgType uint, data []byte) (protocol.Message, error) {
@@ -62,6 +69,10 @@ func NewMsgFromCbor(msgType uint, data []byte) (protocol.Message, error) {
 		ret = &MsgNextBlockAndTxsInRange{}
 	case MessageTypeDone:
 		ret = &MsgDone{}
+	case MessageTypeNoBlock:
+		ret = &MsgNoBlock{}
+	case MessageTypeNoBlockTxs:
+		ret = &MsgNoBlockTxs{}
 	}
 	if _, err := cbor.Decode(data, ret); err != nil {
 		return nil, fmt.Errorf("%s: decode error: %w", ProtocolName, err)
@@ -402,6 +413,38 @@ func NewMsgDone() *MsgDone {
 	m := &MsgDone{
 		MessageBase: protocol.MessageBase{
 			MessageType: MessageTypeDone,
+		},
+	}
+	return m
+}
+
+// MsgNoBlock is the server's response to a BlockRequest for an endorser block
+// that is not available. It lets the server decline gracefully instead of
+// returning an error that would tear down the connection.
+type MsgNoBlock struct {
+	protocol.MessageBase
+}
+
+func NewMsgNoBlock() *MsgNoBlock {
+	m := &MsgNoBlock{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeNoBlock,
+		},
+	}
+	return m
+}
+
+// MsgNoBlockTxs is the server's response to a BlockTxsRequest whose endorser
+// block transactions are not available. It lets the server decline gracefully
+// instead of returning an error that would tear down the connection.
+type MsgNoBlockTxs struct {
+	protocol.MessageBase
+}
+
+func NewMsgNoBlockTxs() *MsgNoBlockTxs {
+	m := &MsgNoBlockTxs{
+		MessageBase: protocol.MessageBase{
+			MessageType: MessageTypeNoBlockTxs,
 		},
 	}
 	return m

--- a/protocol/leiosfetch/messages_test.go
+++ b/protocol/leiosfetch/messages_test.go
@@ -415,8 +415,9 @@ func TestMsgNoBlock(t *testing.T) {
 
 	decoded, err := NewMsgFromCbor(MessageTypeNoBlock, encoded)
 	require.NoError(t, err)
-	assert.IsType(t, &MsgNoBlock{}, decoded)
-	assert.Equal(t, uint8(MessageTypeNoBlock), decoded.Type())
+	decodedMsg, ok := decoded.(*MsgNoBlock)
+	require.True(t, ok, "expected *MsgNoBlock")
+	assert.Equal(t, uint8(MessageTypeNoBlock), decodedMsg.MessageType)
 }
 
 func TestMsgNoBlockTxs(t *testing.T) {
@@ -429,8 +430,9 @@ func TestMsgNoBlockTxs(t *testing.T) {
 
 	decoded, err := NewMsgFromCbor(MessageTypeNoBlockTxs, encoded)
 	require.NoError(t, err)
-	assert.IsType(t, &MsgNoBlockTxs{}, decoded)
-	assert.Equal(t, uint8(MessageTypeNoBlockTxs), decoded.Type())
+	decodedMsg, ok := decoded.(*MsgNoBlockTxs)
+	require.True(t, ok, "expected *MsgNoBlockTxs")
+	assert.Equal(t, uint8(MessageTypeNoBlockTxs), decodedMsg.MessageType)
 }
 
 func TestNewMsgFromCborUnknownType(t *testing.T) {

--- a/protocol/leiosfetch/messages_test.go
+++ b/protocol/leiosfetch/messages_test.go
@@ -143,6 +143,16 @@ func getTestDefinitions() []testDefinition {
 			Message:     NewMsgDone(),
 			MessageType: MessageTypeDone,
 		},
+		{
+			Name:        "MsgNoBlock",
+			Message:     NewMsgNoBlock(),
+			MessageType: MessageTypeNoBlock,
+		},
+		{
+			Name:        "MsgNoBlockTxs",
+			Message:     NewMsgNoBlockTxs(),
+			MessageType: MessageTypeNoBlockTxs,
+		},
 	}
 }
 
@@ -393,6 +403,34 @@ func TestMsgDone(t *testing.T) {
 	msg := NewMsgDone()
 
 	assert.Equal(t, uint8(MessageTypeDone), msg.Type())
+}
+
+func TestMsgNoBlock(t *testing.T) {
+	msg := NewMsgNoBlock()
+
+	assert.Equal(t, uint8(MessageTypeNoBlock), msg.Type())
+
+	encoded, err := cbor.Encode(msg)
+	require.NoError(t, err)
+
+	decoded, err := NewMsgFromCbor(MessageTypeNoBlock, encoded)
+	require.NoError(t, err)
+	assert.IsType(t, &MsgNoBlock{}, decoded)
+	assert.Equal(t, uint8(MessageTypeNoBlock), decoded.Type())
+}
+
+func TestMsgNoBlockTxs(t *testing.T) {
+	msg := NewMsgNoBlockTxs()
+
+	assert.Equal(t, uint8(MessageTypeNoBlockTxs), msg.Type())
+
+	encoded, err := cbor.Encode(msg)
+	require.NoError(t, err)
+
+	decoded, err := NewMsgFromCbor(MessageTypeNoBlockTxs, encoded)
+	require.NoError(t, err)
+	assert.IsType(t, &MsgNoBlockTxs{}, decoded)
+	assert.Equal(t, uint8(MessageTypeNoBlockTxs), decoded.Type())
 }
 
 func TestNewMsgFromCborUnknownType(t *testing.T) {

--- a/protocol/leiosfetch/server.go
+++ b/protocol/leiosfetch/server.go
@@ -112,6 +112,23 @@ func (s *Server) handleBlockRequest(msg protocol.Message) error {
 		msgBlockRequest.Point,
 	)
 	if err != nil {
+		// A not-found signal is answered with MsgNoBlock rather than being
+		// propagated as a protocol violation that tears down the connection.
+		if errors.Is(err, ErrBlockNotFound) {
+			s.Protocol.Logger().
+				Debug("endorser block not available",
+					"component", "network",
+					"protocol", ProtocolName,
+					"role", "server",
+					"connection_id", s.callbackContext.ConnectionId.String(),
+					"point", fmt.Sprintf(
+						"%d.%x",
+						msgBlockRequest.Point.Slot,
+						msgBlockRequest.Point.Hash,
+					),
+				)
+			return s.SendMessage(NewMsgNoBlock())
+		}
 		return err
 	}
 	if resp == nil {
@@ -145,6 +162,23 @@ func (s *Server) handleBlockTxsRequest(msg protocol.Message) error {
 		msgBlockTxsRequest.Bitmaps,
 	)
 	if err != nil {
+		// A not-found signal is answered with MsgNoBlockTxs rather than being
+		// propagated as a protocol violation that tears down the connection.
+		if errors.Is(err, ErrBlockTxsNotFound) {
+			s.Protocol.Logger().
+				Debug("endorser block transactions not available",
+					"component", "network",
+					"protocol", ProtocolName,
+					"role", "server",
+					"connection_id", s.callbackContext.ConnectionId.String(),
+					"point", fmt.Sprintf(
+						"%d.%x",
+						msgBlockTxsRequest.Point.Slot,
+						msgBlockTxsRequest.Point.Hash,
+					),
+				)
+			return s.SendMessage(NewMsgNoBlockTxs())
+		}
 		return err
 	}
 	if resp == nil {

--- a/protocol/leiosfetch/server_test.go
+++ b/protocol/leiosfetch/server_test.go
@@ -15,16 +15,108 @@
 package leiosfetch
 
 import (
+	"bytes"
+	"encoding/binary"
 	"errors"
+	"fmt"
+	"io"
 	"net"
 	"testing"
+	"time"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/muxer"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func readLeiosFetchTestSegment(
+	t *testing.T,
+	conn net.Conn,
+) (*muxer.Segment, error) {
+	t.Helper()
+	header := muxer.SegmentHeader{}
+	if err := binary.Read(conn, binary.BigEndian, &header); err != nil {
+		return nil, err
+	}
+	payload := make([]byte, header.PayloadLength)
+	if _, err := io.ReadFull(conn, payload); err != nil {
+		return nil, err
+	}
+	return &muxer.Segment{
+		SegmentHeader: header,
+		Payload:       payload,
+	}, nil
+}
+
+func writeLeiosFetchTestSegment(
+	t *testing.T,
+	conn net.Conn,
+	segment *muxer.Segment,
+) {
+	t.Helper()
+	require.NotNil(t, segment)
+	buf := &bytes.Buffer{}
+	require.NoError(t, binary.Write(buf, binary.BigEndian, segment.SegmentHeader))
+	_, err := buf.Write(segment.Payload)
+	require.NoError(t, err)
+	_, err = conn.Write(buf.Bytes())
+	require.NoError(t, err)
+}
+
+// sendNotFoundTest drives a real server over a muxer, sending it the given
+// request and returning the message type of the server's response segment. It
+// is used to verify that a not-found callback signal produces the graceful
+// MsgNoBlock/MsgNoBlockTxs response instead of tearing down the connection.
+func sendNotFoundTest(
+	t *testing.T,
+	cfg Config,
+	request protocol.Message,
+) uint {
+	t.Helper()
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	connA, connB := net.Pipe()
+	defer connA.Close()
+	defer connB.Close()
+	m := muxer.New(connA)
+	defer m.Stop()
+
+	server := NewServer(protocol.ProtocolOptions{
+		ConnectionId: connId,
+		Muxer:        m,
+	}, &cfg)
+	server.Start()
+	defer server.Protocol.Stop()
+	m.Start()
+
+	requestData, err := cbor.Encode(request)
+	require.NoError(t, err)
+	writeLeiosFetchTestSegment(
+		t,
+		connB,
+		muxer.NewSegment(ProtocolId, requestData, false),
+	)
+	require.NoError(t, connB.SetReadDeadline(time.Now().Add(time.Second)))
+	segment, err := readLeiosFetchTestSegment(t, connB)
+	require.NoError(t, err)
+	assert.True(t, segment.IsResponse())
+	assert.Equal(t, ProtocolId, segment.GetProtocolId())
+
+	var elems []cbor.RawMessage
+	_, err = cbor.Decode(segment.Payload, &elems)
+	require.NoError(t, err)
+	require.NotEmpty(t, elems)
+	var msgType uint
+	_, err = cbor.Decode(elems[0], &msgType)
+	require.NoError(t, err)
+	return msgType
+}
 
 func TestNewServer(t *testing.T) {
 	connId := connection.ConnectionId{
@@ -165,6 +257,79 @@ func TestHandleBlockRequest_NilResponse(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "callback returned nil")
+}
+
+func TestHandleBlockRequestNotFoundSendsMsgNoBlock(t *testing.T) {
+	cfg := NewConfig(
+		WithBlockRequestFunc(func(CallbackContext, pcommon.Point) (protocol.Message, error) {
+			return nil, ErrBlockNotFound
+		}),
+	)
+	msgType := sendNotFoundTest(
+		t,
+		cfg,
+		NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02})),
+	)
+	assert.Equal(t, uint(MessageTypeNoBlock), msgType)
+}
+
+func TestHandleBlockRequestWrappedNotFoundSendsMsgNoBlock(t *testing.T) {
+	cfg := NewConfig(
+		WithBlockRequestFunc(func(_ CallbackContext, point pcommon.Point) (protocol.Message, error) {
+			return nil, fmt.Errorf(
+				"cache miss for %d: %w",
+				point.Slot,
+				ErrBlockNotFound,
+			)
+		}),
+	)
+	msgType := sendNotFoundTest(
+		t,
+		cfg,
+		NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02})),
+	)
+	assert.Equal(t, uint(MessageTypeNoBlock), msgType)
+}
+
+func TestHandleBlockTxsRequestNotFoundSendsMsgNoBlockTxs(t *testing.T) {
+	cfg := NewConfig(
+		WithBlockTxsRequestFunc(func(CallbackContext, pcommon.Point, map[uint16]uint64) (protocol.Message, error) {
+			return nil, ErrBlockTxsNotFound
+		}),
+	)
+	msgType := sendNotFoundTest(
+		t,
+		cfg,
+		NewMsgBlockTxsRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02}), nil),
+	)
+	assert.Equal(t, uint(MessageTypeNoBlockTxs), msgType)
+}
+
+func TestHandleBlockRequest_NonNotFoundErrorPropagates(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+
+	expectedError := errors.New("some other failure")
+	cfg := NewConfig(
+		WithBlockRequestFunc(func(CallbackContext, pcommon.Point) (protocol.Message, error) {
+			return nil, expectedError
+		}),
+	)
+
+	server := &Server{
+		config:          &cfg,
+		callbackContext: CallbackContext{ConnectionId: connId},
+	}
+	server.initProtocol()
+
+	msg := NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02}))
+	err := server.handleBlockRequest(msg)
+
+	// A non-not-found error is still propagated as a protocol violation
+	assert.Equal(t, expectedError, err)
+	assert.NotErrorIs(t, err, ErrBlockNotFound)
 }
 
 func TestHandleBlockTxsRequest_CallbackIsCalled(t *testing.T) {


### PR DESCRIPTION
## Problem

The leios-fetch state machine had no "don't have it" response: `StateBlock`
only allowed `MsgBlock` and `StateBlockTxs` only allowed `MsgBlockTxs`. When a
server cannot serve a requested endorser block (e.g. a synced relay whose
in-memory cache has expired), its callback can only return an error — which the
server framework propagates as a protocol violation and tears down the entire
NtN connection, escalating the downstream node's short-lived-connection backoff
and degrading catch-up throughput.

## Change

Add server→client `MsgNoBlock` (10) and `MsgNoBlockTxs` (11) so the server can
decline gracefully.

- **`messages.go`** — type constants, structs, constructors, and `NewMsgFromCbor`
  cases for both. IDs 10/11 are placeholders pending confirmation against the
  Leios spec (CIP-0164 or equivalent), noted alongside the existing dummy-ID
  `NOTE:`.
- **`leiosfetch.go`** — `StateBlock`/`StateBlockTxs` now also transition back to
  `StateIdle` on the new messages.
- **`error.go`** — `ErrBlockNotFound`/`ErrBlockTxsNotFound` sentinels (following
  the sibling `leiosnotify/error.go` convention).
- **`server.go`** — a `BlockRequestFunc`/`BlockTxsRequestFunc` callback that
  returns the sentinel (directly or wrapped with `%w`) sends
  `MsgNoBlock`/`MsgNoBlockTxs` instead of propagating the error. Any other error
  is still treated as a protocol violation.
- **`client.go`** — inbound `MsgNoBlock`/`MsgNoBlockTxs` log at Debug;
  `BlockRequest`/`BlockTxsRequest` return the typed sentinel so callers can
  distinguish "not available" from a real protocol error with `errors.Is`.
- **`README.md`** — documented the messages, transitions, diagram, and the
  not-found contract.

### Design

The callback signals not-found via a sentinel error (`errors.Is`-testable, works
when wrapped) rather than requiring callers to construct the wire message. This
gives symmetric client/server semantics with one sentinel per message type.

## Tests

`make test`/`-race`, `golangci-lint`, and `gofmt` all clean. Coverage:

- Message CBOR round-trip/decode/encode for both new types + dedicated type tests
- State-transition assertions updated (2 transitions from `StateBlock`/`StateBlockTxs`)
- Client message-handler routing for the new types
- Server not-found send over a real muxer (`net.Pipe`) — verifies the messages
  actually go on the wire — plus the wrapped-sentinel and non-not-found cases
- End-to-end client sentinel returns via `ouroboros-mock`

## Related

- Closes #1849
- blinklabs-io/dingo#2662 — persists EBs to the blob store so the not-found case
  is rare; this handles the residual case when data is truly absent
- Unblocks the downstream dingo client-side backoff-exemption follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds server→client `MsgNoBlock`/`MsgNoBlockTxs` so `leiosfetch` can say “not available” without tearing down the NtN connection, and introduces typed sentinel errors to let callers distinguish not-found from real protocol errors.

- **New Features**
  - New responses: `MsgNoBlock` and `MsgNoBlockTxs`. `StateBlock`/`StateBlockTxs` now return to Idle on these.
  - New sentinels: `ErrBlockNotFound` and `ErrBlockTxsNotFound`. Server callbacks can return them (directly or wrapped) to send the new messages; clients receive them via `BlockRequest`/`BlockTxsRequest` and can check with `errors.Is`.
  - Client logs not-found at Debug.
  - Message IDs `10`/`11` are placeholders pending spec confirmation; README updated. Tests cover CBOR, transitions, server send, wrapped sentinel, non-not-found errors, and end-to-end behavior.
  - Polish: simplified sentinel error messages for consistency; tests hardened to avoid a potential nil panic and use `assert.ErrorIs`.

- **Migration**
  - Server: In `BlockRequestFunc`/`BlockTxsRequestFunc`, return `leiosfetch.ErrBlockNotFound`/`leiosfetch.ErrBlockTxsNotFound` when data is missing (wrapping is fine). The server will send `MsgNoBlock`/`MsgNoBlockTxs`.
  - Client: Handle not-found with `errors.Is(err, leiosfetch.ErrBlockNotFound)` or `errors.Is(err, leiosfetch.ErrBlockTxsNotFound)` instead of treating as a protocol error.

<sup>Written for commit f31380c80f2d037113d8fed789a5b7a9fbd40b18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added explicit “block unavailable” and “block transactions unavailable” responses.
  - Clients now receive dedicated not-found errors instead of protocol failures when requested data is unavailable.
  - Servers can report missing data without terminating the connection.
  - Added support for encoding, decoding, and processing the new response messages.

- **Documentation**
  - Documented not-found behavior, error handling, and protocol state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->