### PR TITLE
fix(localstatequery): decode GetCBOR-wrapped queries

### DIFF
--- a/protocol/localstatequery/client.go
+++ b/protocol/localstatequery/client.go
@@ -902,12 +902,18 @@ func (c *Client) GetStakeSnapshots(
 	if err != nil {
 		return nil, err
 	}
-	// Wrap the poolIds in a CBOR set (tag 258)
-	poolIdSet := cbor.NewSetType(poolIds, true)
+	// GetStakeSnapshots takes a StrictMaybe (Set PoolId), encoded as a
+	// list: an empty list selects all pools (SNothing), while a
+	// single-element list holding a tag-258 set restricts the result to
+	// those pools (SJust). See dingo issue #2917.
+	poolFilter := []any{}
+	if len(poolIds) > 0 {
+		poolFilter = append(poolFilter, cbor.NewSetType(poolIds, true))
+	}
 	query := buildShelleyQuery(
 		currentEra,
 		QueryTypeShelleyStakeSnapshots,
-		poolIdSet,
+		poolFilter,
 	)
 	// The result is wrapped in a single-element array
 	var wrappedResult []StakeSnapshotsResult

--- a/protocol/localstatequery/queries.go
+++ b/protocol/localstatequery/queries.go
@@ -200,52 +200,63 @@ func (q *ShelleyQuery) UnmarshalCBOR(data []byte) error {
 		return err
 	}
 	// Decode query
-	tmpQuery, err := decodeQuery(
-		tmpData.Inner.SubQuery,
-		"Block",
-		map[int]any{
-			QueryTypeShelleyLedgerTip:                           &ShelleyLedgerTipQuery{},
-			QueryTypeShelleyEpochNo:                             &ShelleyEpochNoQuery{},
-			QueryTypeShelleyNonMyopicMemberRewards:              &ShelleyNonMyopicMemberRewardsQuery{},
-			QueryTypeShelleyCurrentProtocolParams:               &ShelleyCurrentProtocolParamsQuery{},
-			QueryTypeShelleyProposedProtocolParamsUpdates:       &ShelleyProposedProtocolParamsUpdatesQuery{},
-			QueryTypeShelleyStakeDistribution:                   &ShelleyStakeDistributionQuery{},
-			QueryTypeShelleyUtxoByAddress:                       &ShelleyUtxoByAddressQuery{},
-			QueryTypeShelleyUtxoWhole:                           &ShelleyUtxoWholeQuery{},
-			QueryTypeShelleyDebugEpochState:                     &ShelleyDebugEpochStateQuery{},
-			QueryTypeShelleyCbor:                                &ShelleyCborQuery{},
-			QueryTypeShelleyFilteredDelegationAndRewardAccounts: &ShelleyFilteredDelegationAndRewardAccountsQuery{},
-			QueryTypeShelleyGenesisConfig:                       &ShelleyGenesisConfigQuery{},
-			QueryTypeShelleyDebugNewEpochState:                  &ShelleyDebugNewEpochStateQuery{},
-			QueryTypeShelleyDebugChainDepState:                  &ShelleyDebugChainDepStateQuery{},
-			QueryTypeShelleyRewardProvenance:                    &ShelleyRewardProvenanceQuery{},
-			QueryTypeShelleyUtxoByTxin:                          &ShelleyUtxoByTxinQuery{},
-			QueryTypeShelleyStakePools:                          &ShelleyStakePoolsQuery{},
-			QueryTypeShelleyStakePoolParams:                     &ShelleyStakePoolParamsQuery{},
-			QueryTypeShelleyRewardInfoPools:                     &ShelleyRewardInfoPoolsQuery{},
-			QueryTypeShelleyPoolState:                           &ShelleyPoolStateQuery{},
-			QueryTypeShelleyStakeSnapshots:                      &ShelleyStakeSnapshotsQuery{},
-			QueryTypeShelleyPoolDistr:                           &ShelleyPoolDistrQuery{},
-			// Conway governance queries
-			QueryTypeShelleyConstitution:           &ShelleyConstitutionQuery{},
-			QueryTypeShelleyGovState:               &ShelleyGovStateQuery{},
-			QueryTypeShelleyDRepState:              &ShelleyDRepStateQuery{},
-			QueryTypeShelleyDRepStakeDistr:         &ShelleyDRepStakeDistrQuery{},
-			QueryTypeShelleyCommitteeMembersState:  &ShelleyCommitteeMembersStateQuery{},
-			QueryTypeShelleyFilteredVoteDelegatees: &ShelleyFilteredVoteDelegateesQuery{},
-			QueryTypeShelleyAccountState:           &ShelleyAccountStateQuery{},
-			QueryTypeShelleySPOStakeDistr:          &ShelleySPOStakeDistrQuery{},
-			QueryTypeShelleyGetProposals:           &ShelleyGetProposalsQuery{},
-			QueryTypeShelleyGetRatifyState:         &ShelleyGetRatifyStateQuery{},
-			QueryTypeShelleyGetLedgerPeerSnapshot:  &ShelleyGetLedgerPeerSnapshotQuery{},
-		},
-	)
+	tmpQuery, err := decodeShelleyQuery(tmpData.Inner.SubQuery)
 	if err != nil {
 		return err
 	}
 	q.Era = tmpData.Inner.Era
 	q.Query = tmpQuery
 	return nil
+}
+
+// shelleyQueryTypes returns a fresh decode target for every Shelley
+// block-query leaf. A new map with new pointer values is built per call so
+// concurrent decodes never share mutable state.
+func shelleyQueryTypes() map[int]any {
+	return map[int]any{
+		QueryTypeShelleyLedgerTip:                           &ShelleyLedgerTipQuery{},
+		QueryTypeShelleyEpochNo:                             &ShelleyEpochNoQuery{},
+		QueryTypeShelleyNonMyopicMemberRewards:              &ShelleyNonMyopicMemberRewardsQuery{},
+		QueryTypeShelleyCurrentProtocolParams:               &ShelleyCurrentProtocolParamsQuery{},
+		QueryTypeShelleyProposedProtocolParamsUpdates:       &ShelleyProposedProtocolParamsUpdatesQuery{},
+		QueryTypeShelleyStakeDistribution:                   &ShelleyStakeDistributionQuery{},
+		QueryTypeShelleyUtxoByAddress:                       &ShelleyUtxoByAddressQuery{},
+		QueryTypeShelleyUtxoWhole:                           &ShelleyUtxoWholeQuery{},
+		QueryTypeShelleyDebugEpochState:                     &ShelleyDebugEpochStateQuery{},
+		QueryTypeShelleyCbor:                                &ShelleyCborQuery{},
+		QueryTypeShelleyFilteredDelegationAndRewardAccounts: &ShelleyFilteredDelegationAndRewardAccountsQuery{},
+		QueryTypeShelleyGenesisConfig:                       &ShelleyGenesisConfigQuery{},
+		QueryTypeShelleyDebugNewEpochState:                  &ShelleyDebugNewEpochStateQuery{},
+		QueryTypeShelleyDebugChainDepState:                  &ShelleyDebugChainDepStateQuery{},
+		QueryTypeShelleyRewardProvenance:                    &ShelleyRewardProvenanceQuery{},
+		QueryTypeShelleyUtxoByTxin:                          &ShelleyUtxoByTxinQuery{},
+		QueryTypeShelleyStakePools:                          &ShelleyStakePoolsQuery{},
+		QueryTypeShelleyStakePoolParams:                     &ShelleyStakePoolParamsQuery{},
+		QueryTypeShelleyRewardInfoPools:                     &ShelleyRewardInfoPoolsQuery{},
+		QueryTypeShelleyPoolState:                           &ShelleyPoolStateQuery{},
+		QueryTypeShelleyStakeSnapshots:                      &ShelleyStakeSnapshotsQuery{},
+		QueryTypeShelleyPoolDistr:                           &ShelleyPoolDistrQuery{},
+		// Conway governance queries
+		QueryTypeShelleyConstitution:           &ShelleyConstitutionQuery{},
+		QueryTypeShelleyGovState:               &ShelleyGovStateQuery{},
+		QueryTypeShelleyDRepState:              &ShelleyDRepStateQuery{},
+		QueryTypeShelleyDRepStakeDistr:         &ShelleyDRepStakeDistrQuery{},
+		QueryTypeShelleyCommitteeMembersState:  &ShelleyCommitteeMembersStateQuery{},
+		QueryTypeShelleyFilteredVoteDelegatees: &ShelleyFilteredVoteDelegateesQuery{},
+		QueryTypeShelleyAccountState:           &ShelleyAccountStateQuery{},
+		QueryTypeShelleySPOStakeDistr:          &ShelleySPOStakeDistrQuery{},
+		QueryTypeShelleyGetProposals:           &ShelleyGetProposalsQuery{},
+		QueryTypeShelleyGetRatifyState:         &ShelleyGetRatifyStateQuery{},
+		QueryTypeShelleyGetLedgerPeerSnapshot:  &ShelleyGetLedgerPeerSnapshotQuery{},
+	}
+}
+
+// decodeShelleyQuery decodes a single Shelley block-query leaf (the
+// [tag, args...] form without the surrounding era wrapper). It is shared by
+// the era-wrapped path in ShelleyQuery and by the inner query carried by the
+// GetCBOR combinator (ShelleyCborQuery).
+func decodeShelleyQuery(data []byte) (any, error) {
+	return decodeQuery(data, "Block", shelleyQueryTypes())
 }
 
 type HardForkQuery struct {
@@ -324,8 +335,40 @@ type ShelleyDebugEpochStateQuery struct {
 	simpleQueryBase
 }
 
+// ShelleyCborQuery is the GetCBOR query combinator (Shelley sub-query 9).
+// It wraps an inner Shelley block-query whose result the client wants
+// returned as raw serialised CBOR (CBOR-in-CBOR, tag 24). On the wire it is
+// [9, innerQuery]; cardano-cli emits this shape for several queries,
+// e.g. `query stake-snapshot`. Modelling it as a bare [9] (simpleQueryBase)
+// made any GetCBOR-wrapped query fail to decode with "cannot decode CBOR
+// array to struct with different number of elements", closing the NtC
+// connection. See dingo issue #2917.
 type ShelleyCborQuery struct {
-	simpleQueryBase
+	cbor.StructAsArray
+	Type  int
+	Query any
+}
+
+func (q *ShelleyCborQuery) UnmarshalCBOR(data []byte) error {
+	var tmp struct {
+		cbor.StructAsArray
+		Type     int
+		SubQuery cbor.RawMessage
+	}
+	if _, err := cbor.Decode(data, &tmp); err != nil {
+		return err
+	}
+	inner, err := decodeShelleyQuery(tmp.SubQuery)
+	if err != nil {
+		return err
+	}
+	q.Type = tmp.Type
+	q.Query = inner
+	return nil
+}
+
+func (q *ShelleyCborQuery) MarshalCBOR() ([]byte, error) {
+	return cbor.Encode([]any{q.Type, q.Query})
 }
 
 type ShelleyFilteredDelegationAndRewardAccountsQuery struct {
@@ -374,8 +417,52 @@ type ShelleyPoolStateQuery struct {
 	simpleQueryBase
 }
 
+// ShelleyStakeSnapshotsQuery is GetStakeSnapshots (Shelley sub-query 20).
+// On the wire it is [20, poolFilter] where poolFilter is a StrictMaybe of a
+// pool-id set, encoded as a list: [] (SNothing) means "all pools", while
+// [ 258{poolids} ] (SJust) restricts the result to the given pools. It was
+// previously modelled as a bare [20] (simpleQueryBase), which could not
+// decode the pool-filter argument once the GetCBOR wrapper around it was
+// decodable. See dingo issue #2917.
 type ShelleyStakeSnapshotsQuery struct {
-	simpleQueryBase
+	cbor.StructAsArray
+	Type  int
+	Pools []cbor.SetType[ledger.PoolId]
+}
+
+func (q *ShelleyStakeSnapshotsQuery) UnmarshalCBOR(data []byte) error {
+	var tmp struct {
+		cbor.StructAsArray
+		Type  int
+		Pools []cbor.SetType[ledger.PoolId]
+	}
+	if _, err := cbor.Decode(data, &tmp); err != nil {
+		return err
+	}
+	// The pool filter is a StrictMaybe (Set PoolId): SNothing ([]) or SJust
+	// ([set]). The CBOR array decodes into a Go slice of any length, so
+	// reject a malformed encoding that carries more than one set rather than
+	// silently dropping the extras in PoolFilter.
+	if len(tmp.Pools) > 1 {
+		return fmt.Errorf(
+			"invalid GetStakeSnapshots pool filter: expected at most one pool set, got %d",
+			len(tmp.Pools),
+		)
+	}
+	q.Type = tmp.Type
+	q.Pools = tmp.Pools
+	return nil
+}
+
+// PoolFilter reports the pool IDs the query is restricted to. When all is
+// true the query covers every pool (the StrictMaybe was SNothing) and pools
+// is nil; when all is false only the returned pools are requested (which may
+// be empty for an explicit SJust of the empty set).
+func (q *ShelleyStakeSnapshotsQuery) PoolFilter() (pools []ledger.PoolId, all bool) {
+	if len(q.Pools) == 0 {
+		return nil, true
+	}
+	return q.Pools[0].Items(), false
 }
 
 type ShelleyPoolDistrQuery struct {

--- a/protocol/localstatequery/stake_snapshot_query_test.go
+++ b/protocol/localstatequery/stake_snapshot_query_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localstatequery
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The fixtures below are the exact LocalStateQuery MsgQuery payloads
+// (mini-protocol 7) captured off the wire from cardano-cli 11.0.0.0
+// `query stake-snapshot` talking to cardano-node 11.0.1. They decode to:
+//
+//	[3, [0, [0, [6, [9, [20, poolFilter]]]]]]
+//	MsgQuery( Block( Shelley( era=6, GetCBOR( GetStakeSnapshots(poolFilter) ) )))
+//
+// Modelling ShelleyCborQuery (GetCBOR, tag 9) as a bare [9] made both fail
+// to decode with "cannot decode CBOR array to struct with different number
+// of elements", closing the NtC connection. See dingo issue #2917.
+const (
+	// stake-snapshot --stake-pool-id <pool>; poolFilter = [ 258{pool} ]
+	stakeSnapshotQueryOnePoolHex = "82038200820082068209821481" +
+		"d9010281581c728ea45cc4888f97d1c3233956fd6abf9362854d880efd6e577807f2"
+	// stake-snapshot --all-stake-pools; poolFilter = [] (SNothing)
+	stakeSnapshotQueryAllPoolsHex = "82038200820082068209821480"
+	// The single pool ID carried by the one-pool query.
+	stakeSnapshotPoolIDHex = "728ea45cc4888f97d1c3233956fd6abf9362854d880efd6e577807f2"
+	// Malformed: poolFilter = [ 258{poolA}, 258{poolB} ]. A StrictMaybe may
+	// carry at most one set, so this must be rejected at decode.
+	stakeSnapshotQueryTwoSetsHex = "820382008200820682098214" + "82" +
+		"d9010281581c728ea45cc4888f97d1c3233956fd6abf9362854d880efd6e577807f2" +
+		"d9010281581cccfa09b0c1f3fe9650a11b4d23d5c461df76f6ff10eb95018940984f"
+)
+
+// decodeStakeSnapshotsQuery decodes a captured MsgQuery payload and walks the
+// wrapper chain down to the GetStakeSnapshots leaf, asserting each layer's
+// type, era, and query tag.
+func decodeStakeSnapshotsQuery(
+	t *testing.T,
+	payloadHex string,
+) *ShelleyStakeSnapshotsQuery {
+	t.Helper()
+	data, err := hex.DecodeString(payloadHex)
+	require.NoError(t, err)
+	msg, err := NewMsgFromCbor(MessageTypeQuery, data)
+	require.NoError(t, err, "captured stake-snapshot query must decode (issue #2917)")
+
+	msgQuery, ok := msg.(*MsgQuery)
+	require.Truef(t, ok, "expected *MsgQuery, got %T", msg)
+	blockQuery, ok := msgQuery.Query.Query.(*BlockQuery)
+	require.Truef(t, ok, "expected *BlockQuery, got %T", msgQuery.Query.Query)
+	shelleyQuery, ok := blockQuery.Query.(*ShelleyQuery)
+	require.Truef(t, ok, "expected *ShelleyQuery, got %T", blockQuery.Query)
+	require.Equal(t, uint(6), shelleyQuery.Era, "expected era 6 (Conway)")
+	cborQuery, ok := shelleyQuery.Query.(*ShelleyCborQuery)
+	require.Truef(t, ok, "expected *ShelleyCborQuery (GetCBOR), got %T", shelleyQuery.Query)
+	require.Equal(t, QueryTypeShelleyCbor, cborQuery.Type, "expected GetCBOR tag")
+	snapQuery, ok := cborQuery.Query.(*ShelleyStakeSnapshotsQuery)
+	require.Truef(t, ok, "expected *ShelleyStakeSnapshotsQuery, got %T", cborQuery.Query)
+	require.Equal(
+		t,
+		QueryTypeShelleyStakeSnapshots,
+		snapQuery.Type,
+		"expected GetStakeSnapshots tag",
+	)
+	return snapQuery
+}
+
+func TestDecodeStakeSnapshotsQuerySpecificPool(t *testing.T) {
+	snapQuery := decodeStakeSnapshotsQuery(t, stakeSnapshotQueryOnePoolHex)
+	pools, all := snapQuery.PoolFilter()
+	require.False(t, all, "expected a specific-pool filter, not all-pools (SNothing)")
+	require.Len(t, pools, 1)
+
+	wantPool, err := hex.DecodeString(stakeSnapshotPoolIDHex)
+	require.NoError(t, err)
+	assert.Equal(t, stakeSnapshotPoolIDHex, hex.EncodeToString(pools[0][:]), "pool ID mismatch")
+	// Sanity: the requested pool must round-trip through ledger.PoolId.
+	var wantID ledger.PoolId
+	copy(wantID[:], wantPool)
+	assert.Equal(t, wantID, pools[0], "pool ID did not round-trip through ledger.PoolId")
+}
+
+func TestDecodeStakeSnapshotsQueryAllPools(t *testing.T) {
+	snapQuery := decodeStakeSnapshotsQuery(t, stakeSnapshotQueryAllPoolsHex)
+	pools, all := snapQuery.PoolFilter()
+	require.True(t, all, "expected all-pools (SNothing)")
+	assert.Nil(t, pools, "expected nil pool slice for all-pools")
+}
+
+// TestDecodeStakeSnapshotsQueryRejectsMultipleSets ensures a malformed
+// StrictMaybe carrying more than one pool set is rejected at decode rather
+// than silently dropping the extra sets.
+func TestDecodeStakeSnapshotsQueryRejectsMultipleSets(t *testing.T) {
+	data, err := hex.DecodeString(stakeSnapshotQueryTwoSetsHex)
+	require.NoError(t, err)
+	_, err = NewMsgFromCbor(MessageTypeQuery, data)
+	require.Error(t, err, "a pool filter with more than one set must be rejected")
+	assert.Contains(t, err.Error(), "at most one pool set")
+}


### PR DESCRIPTION
## Problem

`cardano-cli query stake-snapshot` (and other commands) wrap their query in
the **GetCBOR** combinator — Shelley sub-query tag `9` — which carries an
inner query on the wire as `[9, innerQuery]`. `ShelleyCborQuery` was modelled
as a bare `[9]` (`simpleQueryBase`), so decoding the 2-element array failed:

```
local-state-query: decode error: cbor: cannot unmarshal array into Go struct
field localstatequery.MsgQuery.Query of type localstatequery.ShelleyCborQuery
(cannot decode CBOR array to struct with different number of elements)
```

The server then closes the node-to-client connection (the client sees
`BearerClosed "<socket: 11>"`). Reported downstream as blinklabs-io/dingo#2917.

## Fix

- `ShelleyCborQuery` decodes `[9, innerQuery]` and recursively decodes the
  inner query via a shared `shelleyQueryTypes()` / `decodeShelleyQuery()`
  helper (extracted from `ShelleyQuery.UnmarshalCBOR`).
- `ShelleyStakeSnapshotsQuery` (`GetStakeSnapshots`, tag `20`) decodes its
  `StrictMaybe (Set PoolId)` argument — `[]` = all pools, `[258{...}]` =
  specific — exposed via `PoolFilter()`. It was also mis-modelled as
  parameterless.
- The client `GetStakeSnapshots` builder is corrected to send the
  `Maybe`-wrapped set (it previously sent a bare set, which real cardano-node
  rejects).

## Tests

`stake_snapshot_query_test.go` adds byte-exact decode tests for both the
single-pool and all-pools `MsgQuery` payloads, captured off the wire from
`cardano-cli 11.0.0.0` talking to `cardano-node 11.0.1`. `go test ./protocol/localstatequery/...`
and `golangci-lint` pass.

## Note on base

This branch is based on `v0.179.0` (the version the downstream consumer pins);
the diff is limited to `localstatequery`. When rebasing onto `main`, the new
`shelleyQueryTypes()` map must also include `QueryTypeShelleyAccountState`
(added after v0.179.0) — the only entry added to the Shelley query map since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix decoding of `GetCBOR`-wrapped Shelley queries and correct the `GetStakeSnapshots` pool filter, so `cardano-cli query stake-snapshot` works without closing the node-to-client connection.

- **Bug Fixes**
  - Decode `ShelleyCborQuery` as `[9, innerQuery]` and recursively decode the inner query via shared `shelleyQueryTypes()` / `decodeShelleyQuery()`.
  - Model `ShelleyStakeSnapshotsQuery` as `[20, poolFilter]` with `StrictMaybe (Set PoolId)`; expose `PoolFilter()` and reject multiple-set encodings.
  - Update client `GetStakeSnapshots` to send an empty list for all pools or a single tag-258 set for specific pools.
  - Add byte-exact decode tests for specific/all pools and a malformed multi-set case using payloads captured from `cardano-cli 11.0.0.0` against `cardano-node 11.0.1`.

<sup>Written for commit db296d8a6eeae661d5dda6fddb82bd075939c970. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected stake snapshot queries so pool filters are encoded and interpreted properly.
  * Restored accurate handling of queries targeting all pools or a specific pool.

* **Reliability**
  * Improved decoding of Shelley queries for consistent behavior during concurrent processing.

* **Tests**
  * Added coverage for stake snapshot requests covering both specific-pool and all-pool scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->