### PR TITLE
feat(localstatequery): decode chain-dep-state opcert counters

### DIFF
--- a/protocol/localstatequery/README.md
+++ b/protocol/localstatequery/README.md
@@ -152,6 +152,8 @@ client.Release()
 - **GetRewardProvenance**: Reward calculation details
 - **GetStakePools**: Registered stake pools
 - **GetStakePoolParams**: Stake pool parameters
+- **GetOpCertCounters**: On-chain operational-certificate counters (pool cold-key hash → highest accepted opcert issue number), the counter a synced node enforces
+- **DebugChainDepState**: Full consensus chain-dependent state (opcert counters, last slot, and evolving/candidate/epoch nonces); supports both the Praos (Babbage+) and TPraos (Shelley–Alonzo) serialisations
 
 ## Notes
 

--- a/protocol/localstatequery/chain_dep_state.go
+++ b/protocol/localstatequery/chain_dep_state.go
@@ -1,0 +1,175 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localstatequery
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// ChainDepStateProtocol identifies which consensus protocol produced a
+// DebugChainDepState result. The two protocols serialise the chain-dependent
+// state with different on-wire layouts, distinguished by a leading version
+// number, so callers can tell which optional fields are populated.
+type ChainDepStateProtocol int
+
+const (
+	// ChainDepStateProtocolTPraos is the Transitional Praos protocol used by
+	// the Shelley, Allegra, Mary and Alonzo eras (serialisation version 1).
+	ChainDepStateProtocolTPraos ChainDepStateProtocol = 1
+	// ChainDepStateProtocolPraos is the Praos protocol used by the Babbage
+	// era and later, including Conway (serialisation version 0).
+	ChainDepStateProtocolPraos ChainDepStateProtocol = 0
+)
+
+// chainDepState serialisation version tags, as emitted by
+// Ouroboros.Consensus.Protocol.{Praos,TPraos} `encodeVersion`.
+const (
+	chainDepStateVersionPraos  uint64 = 0
+	chainDepStateVersionTPraos uint64 = 1
+)
+
+// DebugChainDepStateResult is the typed result of a DebugChainDepState query
+// (Shelley sub-query 13). It decodes the consensus chain-dependent state and
+// exposes the authoritative on-chain operational-certificate counters that a
+// synced node enforces when validating blocks.
+//
+// The wire layout is the `encodeVersion`-wrapped serialisation from
+// ouroboros-consensus:
+//
+//	Praos  (Babbage+): [0, [lastSlot, opCertCounters, evolvingNonce,
+//	                        candidateNonce, epochNonce, previousEpochNonce,
+//	                        labNonce, lastEpochBlockNonce]]
+//	TPraos (Shelley..Alonzo): [1, [lastSlot,
+//	                        [opCertCounters, evolvingNonce, candidateNonce]]]
+//
+// OpCertCounters and the two shared nonces are present for both protocols; the
+// remaining nonce fields are Praos-only and are nil when Protocol is TPraos.
+type DebugChainDepStateResult struct {
+	// Protocol is the consensus protocol the state was serialised for.
+	Protocol ChainDepStateProtocol
+	// LastSlot is the slot of the last block applied to the acquired state, or
+	// Origin if no block has been applied yet.
+	LastSlot WithOriginSlot
+	// OpCertCounters maps each block-issuer key hash (a stake pool's cold-key
+	// hash) to the highest operational-certificate issue number the chain has
+	// accepted for it. This is the authoritative counter the node enforces: a
+	// new block whose opcert issue number is lower is rejected.
+	OpCertCounters map[ledger.Blake2b224]uint64
+	// EvolvingNonce and CandidateNonce are present for both protocols.
+	EvolvingNonce  lcommon.Nonce
+	CandidateNonce lcommon.Nonce
+	// EpochNonce, PreviousEpochNonce, LabNonce and LastEpochBlockNonce are
+	// Praos-only (Babbage era and later); they are nil for TPraos results.
+	EpochNonce          *lcommon.Nonce
+	PreviousEpochNonce  *lcommon.Nonce
+	LabNonce            *lcommon.Nonce
+	LastEpochBlockNonce *lcommon.Nonce
+}
+
+// OpCertCounter returns the on-chain operational-certificate counter for a
+// single block issuer (a stake pool's cold-key hash), and whether the chain
+// has recorded a counter for it. A pool that has never minted a block under an
+// operational certificate has no counter and returns (0, false).
+func (r *DebugChainDepStateResult) OpCertCounter(
+	poolKeyHash ledger.Blake2b224,
+) (uint64, bool) {
+	v, ok := r.OpCertCounters[poolKeyHash]
+	return v, ok
+}
+
+func (r *DebugChainDepStateResult) UnmarshalCBOR(data []byte) error {
+	// Both protocols wrap the state in `encodeVersion N`, which serialises as
+	// a 2-element array [version, innerState]. The version selects the layout
+	// of innerState.
+	var outer struct {
+		cbor.StructAsArray
+		Version uint64
+		Inner   cbor.RawMessage
+	}
+	if _, err := cbor.Decode(data, &outer); err != nil {
+		return err
+	}
+	switch outer.Version {
+	case chainDepStateVersionPraos:
+		// Praos (Babbage era and later): an 8-element array.
+		var p struct {
+			cbor.StructAsArray
+			LastSlot            WithOriginSlot
+			OpCertCounters      map[ledger.Blake2b224]uint64
+			EvolvingNonce       lcommon.Nonce
+			CandidateNonce      lcommon.Nonce
+			EpochNonce          lcommon.Nonce
+			PreviousEpochNonce  lcommon.Nonce
+			LabNonce            lcommon.Nonce
+			LastEpochBlockNonce lcommon.Nonce
+		}
+		if _, err := cbor.Decode(outer.Inner, &p); err != nil {
+			return err
+		}
+		r.Protocol = ChainDepStateProtocolPraos
+		r.LastSlot = p.LastSlot
+		r.OpCertCounters = p.OpCertCounters
+		r.EvolvingNonce = p.EvolvingNonce
+		r.CandidateNonce = p.CandidateNonce
+		// Copy into fresh locals so the pointers do not alias the decode
+		// scratch struct.
+		epochNonce := p.EpochNonce
+		previousEpochNonce := p.PreviousEpochNonce
+		labNonce := p.LabNonce
+		lastEpochBlockNonce := p.LastEpochBlockNonce
+		r.EpochNonce = &epochNonce
+		r.PreviousEpochNonce = &previousEpochNonce
+		r.LabNonce = &labNonce
+		r.LastEpochBlockNonce = &lastEpochBlockNonce
+	case chainDepStateVersionTPraos:
+		// TPraos (Shelley through Alonzo): [lastSlot, PrtclState], where
+		// PrtclState is [opCertCounters, evolvingNonce, candidateNonce].
+		var t struct {
+			cbor.StructAsArray
+			LastSlot   WithOriginSlot
+			PrtclState struct {
+				cbor.StructAsArray
+				OpCertCounters map[ledger.Blake2b224]uint64
+				EvolvingNonce  lcommon.Nonce
+				CandidateNonce lcommon.Nonce
+			}
+		}
+		if _, err := cbor.Decode(outer.Inner, &t); err != nil {
+			return err
+		}
+		r.Protocol = ChainDepStateProtocolTPraos
+		r.LastSlot = t.LastSlot
+		r.OpCertCounters = t.PrtclState.OpCertCounters
+		r.EvolvingNonce = t.PrtclState.EvolvingNonce
+		r.CandidateNonce = t.PrtclState.CandidateNonce
+		// EpochNonce and the other Praos-only nonces do not exist in TPraos;
+		// they are left nil.
+	default:
+		return fmt.Errorf(
+			"unsupported ChainDepState serialisation version: %d",
+			outer.Version,
+		)
+	}
+	// Normalise a missing/absent counter map to an empty (non-nil) map so
+	// callers can range over it and look up keys without a nil check.
+	if r.OpCertCounters == nil {
+		r.OpCertCounters = map[ledger.Blake2b224]uint64{}
+	}
+	return nil
+}

