### PR TITLE
fix(protocol): chainsync reject unkown era

### DIFF
--- a/protocol/chainsync/client.go
+++ b/protocol/chainsync/client.go
@@ -796,7 +796,6 @@ func (c *Client) handleRollForward(msgGeneric protocol.Message) error {
 	var callbackErr error
 	if c.Mode() == protocol.ProtocolModeNodeToNode {
 		msg := msgGeneric.(*MsgRollForwardNtN)
-		c.sendCurrentTip(msg.Tip)
 
 		var blockHeader ledger.BlockHeader
 		var blockHeaderBytes []byte
@@ -809,9 +808,17 @@ func (c *Client) handleRollForward(msgGeneric protocol.Message) error {
 			blockHeaderBytes = msg.WrappedHeader.HeaderCbor()
 		default:
 			// Map block header type to block type
-			blockType = ledger.BlockHeaderToBlockTypeMap[blockEra]
+			var ok bool
+			blockType, ok = ledger.BlockHeaderToBlockTypeMap[blockEra]
+			if !ok {
+				return fmt.Errorf(
+					"unknown block header era: %d",
+					blockEra,
+				)
+			}
 			blockHeaderBytes = msg.WrappedHeader.HeaderCbor()
 		}
+		c.sendCurrentTip(msg.Tip)
 		if firstBlockChan != nil || c.config.RollForwardFunc != nil {
 			// Decode header
 			var err error

--- a/protocol/chainsync/security_test.go
+++ b/protocol/chainsync/security_test.go
@@ -15,10 +15,13 @@
 package chainsync
 
 import (
+	"net"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/protocol"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/require"
 )
@@ -73,4 +76,71 @@ func TestWrappedHeaderUnmarshalRejectsNonByteByronTagContent(t *testing.T) {
 	err = wrapped.UnmarshalCBOR(data)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "wrapped byron header tag content must be []byte")
+}
+
+func TestHandleRollForwardNtNRejectsUnknownHeaderEra(t *testing.T) {
+	callbackCalled := false
+	client := NewClient(
+		protocol.ProtocolOptions{
+			ConnectionId: testConnectionId(),
+			Mode:         protocol.ProtocolModeNodeToNode,
+		},
+		&Config{
+			RollForwardFunc: func(
+				CallbackContext,
+				uint,
+				any,
+				Tip,
+			) error {
+				callbackCalled = true
+				return nil
+			},
+		},
+	)
+	const unknownEra = uint(999)
+	msg := &MsgRollForwardNtN{
+		WrappedHeader: WrappedHeader{Era: unknownEra},
+	}
+
+	err := client.handleRollForward(msg)
+
+	require.EqualError(t, err, "unknown block header era: 999")
+	require.False(t, callbackCalled)
+}
+
+func TestHandleRollForwardNtNUnknownEraSkipsRawCallback(t *testing.T) {
+	callbackCalled := false
+	client := NewClient(
+		protocol.ProtocolOptions{
+			ConnectionId: testConnectionId(),
+			Mode:         protocol.ProtocolModeNodeToNode,
+		},
+		&Config{
+			RollForwardRawFunc: func(
+				CallbackContext,
+				uint,
+				[]byte,
+				Tip,
+			) error {
+				callbackCalled = true
+				return nil
+			},
+		},
+	)
+	const unknownEra = uint(999)
+	msg := &MsgRollForwardNtN{
+		WrappedHeader: WrappedHeader{Era: unknownEra},
+	}
+
+	err := client.handleRollForward(msg)
+
+	require.EqualError(t, err, "unknown block header era: 999")
+	require.False(t, callbackCalled)
+}
+
+func testConnectionId() connection.ConnectionId {
+	return connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{},
+		RemoteAddr: &net.TCPAddr{},
+	}
 }

--- a/protocol/chainsync/server.go
+++ b/protocol/chainsync/server.go
@@ -160,7 +160,10 @@ func (s *Server) RollForward(blockType uint, blockData []byte, tip Tip) error {
 		s.callbackContext.ConnectionId.String(),
 	)
 	if p.Mode() == protocol.ProtocolModeNodeToNode {
-		eraId := ledger.BlockToBlockHeaderTypeMap[blockType]
+		eraId, ok := ledger.BlockToBlockHeaderTypeMap[blockType]
+		if !ok {
+			return fmt.Errorf("unknown block type: %d", blockType)
+		}
 		msg, err := NewMsgRollForwardNtN(
 			eraId,
 			0,

--- a/protocol/chainsync/server_test.go
+++ b/protocol/chainsync/server_test.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/protocol"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -92,4 +93,18 @@ func TestLogRollForwardDoesNotLogBlockData(t *testing.T) {
 		"deadbeef",
 		"serialized block data should not be logged",
 	)
+}
+
+func TestRollForwardNtNRejectsUnknownBlockType(t *testing.T) {
+	server := NewServer(
+		protocol.ProtocolOptions{
+			ConnectionId: testConnectionId(),
+			Mode:         protocol.ProtocolModeNodeToNode,
+		},
+		nil,
+	)
+
+	err := server.RollForward(999, nil, Tip{})
+
+	require.EqualError(t, err, "unknown block type: 999")
 }


### PR DESCRIPTION
Closes #1864 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject unknown block header eras and block types in `protocol/chainsync` to prevent invalid data from being processed and to avoid triggering callbacks on bad input.

- **Bug Fixes**
  - Client: validate `WrappedHeader.Era` via `ledger.BlockHeaderToBlockTypeMap`; return `unknown block header era: <id>` and skip callbacks on failure.
  - Server: validate block type via `ledger.BlockToBlockHeaderTypeMap`; return `unknown block type: <id>` on failure.
  - Tests: add coverage to ensure errors are returned and no callbacks run on unknown eras/types.

<sup>Written for commit 33d4cb69f12849792a1a5041b4c499d55151a51e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

