### PR TITLE
docs: update bot files for SetCbor(nil) cache invalidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ Rules:
 - Map key order uses Cardano rules (e.g. shortLex for language views).
 - Indefinite vs definite length matters for some encodings.
 - `EncMode`/`DecMode` are globally cached via `sync.Once`; don't construct per call.
+- `MarshalCBOR()` on a `DecodeStoreCbor`-embedding type returns the stored bytes verbatim whenever `Cbor()` is non-nil, even after you mutate the struct's fields. Call `SetCbor(nil)` before marshaling to force a real re-encode of the mutated fields.
 
 ## ScriptDataHash
 
@@ -202,6 +203,7 @@ Error files: `ledger/{shelley,allegra,alonzo,babbage,conway,common}/errors.go`.
 7. `DecodeStoreCbor` requires a custom `UnmarshalCBOR` calling `SetCbor()`.
 8. Withdrawal amount validation is intentionally disabled (see `NOTE:` at `conway/rules.go` `UtxoValidateWithdrawals`). Spec requires `amount == balance`, not `amount > 0`; zero-amount withdrawals from zero-balance accounts are spec-valid. Multi-tx balance tracking is deferred.
 9. Read code before claiming "just delegates" or "missing check". `NOTE:` comments mark deliberate decisions.
+10. Mutating a decoded `DecodeStoreCbor`-embedding struct and re-marshaling does not pick up the change — `MarshalCBOR()` returns the stored bytes as-is. Call `SetCbor(nil)` first.
 
 ## Reviewer guardrails
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ grep -cE "^    --- FAIL: TestRulesConformanceVectors/" /tmp/conformance.txt
 7. `NOTE:` comments mark load-bearing intentional decisions. Don't "clean them up".
 8. `NewTransactionBuilder()` returns `*MockTransaction`; use the concrete type for `WithWithdrawals`, `WithCollateral`, `WithReferenceInputs`, etc. The `TransactionBuilder` interface doesn't expose them.
 9. All mock fixtures live in `github.com/blinklabs-io/ouroboros-mock`. Never inline local mocks. Missing fixture → add it upstream, bump the dep.
+10. Types embedding `DecodeStoreCbor` short-circuit `MarshalCBOR()` to the stored bytes whenever `Cbor()` is non-nil. Mutating a decoded struct's fields and re-marshaling silently re-emits the pre-mutation bytes — call `SetCbor(nil)` first to force a real re-encode.
 
 ## Performance
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified CBOR cache invalidation for types embedding `DecodeStoreCbor`. Added docs noting that `MarshalCBOR()` emits stored bytes when `Cbor()` is non-nil and that you must call `SetCbor(nil)` before marshaling after mutating fields (updates in AGENTS.md and CLAUDE.md).

<sup>Written for commit 5bf9e74d2868b2d92fd7346db2c63f2c85d3dfda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