--- a/protocol/localstatequery/chain_dep_state.go
+++ b/protocol/localstatequery/chain_dep_state.go
@@ -158,8 +158,13 @@ func (r *DebugChainDepStateResult) UnmarshalCBOR(data []byte) error {
 		r.OpCertCounters = t.PrtclState.OpCertCounters
 		r.EvolvingNonce = t.PrtclState.EvolvingNonce
 		r.CandidateNonce = t.PrtclState.CandidateNonce
-		// EpochNonce and the other Praos-only nonces do not exist in TPraos;
-		// they are left nil.
+		// EpochNonce and the other Praos-only nonces do not exist in TPraos.
+		// Clear them explicitly so decoding into a reused result cannot leave
+		// stale Praos values from a previous decode.
+		r.EpochNonce = nil
+		r.PreviousEpochNonce = nil
+		r.LabNonce = nil
+		r.LastEpochBlockNonce = nil
 	default:
 		return fmt.Errorf(
 			"unsupported ChainDepState serialisation version: %d",

--- a/protocol/localstatequery/chain_dep_state_integration_test.go
+++ b/protocol/localstatequery/chain_dep_state_integration_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build chain_dep_state_integration
+
+// This file is excluded from the default Go build. To run it:
+//
+//   GOUROBOROS_NTC_SOCKET=/path/to/node.socket \
+//   GOUROBOROS_NETWORK_MAGIC=764824073 \
+//   go test -tags=chain_dep_state_integration \
+//     -run TestDebugChainDepStateIntegration -v \
+//     ./protocol/localstatequery/...
+//
+// The test connects to a running, synced cardano-node over its node-to-client
+// socket and exercises DebugChainDepState / GetOpCertCounters end-to-end
+// against the real wire format. It satisfies the "spot-check against a live
+// node" acceptance criterion for the on-chain opcert counter (issue #1890) and
+// is gated by a build tag so CI without a node does not attempt the call.
+
+package localstatequery_test
+
+import (
+	"context"
+	"net"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+)
+
+func TestDebugChainDepStateIntegration(t *testing.T) {
+	socketPath := os.Getenv("GOUROBOROS_NTC_SOCKET")
+	if socketPath == "" {
+		t.Skip("GOUROBOROS_NTC_SOCKET not set; skipping integration test")
+	}
+	magicStr := os.Getenv("GOUROBOROS_NETWORK_MAGIC")
+	if magicStr == "" {
+		t.Fatal("GOUROBOROS_NETWORK_MAGIC must be set when GOUROBOROS_NTC_SOCKET is set")
+	}
+	magic, err := strconv.ParseUint(magicStr, 10, 32)
+	if err != nil {
+		t.Fatalf("invalid GOUROBOROS_NETWORK_MAGIC %q: %s", magicStr, err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	d := net.Dialer{}
+	conn, err := d.DialContext(ctx, "unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial %s: %s", socketPath, err)
+	}
+
+	oConn, err := ouroboros.New(
+		ouroboros.WithConnection(conn),
+		ouroboros.WithNetworkMagic(uint32(magic)),
+		ouroboros.WithNodeToNode(false),
+		ouroboros.WithKeepAlive(false),
+	)
+	if err != nil {
+		t.Fatalf("ouroboros handshake: %s", err)
+	}
+	defer func() {
+		_ = oConn.Close()
+	}()
+
+	client := oConn.LocalStateQuery().Client
+
+	state, err := client.DebugChainDepState()
+	if err != nil {
+		t.Fatalf("DebugChainDepState: %s", err)
+	}
+	switch state.Protocol {
+	case localstatequery.ChainDepStateProtocolPraos,
+		localstatequery.ChainDepStateProtocolTPraos:
+	default:
+		t.Fatalf("unexpected protocol tag: %d", state.Protocol)
+	}
+	if len(state.OpCertCounters) == 0 {
+		t.Fatal("expected at least one on-chain opcert counter on a synced node")
+	}
+	t.Logf(
+		"chain-dep-state OK: protocol=%d slot=%+v counters=%d",
+		state.Protocol,
+		state.LastSlot,
+		len(state.OpCertCounters),
+	)
+
+	// The convenience helper must agree with the full result.
+	counters, err := client.GetOpCertCounters()
+	if err != nil {
+		t.Fatalf("GetOpCertCounters: %s", err)
+	}
+	if len(counters) != len(state.OpCertCounters) {
+		t.Fatalf(
+			"GetOpCertCounters size mismatch: got %d want %d",
+			len(counters),
+			len(state.OpCertCounters),
+		)
+	}
+	for pool, want := range state.OpCertCounters {
+		if got, ok := counters[pool]; !ok || got != want {
+			t.Fatalf("counter for %s: got (%d,%v) want (%d,true)",
+				pool, got, ok, want)
+		}
+	}
+}

--- a/protocol/localstatequery/chain_dep_state_integration_test.go
+++ b/protocol/localstatequery/chain_dep_state_integration_test.go
@@ -40,6 +40,8 @@ import (
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDebugChainDepStateIntegration(t *testing.T) {
@@ -48,22 +50,20 @@ func TestDebugChainDepStateIntegration(t *testing.T) {
 		t.Skip("GOUROBOROS_NTC_SOCKET not set; skipping integration test")
 	}
 	magicStr := os.Getenv("GOUROBOROS_NETWORK_MAGIC")
-	if magicStr == "" {
-		t.Fatal("GOUROBOROS_NETWORK_MAGIC must be set when GOUROBOROS_NTC_SOCKET is set")
-	}
+	require.NotEmpty(
+		t,
+		magicStr,
+		"GOUROBOROS_NETWORK_MAGIC must be set when GOUROBOROS_NTC_SOCKET is set",
+	)
 	magic, err := strconv.ParseUint(magicStr, 10, 32)
-	if err != nil {
-		t.Fatalf("invalid GOUROBOROS_NETWORK_MAGIC %q: %s", magicStr, err)
-	}
+	require.NoError(t, err, "invalid GOUROBOROS_NETWORK_MAGIC %q", magicStr)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	d := net.Dialer{}
 	conn, err := d.DialContext(ctx, "unix", socketPath)
-	if err != nil {
-		t.Fatalf("dial %s: %s", socketPath, err)
-	}
+	require.NoError(t, err, "dial %s", socketPath)
 
 	oConn, err := ouroboros.New(
 		ouroboros.WithConnection(conn),
@@ -71,9 +71,7 @@ func TestDebugChainDepStateIntegration(t *testing.T) {
 		ouroboros.WithNodeToNode(false),
 		ouroboros.WithKeepAlive(false),
 	)
-	if err != nil {
-		t.Fatalf("ouroboros handshake: %s", err)
-	}
+	require.NoError(t, err, "ouroboros handshake")
 	defer func() {
 		_ = oConn.Close()
 	}()
@@ -81,18 +79,21 @@ func TestDebugChainDepStateIntegration(t *testing.T) {
 	client := oConn.LocalStateQuery().Client
 
 	state, err := client.DebugChainDepState()
-	if err != nil {
-		t.Fatalf("DebugChainDepState: %s", err)
-	}
-	switch state.Protocol {
-	case localstatequery.ChainDepStateProtocolPraos,
-		localstatequery.ChainDepStateProtocolTPraos:
-	default:
-		t.Fatalf("unexpected protocol tag: %d", state.Protocol)
-	}
-	if len(state.OpCertCounters) == 0 {
-		t.Fatal("expected at least one on-chain opcert counter on a synced node")
-	}
+	require.NoError(t, err, "DebugChainDepState")
+	require.Contains(
+		t,
+		[]localstatequery.ChainDepStateProtocol{
+			localstatequery.ChainDepStateProtocolPraos,
+			localstatequery.ChainDepStateProtocolTPraos,
+		},
+		state.Protocol,
+		"unexpected protocol tag",
+	)
+	require.NotEmpty(
+		t,
+		state.OpCertCounters,
+		"expected at least one on-chain opcert counter on a synced node",
+	)
 	t.Logf(
 		"chain-dep-state OK: protocol=%d slot=%+v counters=%d",
 		state.Protocol,
@@ -102,20 +103,11 @@ func TestDebugChainDepStateIntegration(t *testing.T) {
 
 	// The convenience helper must agree with the full result.
 	counters, err := client.GetOpCertCounters()
-	if err != nil {
-		t.Fatalf("GetOpCertCounters: %s", err)
-	}
-	if len(counters) != len(state.OpCertCounters) {
-		t.Fatalf(
-			"GetOpCertCounters size mismatch: got %d want %d",
-			len(counters),
-			len(state.OpCertCounters),
-		)
-	}
+	require.NoError(t, err, "GetOpCertCounters")
+	assert.Len(t, counters, len(state.OpCertCounters))
 	for pool, want := range state.OpCertCounters {
-		if got, ok := counters[pool]; !ok || got != want {
-			t.Fatalf("counter for %s: got (%d,%v) want (%d,true)",
-				pool, got, ok, want)
-		}
+		got, ok := counters[pool]
+		assert.Truef(t, ok, "counter for %s missing", pool)
+		assert.Equalf(t, want, got, "counter for %s", pool)
 	}
 }

--- a/protocol/localstatequery/chain_dep_state_test.go
+++ b/protocol/localstatequery/chain_dep_state_test.go
@@ -21,25 +21,25 @@ import (
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // poolKeyHashHex is an arbitrary 28-byte block-issuer (pool cold) key hash
 // used across the chain-dep-state fixtures.
-const poolKeyHashHex = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c"
+const poolKeyHashHex = "0102030405060708090a0b0c0d0e0f10" +
+	"1112131415161718191a1b1c"
 
 // poolKeyHashHex2 is a second, distinct 28-byte key hash for multi-pool cases.
-const poolKeyHashHex2 = "1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"
+const poolKeyHashHex2 = "1c1b1a191817161514131211100f0e0d" +
+	"0c0b0a090807060504030201"
 
 func blake224(t *testing.T, s string) ledger.Blake2b224 {
 	t.Helper()
 	var h ledger.Blake2b224
 	raw, err := hex.DecodeString(s)
-	if err != nil {
-		t.Fatalf("decode key hash %q: %s", s, err)
-	}
-	if len(raw) != len(h) {
-		t.Fatalf("key hash %q: expected %d bytes, got %d", s, len(h), len(raw))
-	}
+	require.NoError(t, err, "decode key hash %q", s)
+	require.Len(t, raw, len(h), "key hash %q wrong length", s)
 	copy(h[:], raw)
 	return h
 }
@@ -75,14 +75,9 @@ func TestDebugChainDepStateQueryBuildShelleyQuery(t *testing.T) {
 	const era = 6 // Conway
 	q := buildShelleyQuery(era, QueryTypeShelleyDebugChainDepState)
 	data, err := cbor.Encode(q)
-	if err != nil {
-		t.Fatalf("encode: %s", err)
-	}
+	require.NoError(t, err)
 	// [0, [0, [6, [13]]]]  =>  82 00 82 00 82 06 81 0d
-	want := "820082008206810d"
-	if got := hex.EncodeToString(data); got != want {
-		t.Fatalf("built query mismatch:\n  got:  %s\n  want: %s", got, want)
-	}
+	require.Equal(t, "820082008206810d", hex.EncodeToString(data))
 }
 
 // TestDebugChainDepStatePraos decodes a Praos (Babbage+/Conway) chain-dep-state
@@ -102,44 +97,33 @@ func TestDebugChainDepStatePraos(t *testing.T) {
 		nonceNeutral,            // last epoch block
 	}
 	wire, err := cbor.Encode([]any{chainDepStateVersionPraos, inner})
-	if err != nil {
-		t.Fatalf("encode fixture: %s", err)
-	}
+	require.NoError(t, err, "encode fixture")
 
 	var got DebugChainDepStateResult
-	if _, err := cbor.Decode(wire, &got); err != nil {
-		t.Fatalf("decode: %s", err)
-	}
+	_, err = cbor.Decode(wire, &got)
+	require.NoError(t, err, "decode")
 
-	if got.Protocol != ChainDepStateProtocolPraos {
-		t.Fatalf("protocol: got %d want Praos", got.Protocol)
-	}
-	if !got.LastSlot.HasSlot || got.LastSlot.Slot != 9_000_000 {
-		t.Fatalf("last slot: got %#v want At 9000000", got.LastSlot)
-	}
-	if v, ok := got.OpCertCounter(pool1); !ok || v != 7 {
-		t.Fatalf("pool1 counter: got (%d,%v) want (7,true)", v, ok)
-	}
-	if v, ok := got.OpCertCounter(pool2); !ok || v != 42 {
-		t.Fatalf("pool2 counter: got (%d,%v) want (42,true)", v, ok)
-	}
-	if got.EvolvingNonce.Type != lcommon.NonceTypeNonce {
-		t.Fatalf("evolving nonce type: got %d want Nonce", got.EvolvingNonce.Type)
-	}
-	if hex.EncodeToString(got.EvolvingNonce.Value[:]) != hex.EncodeToString(hash32(0xaa)) {
-		t.Fatalf("evolving nonce value mismatch")
-	}
-	if got.CandidateNonce.Type != lcommon.NonceTypeNeutral {
-		t.Fatalf("candidate nonce: got type %d want Neutral", got.CandidateNonce.Type)
-	}
+	assert.Equal(t, ChainDepStateProtocolPraos, got.Protocol)
+	assert.True(t, got.LastSlot.HasSlot)
+	assert.Equal(t, uint64(9_000_000), got.LastSlot.Slot)
+
+	v, ok := got.OpCertCounter(pool1)
+	assert.True(t, ok)
+	assert.Equal(t, uint64(7), v)
+	v, ok = got.OpCertCounter(pool2)
+	assert.True(t, ok)
+	assert.Equal(t, uint64(42), v)
+
+	assert.Equal(t, uint(lcommon.NonceTypeNonce), got.EvolvingNonce.Type)
+	assert.Equal(t, hash32(0xaa), got.EvolvingNonce.Value[:])
+	assert.Equal(t, uint(lcommon.NonceTypeNeutral), got.CandidateNonce.Type)
+
 	// Praos-only nonces must be populated.
-	if got.EpochNonce == nil || got.EpochNonce.Type != lcommon.NonceTypeNonce {
-		t.Fatalf("epoch nonce: got %#v want non-nil Nonce", got.EpochNonce)
-	}
-	if got.PreviousEpochNonce == nil || got.LabNonce == nil ||
-		got.LastEpochBlockNonce == nil {
-		t.Fatal("Praos-only nonce pointers must be non-nil")
-	}
+	require.NotNil(t, got.EpochNonce)
+	assert.Equal(t, uint(lcommon.NonceTypeNonce), got.EpochNonce.Type)
+	assert.NotNil(t, got.PreviousEpochNonce)
+	assert.NotNil(t, got.LabNonce)
+	assert.NotNil(t, got.LastEpochBlockNonce)
 }
 
 // TestDebugChainDepStateTPraos decodes a TPraos (Shelley..Alonzo)
@@ -157,34 +141,75 @@ func TestDebugChainDepStateTPraos(t *testing.T) {
 		},
 	}
 	wire, err := cbor.Encode([]any{chainDepStateVersionTPraos, inner})
-	if err != nil {
-		t.Fatalf("encode fixture: %s", err)
-	}
+	require.NoError(t, err, "encode fixture")
 
 	var got DebugChainDepStateResult
-	if _, err := cbor.Decode(wire, &got); err != nil {
-		t.Fatalf("decode: %s", err)
-	}
+	_, err = cbor.Decode(wire, &got)
+	require.NoError(t, err, "decode")
 
-	if got.Protocol != ChainDepStateProtocolTPraos {
-		t.Fatalf("protocol: got %d want TPraos", got.Protocol)
+	assert.Equal(t, ChainDepStateProtocolTPraos, got.Protocol)
+	assert.True(t, got.LastSlot.HasSlot)
+	assert.Equal(t, uint64(123), got.LastSlot.Slot)
+
+	v, ok := got.OpCertCounter(pool1)
+	assert.True(t, ok)
+	assert.Equal(t, uint64(3), v)
+
+	assert.Equal(t, uint(lcommon.NonceTypeNonce), got.EvolvingNonce.Type)
+	assert.Equal(t, uint(lcommon.NonceTypeNeutral), got.CandidateNonce.Type)
+
+	assert.Nil(t, got.EpochNonce)
+	assert.Nil(t, got.PreviousEpochNonce)
+	assert.Nil(t, got.LabNonce)
+	assert.Nil(t, got.LastEpochBlockNonce)
+}
+
+// TestDebugChainDepStateReusedResultClearsPraosNonces guards against stale
+// state: decoding a TPraos result into a value previously populated by a Praos
+// decode must leave every Praos-only nonce nil.
+func TestDebugChainDepStateReusedResultClearsPraosNonces(t *testing.T) {
+	pool1 := blake224(t, poolKeyHashHex)
+
+	praosInner := []any{
+		slotAt(10),
+		map[ledger.Blake2b224]uint64{pool1: 1},
+		nonceHash(hash32(0x11)),
+		nonceHash(hash32(0x22)),
+		nonceHash(hash32(0x33)),
+		nonceHash(hash32(0x44)),
+		nonceHash(hash32(0x55)),
+		nonceHash(hash32(0x66)),
 	}
-	if !got.LastSlot.HasSlot || got.LastSlot.Slot != 123 {
-		t.Fatalf("last slot: got %#v want At 123", got.LastSlot)
+	praosWire, err := cbor.Encode([]any{chainDepStateVersionPraos, praosInner})
+	require.NoError(t, err)
+
+	// Reuse the same result value for the second decode.
+	var result DebugChainDepStateResult
+	_, err = cbor.Decode(praosWire, &result)
+	require.NoError(t, err)
+	require.NotNil(t, result.EpochNonce, "Praos decode should populate nonces")
+
+	tpraosInner := []any{
+		slotAt(20),
+		[]any{
+			map[ledger.Blake2b224]uint64{pool1: 2},
+			nonceHash(hash32(0x77)),
+			nonceNeutral,
+		},
 	}
-	if v, ok := got.OpCertCounter(pool1); !ok || v != 3 {
-		t.Fatalf("pool1 counter: got (%d,%v) want (3,true)", v, ok)
-	}
-	if got.EvolvingNonce.Type != lcommon.NonceTypeNonce {
-		t.Fatalf("evolving nonce: got type %d want Nonce", got.EvolvingNonce.Type)
-	}
-	if got.CandidateNonce.Type != lcommon.NonceTypeNeutral {
-		t.Fatalf("candidate nonce: got type %d want Neutral", got.CandidateNonce.Type)
-	}
-	if got.EpochNonce != nil || got.PreviousEpochNonce != nil ||
-		got.LabNonce != nil || got.LastEpochBlockNonce != nil {
-		t.Fatal("TPraos result must leave Praos-only nonce pointers nil")
-	}
+	tpraosWire, err := cbor.Encode(
+		[]any{chainDepStateVersionTPraos, tpraosInner},
+	)
+	require.NoError(t, err)
+
+	_, err = cbor.Decode(tpraosWire, &result)
+	require.NoError(t, err)
+
+	assert.Equal(t, ChainDepStateProtocolTPraos, result.Protocol)
+	assert.Nil(t, result.EpochNonce)
+	assert.Nil(t, result.PreviousEpochNonce)
+	assert.Nil(t, result.LabNonce)
+	assert.Nil(t, result.LastEpochBlockNonce)
 }
 
 // TestDebugChainDepStateOriginSlot verifies a chain-dep-state taken at chain
@@ -201,22 +226,16 @@ func TestDebugChainDepStateOriginSlot(t *testing.T) {
 		nonceNeutral,
 	}
 	wire, err := cbor.Encode([]any{chainDepStateVersionPraos, inner})
-	if err != nil {
-		t.Fatalf("encode fixture: %s", err)
-	}
+	require.NoError(t, err, "encode fixture")
+
 	var got DebugChainDepStateResult
-	if _, err := cbor.Decode(wire, &got); err != nil {
-		t.Fatalf("decode: %s", err)
-	}
-	if got.LastSlot.HasSlot {
-		t.Fatalf("expected origin slot, got %#v", got.LastSlot)
-	}
-	if len(got.OpCertCounters) != 0 {
-		t.Fatalf("expected empty counters, got %d", len(got.OpCertCounters))
-	}
-	if _, ok := got.OpCertCounter(blake224(t, poolKeyHashHex)); ok {
-		t.Fatal("absent pool must return ok=false")
-	}
+	_, err = cbor.Decode(wire, &got)
+	require.NoError(t, err, "decode")
+
+	assert.False(t, got.LastSlot.HasSlot)
+	assert.Empty(t, got.OpCertCounters)
+	_, ok := got.OpCertCounter(blake224(t, poolKeyHashHex))
+	assert.False(t, ok, "absent pool must return ok=false")
 }
 
 // TestDebugChainDepStateGolden pins the exact Praos wire bytes so the decoded
@@ -232,26 +251,22 @@ func TestDebugChainDepStateGolden(t *testing.T) {
 		"820088820101a1581c" + poolKeyHashHex + "01" +
 			"810081008100810081008100",
 	)
-	if err != nil {
-		t.Fatalf("hex: %s", err)
-	}
+	require.NoError(t, err, "hex")
+
 	var got DebugChainDepStateResult
-	if _, err := cbor.Decode(wire, &got); err != nil {
-		t.Fatalf("decode: %s", err)
-	}
-	if got.Protocol != ChainDepStateProtocolPraos {
-		t.Fatalf("protocol: got %d want Praos", got.Protocol)
-	}
-	if !got.LastSlot.HasSlot || got.LastSlot.Slot != 1 {
-		t.Fatalf("last slot: got %#v want At 1", got.LastSlot)
-	}
-	if v, ok := got.OpCertCounter(blake224(t, poolKeyHashHex)); !ok || v != 1 {
-		t.Fatalf("counter: got (%d,%v) want (1,true)", v, ok)
-	}
+	_, err = cbor.Decode(wire, &got)
+	require.NoError(t, err, "decode")
+
+	assert.Equal(t, ChainDepStateProtocolPraos, got.Protocol)
+	assert.True(t, got.LastSlot.HasSlot)
+	assert.Equal(t, uint64(1), got.LastSlot.Slot)
+
+	v, ok := got.OpCertCounter(blake224(t, poolKeyHashHex))
+	assert.True(t, ok)
+	assert.Equal(t, uint64(1), v)
+
 	for _, n := range []lcommon.Nonce{got.EvolvingNonce, got.CandidateNonce} {
-		if n.Type != lcommon.NonceTypeNeutral {
-			t.Fatalf("expected neutral nonce, got type %d", n.Type)
-		}
+		assert.Equal(t, uint(lcommon.NonceTypeNeutral), n.Type)
 	}
 }
 
@@ -260,13 +275,11 @@ func TestDebugChainDepStateGolden(t *testing.T) {
 // producing an empty/mislabelled result.
 func TestDebugChainDepStateRejectsUnknownVersion(t *testing.T) {
 	wire, err := cbor.Encode([]any{uint64(2), []any{}})
-	if err != nil {
-		t.Fatalf("encode fixture: %s", err)
-	}
+	require.NoError(t, err, "encode fixture")
+
 	var got DebugChainDepStateResult
-	if _, err := cbor.Decode(wire, &got); err == nil {
-		t.Fatal("expected decode error for unknown version, got nil")
-	}
+	_, err = cbor.Decode(wire, &got)
+	require.Error(t, err, "expected decode error for unknown version")
 }
 
 // TestDebugChainDepStateOpCertCounterLookup exercises the per-pool lookup
@@ -289,9 +302,8 @@ func TestDebugChainDepStateOpCertCounterLookup(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			v, ok := r.OpCertCounter(tc.pool)
-			if v != tc.wantVal || ok != tc.wantOk {
-				t.Fatalf("got (%d,%v) want (%d,%v)", v, ok, tc.wantVal, tc.wantOk)
-			}
+			assert.Equal(t, tc.wantVal, v)
+			assert.Equal(t, tc.wantOk, ok)
 		})
 	}
 }

--- a/protocol/localstatequery/chain_dep_state_test.go
+++ b/protocol/localstatequery/chain_dep_state_test.go
@@ -1,0 +1,297 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localstatequery
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// poolKeyHashHex is an arbitrary 28-byte block-issuer (pool cold) key hash
+// used across the chain-dep-state fixtures.
+const poolKeyHashHex = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c"
+
+// poolKeyHashHex2 is a second, distinct 28-byte key hash for multi-pool cases.
+const poolKeyHashHex2 = "1c1b1a191817161514131211100f0e0d0c0b0a090807060504030201"
+
+func blake224(t *testing.T, s string) ledger.Blake2b224 {
+	t.Helper()
+	var h ledger.Blake2b224
+	raw, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("decode key hash %q: %s", s, err)
+	}
+	if len(raw) != len(h) {
+		t.Fatalf("key hash %q: expected %d bytes, got %d", s, len(h), len(raw))
+	}
+	copy(h[:], raw)
+	return h
+}
+
+// hash32 returns a 32-byte slice filled with b, for use as a Nonce value.
+func hash32(b byte) []byte {
+	out := make([]byte, 32)
+	for i := range out {
+		out[i] = b
+	}
+	return out
+}
+
+// The following builders assemble the raw CBOR terms for chain-dep-state
+// fixtures independently of the type under test, following the encodings
+// verified against ouroboros-consensus / cardano-ledger:
+//
+//	WithOrigin SlotNo : Origin -> [0]            At s -> [1, s]
+//	Nonce             : Neutral -> [0]           Nonce h -> [1, h]
+
+func slotAt(s uint64) []any { return []any{1, s} }
+
+var slotOrigin = []any{0}
+
+func nonceHash(b []byte) []any { return []any{1, b} }
+
+var nonceNeutral = []any{0}
+
+// TestDebugChainDepStateQueryBuildShelleyQuery verifies the DebugChainDepState
+// (sub-query 13) leaf wraps through buildShelleyQuery into the full
+// BlockQuery -> ShelleyQuery -> era -> [13] envelope cardano-node expects.
+func TestDebugChainDepStateQueryBuildShelleyQuery(t *testing.T) {
+	const era = 6 // Conway
+	q := buildShelleyQuery(era, QueryTypeShelleyDebugChainDepState)
+	data, err := cbor.Encode(q)
+	if err != nil {
+		t.Fatalf("encode: %s", err)
+	}
+	// [0, [0, [6, [13]]]]  =>  82 00 82 00 82 06 81 0d
+	want := "820082008206810d"
+	if got := hex.EncodeToString(data); got != want {
+		t.Fatalf("built query mismatch:\n  got:  %s\n  want: %s", got, want)
+	}
+}
+
+// TestDebugChainDepStatePraos decodes a Praos (Babbage+/Conway) chain-dep-state
+// result and verifies the opcert counters, slot, protocol tag, and nonces.
+func TestDebugChainDepStatePraos(t *testing.T) {
+	pool1 := blake224(t, poolKeyHashHex)
+	pool2 := blake224(t, poolKeyHashHex2)
+
+	inner := []any{
+		slotAt(9_000_000),
+		map[ledger.Blake2b224]uint64{pool1: 7, pool2: 42},
+		nonceHash(hash32(0xaa)), // evolving
+		nonceNeutral,            // candidate
+		nonceHash(hash32(0xbb)), // epoch
+		nonceNeutral,            // previous epoch
+		nonceNeutral,            // lab
+		nonceNeutral,            // last epoch block
+	}
+	wire, err := cbor.Encode([]any{chainDepStateVersionPraos, inner})
+	if err != nil {
+		t.Fatalf("encode fixture: %s", err)
+	}
+
+	var got DebugChainDepStateResult
+	if _, err := cbor.Decode(wire, &got); err != nil {
+		t.Fatalf("decode: %s", err)
+	}
+
+	if got.Protocol != ChainDepStateProtocolPraos {
+		t.Fatalf("protocol: got %d want Praos", got.Protocol)
+	}
+	if !got.LastSlot.HasSlot || got.LastSlot.Slot != 9_000_000 {
+		t.Fatalf("last slot: got %#v want At 9000000", got.LastSlot)
+	}
+	if v, ok := got.OpCertCounter(pool1); !ok || v != 7 {
+		t.Fatalf("pool1 counter: got (%d,%v) want (7,true)", v, ok)
+	}
+	if v, ok := got.OpCertCounter(pool2); !ok || v != 42 {
+		t.Fatalf("pool2 counter: got (%d,%v) want (42,true)", v, ok)
+	}
+	if got.EvolvingNonce.Type != lcommon.NonceTypeNonce {
+		t.Fatalf("evolving nonce type: got %d want Nonce", got.EvolvingNonce.Type)
+	}
+	if hex.EncodeToString(got.EvolvingNonce.Value[:]) != hex.EncodeToString(hash32(0xaa)) {
+		t.Fatalf("evolving nonce value mismatch")
+	}
+	if got.CandidateNonce.Type != lcommon.NonceTypeNeutral {
+		t.Fatalf("candidate nonce: got type %d want Neutral", got.CandidateNonce.Type)
+	}
+	// Praos-only nonces must be populated.
+	if got.EpochNonce == nil || got.EpochNonce.Type != lcommon.NonceTypeNonce {
+		t.Fatalf("epoch nonce: got %#v want non-nil Nonce", got.EpochNonce)
+	}
+	if got.PreviousEpochNonce == nil || got.LabNonce == nil ||
+		got.LastEpochBlockNonce == nil {
+		t.Fatal("Praos-only nonce pointers must be non-nil")
+	}
+}
+
+// TestDebugChainDepStateTPraos decodes a TPraos (Shelley..Alonzo)
+// chain-dep-state result, whose PrtclState nests the counters and the two
+// shared nonces, and verifies the Praos-only nonce pointers stay nil.
+func TestDebugChainDepStateTPraos(t *testing.T) {
+	pool1 := blake224(t, poolKeyHashHex)
+
+	inner := []any{
+		slotAt(123),
+		[]any{ // PrtclState: [counters, evolvingNonce, candidateNonce]
+			map[ledger.Blake2b224]uint64{pool1: 3},
+			nonceHash(hash32(0xcc)),
+			nonceNeutral,
+		},
+	}
+	wire, err := cbor.Encode([]any{chainDepStateVersionTPraos, inner})
+	if err != nil {
+		t.Fatalf("encode fixture: %s", err)
+	}
+
+	var got DebugChainDepStateResult
+	if _, err := cbor.Decode(wire, &got); err != nil {
+		t.Fatalf("decode: %s", err)
+	}
+
+	if got.Protocol != ChainDepStateProtocolTPraos {
+		t.Fatalf("protocol: got %d want TPraos", got.Protocol)
+	}
+	if !got.LastSlot.HasSlot || got.LastSlot.Slot != 123 {
+		t.Fatalf("last slot: got %#v want At 123", got.LastSlot)
+	}
+	if v, ok := got.OpCertCounter(pool1); !ok || v != 3 {
+		t.Fatalf("pool1 counter: got (%d,%v) want (3,true)", v, ok)
+	}
+	if got.EvolvingNonce.Type != lcommon.NonceTypeNonce {
+		t.Fatalf("evolving nonce: got type %d want Nonce", got.EvolvingNonce.Type)
+	}
+	if got.CandidateNonce.Type != lcommon.NonceTypeNeutral {
+		t.Fatalf("candidate nonce: got type %d want Neutral", got.CandidateNonce.Type)
+	}
+	if got.EpochNonce != nil || got.PreviousEpochNonce != nil ||
+		got.LabNonce != nil || got.LastEpochBlockNonce != nil {
+		t.Fatal("TPraos result must leave Praos-only nonce pointers nil")
+	}
+}
+
+// TestDebugChainDepStateOriginSlot verifies a chain-dep-state taken at chain
+// origin (no block applied) and an empty counter map decode cleanly.
+func TestDebugChainDepStateOriginSlot(t *testing.T) {
+	inner := []any{
+		slotOrigin,
+		map[ledger.Blake2b224]uint64{},
+		nonceNeutral,
+		nonceNeutral,
+		nonceNeutral,
+		nonceNeutral,
+		nonceNeutral,
+		nonceNeutral,
+	}
+	wire, err := cbor.Encode([]any{chainDepStateVersionPraos, inner})
+	if err != nil {
+		t.Fatalf("encode fixture: %s", err)
+	}
+	var got DebugChainDepStateResult
+	if _, err := cbor.Decode(wire, &got); err != nil {
+		t.Fatalf("decode: %s", err)
+	}
+	if got.LastSlot.HasSlot {
+		t.Fatalf("expected origin slot, got %#v", got.LastSlot)
+	}
+	if len(got.OpCertCounters) != 0 {
+		t.Fatalf("expected empty counters, got %d", len(got.OpCertCounters))
+	}
+	if _, ok := got.OpCertCounter(blake224(t, poolKeyHashHex)); ok {
+		t.Fatal("absent pool must return ok=false")
+	}
+}
+
+// TestDebugChainDepStateGolden pins the exact Praos wire bytes so the decoded
+// field mapping cannot silently drift from the ouroboros-consensus layout.
+func TestDebugChainDepStateGolden(t *testing.T) {
+	// [0, [ [1,1], {hash:1}, [0],[0],[0],[0],[0],[0] ]]
+	//   82 00                          version 0, outer list-2
+	//   88                             inner list-8
+	//     82 01 01                     lastSlot = At 1
+	//     a1 581c <28-byte hash> 01    opcert counters {hash: 1}
+	//     81 00  (x6)                  six neutral nonces
+	wire, err := hex.DecodeString(
+		"820088820101a1581c" + poolKeyHashHex + "01" +
+			"810081008100810081008100",
+	)
+	if err != nil {
+		t.Fatalf("hex: %s", err)
+	}
+	var got DebugChainDepStateResult
+	if _, err := cbor.Decode(wire, &got); err != nil {
+		t.Fatalf("decode: %s", err)
+	}
+	if got.Protocol != ChainDepStateProtocolPraos {
+		t.Fatalf("protocol: got %d want Praos", got.Protocol)
+	}
+	if !got.LastSlot.HasSlot || got.LastSlot.Slot != 1 {
+		t.Fatalf("last slot: got %#v want At 1", got.LastSlot)
+	}
+	if v, ok := got.OpCertCounter(blake224(t, poolKeyHashHex)); !ok || v != 1 {
+		t.Fatalf("counter: got (%d,%v) want (1,true)", v, ok)
+	}
+	for _, n := range []lcommon.Nonce{got.EvolvingNonce, got.CandidateNonce} {
+		if n.Type != lcommon.NonceTypeNeutral {
+			t.Fatalf("expected neutral nonce, got type %d", n.Type)
+		}
+	}
+}
+
+// TestDebugChainDepStateRejectsUnknownVersion ensures a serialisation version
+// the decoder does not understand is surfaced as an error rather than silently
+// producing an empty/mislabelled result.
+func TestDebugChainDepStateRejectsUnknownVersion(t *testing.T) {
+	wire, err := cbor.Encode([]any{uint64(2), []any{}})
+	if err != nil {
+		t.Fatalf("encode fixture: %s", err)
+	}
+	var got DebugChainDepStateResult
+	if _, err := cbor.Decode(wire, &got); err == nil {
+		t.Fatal("expected decode error for unknown version, got nil")
+	}
+}
+
+// TestDebugChainDepStateOpCertCounterLookup exercises the per-pool lookup
+// helper for present and absent pools.
+func TestDebugChainDepStateOpCertCounterLookup(t *testing.T) {
+	present := blake224(t, poolKeyHashHex)
+	absent := blake224(t, poolKeyHashHex2)
+	r := DebugChainDepStateResult{
+		OpCertCounters: map[ledger.Blake2b224]uint64{present: 99},
+	}
+	cases := []struct {
+		name    string
+		pool    ledger.Blake2b224
+		wantVal uint64
+		wantOk  bool
+	}{
+		{"present", present, 99, true},
+		{"absent", absent, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v, ok := r.OpCertCounter(tc.pool)
+			if v != tc.wantVal || ok != tc.wantOk {
+				t.Fatalf("got (%d,%v) want (%d,%v)", v, ok, tc.wantVal, tc.wantOk)
+			}
+		})
+	}
+}

--- a/protocol/localstatequery/client.go
+++ b/protocol/localstatequery/client.go
@@ -626,6 +626,23 @@ func (c *Client) DebugNewEpochState() (*DebugNewEpochStateResult, error) {
 	return &result, nil
 }
 
+// DebugChainDepState returns the consensus chain-dependent state for the
+// acquired point (Shelley sub-query 13).
+//
+// Use this to read the authoritative on-chain operational-certificate counters
+// the node enforces during block validation: [DebugChainDepStateResult]
+// exposes OpCertCounters, a map from each block-issuer key hash (a stake pool's
+// cold-key hash) to the highest operational-certificate issue number the chain
+// has accepted for it. For the common case of just the counters, prefer
+// [Client.GetOpCertCounters].
+//
+// The result also carries the last-applied slot and the evolving/candidate
+// nonces (plus the Praos-only epoch nonces), so it can be combined with the
+// slots-per-KES-period value from [Client.GetGenesisConfig] to derive
+// KES-period-info for a pool's operational certificate.
+//
+// The decoder handles both the Praos (Babbage era and later, including Conway)
+// and TPraos (Shelley through Alonzo) serialisations.
 func (c *Client) DebugChainDepState() (*DebugChainDepStateResult, error) {
 	c.Protocol.Logger().
 		Debug("calling DebugChainDepState()",
@@ -649,6 +666,22 @@ func (c *Client) DebugChainDepState() (*DebugChainDepStateResult, error) {
 		return nil, err
 	}
 	return &result, nil
+}
+
+// GetOpCertCounters returns the authoritative on-chain operational-certificate
+// issue-number counter the node enforces for each block issuer (a stake pool's
+// cold-key hash). The value for a pool is the highest opcert issue number the
+// chain has accepted; a block presenting a lower number is rejected.
+//
+// This is a typed convenience wrapper over [Client.DebugChainDepState] for the
+// common case of reading only the counters. Use [DebugChainDepStateResult] via
+// DebugChainDepState directly when the slot or nonce fields are also needed.
+func (c *Client) GetOpCertCounters() (map[ledger.Blake2b224]uint64, error) {
+	result, err := c.DebugChainDepState()
+	if err != nil {
+		return nil, err
+	}
+	return result.OpCertCounters, nil
 }
 
 func (c *Client) GetRewardProvenance() (*RewardProvenanceResult, error) {

--- a/protocol/localstatequery/queries.go
+++ b/protocol/localstatequery/queries.go
@@ -716,8 +716,7 @@ type GenesisConfigResultProtocolParameters struct {
 // TODO (#864)
 type DebugNewEpochStateResult any
 
-// TODO (#865)
-type DebugChainDepStateResult any
+// DebugChainDepStateResult (#865) is defined in chain_dep_state.go.
 
 // RewardProvenanceResult is the result of the GetRewardProvenance query.
 // CBOR: array(1)[array(16)[epochLength, poolMints, maxLovelaceSupply,


### PR DESCRIPTION
## Summary

Implements a typed LocalStateQuery path to read the **authoritative on-chain operational-certificate counter** a synced node enforces, so any node-to-client consumer (operator, `dingoctl`, etc.) can read it over an NtC socket without depending on a node-specific API.

Closes #1890. Also implements the previously-`any` `DebugChainDepState` result decoder (closes the #865 TODO).

## What changed

- **`DebugChainDepState` result decoder** (`chain_dep_state.go`): the query result is now decoded into a typed `DebugChainDepStateResult` instead of an `any` stub. It exposes:
  - `OpCertCounters map[ledger.Blake2b224]uint64` — block-issuer key hash (pool cold-key hash) → highest accepted opcert issue number (the counter the node enforces).
  - `LastSlot`, plus the evolving/candidate nonces and (Praos-only) epoch nonces, so callers can combine with `slotsPerKESPeriod` from `GetGenesisConfig` to derive KES-period info.
  - `OpCertCounter(poolKeyHash)` per-pool lookup helper.
- **`GetOpCertCounters()` client helper**: typed convenience wrapper returning just the counter map.
- The decoder is **version-discriminated** and handles both consensus serialisations, reusing the existing `WithOriginSlot` and `ledger/common` `Nonce` types:
  - Praos (Babbage era and later, incl. Conway) — `encodeVersion 0`, 8-element state.
  - TPraos (Shelley through Alonzo) — `encodeVersion 1`, nested `PrtclState`.

## Wire format provenance

Layouts were taken from the upstream Haskell instances (ouroboros-consensus `Praos`/`TPraos`, cardano-ledger `Nonce`/`PrtclState`, cardano-slotting `WithOrigin`), not inferred. `WithOrigin SlotNo` (`[0]`/`[1,slot]`) and `Nonce` (`[0]`/`[1,hash]`) match this repo's existing `WithOriginSlot` and `lcommon.Nonce`.

## Tests

Table-driven decode tests over wire fixtures: Praos golden (incl. exact-byte pin), TPraos golden, chain-origin/empty counters, the `buildShelleyQuery` envelope, and unknown-version rejection, plus the lookup helper.

A **build-tagged integration test** (`-tags=chain_dep_state_integration`, `GOUROBOROS_NTC_SOCKET`/`GOUROBOROS_NETWORK_MAGIC`) provides the live-node spot-check harness for the "matches the counter a synced node enforces" acceptance criterion — this environment has no node access, so that spot-check is left to run against a synced node.

`make lint` (0 issues), `make format` (no changes), `go vet ./...`, and the package test suite all pass.

## Notes

- Two docs referenced by the issue (`ROADMAP.md`, `docs/plans/lsq.md`) don't exist in the repo, so the new capability is documented in the package `README.md` instead.
- `#864` (`DebugNewEpochState`) is intentionally left as-is — ChainDepState is the authoritative enforcement source for the counter and fully satisfies the acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a typed `DebugChainDepState` decoder and a `GetOpCertCounters()` helper to read authoritative on-chain opcert counters over LocalStateQuery, with robust decoding across Praos and TPraos and safe reuse of result structs.

- **New Features**
  - Typed `DebugChainDepStateResult` with `OpCertCounters` (pool cold-key `ledger.Blake2b224` → highest opcert issue number), `LastSlot`, evolving/candidate/epoch nonces, and `OpCertCounter()` lookup.
  - Version-discriminated decoder for Praos (`encodeVersion 0`) and TPraos (`encodeVersion 1`), reusing `WithOriginSlot` and `ledger/common` `Nonce`.
  - `GetOpCertCounters()` convenience wrapper returning only the counter map.

- **Bug Fixes**
  - Clear Praos-only nonce pointers in the TPraos decode path to prevent stale values when decoding into a reused result; added a reuse regression test and updated tests to `testify` assert/require.

<sup>Written for commit 0e8643178360dd170510eb776c303198991754a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for querying consensus chain-dependent state, including operational-certificate counters, slots, and nonces.
  * Added a convenient method to retrieve operational-certificate counters directly.
  * Supports both Praos and TPraos result formats.
  * Documented the new LocalStateQuery options.

* **Tests**
  * Added coverage for query construction, result decoding, protocol variations, invalid versions, and counter lookups.
  * Added optional integration coverage against a running node.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->