### PR TITLE
fix(localstatequery): support stake address info queries

### DIFF
--- a/ledger/common/certs.go
+++ b/ledger/common/certs.go
@@ -142,6 +142,17 @@ type Drep struct {
 	Credential []byte
 }
 
+func (d Drep) MarshalCBOR() ([]byte, error) {
+	switch d.Type {
+	case DrepTypeAddrKeyHash, DrepTypeScriptHash:
+		return cbor.Encode([]any{d.Type, d.Credential})
+	case DrepTypeAbstain, DrepTypeNoConfidence:
+		return cbor.Encode([]any{d.Type})
+	default:
+		return nil, fmt.Errorf("unknown drep type: %d", d.Type)
+	}
+}
+
 func (d *Drep) UnmarshalCBOR(data []byte) error {
 	drepType, err := cbor.DecodeIdFromList(data)
 	if err != nil {

--- a/ledger/common/certs_test.go
+++ b/ledger/common/certs_test.go
@@ -313,3 +313,20 @@ func TestLeiosKeyRejectsInvalidLengths(t *testing.T) {
 		})
 	}
 }
+
+func TestDrepCBORRoundTrip(t *testing.T) {
+	testCases := []Drep{
+		{Type: DrepTypeAddrKeyHash, Credential: make([]byte, 28)},
+		{Type: DrepTypeScriptHash, Credential: bytes.Repeat([]byte{0xaa}, 28)},
+		{Type: DrepTypeAbstain},
+		{Type: DrepTypeNoConfidence},
+	}
+	for _, expected := range testCases {
+		encoded, err := cbor.Encode(expected)
+		require.NoError(t, err)
+		var actual Drep
+		_, err = cbor.Decode(encoded, &actual)
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	}
+}

--- a/protocol/localstatequery/client.go
+++ b/protocol/localstatequery/client.go
@@ -576,6 +576,36 @@ func (c *Client) GetFilteredDelegationsAndRewardAccounts(
 	return &result, nil
 }
 
