### PR TITLE
fix: reject Byron EBB block decoded with null header

### DIFF
--- a/ledger/byron/block_test.go
+++ b/ledger/byron/block_test.go
@@ -90,6 +90,19 @@ func TestByronBlock_CborRoundTrip_UsingCborEncode(t *testing.T) {
 	}
 }
 
+func TestByronEpochBoundaryBlockNullHeader(t *testing.T) {
+	// [null, [], []]: an EBB block whose header is CBOR null
+	dataBytes, err := hex.DecodeString("83f68080")
+	if err != nil {
+		t.Fatalf("Failed to decode hex string into CBOR bytes: %v", err)
+	}
+	var block byron.ByronEpochBoundaryBlock
+	err = block.UnmarshalCBOR(dataBytes)
+	if err == nil {
+		t.Fatal("expected error decoding EBB block with null header, got none")
+	}
+}
+
 func TestByronTransaction_Utxorpc(t *testing.T) {
 	// Decode the hex string to bytes
 	blockBytes, err := hex.DecodeString(strings.TrimSpace(testdata.ByronBlockHex))

--- a/ledger/byron/byron.go
+++ b/ledger/byron/byron.go
@@ -1204,6 +1204,9 @@ func (b *ByronEpochBoundaryBlock) UnmarshalCBOR(cborData []byte) error {
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
 		return err
 	}
+	if tmp.BlockHeader == nil {
+		return errors.New("byron EBB block missing header")
+	}
 	*b = ByronEpochBoundaryBlock(tmp)
 	b.SetCbor(cborData)
 	return nil


### PR DESCRIPTION
`ByronEpochBoundaryBlock.UnmarshalCBOR` now returns an error when the decoded header is nil (CBOR null), instead of leaving a block whose header-backed accessors dereference a nil pointer. Added a decode test with a null-header EBB payload; it fails without the guard.

Fixes #1896


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject EBB blocks with a null header during CBOR decode to prevent nil-pointer dereferences and return a clear error. Fixes #1896.

- **Bug Fixes**
  - `ByronEpochBoundaryBlock.UnmarshalCBOR` now errors when the decoded `BlockHeader` is `null`.
  - Added a decode test for `[null, [], []]` to ensure the guard works.

<sup>Written for commit a53801ab98942d5f5b1191e82435db19df9a7aec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Byron epoch boundary blocks with missing headers are now rejected with a clear decoding error instead of being processed incorrectly.

* **Tests**
  * Added coverage to verify that blocks containing a null header fail decoding as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->