### PR TITLE
perf(protocol): fix chainsync rollforward debug log

### DIFF
--- a/protocol/chainsync/server.go
+++ b/protocol/chainsync/server.go
@@ -17,6 +17,7 @@ package chainsync
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 
 	"github.com/blinklabs-io/gouroboros/ledger"
@@ -151,19 +152,13 @@ func (s *Server) AwaitReply() error {
 
 func (s *Server) RollForward(blockType uint, blockData []byte, tip Tip) error {
 	p := s.ProtocolInstance()
-	p.Logger().
-		Debug(
-			fmt.Sprintf("calling RollForward(blockType: %+x, blockData: %x, tip: {Point: {Slot: %d, Hash: %x}, BlockNumber: %d})",
-				blockType,
-				blockData,
-				tip.Point.Slot, tip.Point.Hash,
-				tip.BlockNumber,
-			),
-			"component", "network",
-			"protocol", ProtocolName,
-			"role", "server",
-			"connection_id", s.callbackContext.ConnectionId.String(),
-		)
+	logRollForward(
+		p.Logger(),
+		blockType,
+		blockData,
+		tip,
+		s.callbackContext.ConnectionId.String(),
+	)
 	if p.Mode() == protocol.ProtocolModeNodeToNode {
 		eraId := ledger.BlockToBlockHeaderTypeMap[blockType]
 		msg, err := NewMsgRollForwardNtN(
@@ -195,6 +190,27 @@ func (s *Server) RollForward(blockType uint, blockData []byte, tip Tip) error {
 		}
 		return p.SendMessage(msg)
 	}
+}
+
+func logRollForward(
+	logger *slog.Logger,
+	blockType uint,
+	blockData []byte,
+	tip Tip,
+	connectionId string,
+) {
+	logger.Debug(
+		"calling RollForward",
+		"block_type", blockType,
+		"block_size", len(blockData),
+		"tip_slot", tip.Point.Slot,
+		"tip_hash", tip.Point.Hash,
+		"tip_block_number", tip.BlockNumber,
+		"component", "network",
+		"protocol", ProtocolName,
+		"role", "server",
+		"connection_id", connectionId,
+	)
 }
 
 func (s *Server) messageHandler(msg protocol.Message) error {

--- a/protocol/chainsync/server_test.go
+++ b/protocol/chainsync/server_test.go
@@ -15,9 +15,13 @@
 package chainsync
 
 import (
+	"bytes"
+	"log/slog"
 	"testing"
 
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHandleRequestNext_Callback(t *testing.T) {
@@ -51,4 +55,41 @@ func TestHandleRequestNext_NilCallback(t *testing.T) {
 
 	assert.Error(t, err, "expected an error due to nil callback")
 	assert.EqualError(t, err, expectedError)
+}
+
+func TestLogRollForwardDoesNotLogBlockData(t *testing.T) {
+	var logOutput bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(
+		&logOutput,
+		&slog.HandlerOptions{Level: slog.LevelDebug},
+	))
+	tip := Tip{
+		Point: pcommon.Point{
+			Slot: 42,
+			Hash: []byte{0xca, 0xfe},
+		},
+		BlockNumber: 24,
+	}
+
+	logRollForward(
+		logger,
+		5,
+		[]byte{0xde, 0xad, 0xbe, 0xef},
+		tip,
+		"connection-id",
+	)
+
+	output := logOutput.String()
+	require.NotEmpty(t, output)
+	assert.Contains(t, output, "msg=\"calling RollForward\"")
+	assert.Contains(t, output, "block_type=5")
+	assert.Contains(t, output, "block_size=4")
+	assert.Contains(t, output, "tip_slot=42")
+	assert.Contains(t, output, "tip_block_number=24")
+	assert.NotContains(
+		t,
+		output,
+		"deadbeef",
+		"serialized block data should not be logged",
+	)
 }


### PR DESCRIPTION
Closes #1906 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reworked chainsync RollForward debug logging to use structured `log/slog` and stop logging raw block bytes. This cuts log size and noise while keeping key context.

- **Bug Fixes**
  - Replace string-formatted debug with `logRollForward` helper using `log/slog`.
  - Log `block_type` and `block_size` instead of serialized `blockData`.
  - Keep useful fields: `tip_slot`, `tip_hash`, `tip_block_number`, `connection_id`.
  - Add test `TestLogRollForwardDoesNotLogBlockData` to ensure block bytes never appear in logs.

<sup>Written for commit 732503e74ffd7e0ffae31c4f3544e9f33ea557d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