+// GetStakeDelegDeposits returns the deposits currently locked by the requested
+// registered stake credentials.
+func (c *Client) GetStakeDelegDeposits(
+	creds []StakeCredential,
+) (*StakeDelegDepositsResult, error) {
+	c.Protocol.Logger().
+		Debug(fmt.Sprintf("calling GetStakeDelegDeposits(creds: %+v)", creds),
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "client",
+			"connection_id", c.callbackContext.ConnectionId.String(),
+		)
+	c.busyMutex.Lock()
+	defer c.busyMutex.Unlock()
+	currentEra, err := c.getCurrentEra()
+	if err != nil {
+		return nil, err
+	}
+	query := buildShelleyQuery(
+		currentEra,
+		QueryTypeShelleyStakeDelegDeposits,
+		cbor.NewSetType(creds, true),
+	)
+	var result StakeDelegDepositsResult
+	if err := c.runQuery(query, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 func (c *Client) GetGenesisConfig() (*GenesisConfigResult, error) {
 	c.Protocol.Logger().
 		Debug("calling GetGenesisConfig()",
@@ -1392,6 +1422,7 @@ func (c *Client) GetProposals() (*ProposalsResult, error) {
 	query := buildShelleyQuery(
 		currentEra,
 		QueryTypeShelleyGetProposals,
+		cbor.NewSetType([]lcommon.GovActionId{}, true),
 	)
 	var result ProposalsResult
 	if err := c.runQuery(query, &result); err != nil {

--- a/protocol/localstatequery/client_test.go
+++ b/protocol/localstatequery/client_test.go
@@ -943,7 +943,7 @@ func TestGetDRepStatePreConway(t *testing.T) {
 func TestGetProposalsEmpty(t *testing.T) {
 	// Empty proposals list
 	expectedResult := localstatequery.ProposalsResult{}
-	cborData, err := cbor.Encode(expectedResult)
+	cborData, err := cbor.Encode([]any{expectedResult})
 	if err != nil {
 		t.Fatalf("unexpected error encoding: %s", err)
 	}
@@ -1100,7 +1100,7 @@ func TestGetProposalsSingleProposal(t *testing.T) {
 		ExpiresAfter:      110,
 	}
 	expectedResult := localstatequery.ProposalsResult{proposal}
-	cborData, err := cbor.Encode(expectedResult)
+	cborData, err := cbor.Encode([]any{expectedResult})
 	if err != nil {
 		t.Fatalf("unexpected error encoding: %s", err)
 	}
@@ -1211,7 +1211,7 @@ func TestFilteredVoteDelegateesResultDecode(t *testing.T) {
 			Credential: drepCredBytes,
 		},
 	}
-	cborData, err := cbor.Encode(encodableMap)
+	cborData, err := cbor.Encode([]any{encodableMap})
 	require.NoError(t, err, "unexpected error encoding map")
 
 	// Decode into FilteredVoteDelegateesResult
@@ -1247,7 +1247,7 @@ func TestGetFilteredVoteDelegatees(t *testing.T) {
 			Credential: drepCredBytes,
 		},
 	}
-	cborData, err := cbor.Encode(encodableMap)
+	cborData, err := cbor.Encode([]any{encodableMap})
 	require.NoError(t, err, "unexpected error encoding result")
 
 	conversation := append(

--- a/protocol/localstatequery/queries.go
+++ b/protocol/localstatequery/queries.go
@@ -63,6 +63,7 @@ const (
 	QueryTypeShelleyPoolState                           = 19
 	QueryTypeShelleyStakeSnapshots                      = 20
 	QueryTypeShelleyPoolDistr                           = 21
+	QueryTypeShelleyStakeDelegDeposits                  = 22
 
 	// Conway governance queries (v8+)
 	QueryTypeShelleyConstitution           = 23
@@ -236,6 +237,7 @@ func shelleyQueryTypes() map[int]any {
 		QueryTypeShelleyPoolState:                           &ShelleyPoolStateQuery{},
 		QueryTypeShelleyStakeSnapshots:                      &ShelleyStakeSnapshotsQuery{},
 		QueryTypeShelleyPoolDistr:                           &ShelleyPoolDistrQuery{},
+		QueryTypeShelleyStakeDelegDeposits:                  &ShelleyStakeDelegDepositsQuery{},
 		// Conway governance queries
 		QueryTypeShelleyConstitution:           &ShelleyConstitutionQuery{},
 		QueryTypeShelleyGovState:               &ShelleyGovStateQuery{},
@@ -372,6 +374,15 @@ func (q *ShelleyCborQuery) MarshalCBOR() ([]byte, error) {
 }
 
 type ShelleyFilteredDelegationAndRewardAccountsQuery struct {
+	cbor.StructAsArray
+	Type  int
+	Creds cbor.SetType[StakeCredential]
+}
+
+// ShelleyStakeDelegDepositsQuery returns the deposit locked by each requested
+// registered stake credential. It was added with node-to-client version 16 and
+// is used by cardano-cli query stake-address-info.
+type ShelleyStakeDelegDepositsQuery struct {
 	cbor.StructAsArray
 	Type  int
 	Creds cbor.SetType[StakeCredential]
@@ -741,6 +752,22 @@ type FilteredDelegationsAndRewardAccountsResult struct {
 	Rewards     map[StakeCredential]uint64
 }
 
+// StakeDelegDepositsResult is the result of GetStakeDelegDeposits.
+// The map is wrapped in a one-element array by the Shelley era codec.
+type StakeDelegDepositsResult map[StakeCredential]uint64
+
+func (r *StakeDelegDepositsResult) UnmarshalCBOR(data []byte) error {
+	var tmp struct {
+		cbor.StructAsArray
+		Deposits map[StakeCredential]uint64
+	}
+	if _, err := cbor.Decode(data, &tmp); err != nil {
+		return err
+	}
+	*r = tmp.Deposits
+	return nil
+}
+
 func (r *FilteredDelegationsAndRewardAccountsResult) UnmarshalCBOR(data []byte) error {
 	var tmp struct {
 		cbor.StructAsArray
@@ -1099,7 +1126,9 @@ type ShelleyAccountStateQuery struct {
 }
 
 type ShelleyGetProposalsQuery struct {
-	simpleQueryBase
+	cbor.StructAsArray
+	Type      int
+	ActionIds cbor.SetType[lcommon.GovActionId]
 }
 
 type ShelleyGetRatifyStateQuery struct {
@@ -1465,7 +1494,20 @@ type CommitteeMembersStateResult struct {
 // FilteredVoteDelegateesResult represents the vote delegatees
 // for stake credentials.
 // The result maps stake credentials to their DRep delegations
+// and is wrapped in a one-element array by the Shelley era codec.
 type FilteredVoteDelegateesResult map[StakeCredential]lcommon.Drep
+
+func (r *FilteredVoteDelegateesResult) UnmarshalCBOR(data []byte) error {
+	var tmp struct {
+		cbor.StructAsArray
+		Delegatees map[StakeCredential]lcommon.Drep
+	}
+	if _, err := cbor.Decode(data, &tmp); err != nil {
+		return err
+	}
+	*r = tmp.Delegatees
+	return nil
+}
 
 // SPOStakeDistrResult represents the SPO stake distribution for governance
 // Maps pool IDs to their governance voting power
@@ -1476,7 +1518,20 @@ type SPOStakeDistrResult struct {
 
 // ProposalsResult represents the result of a GetProposals query.
 // It contains a list of governance action states for all active proposals.
+// The list is wrapped in a one-element array by the Shelley era codec.
 type ProposalsResult []GovActionState
+
+func (r *ProposalsResult) UnmarshalCBOR(data []byte) error {
+	var tmp struct {
+		cbor.StructAsArray
+		Proposals []GovActionState
+	}
+	if _, err := cbor.Decode(data, &tmp); err != nil {
+		return err
+	}
+	*r = tmp.Proposals
+	return nil
+}
 
 // EnactState represents the enactment state within a ratify state result.
 // It contains the current committee, constitution, protocol parameters,

--- a/protocol/localstatequery/stake_deleg_deposits_query_test.go
+++ b/protocol/localstatequery/stake_deleg_deposits_query_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localstatequery
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/stretchr/testify/require"
+)
+
+// This is the MsgQuery shape emitted by cardano-cli for
+// query stake-address-info:
+//
+//	MsgQuery(Block(Shelley(era=6, GetStakeDelegDeposits({key credential})))))
+//
+// Before query 22 was registered in shelleyQueryTypes, decoding this message
+// failed and the node-to-client connection closed without returning a result.
+func TestDecodeStakeDelegDepositsQuery(t *testing.T) {
+	const payloadHex = "82038200820082068216d90102818200581c" +
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	payload, err := hex.DecodeString(payloadHex)
+	require.NoError(t, err)
+
+	msg, err := NewMsgFromCbor(MessageTypeQuery, payload)
+	require.NoError(t, err)
+	msgQuery, ok := msg.(*MsgQuery)
+	require.True(t, ok)
+	blockQuery, ok := msgQuery.Query.Query.(*BlockQuery)
+	require.True(t, ok)
+	shelleyQuery, ok := blockQuery.Query.(*ShelleyQuery)
+	require.True(t, ok)
+	require.Equal(t, uint(6), shelleyQuery.Era)
+	query, ok := shelleyQuery.Query.(*ShelleyStakeDelegDepositsQuery)
+	require.True(t, ok)
+	require.Equal(t, QueryTypeShelleyStakeDelegDeposits, query.Type)
+	require.Len(t, query.Creds.Items(), 1)
+	require.Equal(t, uint64(0), query.Creds.Items()[0].Tag)
+	require.Equal(
+		t,
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		hex.EncodeToString(query.Creds.Items()[0].Bytes[:]),
+	)
+}
+
+func TestDecodeGetProposalsQueryWithFilter(t *testing.T) {
+	const payloadHex = "820382008200820682181fd9010280"
+	payload, err := hex.DecodeString(payloadHex)
+	require.NoError(t, err)
+
+	msg, err := NewMsgFromCbor(MessageTypeQuery, payload)
+	require.NoError(t, err)
+	msgQuery := msg.(*MsgQuery)
+	blockQuery := msgQuery.Query.Query.(*BlockQuery)
+	shelleyQuery := blockQuery.Query.(*ShelleyQuery)
+	query, ok := shelleyQuery.Query.(*ShelleyGetProposalsQuery)
+	require.True(t, ok)
+	require.Equal(t, QueryTypeShelleyGetProposals, query.Type)
+	require.Empty(t, query.ActionIds.Items())
+}
+
+func TestDecodeFilteredDelegationsAndRewardAccountsResult(t *testing.T) {
+	payload, err := hex.DecodeString("8182a0a0")
+	require.NoError(t, err)
+
+	var result FilteredDelegationsAndRewardAccountsResult
+	_, err = cbor.Decode(payload, &result)
+	require.NoError(t, err)
+	require.Empty(t, result.Delegations)
+	require.Empty(t, result.Rewards)
+}
+
+func TestDecodeStakeAddressInfoEraResults(t *testing.T) {
+	var deposits StakeDelegDepositsResult
+	_, err := cbor.Decode([]byte{0x81, 0xa0}, &deposits)
+	require.NoError(t, err)
+	require.Empty(t, deposits)
+
+	var delegatees FilteredVoteDelegateesResult
+	_, err = cbor.Decode([]byte{0x81, 0xa0}, &delegatees)
+	require.NoError(t, err)
+	require.Empty(t, delegatees)
+
+	var proposals ProposalsResult
+	_, err = cbor.Decode([]byte{0x81, 0x80}, &proposals)
+	require.NoError(t, err)
+	require.Empty(t, proposals)
+}


### PR DESCRIPTION
Relates to blinklabs-io/dingo#2947

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds local state query support for stake address info by adding the Shelley StakeDelegDeposits query and fixing CBOR shapes. This enables `cardano-cli query stake-address-info` decoding and prevents node-to-client disconnects.

- **New Features**
  - Implemented `ShelleyStakeDelegDepositsQuery` (type 22) and registered it in `shelleyQueryTypes`.
  - Added `Client.GetStakeDelegDeposits(creds []StakeCredential)` in `protocol/localstatequery`.

- **Bug Fixes**
  - Added CBOR decoders that unwrap Shelley-era single-element arrays for `StakeDelegDepositsResult`, `FilteredVoteDelegateesResult`, and `ProposalsResult`.
  - Fixed `ShelleyGetProposalsQuery` wire shape to `StructAsArray` with a `cbor.SetType[lcommon.GovActionId]` filter; `Client.GetProposals` now sends the empty filter by default.
  - Implemented `Drep.MarshalCBOR` to correctly encode key-hash, script-hash, abstain, and no-confidence variants.

<sup>Written for commit 70bd56e0dc4df4261689e37d498da41ba03f43c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

