### PR TITLE
fix(ledger): conway zero withdrawal

### DIFF
--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -2520,8 +2520,9 @@ func UtxoValidateDelegation(
 // UtxoValidateWithdrawals validates withdrawals against ledger state.
 // For phase-2 invalid transactions (IsValid=false), withdrawal validation is
 // skipped since their effects are reverted and only collateral rules apply.
-// PV10 and PV11 also require each withdrawing stake credential to have a DRep
-// vote delegation. PV12 removes that requirement per CIP-181.
+// PV10 and PV11 also require each stake credential withdrawing a non-zero
+// amount to have a DRep vote delegation. PV12 removes that requirement per
+// CIP-181.
 func UtxoValidateWithdrawals(
 	tx common.Transaction,
 	slot uint64,
@@ -2534,7 +2535,8 @@ func UtxoValidateWithdrawals(
 	if err := shelley.UtxoValidateWithdrawals(tx, slot, ls, pp); err != nil {
 		return err
 	}
-	if len(tx.Withdrawals()) == 0 {
+	withdrawals := tx.Withdrawals()
+	if len(withdrawals) == 0 {
 		return nil
 	}
 	versionedPparams, ok := pp.(interface {
@@ -2548,11 +2550,18 @@ func UtxoValidateWithdrawals(
 		protocolMajor >= common.ProtocolVersionDijkstra {
 		return nil
 	}
-	delegationState, ok := ls.(common.DRepDelegationState)
-	if !ok {
-		return DRepDelegationStateUnavailableError{}
-	}
-	for addr := range tx.Withdrawals() {
+	var delegationState common.DRepDelegationState
+	for addr, amount := range withdrawals {
+		if amount == nil || amount.Sign() == 0 {
+			continue
+		}
+		if delegationState == nil {
+			var ok bool
+			delegationState, ok = ls.(common.DRepDelegationState)
+			if !ok {
+				return DRepDelegationStateUnavailableError{}
+			}
+		}
 		credential, ok := addr.StakeCredential()
 		if !ok {
 			continue

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -138,6 +138,65 @@ func TestUtxoValidateWithdrawals_DRepDelegationProtocolGate(t *testing.T) {
 		))
 	})
 
+	for _, major := range []uint{
+		common.ProtocolVersionPlomin,
+		common.ProtocolVersionVanRossem,
+	} {
+		t.Run(fmt.Sprintf("PV%d zero amount", major), func(t *testing.T) {
+			zeroTx := *tx
+			zeroTx.Body.TxWithdrawals = map[*common.Address]uint64{
+				&rewardAddr: 0,
+			}
+			pp := &conway.ConwayProtocolParameters{
+				ProtocolVersion: common.ProtocolParametersProtocolVersion{
+					Major: major,
+				},
+			}
+			require.NoError(t, conway.UtxoValidateWithdrawals(
+				&zeroTx,
+				0,
+				struct{ common.LedgerState }{LedgerState: baseState},
+				pp,
+			))
+		})
+	}
+
+	t.Run("PV10 mixed amounts checks non-zero withdrawal", func(t *testing.T) {
+		otherStakeKeyHash := common.Blake2b224Hash(
+			[]byte("other-withdrawal-stake-key"),
+		)
+		otherRewardAddr := makeConwayRewardAddress(t, otherStakeKeyHash)
+		mixedTx := *tx
+		mixedTx.Body.TxWithdrawals = map[*common.Address]uint64{
+			&rewardAddr:      0,
+			&otherRewardAddr: 1_000_000,
+		}
+		mixedState := mockledger.NewLedgerStateBuilder().
+			WithRewardAccountBalance(stakeKeyHash, 1_000_000).
+			WithRewardAccountBalance(otherStakeKeyHash, 1_000_000).
+			WithDRepDelegation(func(
+				credential common.Credential,
+			) (*common.Drep, error) {
+				assert.Equal(t, otherStakeKeyHash, credential.Credential)
+				return nil, nil
+			}).
+			Build()
+		pp := &conway.ConwayProtocolParameters{
+			ProtocolVersion: common.ProtocolParametersProtocolVersion{
+				Major: common.ProtocolVersionPlomin,
+			},
+		}
+		err := conway.UtxoValidateWithdrawals(
+			&mixedTx,
+			0,
+			mixedState,
+			pp,
+		)
+		var target conway.WithdrawalNotDelegatedToDRepError
+		require.ErrorAs(t, err, &target)
+		assert.Equal(t, otherRewardAddr, target.RewardAddress)
+	})
+
 	t.Run("PV10 requires delegation lookup support", func(t *testing.T) {
 		pp := &conway.ConwayProtocolParameters{
 			ProtocolVersion: common.ProtocolParametersProtocolVersion{


### PR DESCRIPTION
Closes #1903 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Conway withdrawal validation: zero-amount withdrawals no longer require DRep delegation in PV10/11, and only non‑zero withdrawals are checked. PV12 behavior remains unchanged per CIP-181.

- **Bug Fixes**
  - Update withdrawal checks to only require DRep delegation for non‑zero amounts in PV10/11; lazily access delegation state only when needed.
  - Add tests for zero-amount withdrawals and mixed zero/non‑zero cases, including correct error target on non‑delegated non‑zero withdrawals.

<sup>Written for commit 773bcc9657790fc1e0a1ae03ffb095a1e7794b55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

