### PR TITLE
fix: fail withdrawals on pv10/pv11 w/o drep

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -40,7 +40,7 @@ Gouroboros is a Go implementation of the Cardano blockchain protocol, providing 
         ┌────────┴─────────────────────────────────┐
         │  Era-Specific Implementations            │
         │  Byron → Shelley → Allegra → Mary →      │
-        │  Alonzo → Babbage → Conway → Leios       │
+        │  Alonzo → Babbage → Conway → Dijkstra    │
         └───────────────────────────────────────────┘
              │
     ┌────────┴──────────────┬──────────────┬────────────┐
@@ -139,7 +139,9 @@ type TransactionBody interface {
 
 ### Era Hierarchy
 
-Each era builds on the previous, delegating unchanged validation rules:
+Post-Byron eras build on their predecessors and may delegate individual
+validation rules when their behavior is unchanged. Delegation is not
+universal; era-specific rule bodies must be inspected before assuming it.
 
 ```
 Byron (genesis)
@@ -149,12 +151,18 @@ Byron (genesis)
               └─ Alonzo (Plutus scripts)
                   └─ Babbage (reference scripts)
                       └─ Conway (governance)
-                          └─ Leios (experimental)
+                          └─ Dijkstra (PV12)
 ```
+
+Leios is not a ledger era. It is a higher-throughput overlay protocol
+introduced with Dijkstra; its shared ledger types live in
+`ledger/common/leios*.go`, and its mini-protocols live under
+`protocol/leios{fetch,notify,votes}/`.
 
 ### Validation Pattern
 
-Each era defines validation rules that delegate to earlier eras for unchanged logic:
+Each era defines its validation rules. A rule can delegate to an earlier era
+when its behavior is unchanged:
 
 ```go
 // shelley/rules.go - defines base rules
@@ -181,8 +189,38 @@ func UtxoValidateTimeToLive(tx, slot, ls, pp) error {
 | Mary | Multi-asset support (native tokens) |
 | Alonzo | Plutus smart contracts, redeemers, datums |
 | Babbage | Reference scripts, inline datums |
-| Conway | On-chain governance, DReps, proposals |
-| Leios | Experimental (input blocks, endorser blocks) |
+| Conway | Governance; PV10/PV11 DRep-gated reward withdrawals |
+| Dijkstra | PV12; CIP-181 removes the reward-withdrawal DRep gate |
+
+### Conway Reward Withdrawal Gate
+
+`conway.UtxoValidateWithdrawals` has an era-specific implementation. It skips
+withdrawal validation for phase-2-invalid transactions, then applies the
+Shelley reward-account registration check. For transactions with withdrawals,
+the remaining behavior is selected by the active major protocol version:
+
+| Protocol version | DRep vote delegation required? |
+|------------------|-------------------------------|
+| PV9 and earlier | No |
+| PV10 (Plomin) and PV11 (Van Rossem) | Yes |
+| PV12 (Dijkstra) and later | No, per CIP-181 |
+
+The active protocol version comes from
+`conway.ConwayProtocolParameters.ProtocolMajorVersion`; Dijkstra protocol
+parameters inherit that method. At PV10/PV11, ledger states must additionally
+implement the optional `common.DRepDelegationState` capability:
+
+```go
+type DRepDelegationState interface {
+    DRepDelegation(Credential) (*Drep, error)
+}
+```
+
+A `nil` delegation rejects the withdrawal with
+`WithdrawalNotDelegatedToDRepError`. A ledger state that cannot perform the
+lookup returns `DRepDelegationStateUnavailableError`. The capability is kept
+separate from `common.LedgerState` so implementations that do not validate
+PV10/PV11 withdrawals do not need to provide it.
 
 ## Protocol Layer (protocol/)
 
@@ -465,7 +503,8 @@ ls := ledgertest.NewLedgerStateBuilder().
 
 ## Design Principles
 
-1. Era Delegation: Later eras delegate unchanged rules to earlier eras, minimizing duplication.
+1. Era Delegation: Later eras may delegate unchanged rules to earlier eras,
+   while changed rules retain era-specific implementations.
 
 2. Interface-Based Validation: Rules operate on interfaces, enabling easy mocking and cross-era compatibility.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ grep -cE "^    --- FAIL: TestRulesConformanceVectors/" /tmp/conformance.txt
 
 ## Rules Claude gets wrong without being told
 
-1. Era delegation is not universal. Conway `UtxoValidateWithdrawals` has its own body with an intentional spec deviation (`NOTE:`). Grep the function before describing behavior.
+1. Era delegation is not universal — grep the era's function body before describing behavior; don't assume it forwards to the previous era. E.g. `conway.UtxoValidateWithdrawals` (`ledger/conway/rules.go`) skips phase-2-invalid txs, checks reward-account registration, requires a DRep vote delegation at PV10/PV11, and removes that requirement at PV12 per CIP-181.
 2. `DecodeStoreCbor` requires a custom `UnmarshalCBOR` that calls `SetCbor(cborData)`. Missing → `Cbor()` returns nil → hashing breaks.
 3. Hash from preserved `.Cbor()` bytes. Never re-encode and hash.
 4. CBOR `EncMode`/`DecMode` are globally cached via `sync.Once` in `cbor/{encode,decode}.go`. Don't construct per call.

--- a/README.md
+++ b/README.md
@@ -147,12 +147,15 @@ This is not an exhaustive list of existing and planned features, but it covers t
       - [X] TX inputs
       - [X] TX outputs
       - [X] Parameter updates
+      - [X] Reward withdrawals require a DRep vote delegation at PV10/PV11
     - [X] Dijkstra
       - [X] Blocks
       - [X] Transactions
       - [X] TX inputs
       - [X] TX outputs
       - [X] Parameter updates
+      - [X] Reward withdrawals no longer require a DRep vote delegation at
+        PV12+ ([CIP-0181](https://cips.cardano.org/cip/CIP-0181))
   - [X] Transaction attributes
     - [X] Inputs
     - [X] Outputs
@@ -160,7 +163,7 @@ This is not an exhaustive list of existing and planned features, but it covers t
     - [X] Fees
     - [X] TTL
     - [X] Certificates
-    - [X] Staking reward withdrawls
+    - [X] Staking reward withdrawals
     - [X] Protocol parameter updates
     - [X] Auxiliary data hash
     - [X] Validity interval start

--- a/examples/block-fetch/go.sum
+++ b/examples/block-fetch/go.sum
@@ -4,8 +4,8 @@ github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/ouroboros-mock v0.14.0 h1:tWOjItzHmdcGv1HfH23jJxumOQ0wbeRnayG4mQv5QQg=
-github.com/blinklabs-io/ouroboros-mock v0.14.0/go.mod h1:nvY6cwqImZekjCfuutzTjdMR4/gOkNUO9lZuOGlQGl4=
+github.com/blinklabs-io/ouroboros-mock v0.15.0 h1:IB35erNGObqilpOLkrmdp0fH2aKKoVLW9pis7HkGve0=
+github.com/blinklabs-io/ouroboros-mock v0.15.0/go.mod h1:ysGU8dMjG8ShMQco/aarR1xIRH7GPCIdhrnkM+J4IVA=
 github.com/blinklabs-io/plutigo v0.1.17 h1:44JJf9Y4G7fminNJp4H6fBQbW8nzrevSlap9a1V0EHs=
 github.com/blinklabs-io/plutigo v0.1.17/go.mod h1:X+Ydplpgftjjq5Y1Oc3dRebGgdBSeAbOi1+ItJhQths=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=

--- a/examples/chain-sync/go.sum
+++ b/examples/chain-sync/go.sum
@@ -4,8 +4,8 @@ github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/ouroboros-mock v0.14.0 h1:tWOjItzHmdcGv1HfH23jJxumOQ0wbeRnayG4mQv5QQg=
-github.com/blinklabs-io/ouroboros-mock v0.14.0/go.mod h1:nvY6cwqImZekjCfuutzTjdMR4/gOkNUO9lZuOGlQGl4=
+github.com/blinklabs-io/ouroboros-mock v0.15.0 h1:IB35erNGObqilpOLkrmdp0fH2aKKoVLW9pis7HkGve0=
+github.com/blinklabs-io/ouroboros-mock v0.15.0/go.mod h1:ysGU8dMjG8ShMQco/aarR1xIRH7GPCIdhrnkM+J4IVA=
 github.com/blinklabs-io/plutigo v0.1.17 h1:44JJf9Y4G7fminNJp4H6fBQbW8nzrevSlap9a1V0EHs=
 github.com/blinklabs-io/plutigo v0.1.17/go.mod h1:X+Ydplpgftjjq5Y1Oc3dRebGgdBSeAbOi1+ItJhQths=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=

--- a/examples/chain-tip/go.sum
+++ b/examples/chain-tip/go.sum
@@ -4,8 +4,8 @@ github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/ouroboros-mock v0.14.0 h1:tWOjItzHmdcGv1HfH23jJxumOQ0wbeRnayG4mQv5QQg=
-github.com/blinklabs-io/ouroboros-mock v0.14.0/go.mod h1:nvY6cwqImZekjCfuutzTjdMR4/gOkNUO9lZuOGlQGl4=
+github.com/blinklabs-io/ouroboros-mock v0.15.0 h1:IB35erNGObqilpOLkrmdp0fH2aKKoVLW9pis7HkGve0=
+github.com/blinklabs-io/ouroboros-mock v0.15.0/go.mod h1:ysGU8dMjG8ShMQco/aarR1xIRH7GPCIdhrnkM+J4IVA=
 github.com/blinklabs-io/plutigo v0.1.17 h1:44JJf9Y4G7fminNJp4H6fBQbW8nzrevSlap9a1V0EHs=
 github.com/blinklabs-io/plutigo v0.1.17/go.mod h1:X+Ydplpgftjjq5Y1Oc3dRebGgdBSeAbOi1+ItJhQths=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=

--- a/examples/peer-sharing/go.sum
+++ b/examples/peer-sharing/go.sum
@@ -4,8 +4,8 @@ github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/ouroboros-mock v0.14.0 h1:tWOjItzHmdcGv1HfH23jJxumOQ0wbeRnayG4mQv5QQg=
-github.com/blinklabs-io/ouroboros-mock v0.14.0/go.mod h1:nvY6cwqImZekjCfuutzTjdMR4/gOkNUO9lZuOGlQGl4=
+github.com/blinklabs-io/ouroboros-mock v0.15.0 h1:IB35erNGObqilpOLkrmdp0fH2aKKoVLW9pis7HkGve0=
+github.com/blinklabs-io/ouroboros-mock v0.15.0/go.mod h1:ysGU8dMjG8ShMQco/aarR1xIRH7GPCIdhrnkM+J4IVA=
 github.com/blinklabs-io/plutigo v0.1.17 h1:44JJf9Y4G7fminNJp4H6fBQbW8nzrevSlap9a1V0EHs=
 github.com/blinklabs-io/plutigo v0.1.17/go.mod h1:X+Ydplpgftjjq5Y1Oc3dRebGgdBSeAbOi1+ItJhQths=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=

--- a/examples/ping/go.sum
+++ b/examples/ping/go.sum
@@ -4,8 +4,8 @@ github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/ouroboros-mock v0.14.0 h1:tWOjItzHmdcGv1HfH23jJxumOQ0wbeRnayG4mQv5QQg=
-github.com/blinklabs-io/ouroboros-mock v0.14.0/go.mod h1:nvY6cwqImZekjCfuutzTjdMR4/gOkNUO9lZuOGlQGl4=
+github.com/blinklabs-io/ouroboros-mock v0.15.0 h1:IB35erNGObqilpOLkrmdp0fH2aKKoVLW9pis7HkGve0=
+github.com/blinklabs-io/ouroboros-mock v0.15.0/go.mod h1:ysGU8dMjG8ShMQco/aarR1xIRH7GPCIdhrnkM+J4IVA=
 github.com/blinklabs-io/plutigo v0.1.17 h1:44JJf9Y4G7fminNJp4H6fBQbW8nzrevSlap9a1V0EHs=
 github.com/blinklabs-io/plutigo v0.1.17/go.mod h1:X+Ydplpgftjjq5Y1Oc3dRebGgdBSeAbOi1+ItJhQths=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=

--- a/examples/state-query/go.sum
+++ b/examples/state-query/go.sum
@@ -4,8 +4,8 @@ github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/ouroboros-mock v0.14.0 h1:tWOjItzHmdcGv1HfH23jJxumOQ0wbeRnayG4mQv5QQg=
-github.com/blinklabs-io/ouroboros-mock v0.14.0/go.mod h1:nvY6cwqImZekjCfuutzTjdMR4/gOkNUO9lZuOGlQGl4=
+github.com/blinklabs-io/ouroboros-mock v0.15.0 h1:IB35erNGObqilpOLkrmdp0fH2aKKoVLW9pis7HkGve0=
+github.com/blinklabs-io/ouroboros-mock v0.15.0/go.mod h1:ysGU8dMjG8ShMQco/aarR1xIRH7GPCIdhrnkM+J4IVA=
 github.com/blinklabs-io/plutigo v0.1.17 h1:44JJf9Y4G7fminNJp4H6fBQbW8nzrevSlap9a1V0EHs=
 github.com/blinklabs-io/plutigo v0.1.17/go.mod h1:X+Ydplpgftjjq5Y1Oc3dRebGgdBSeAbOi1+ItJhQths=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=

--- a/examples/tx-monitor/go.sum
+++ b/examples/tx-monitor/go.sum
@@ -4,8 +4,8 @@ github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/ouroboros-mock v0.14.0 h1:tWOjItzHmdcGv1HfH23jJxumOQ0wbeRnayG4mQv5QQg=
-github.com/blinklabs-io/ouroboros-mock v0.14.0/go.mod h1:nvY6cwqImZekjCfuutzTjdMR4/gOkNUO9lZuOGlQGl4=
+github.com/blinklabs-io/ouroboros-mock v0.15.0 h1:IB35erNGObqilpOLkrmdp0fH2aKKoVLW9pis7HkGve0=
+github.com/blinklabs-io/ouroboros-mock v0.15.0/go.mod h1:ysGU8dMjG8ShMQco/aarR1xIRH7GPCIdhrnkM+J4IVA=
 github.com/blinklabs-io/plutigo v0.1.17 h1:44JJf9Y4G7fminNJp4H6fBQbW8nzrevSlap9a1V0EHs=
 github.com/blinklabs-io/plutigo v0.1.17/go.mod h1:X+Ydplpgftjjq5Y1Oc3dRebGgdBSeAbOi1+ItJhQths=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=

--- a/examples/tx-submission/go.sum
+++ b/examples/tx-submission/go.sum
@@ -4,8 +4,8 @@ github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/ouroboros-mock v0.14.0 h1:tWOjItzHmdcGv1HfH23jJxumOQ0wbeRnayG4mQv5QQg=
-github.com/blinklabs-io/ouroboros-mock v0.14.0/go.mod h1:nvY6cwqImZekjCfuutzTjdMR4/gOkNUO9lZuOGlQGl4=
+github.com/blinklabs-io/ouroboros-mock v0.15.0 h1:IB35erNGObqilpOLkrmdp0fH2aKKoVLW9pis7HkGve0=
+github.com/blinklabs-io/ouroboros-mock v0.15.0/go.mod h1:ysGU8dMjG8ShMQco/aarR1xIRH7GPCIdhrnkM+J4IVA=
 github.com/blinklabs-io/plutigo v0.1.17 h1:44JJf9Y4G7fminNJp4H6fBQbW8nzrevSlap9a1V0EHs=
 github.com/blinklabs-io/plutigo v0.1.17/go.mod h1:X+Ydplpgftjjq5Y1Oc3dRebGgdBSeAbOi1+ItJhQths=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.25.8
 
 require (
 	filippo.io/edwards25519 v1.2.0
-	github.com/blinklabs-io/ouroboros-mock v0.14.0
+	github.com/blinklabs-io/ouroboros-mock v0.15.0
 	github.com/blinklabs-io/plutigo v0.1.17
 	github.com/btcsuite/btcd/btcutil v1.2.0
 	github.com/fxamacker/cbor/v2 v2.9.2

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
 github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/ouroboros-mock v0.14.0 h1:tWOjItzHmdcGv1HfH23jJxumOQ0wbeRnayG4mQv5QQg=
-github.com/blinklabs-io/ouroboros-mock v0.14.0/go.mod h1:nvY6cwqImZekjCfuutzTjdMR4/gOkNUO9lZuOGlQGl4=
+github.com/blinklabs-io/ouroboros-mock v0.15.0 h1:IB35erNGObqilpOLkrmdp0fH2aKKoVLW9pis7HkGve0=
+github.com/blinklabs-io/ouroboros-mock v0.15.0/go.mod h1:ysGU8dMjG8ShMQco/aarR1xIRH7GPCIdhrnkM+J4IVA=
 github.com/blinklabs-io/plutigo v0.1.17 h1:44JJf9Y4G7fminNJp4H6fBQbW8nzrevSlap9a1V0EHs=
 github.com/blinklabs-io/plutigo v0.1.17/go.mod h1:X+Ydplpgftjjq5Y1Oc3dRebGgdBSeAbOi1+ItJhQths=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=

--- a/ledger/common/address.go
+++ b/ledger/common/address.go
@@ -593,6 +593,29 @@ func (a *Address) StakingPayload() AddressPayload {
 	return a.stakingPayload
 }
 
+// StakeCredential returns the key or script credential carried by the
+// address's staking payload. Pointer and absent staking payloads do not contain
+// a credential.
+func (a *Address) StakeCredential() (Credential, bool) {
+	if a == nil {
+		return Credential{}, false
+	}
+	switch payload := a.stakingPayload.(type) {
+	case AddressPayloadKeyHash:
+		return Credential{
+			CredType:   CredentialTypeAddrKeyHash,
+			Credential: NewBlake2b224(payload.Hash.Bytes()),
+		}, true
+	case AddressPayloadScriptHash:
+		return Credential{
+			CredType:   CredentialTypeScriptHash,
+			Credential: NewBlake2b224(payload.Hash.Bytes()),
+		}, true
+	default:
+		return Credential{}, false
+	}
+}
+
 func (a *Address) ByronAttr() ByronAddressAttributes {
 	return a.byronAddressAttr
 }

--- a/ledger/common/address_test.go
+++ b/ledger/common/address_test.go
@@ -320,6 +320,51 @@ func TestAddressStakeAddress(t *testing.T) {
 	}
 }
 
+func TestAddressStakeCredential(t *testing.T) {
+	credentialHash := NewBlake2b224([]byte("stake-credential"))
+	tests := []struct {
+		name     string
+		addr     *Address
+		wantType uint
+		wantOK   bool
+	}{
+		{
+			name: "key hash",
+			addr: &Address{stakingPayload: AddressPayloadKeyHash{
+				Hash: AddrKeyHash(credentialHash),
+			}},
+			wantType: CredentialTypeAddrKeyHash,
+			wantOK:   true,
+		},
+		{
+			name: "script hash",
+			addr: &Address{stakingPayload: AddressPayloadScriptHash{
+				Hash: ScriptHash(credentialHash),
+			}},
+			wantType: CredentialTypeScriptHash,
+			wantOK:   true,
+		},
+		{
+			name: "pointer",
+			addr: &Address{stakingPayload: AddressPayloadPointer{
+				Slot: 1,
+			}},
+		},
+		{name: "absent", addr: &Address{}},
+		{name: "nil address"},
+	}
+	for _, testDef := range tests {
+		t.Run(testDef.name, func(t *testing.T) {
+			credential, ok := testDef.addr.StakeCredential()
+			assert.Equal(t, testDef.wantOK, ok)
+			if testDef.wantOK {
+				assert.Equal(t, testDef.wantType, credential.CredType)
+				assert.Equal(t, credentialHash, credential.Credential)
+			}
+		})
+	}
+}
+
 func TestAddressPaymentAddress_MixedCase(t *testing.T) {
 	// address with mixed case Byron address
 	mixedCaseAddress := "Ae2tdPwUPEYwFx4dmJheyNPPYXtvHbJLeCaA96o6Y2iiUL18cAt7AizN2zG"

--- a/ledger/common/protocol_version.go
+++ b/ledger/common/protocol_version.go
@@ -25,6 +25,7 @@ const (
 	ProtocolVersionConway    uint = 9
 	ProtocolVersionPlomin    uint = 10 // PV10 intra-era hard fork; enabled full governance (incl. treasury withdrawals)
 	ProtocolVersionVanRossem uint = 11 // PV11 intra-era hard fork
+	ProtocolVersionDijkstra  uint = 12 // PV12 Dijkstra hard fork
 )
 
 // IsProtocolVersionAtLeast checks if the given protocol version (major.minor)

--- a/ledger/common/protocol_version_test.go
+++ b/ledger/common/protocol_version_test.go
@@ -30,6 +30,7 @@ func TestProtocolVersionConstants(t *testing.T) {
 	assert.Equal(t, uint(9), ProtocolVersionConway)
 	assert.Equal(t, uint(10), ProtocolVersionPlomin)
 	assert.Equal(t, uint(11), ProtocolVersionVanRossem)
+	assert.Equal(t, uint(12), ProtocolVersionDijkstra)
 }
 
 func TestIsProtocolVersionAtLeast(t *testing.T) {

--- a/ledger/common/state.go
+++ b/ledger/common/state.go
@@ -141,8 +141,11 @@ type DRepRegistration struct {
 	Deposit    uint64
 }
 
-type DRepDelegation struct {
-	DRep Blake2b224
+// DRepDelegationState is the optional ledger-state capability used to query
+// governance vote delegations. Ledger states used to validate PV10 or PV11
+// reward withdrawals must implement this interface.
+type DRepDelegationState interface {
+	DRepDelegation(Credential) (*Drep, error)
 }
 
 type PoolDelegation struct {

--- a/ledger/conway/errors.go
+++ b/ledger/conway/errors.go
@@ -324,6 +324,25 @@ func (e DelegateVoteToUnregisteredDRepError) Error() string {
 // WithdrawalFromUnregisteredRewardAccountError indicates withdrawal from an unregistered reward account
 type WithdrawalFromUnregisteredRewardAccountError = shelley.WithdrawalFromUnregisteredRewardAccountError
 
+// WithdrawalNotDelegatedToDRepError indicates a PV10/PV11 reward withdrawal
+// whose stake credential has no governance vote delegation.
+type WithdrawalNotDelegatedToDRepError struct {
+	RewardAddress common.Address
+}
+
+func (e WithdrawalNotDelegatedToDRepError) Error() string {
+	return "reward withdrawal is not delegated to a DRep: " +
+		e.RewardAddress.String()
+}
+
+// DRepDelegationStateUnavailableError indicates that a ledger state cannot
+// answer the DRep-delegation query required for PV10/PV11 withdrawals.
+type DRepDelegationStateUnavailableError struct{}
+
+func (DRepDelegationStateUnavailableError) Error() string {
+	return "ledger state does not support DRep delegation lookups"
+}
+
 // StakeCredentialAlreadyRegisteredError indicates attempting to register an already registered stake credential
 type StakeCredentialAlreadyRegisteredError struct {
 	Credential common.Credential

--- a/ledger/conway/errors_test.go
+++ b/ledger/conway/errors_test.go
@@ -16,6 +16,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestWithdrawalNotDelegatedToDRepError(t *testing.T) {
+	addr, err := common.NewAddressFromBytes(append(
+		[]byte{0xe1},
+		make([]byte, common.AddressHashSize)...,
+	))
+	assert.NoError(t, err)
+	testErr := conway.WithdrawalNotDelegatedToDRepError{
+		RewardAddress: addr,
+	}
+	assert.Contains(t, testErr.Error(), addr.String())
+	assert.Equal(
+		t,
+		"ledger state does not support DRep delegation lookups",
+		conway.DRepDelegationStateUnavailableError{}.Error(),
+	)
+}
+
 func TestConway_CostModelsPresent_UnresolvedReferenceInputReturnsError(
 	t *testing.T,
 ) {

--- a/ledger/conway/errors_test.go
+++ b/ledger/conway/errors_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWithdrawalNotDelegatedToDRepError(t *testing.T) {
@@ -21,7 +22,7 @@ func TestWithdrawalNotDelegatedToDRepError(t *testing.T) {
 		[]byte{0xe1},
 		make([]byte, common.AddressHashSize)...,
 	))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	testErr := conway.WithdrawalNotDelegatedToDRepError{
 		RewardAddress: addr,
 	}

--- a/ledger/conway/pparams.go
+++ b/ledger/conway/pparams.go
@@ -62,6 +62,11 @@ type ConwayProtocolParameters struct {
 	MinFeeRefScriptCostPerByte *cbor.Rat
 }
 
+// ProtocolMajorVersion returns the active major protocol version.
+func (p *ConwayProtocolParameters) ProtocolMajorVersion() uint {
+	return p.ProtocolVersion.Major
+}
+
 // KeyDepositAmount returns the key deposit as a *big.Int
 func (p *ConwayProtocolParameters) KeyDepositAmount() *big.Int {
 	return new(big.Int).SetUint64(uint64(p.KeyDeposit))

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -2520,6 +2520,8 @@ func UtxoValidateDelegation(
 // UtxoValidateWithdrawals validates withdrawals against ledger state.
 // For phase-2 invalid transactions (IsValid=false), withdrawal validation is
 // skipped since their effects are reverted and only collateral rules apply.
+// PV10 and PV11 also require each withdrawing stake credential to have a DRep
+// vote delegation. PV12 removes that requirement per CIP-181.
 func UtxoValidateWithdrawals(
 	tx common.Transaction,
 	slot uint64,
@@ -2529,7 +2531,71 @@ func UtxoValidateWithdrawals(
 	if !tx.IsValid() {
 		return nil
 	}
-	return shelley.UtxoValidateWithdrawals(tx, slot, ls, pp)
+	if err := shelley.UtxoValidateWithdrawals(tx, slot, ls, pp); err != nil {
+		return err
+	}
+	if len(tx.Withdrawals()) == 0 {
+		return nil
+	}
+	versionedPparams, ok := pp.(interface {
+		ProtocolMajorVersion() uint
+	})
+	if !ok {
+		return nil
+	}
+	protocolMajor := versionedPparams.ProtocolMajorVersion()
+	if protocolMajor < common.ProtocolVersionPlomin ||
+		protocolMajor >= common.ProtocolVersionDijkstra {
+		return nil
+	}
+	delegationState, ok := ls.(common.DRepDelegationState)
+	if !ok {
+		return DRepDelegationStateUnavailableError{}
+	}
+	for addr := range tx.Withdrawals() {
+		credential, ok := rewardAddressCredential(addr)
+		if !ok {
+			continue
+		}
+		delegation, err := delegationState.DRepDelegation(credential)
+		if err != nil {
+			return err
+		}
+		if delegation == nil {
+			return WithdrawalNotDelegatedToDRepError{
+				RewardAddress: *addr,
+			}
+		}
+	}
+	return nil
+}
+
+func rewardAddressCredential(addr *common.Address) (common.Credential, bool) {
+	if addr == nil {
+		return common.Credential{}, false
+	}
+	stakingPayload := addr.StakingPayload()
+	if stakingPayload == nil {
+		return common.Credential{}, false
+	}
+	switch payload := stakingPayload.(type) {
+	case common.AddressPayloadKeyHash:
+		return common.Credential{
+			CredType: common.CredentialTypeAddrKeyHash,
+			Credential: common.NewBlake2b224(
+				payload.Hash.Bytes(),
+			),
+		}, true
+	case common.AddressPayloadScriptHash:
+		return common.Credential{
+			CredType: common.CredentialTypeScriptHash,
+			Credential: common.NewBlake2b224(
+				payload.Hash.Bytes(),
+			),
+		}, true
+	default:
+		return common.Credential{}, false
+	}
 }
 
 func UtxoValidateCommitteeCertificates(

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -2553,7 +2553,7 @@ func UtxoValidateWithdrawals(
 		return DRepDelegationStateUnavailableError{}
 	}
 	for addr := range tx.Withdrawals() {
-		credential, ok := rewardAddressCredential(addr)
+		credential, ok := addr.StakeCredential()
 		if !ok {
 			continue
 		}
@@ -2568,34 +2568,6 @@ func UtxoValidateWithdrawals(
 		}
 	}
 	return nil
-}
-
-func rewardAddressCredential(addr *common.Address) (common.Credential, bool) {
-	if addr == nil {
-		return common.Credential{}, false
-	}
-	stakingPayload := addr.StakingPayload()
-	if stakingPayload == nil {
-		return common.Credential{}, false
-	}
-	switch payload := stakingPayload.(type) {
-	case common.AddressPayloadKeyHash:
-		return common.Credential{
-			CredType: common.CredentialTypeAddrKeyHash,
-			Credential: common.NewBlake2b224(
-				payload.Hash.Bytes(),
-			),
-		}, true
-	case common.AddressPayloadScriptHash:
-		return common.Credential{
-			CredType: common.CredentialTypeScriptHash,
-			Credential: common.NewBlake2b224(
-				payload.Hash.Bytes(),
-			),
-		}, true
-	default:
-		return common.Credential{}, false
-	}
 }
 
 func UtxoValidateCommitteeCertificates(

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -51,6 +51,141 @@ func makeConwayRewardAddress(
 	return addr
 }
 
+type drepDelegationLedgerState struct {
+	common.LedgerState
+	lookup func(common.Credential) (*common.Drep, error)
+}
+
+type ledgerStateWithoutDRepDelegation struct {
+	common.LedgerState
+}
+
+func (s drepDelegationLedgerState) DRepDelegation(
+	credential common.Credential,
+) (*common.Drep, error) {
+	return s.lookup(credential)
+}
+
+func TestUtxoValidateWithdrawals_DRepDelegationProtocolGate(t *testing.T) {
+	stakeKeyHash := common.Blake2b224Hash([]byte("withdrawal-stake-key"))
+	rewardAddr := makeConwayRewardAddress(t, stakeKeyHash)
+	tx := &conway.ConwayTransaction{
+		Body: conway.ConwayTransactionBody{
+			TxWithdrawals: map[*common.Address]uint64{
+				&rewardAddr: 1_000_000,
+			},
+		},
+		TxIsValid: true,
+	}
+	baseState := mockledger.NewLedgerStateBuilder().
+		WithRewardAccountBalance(stakeKeyHash, 1_000_000).
+		Build()
+	undelegatedState := drepDelegationLedgerState{
+		LedgerState: baseState,
+		lookup: func(
+			common.Credential,
+		) (*common.Drep, error) {
+			return nil, nil
+		},
+	}
+
+	tests := []struct {
+		name      string
+		major     uint
+		wantError bool
+	}{
+		{name: "PV9 bootstrap", major: common.ProtocolVersionConway},
+		{
+			name:      "PV10 Plomin",
+			major:     common.ProtocolVersionPlomin,
+			wantError: true,
+		},
+		{
+			name:      "PV11 Van Rossem",
+			major:     common.ProtocolVersionVanRossem,
+			wantError: true,
+		},
+		{name: "PV12 CIP-181", major: common.ProtocolVersionDijkstra},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pp := &conway.ConwayProtocolParameters{
+				ProtocolVersion: common.ProtocolParametersProtocolVersion{
+					Major: tc.major,
+				},
+			}
+			err := conway.UtxoValidateWithdrawals(
+				tx,
+				0,
+				undelegatedState,
+				pp,
+			)
+			if tc.wantError {
+				var target conway.WithdrawalNotDelegatedToDRepError
+				require.ErrorAs(t, err, &target)
+				assert.Equal(t, rewardAddr, target.RewardAddress)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+
+	t.Run("PV10 delegated", func(t *testing.T) {
+		delegatedState := drepDelegationLedgerState{
+			LedgerState: baseState,
+			lookup: func(
+				credential common.Credential,
+			) (*common.Drep, error) {
+				assert.Equal(t, stakeKeyHash, credential.Credential)
+				return &common.Drep{}, nil
+			},
+		}
+		pp := &conway.ConwayProtocolParameters{
+			ProtocolVersion: common.ProtocolParametersProtocolVersion{
+				Major: common.ProtocolVersionPlomin,
+			},
+		}
+		require.NoError(t, conway.UtxoValidateWithdrawals(
+			tx,
+			0,
+			delegatedState,
+			pp,
+		))
+	})
+
+	t.Run("PV10 requires delegation lookup support", func(t *testing.T) {
+		pp := &conway.ConwayProtocolParameters{
+			ProtocolVersion: common.ProtocolParametersProtocolVersion{
+				Major: common.ProtocolVersionPlomin,
+			},
+		}
+		err := conway.UtxoValidateWithdrawals(
+			tx,
+			0,
+			ledgerStateWithoutDRepDelegation{LedgerState: baseState},
+			pp,
+		)
+		var target conway.DRepDelegationStateUnavailableError
+		require.ErrorAs(t, err, &target)
+	})
+
+	t.Run("phase-2 invalid skips DRep delegation check", func(t *testing.T) {
+		invalidTx := *tx
+		invalidTx.TxIsValid = false
+		pp := &conway.ConwayProtocolParameters{
+			ProtocolVersion: common.ProtocolParametersProtocolVersion{
+				Major: common.ProtocolVersionPlomin,
+			},
+		}
+		require.NoError(t, conway.UtxoValidateWithdrawals(
+			&invalidTx,
+			0,
+			baseState,
+			pp,
+		))
+	})
+}
+
 func TestUtxoValidateWitnessRules_Conway(t *testing.T) {
 	// Required vkey witnesses
 	t.Run("no required signers", func(t *testing.T) {

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -51,21 +51,6 @@ func makeConwayRewardAddress(
 	return addr
 }
 
-type drepDelegationLedgerState struct {
-	common.LedgerState
-	lookup func(common.Credential) (*common.Drep, error)
-}
-
-type ledgerStateWithoutDRepDelegation struct {
-	common.LedgerState
-}
-
-func (s drepDelegationLedgerState) DRepDelegation(
-	credential common.Credential,
-) (*common.Drep, error) {
-	return s.lookup(credential)
-}
-
 func TestUtxoValidateWithdrawals_DRepDelegationProtocolGate(t *testing.T) {
 	stakeKeyHash := common.Blake2b224Hash([]byte("withdrawal-stake-key"))
 	rewardAddr := makeConwayRewardAddress(t, stakeKeyHash)
@@ -80,14 +65,14 @@ func TestUtxoValidateWithdrawals_DRepDelegationProtocolGate(t *testing.T) {
 	baseState := mockledger.NewLedgerStateBuilder().
 		WithRewardAccountBalance(stakeKeyHash, 1_000_000).
 		Build()
-	undelegatedState := drepDelegationLedgerState{
-		LedgerState: baseState,
-		lookup: func(
+	undelegatedState := mockledger.NewLedgerStateBuilder().
+		WithRewardAccountBalance(stakeKeyHash, 1_000_000).
+		WithDRepDelegation(func(
 			common.Credential,
 		) (*common.Drep, error) {
 			return nil, nil
-		},
-	}
+		}).
+		Build()
 
 	tests := []struct {
 		name      string
@@ -131,15 +116,15 @@ func TestUtxoValidateWithdrawals_DRepDelegationProtocolGate(t *testing.T) {
 	}
 
 	t.Run("PV10 delegated", func(t *testing.T) {
-		delegatedState := drepDelegationLedgerState{
-			LedgerState: baseState,
-			lookup: func(
+		delegatedState := mockledger.NewLedgerStateBuilder().
+			WithRewardAccountBalance(stakeKeyHash, 1_000_000).
+			WithDRepDelegation(func(
 				credential common.Credential,
 			) (*common.Drep, error) {
 				assert.Equal(t, stakeKeyHash, credential.Credential)
 				return &common.Drep{}, nil
-			},
-		}
+			}).
+			Build()
 		pp := &conway.ConwayProtocolParameters{
 			ProtocolVersion: common.ProtocolParametersProtocolVersion{
 				Major: common.ProtocolVersionPlomin,
@@ -162,7 +147,7 @@ func TestUtxoValidateWithdrawals_DRepDelegationProtocolGate(t *testing.T) {
 		err := conway.UtxoValidateWithdrawals(
 			tx,
 			0,
-			ledgerStateWithoutDRepDelegation{LedgerState: baseState},
+			struct{ common.LedgerState }{LedgerState: baseState},
 			pp,
 		)
 		var target conway.DRepDelegationStateUnavailableError

--- a/ledger/shelley/rules.go
+++ b/ledger/shelley/rules.go
@@ -625,26 +625,9 @@ func UtxoValidateWithdrawals(
 	}
 
 	for addr := range withdrawals {
-		// Extract credential from reward address staking payload
-		stakingPayload := addr.StakingPayload()
-		if stakingPayload == nil {
+		cred, ok := addr.StakeCredential()
+		if !ok {
 			continue
-		}
-
-		var cred common.Credential
-		switch p := stakingPayload.(type) {
-		case common.AddressPayloadKeyHash:
-			cred = common.Credential{
-				CredType:   common.CredentialTypeAddrKeyHash,
-				Credential: common.NewBlake2b224(p.Hash.Bytes()),
-			}
-		case common.AddressPayloadScriptHash:
-			cred = common.Credential{
-				CredType:   common.CredentialTypeScriptHash,
-				Credential: common.NewBlake2b224(p.Hash.Bytes()),
-			}
-		default:
-			continue // Pointer addresses not supported
 		}
 
 		// Check if reward account is registered


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces Conway-era reward withdrawals to require a DRep vote delegation at PV10/PV11 and removes that gate at PV12 per CIP-181. This blocks un-delegated withdrawals in PV10/PV11 and aligns PV12 behavior with CIP-181.

- **Bug Fixes**
  - Implemented PV10/PV11 DRep delegation check in `ledger/conway/rules.go`; skipped for phase-2-invalid txs and PV9/PV12+.
  - Added optional `common.DRepDelegationState` for delegation lookups.
  - Introduced `WithdrawalNotDelegatedToDRepError` and `DRepDelegationStateUnavailableError`.
  - Added `common.ProtocolVersionDijkstra` and `ConwayProtocolParameters.ProtocolMajorVersion()` to select PV10/11/12 behavior.
  - Extracted `Address.StakeCredential()` and used it in Shelley withdrawal validation.
  - Added tests for protocol gating, delegation presence, missing capability, and phase-2 invalid txs. Updated docs to reflect PV12 (Dijkstra) and CIP-181.

- **Dependencies**
  - Bumped `github.com/blinklabs-io/ouroboros-mock` to `v0.15.0`.

<sup>Written for commit 822ec46cfc4ca03e4515860f83ec8d04b190d562. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added protocol-aware validation for reward withdrawals: DRep delegation is required in protocol versions 10–11 and no longer required from version 12 onward.
  * Added clear validation errors for missing delegation or unavailable delegation state.
  * Added support for identifying the active protocol major version.

* **Documentation**
  * Updated architecture, README, and contributor guidance with the revised delegation behavior and Conway withdrawal requirements.
  * Corrected the “staking reward withdrawals” feature description.

* **Tests**
  * Added coverage for protocol-version gates, missing delegation, supported delegation, and phase-2 transaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->