### PR TITLE
fix(consensus): mode threshold

### DIFF
--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -164,10 +164,25 @@ func IsSlotLeaderWithMode(
 	}
 
 	// Step 3: Compute threshold (mode-aware)
-	threshold := CertifiedNatThresholdWithMode(poolStake, totalStake, activeSlotCoeff, mode)
+	threshold, err := CertifiedNatThresholdWithMode(
+		poolStake,
+		totalStake,
+		activeSlotCoeff,
+		mode,
+	)
+	if err != nil {
+		return nil, err
+	}
 
 	// Step 4: Check eligibility (mode-aware)
-	eligible := IsVRFOutputBelowThresholdWithMode(output, threshold, mode)
+	eligible, err := IsVRFOutputBelowThresholdWithMode(
+		output,
+		threshold,
+		mode,
+	)
+	if err != nil {
+		return nil, err
+	}
 
 	return &LeaderElectionResult{
 		Eligible:  eligible,
@@ -193,7 +208,14 @@ func IsSlotLeaderFromComponents(
 	totalStake uint64,
 	activeSlotCoeff *big.Rat,
 ) bool {
-	return IsSlotLeaderFromComponentsWithMode(vrfOutput, poolStake, totalStake, activeSlotCoeff, ConsensusModeCPraos)
+	eligible, _ := IsSlotLeaderFromComponentsWithMode(
+		vrfOutput,
+		poolStake,
+		totalStake,
+		activeSlotCoeff,
+		ConsensusModeCPraos,
+	)
+	return eligible
 }
 
 // IsSlotLeaderFromComponentsWithMode performs leader election check from pre-computed
@@ -206,22 +228,37 @@ func IsSlotLeaderFromComponents(
 //   - activeSlotCoeff: the active slot coefficient (f)
 //   - mode: the consensus mode (CPRAOS or TPraos)
 //
-// Returns true if the pool is eligible to be the slot leader.
+// Returns true if the pool is eligible to be the slot leader, or an error if
+// the consensus mode is unknown.
 func IsSlotLeaderFromComponentsWithMode(
 	vrfOutput []byte,
 	poolStake uint64,
 	totalStake uint64,
 	activeSlotCoeff *big.Rat,
 	mode ConsensusMode,
-) bool {
-	if activeSlotCoeff == nil || totalStake == 0 || poolStake == 0 {
-		return false
-	}
-	if len(vrfOutput) != 64 {
-		return false
+) (bool, error) {
+	switch mode {
+	case ConsensusModeCPraos, ConsensusModeTPraos:
+	default:
+		return false, fmt.Errorf("unknown consensus mode: %d", mode)
 	}
 
-	threshold := CertifiedNatThresholdWithMode(poolStake, totalStake, activeSlotCoeff, mode)
+	if activeSlotCoeff == nil || totalStake == 0 || poolStake == 0 {
+		return false, nil
+	}
+	if len(vrfOutput) != 64 {
+		return false, nil
+	}
+
+	threshold, err := CertifiedNatThresholdWithMode(
+		poolStake,
+		totalStake,
+		activeSlotCoeff,
+		mode,
+	)
+	if err != nil {
+		return false, err
+	}
 	return IsVRFOutputBelowThresholdWithMode(vrfOutput, threshold, mode)
 }
 

--- a/consensus/threshold.go
+++ b/consensus/threshold.go
@@ -15,6 +15,7 @@
 package consensus
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/blinklabs-io/gouroboros/ledger/common"
@@ -79,7 +80,13 @@ func CertifiedNatThreshold(
 	totalStake uint64,
 	activeSlotCoeff *big.Rat,
 ) *big.Int {
-	return CertifiedNatThresholdWithMode(poolStake, totalStake, activeSlotCoeff, ConsensusModeCPraos)
+	threshold, _ := CertifiedNatThresholdWithMode(
+		poolStake,
+		totalStake,
+		activeSlotCoeff,
+		ConsensusModeCPraos,
+	)
+	return threshold
 }
 
 // CertifiedNatThresholdWithMode computes the leadership threshold for a pool
@@ -92,20 +99,32 @@ func CertifiedNatThreshold(
 // For TPraos (Shelley-Alonzo):
 //
 //	T = 2^512 * (1 - (1-f)^σ)
+//
+// Returns an error if the consensus mode is unknown.
 func CertifiedNatThresholdWithMode(
 	poolStake uint64,
 	totalStake uint64,
 	activeSlotCoeff *big.Rat,
 	mode ConsensusMode,
-) *big.Int {
+) (*big.Int, error) {
+	var upperBound *big.Int
+	switch mode {
+	case ConsensusModeCPraos:
+		upperBound = twoTo256
+	case ConsensusModeTPraos:
+		upperBound = twoTo512
+	default:
+		return nil, fmt.Errorf("unknown consensus mode: %d", mode)
+	}
+
 	if activeSlotCoeff == nil {
-		return big.NewInt(0)
+		return big.NewInt(0), nil
 	}
 	if totalStake == 0 {
-		return big.NewInt(0)
+		return big.NewInt(0), nil
 	}
 	if poolStake == 0 {
-		return big.NewInt(0)
+		return big.NewInt(0), nil
 	}
 	if poolStake > totalStake {
 		poolStake = totalStake
@@ -136,14 +155,6 @@ func CertifiedNatThresholdWithMode(
 		oneMinusFPowerSigma,
 	)
 
-	// Select the appropriate upper bound based on consensus mode
-	var upperBound *big.Int
-	if mode == ConsensusModeTPraos {
-		upperBound = twoTo512
-	} else {
-		upperBound = twoTo256
-	}
-
 	// threshold = floor(probability * upperBound)
 	upperBoundFloat := new(big.Float).SetPrec(prec).SetInt(upperBound)
 	thresholdFloat := new(big.Float).SetPrec(prec).Mul(
@@ -152,7 +163,7 @@ func CertifiedNatThresholdWithMode(
 	)
 	threshold, _ := thresholdFloat.Int(nil)
 
-	return threshold
+	return threshold, nil
 }
 
 // lnOneMinusFloat computes ln(1-x) for 0 < x < 1 using Taylor series:
@@ -248,7 +259,12 @@ func VRFOutputToInt(output []byte) *big.Int {
 // It first computes the CPRAOS leader value (BLAKE2b-256 hash with "L" prefix)
 // then compares against the threshold.
 func IsVRFOutputBelowThreshold(vrfOutput []byte, threshold *big.Int) bool {
-	return IsVRFOutputBelowThresholdWithMode(vrfOutput, threshold, ConsensusModeCPraos)
+	below, _ := IsVRFOutputBelowThresholdWithMode(
+		vrfOutput,
+		threshold,
+		ConsensusModeCPraos,
+	)
+	return below
 }
 
 // IsVRFOutputBelowThresholdWithMode checks if a VRF output is below the leadership
@@ -261,25 +277,33 @@ func IsVRFOutputBelowThreshold(vrfOutput []byte, threshold *big.Int) bool {
 // For TPraos (Shelley-Alonzo):
 //   - Uses raw 64-byte VRF output directly
 //   - Compares against threshold (based on 2^512)
-//
-// Unknown consensus modes are treated as CPRAOS (the current default).
-func IsVRFOutputBelowThresholdWithMode(vrfOutput []byte, threshold *big.Int, mode ConsensusMode) bool {
+func IsVRFOutputBelowThresholdWithMode(
+	vrfOutput []byte,
+	threshold *big.Int,
+	mode ConsensusMode,
+) (bool, error) {
+	var useRawOutput bool
+	switch mode {
+	case ConsensusModeCPraos:
+	case ConsensusModeTPraos:
+		useRawOutput = true
+	default:
+		return false, fmt.Errorf("unknown consensus mode: %d", mode)
+	}
+
 	if threshold == nil {
-		return false
+		return false, nil
 	}
 	if len(vrfOutput) == 0 {
-		return false
+		return false, nil
 	}
 
 	var leaderValue []byte
-	if mode == ConsensusModeTPraos {
-		// TPraos: use raw VRF output directly
+	if useRawOutput {
 		leaderValue = vrfOutput
 	} else {
-		// CPRAOS (default): hash with "L" prefix
 		leaderValue = VrfLeaderValue(vrfOutput)
 	}
-
 	vrfInt := VRFOutputToInt(leaderValue)
-	return vrfInt.Cmp(threshold) < 0
+	return vrfInt.Cmp(threshold) < 0, nil
 }

--- a/consensus/threshold_test.go
+++ b/consensus/threshold_test.go
@@ -195,6 +195,37 @@ func TestIsVRFOutputBelowThreshold(t *testing.T) {
 	}
 }
 
+func TestThresholdHelpersRejectUnknownConsensusMode(t *testing.T) {
+	const unknownMode = ConsensusMode(99)
+
+	threshold, err := CertifiedNatThresholdWithMode(
+		1,
+		1,
+		big.NewRat(1, 20),
+		unknownMode,
+	)
+	require.EqualError(t, err, "unknown consensus mode: 99")
+	require.Nil(t, threshold)
+
+	below, err := IsVRFOutputBelowThresholdWithMode(
+		make([]byte, 64),
+		big.NewInt(1),
+		unknownMode,
+	)
+	require.EqualError(t, err, "unknown consensus mode: 99")
+	require.False(t, below)
+
+	eligible, err := IsSlotLeaderFromComponentsWithMode(
+		make([]byte, 64),
+		1,
+		1,
+		big.NewRat(1, 20),
+		unknownMode,
+	)
+	require.EqualError(t, err, "unknown consensus mode: 99")
+	require.False(t, eligible)
+}
+
 func TestDifferentActiveSlotCoefficients(t *testing.T) {
 	totalStake := uint64(1000000000)
 	poolStake := uint64(500000000) // 50%

--- a/internal/bench/consensus_bench_test.go
+++ b/internal/bench/consensus_bench_test.go
@@ -119,7 +119,7 @@ func BenchmarkConsensusThresholdWithMode(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				consensusSink = consensus.CertifiedNatThresholdWithMode(
+				consensusSink, _ = consensus.CertifiedNatThresholdWithMode(
 					poolStake,
 					totalStake,
 					activeSlotCoeff,


### PR DESCRIPTION
Closes #1865 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mode-specific leader threshold and eligibility checks: correct upper bounds are used per mode, and unknown modes now return errors instead of silently defaulting to CPraos. This prevents incorrect leader elections and aligns behavior with CPraos/TPraos specs.

- **Bug Fixes**
  - CertifiedNatThresholdWithMode now returns (value, error), validates inputs, selects 2^256 (CPraos) or 2^512 (TPraos), and errors on unknown modes.
  - IsVRFOutputBelowThresholdWithMode and IsSlotLeaderFromComponentsWithMode now return (bool, error) and error on unknown modes; CPraos-only wrappers keep existing signatures.
  - Tests added to assert unknown-mode errors; benchmark updated for new signature.

<sup>Written for commit 1221caf9560ea3dfec6b9711b27b14062810c851. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consensus leader-election handling across supported modes.
  * Invalid consensus modes now return clear errors instead of producing uncertain results.
  * Invalid stake, coefficient, and VRF inputs are handled safely without falsely selecting a leader.

* **Tests**
  * Added coverage confirming unknown consensus modes are rejected consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->