### PR TITLE
fix(cbor): run modernize

### DIFF
--- a/cbor/generic_cache_test.go
+++ b/cbor/generic_cache_test.go
@@ -36,9 +36,7 @@ func TestEncodeGenericTypeCacheConcurrent(t *testing.T) {
 	errs := make(chan error, goroutines)
 	results := make(chan []byte, goroutines*iterations)
 	for range goroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range iterations {
 				result, err := cbor.EncodeGeneric(src)
 				if err != nil {
@@ -47,7 +45,7 @@ func TestEncodeGenericTypeCacheConcurrent(t *testing.T) {
 				}
 				results <- result
 			}
-		}()
+		})
 	}
 	wg.Wait()
 	close(errs)
@@ -73,9 +71,7 @@ func TestDecodeGenericTypeCacheConcurrent(t *testing.T) {
 	errs := make(chan error, goroutines)
 	results := make(chan *decodeGenericTestStruct, goroutines*iterations)
 	for range goroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range iterations {
 				dest := &decodeGenericTestStruct{}
 				if err := cbor.DecodeGeneric(cborData, dest); err != nil {
@@ -84,7 +80,7 @@ func TestDecodeGenericTypeCacheConcurrent(t *testing.T) {
 				}
 				results <- dest
 			}
-		}()
+		})
 	}
 	wg.Wait()
 	close(errs)

--- a/cbor/type_cache.go
+++ b/cbor/type_cache.go
@@ -15,6 +15,7 @@
 package cbor
 
 import (
+	"maps"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -55,9 +56,7 @@ func (c *genericTypeCache) getOrCreate(
 	}
 
 	nextTypes := make(map[reflect.Type]reflect.Type, len(currentTypes)+1)
-	for cachedSrcType, cachedType := range currentTypes {
-		nextTypes[cachedSrcType] = cachedType
-	}
+	maps.Copy(nextTypes, currentTypes)
 	nextTypes[srcType] = createdType
 	c.types.Store(&nextTypes)
 	return createdType, nil


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Modernized the `cbor` generic type cache and concurrent tests for cleaner, safer code. Replaced manual map copying with `maps.Copy` and simplified goroutine handling with `wg.Go`.

- **Refactors**
  - Use `maps.Copy` to clone the cache map in `cbor/type_cache.go`.
  - Replace `wg.Add`/`wg.Done` with `wg.Go` in `cbor/generic_cache_test.go` to streamline concurrency.

<sup>Written for commit 24fcac839824376409410518d831305046a80163. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal generic type-cache copying while preserving existing cache behavior.
  * Simplified concurrent test coordination for encoding and decoding operations.

* **Tests**
  * Maintained coverage for concurrent cache access, result collection, error handling, and final assertions.
  * No changes to public APIs or end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->