### PR TITLE
feat(byron): validate block body proofs at decode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -432,6 +432,22 @@ stake distribution, active slot coefficient, max KES evolutions, or operational
 certificate sequence state. Production chain validation must combine these
 checks with chain-context consensus validation before accepting a block.
 
+Binding the body to the header happens at decode, inside `NewBlockFromCbor`,
+not in `VerifyBlock()`. Every era does this by default and skips it only when
+the caller passes `common.VerifyConfig{SkipBodyHashValidation: true}`. Without
+it a header — and so the block hash and slot — can be genuine while the body
+has been replaced, so a caller accepting blocks from a source it does not
+trust must leave it enabled.
+
+Shelley and later compare a single body hash. Byron instead carries a body
+proof, `[tx_proof, ssc_proof, dlg_proof, upd_proof]`, where `tx_proof` is
+`[tx_count, merkle_root, witnesses_hash]`. `ledger/byron` recomputes the
+transaction count, the merkle root over transaction bodies, the hash over the
+witness list, and the delegation and update payload hashes; epoch boundary
+blocks carry no transactions and are covered by a single body hash. Byron
+merkle roots (`byron.MerkleRoot`) tag leaves and branches distinctly and split
+at the largest power of two below the item count, matching cardano-ledger.
+
 ## Block Pipeline (pipeline/)
 
 The `pipeline` package provides a staged block processing pipeline with worker pools:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -444,7 +444,10 @@ proof, `[tx_proof, ssc_proof, dlg_proof, upd_proof]`, where `tx_proof` is
 `[tx_count, merkle_root, witnesses_hash]`. `ledger/byron` recomputes the
 transaction count, the merkle root over transaction bodies, the hash over the
 witness list, and the delegation and update payload hashes; epoch boundary
-blocks carry no transactions and are covered by a single body hash. Byron
+blocks carry no transactions and are covered by a single body hash. `ssc_proof`
+is not recomputed — see the `NOTE:` in `ledger/byron/bodyproof.go` — so an
+alteration confined to the shared-seed payload is not detected, while
+transaction contents are fully covered. Byron
 merkle roots (`byron.MerkleRoot`) tag leaves and branches distinctly and split
 at the largest power of two below the item count, matching cardano-ledger.
 

--- a/ledger/byron/bodyproof.go
+++ b/ledger/byron/bodyproof.go
@@ -1,0 +1,224 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package byron
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// ErrBodyProofMismatch reports a Byron block whose body does not match the
+// proof carried in its header. The header, and therefore the block hash, can
+// be genuine while the body has been substituted, so this is the only check
+// that binds the two together.
+var ErrBodyProofMismatch = errors.New("byron block body proof mismatch")
+
+// Indices into the Byron header's body proof, which is
+// [tx_proof, ssc_proof, dlg_proof, upd_proof].
+const (
+	bodyProofTxIndex  = 0
+	bodyProofDlgIndex = 2
+	bodyProofUpdIndex = 3
+	bodyProofLength   = 4
+)
+
+// Indices into the Byron tx proof, which is
+// [tx_count, tx_merkle_root, witnesses_hash].
+const (
+	txProofCountIndex     = 0
+	txProofMerkleIndex    = 1
+	txProofWitnessesIndex = 2
+	txProofLength         = 3
+)
+
+// ValidateBodyProof recomputes the transaction, delegation, and update proofs
+// from the block body and checks them against the header.
+//
+// The transaction proof is the load-bearing one: it covers the count, a
+// merkle root over transaction bodies, and a hash over the witness list, so
+// altering, adding, or removing any transaction changes it.
+func (b *ByronMainBlock) ValidateBodyProof() error {
+	proof, ok := b.BlockHeader.BodyProof.([]any)
+	if !ok || len(proof) < bodyProofLength {
+		return fmt.Errorf(
+			"%w: header body proof is not a %d-element array",
+			ErrBodyProofMismatch, bodyProofLength,
+		)
+	}
+	if err := b.validateTxProof(proof[bodyProofTxIndex]); err != nil {
+		return err
+	}
+	if err := checkPayloadHash(
+		"delegation", proof[bodyProofDlgIndex], b.Body.DlgPayloadCbor(),
+	); err != nil {
+		return err
+	}
+	return checkPayloadHash(
+		"update", proof[bodyProofUpdIndex], b.Body.UpdPayloadCbor(),
+	)
+}
+
+func (b *ByronMainBlock) validateTxProof(rawProof any) error {
+	txProof, ok := rawProof.([]any)
+	if !ok || len(txProof) < txProofLength {
+		return fmt.Errorf(
+			"%w: tx proof is not a %d-element array",
+			ErrBodyProofMismatch, txProofLength,
+		)
+	}
+
+	expectedCount, err := asUint(txProof[txProofCountIndex])
+	if err != nil {
+		return fmt.Errorf("%w: tx count: %w", ErrBodyProofMismatch, err)
+	}
+	actualCount := uint64(len(b.Body.TxPayload))
+	if expectedCount != actualCount {
+		return fmt.Errorf(
+			"%w: header declares %d transactions, body carries %d",
+			ErrBodyProofMismatch, expectedCount, actualCount,
+		)
+	}
+
+	// Merkle leaves are the transaction bodies; witnesses are covered
+	// separately by a hash over the encoded witness list.
+	bodies := make([][]byte, 0, len(b.Body.TxPayload))
+	witnesses := make([][]byte, 0, len(b.Body.TxPayload))
+	for i, tx := range b.Body.TxPayload {
+		body := tx.Body.Cbor()
+		if len(body) == 0 {
+			return fmt.Errorf(
+				"%w: transaction %d has no preserved body CBOR",
+				ErrBodyProofMismatch, i,
+			)
+		}
+		bodies = append(bodies, body)
+		witnesses = append(witnesses, tx.WitnessesCbor())
+	}
+
+	if err := checkHash(
+		"tx merkle root", txProof[txProofMerkleIndex], MerkleRoot(bodies),
+	); err != nil {
+		return err
+	}
+
+	return checkHash(
+		"witnesses hash",
+		txProof[txProofWitnessesIndex],
+		common.Blake2b256Hash(encodeWitnessList(witnesses)),
+	)
+}
+
+// encodeWitnessList frames the preserved per-transaction witness CBOR as the
+// indefinite-length array Byron hashes.
+//
+// The array is assembled by hand rather than through the encoder because the
+// element bytes must survive untouched, and because the length must stay
+// indefinite: a definite-length array over the same elements hashes
+// differently and would reject every real block.
+func encodeWitnessList(witnesses [][]byte) []byte {
+	const (
+		indefiniteArrayStart byte = 0x9f
+		indefiniteBreak      byte = 0xff
+	)
+	size := 2
+	for _, w := range witnesses {
+		size += len(w)
+	}
+	encoded := make([]byte, 0, size)
+	encoded = append(encoded, indefiniteArrayStart)
+	for _, w := range witnesses {
+		encoded = append(encoded, w...)
+	}
+	return append(encoded, indefiniteBreak)
+}
+
+// ValidateBodyProof checks an epoch boundary block against the hash carried in
+// its header. EBBs have no transactions, so the whole body is covered by a
+// single hash.
+func (b *ByronEpochBoundaryBlock) ValidateBodyProof() error {
+	bodyCbor := b.BodyCbor()
+	if len(bodyCbor) == 0 {
+		return fmt.Errorf(
+			"%w: epoch boundary block has no preserved body CBOR",
+			ErrBodyProofMismatch,
+		)
+	}
+	return checkHash(
+		"body hash",
+		b.BlockHeader.BodyProof,
+		common.Blake2b256Hash(bodyCbor),
+	)
+}
+
+// checkPayloadHash compares a proof entry against the hash of the payload's
+// original CBOR.
+func checkPayloadHash(label string, expected any, payload []byte) error {
+	if len(payload) == 0 {
+		return fmt.Errorf(
+			"%w: %s payload has no preserved CBOR",
+			ErrBodyProofMismatch, label,
+		)
+	}
+	return checkHash(label, expected, common.Blake2b256Hash(payload))
+}
+
+// checkHash compares a proof entry, which decodes as raw bytes, against a
+// locally computed hash.
+func checkHash(
+	label string,
+	expected any,
+	actual common.Blake2b256,
+) error {
+	expectedBytes, ok := expected.([]byte)
+	if !ok || len(expectedBytes) != common.Blake2b256Size {
+		return fmt.Errorf(
+			"%w: %s in header is not a %d-byte hash",
+			ErrBodyProofMismatch, label, common.Blake2b256Size,
+		)
+	}
+	if !bytes.Equal(expectedBytes, actual[:]) {
+		return fmt.Errorf(
+			"%w: %s is %x, computed %x",
+			ErrBodyProofMismatch, label, expectedBytes, actual[:],
+		)
+	}
+	return nil
+}
+
+// asUint normalises the integer types the CBOR decoder may produce for a
+// count field.
+func asUint(v any) (uint64, error) {
+	switch n := v.(type) {
+	case uint64:
+		return n, nil
+	case uint:
+		return uint64(n), nil
+	case int64:
+		if n < 0 {
+			return 0, fmt.Errorf("negative count %d", n)
+		}
+		return uint64(n), nil
+	case int:
+		if n < 0 {
+			return 0, fmt.Errorf("negative count %d", n)
+		}
+		return uint64(n), nil
+	default:
+		return 0, fmt.Errorf("unexpected type %T", v)
+	}
+}

--- a/ledger/byron/bodyproof.go
+++ b/ledger/byron/bodyproof.go
@@ -63,6 +63,18 @@ func (b *ByronMainBlock) ValidateBodyProof() error {
 	if err := b.validateTxProof(proof[bodyProofTxIndex]); err != nil {
 		return err
 	}
+	// NOTE: ssc_proof (index 1) is deliberately not checked. Its hashes are
+	// taken over cardano-ledger's own encoding of the SSC sub-payloads, which
+	// is not the encoding carried inline in the block: for the mainnet block
+	// in internal/testdata the payload part hashes to 25777aca... while the
+	// header records d36a2619..., so the two are not the same bytes. Modelling
+	// SscPayload well enough to reproduce it is a separate piece of work, and
+	// guessing the encoding from the one available fixture -- whose SSC
+	// payload is empty -- would give false assurance for the non-empty case.
+	//
+	// The consequence is that an alteration confined to the SSC payload is not
+	// detected here. SSC carries shared-seed material, not transactions, so
+	// transaction contents remain fully covered by the tx proof above.
 	if err := checkPayloadHash(
 		"delegation", proof[bodyProofDlgIndex], b.Body.DlgPayloadCbor(),
 	); err != nil {
@@ -107,7 +119,14 @@ func (b *ByronMainBlock) validateTxProof(rawProof any) error {
 			)
 		}
 		bodies = append(bodies, body)
-		witnesses = append(witnesses, tx.WitnessesCbor())
+		witness := tx.WitnessesCbor()
+		if len(witness) == 0 {
+			return fmt.Errorf(
+				"%w: transaction %d has no preserved witness CBOR",
+				ErrBodyProofMismatch, i,
+			)
+		}
+		witnesses = append(witnesses, witness)
 	}
 
 	if err := checkHash(

--- a/ledger/byron/bodyproof_test.go
+++ b/ledger/byron/bodyproof_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package byron_test
+
+import (
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/internal/testdata"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mainnetByronBlock returns the CBOR of the bundled mainnet Byron main block,
+// which carries two transactions and therefore exercises merkle branch
+// combination rather than only the single-leaf case.
+func mainnetByronBlock(t *testing.T) []byte {
+	t.Helper()
+	raw, err := hex.DecodeString(strings.TrimSpace(testdata.ByronBlockHex))
+	require.NoError(t, err)
+	return raw
+}
+
+// withTxPayload re-encodes a Byron main block with its transaction payload
+// replaced, preserving every other component byte-for-byte. This models a
+// hostile archive returning a genuine header with a substituted body.
+func withTxPayload(t *testing.T, blockCbor []byte, txPayload []any) []byte {
+	t.Helper()
+	var block []cbor.RawMessage
+	_, err := cbor.Decode(blockCbor, &block)
+	require.NoError(t, err)
+	require.Len(t, block, 3, "byron main block is [header, body, extra]")
+
+	var body []cbor.RawMessage
+	_, err = cbor.Decode(block[1], &body)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(body), 4)
+
+	newTxPayload, err := cbor.Encode(txPayload)
+	require.NoError(t, err)
+	body[0] = newTxPayload
+
+	newBody, err := cbor.Encode(body)
+	require.NoError(t, err)
+	block[1] = newBody
+
+	tampered, err := cbor.Encode(block)
+	require.NoError(t, err)
+	return tampered
+}
+
+// TestByronMainBlockBodyProofValidates checks the real mainnet block against
+// its own body proof, so the recomputation is pinned to a block produced by
+// the reference implementation rather than to our own encoder.
+func TestByronMainBlockBodyProofValidates(t *testing.T) {
+	block, err := byron.NewByronMainBlockFromCbor(mainnetByronBlock(t))
+	require.NoError(t, err)
+	require.Len(t, block.Body.TxPayload, 2,
+		"fixture must carry two transactions to exercise a merkle branch")
+	require.NoError(t, block.ValidateBodyProof())
+}
+
+// TestByronMainBlockRejectsSubstitutedBody is the regression for a hostile
+// archive returning the requested header with a different body. Decoding must
+// fail rather than hand back a block whose contents were never checked.
+func TestByronMainBlockRejectsSubstitutedBody(t *testing.T) {
+	original := mainnetByronBlock(t)
+
+	tests := []struct {
+		name      string
+		txPayload []any
+	}{
+		{name: "transactions removed", txPayload: []any{}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tampered := withTxPayload(t, original, tc.txPayload)
+			require.NotEqual(t, len(original), len(tampered),
+				"tampering must actually change the encoding")
+
+			_, err := byron.NewByronMainBlockFromCbor(tampered)
+			require.Error(t, err,
+				"a substituted body must not decode successfully")
+			assert.ErrorIs(t, err, byron.ErrBodyProofMismatch)
+		})
+	}
+}
+
+// TestByronMainBlockSkipBodyHashValidation confirms the escape hatch used by
+// callers that already validated the bytes upstream, matching how the
+// Shelley-and-later constructors treat the same option.
+func TestByronMainBlockSkipBodyHashValidation(t *testing.T) {
+	tampered := withTxPayload(t, mainnetByronBlock(t), []any{})
+
+	_, err := byron.NewByronMainBlockFromCbor(
+		tampered,
+		common.VerifyConfig{SkipBodyHashValidation: true},
+	)
+	require.NoError(t, err,
+		"skipping validation must still decode a structurally valid block")
+}
+
+// TestByronEpochBoundaryBlockBodyProofValidates checks a real testnet EBB
+// against its own body hash. EBBs carry no transactions, so the whole body is
+// covered by a single hash rather than a merkle root.
+func TestByronEpochBoundaryBlockBodyProofValidates(t *testing.T) {
+	ebbPath := filepath.Join(
+		"..", "..", "protocol", "chainsync", "testdata",
+		"byron_ebb_testnet_8f8602837f7c6f8b8867dd1cbc1842cf51a27eaed2c70ef48325d00f8efb320f.hex",
+	)
+	hexData, err := os.ReadFile(ebbPath)
+	require.NoError(t, err)
+	raw, err := hex.DecodeString(strings.TrimSpace(string(hexData)))
+	require.NoError(t, err)
+
+	block, err := byron.NewByronEpochBoundaryBlockFromCbor(raw)
+	require.NoError(t, err)
+	require.NoError(t, block.ValidateBodyProof())
+}
+
+// TestByronEpochBoundaryBlockRejectsSubstitutedBody covers the same
+// substitution attack for epoch boundary blocks.
+func TestByronEpochBoundaryBlockRejectsSubstitutedBody(t *testing.T) {
+	ebbPath := filepath.Join(
+		"..", "..", "protocol", "chainsync", "testdata",
+		"byron_ebb_testnet_8f8602837f7c6f8b8867dd1cbc1842cf51a27eaed2c70ef48325d00f8efb320f.hex",
+	)
+	hexData, err := os.ReadFile(ebbPath)
+	require.NoError(t, err)
+	original, err := hex.DecodeString(strings.TrimSpace(string(hexData)))
+	require.NoError(t, err)
+
+	var block []cbor.RawMessage
+	_, err = cbor.Decode(original, &block)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(block), 2)
+
+	// Replace the stakeholder list with an empty one.
+	emptyBody, err := cbor.Encode([]any{})
+	require.NoError(t, err)
+	block[1] = emptyBody
+	tampered, err := cbor.Encode(block)
+	require.NoError(t, err)
+
+	_, err = byron.NewByronEpochBoundaryBlockFromCbor(tampered)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, byron.ErrBodyProofMismatch)
+}
+
+// TestByronMainBlockHeaderUnchangedByTampering documents why the body proof is
+// needed at all: the header, and therefore the block hash and slot, survive a
+// body substitution untouched.
+func TestByronMainBlockHeaderUnchangedByTampering(t *testing.T) {
+	original := mainnetByronBlock(t)
+	tampered := withTxPayload(t, original, []any{})
+
+	genuine, err := byron.NewByronMainBlockFromCbor(original)
+	require.NoError(t, err)
+	substituted, err := byron.NewByronMainBlockFromCbor(
+		tampered,
+		common.VerifyConfig{SkipBodyHashValidation: true},
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, genuine.Hash(), substituted.Hash(),
+		"block hash is derived from the header and cannot detect this")
+	assert.Equal(t, genuine.SlotNumber(), substituted.SlotNumber())
+	assert.NotEqual(t, len(genuine.Cbor()), len(substituted.Cbor()),
+		"the bytes genuinely differ")
+}

--- a/ledger/byron/byron.go
+++ b/ledger/byron/byron.go
@@ -1196,9 +1196,17 @@ type ByronEpochBoundaryBlock struct {
 	BlockHeader *ByronEpochBoundaryBlockHeader
 	Body        []common.Blake2b224
 	Extra       []any
+	bodyRaw     []byte // Original CBOR for body proof validation
 }
 
 func (b *ByronEpochBoundaryBlock) UnmarshalCBOR(cborData []byte) error {
+	// Decode as raw parts first so the body's original CBOR is preserved.
+	// The header's proof is a hash of exactly these bytes, and re-encoding
+	// is not guaranteed to reproduce them.
+	var rawParts []cbor.RawMessage
+	if _, err := cbor.Decode(cborData, &rawParts); err != nil {
+		return err
+	}
 	type tByronEpochBoundaryBlock ByronEpochBoundaryBlock
 	var tmp tByronEpochBoundaryBlock
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
@@ -1208,8 +1216,17 @@ func (b *ByronEpochBoundaryBlock) UnmarshalCBOR(cborData []byte) error {
 		return errors.New("byron EBB block missing header")
 	}
 	*b = ByronEpochBoundaryBlock(tmp)
+	if len(rawParts) >= 2 {
+		b.bodyRaw = []byte(rawParts[1])
+	}
 	b.SetCbor(cborData)
 	return nil
+}
+
+// BodyCbor returns the original CBOR bytes of the epoch boundary block body.
+// This is used for body proof validation.
+func (b *ByronEpochBoundaryBlock) BodyCbor() []byte {
+	return b.bodyRaw
 }
 
 func (ByronEpochBoundaryBlock) Type() int {
@@ -1265,9 +1282,22 @@ func (b *ByronEpochBoundaryBlock) BlockBodyHash() common.Blake2b256 {
 func NewByronEpochBoundaryBlockFromCbor(
 	data []byte, config ...common.VerifyConfig,
 ) (*ByronEpochBoundaryBlock, error) {
+	var cfg common.VerifyConfig
+	if len(config) > 0 {
+		cfg = config[0]
+	}
+	// Default: validation enabled (SkipBodyHashValidation = false)
+
 	var byronEbbBlock ByronEpochBoundaryBlock
 	if _, err := cbor.Decode(data, &byronEbbBlock); err != nil {
 		return nil, fmt.Errorf("decode Byron EBB block error: %w", err)
+	}
+	// Bind the body to the header. Without this the header, and so the
+	// block hash, can be genuine while the body has been substituted.
+	if !cfg.SkipBodyHashValidation {
+		if err := byronEbbBlock.ValidateBodyProof(); err != nil {
+			return nil, err
+		}
 	}
 	return &byronEbbBlock, nil
 }
@@ -1286,9 +1316,22 @@ func NewByronMainBlockFromCbor(
 	data []byte,
 	config ...common.VerifyConfig,
 ) (*ByronMainBlock, error) {
+	var cfg common.VerifyConfig
+	if len(config) > 0 {
+		cfg = config[0]
+	}
+	// Default: validation enabled (SkipBodyHashValidation = false)
+
 	var byronMainBlock ByronMainBlock
 	if _, err := cbor.Decode(data, &byronMainBlock); err != nil {
 		return nil, fmt.Errorf("decode Byron main block error: %w", err)
+	}
+	// Bind the body to the header. Without this the header, and so the
+	// block hash, can be genuine while the body has been substituted.
+	if !cfg.SkipBodyHashValidation {
+		if err := byronMainBlock.ValidateBodyProof(); err != nil {
+			return nil, err
+		}
 	}
 	return &byronMainBlock, nil
 }

--- a/ledger/byron/byron.go
+++ b/ledger/byron/byron.go
@@ -1196,17 +1196,9 @@ type ByronEpochBoundaryBlock struct {
 	BlockHeader *ByronEpochBoundaryBlockHeader
 	Body        []common.Blake2b224
 	Extra       []any
-	bodyRaw     []byte // Original CBOR for body proof validation
 }
 
 func (b *ByronEpochBoundaryBlock) UnmarshalCBOR(cborData []byte) error {
-	// Decode as raw parts first so the body's original CBOR is preserved.
-	// The header's proof is a hash of exactly these bytes, and re-encoding
-	// is not guaranteed to reproduce them.
-	var rawParts []cbor.RawMessage
-	if _, err := cbor.Decode(cborData, &rawParts); err != nil {
-		return err
-	}
 	type tByronEpochBoundaryBlock ByronEpochBoundaryBlock
 	var tmp tByronEpochBoundaryBlock
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
@@ -1216,17 +1208,23 @@ func (b *ByronEpochBoundaryBlock) UnmarshalCBOR(cborData []byte) error {
 		return errors.New("byron EBB block missing header")
 	}
 	*b = ByronEpochBoundaryBlock(tmp)
-	if len(rawParts) >= 2 {
-		b.bodyRaw = []byte(rawParts[1])
-	}
 	b.SetCbor(cborData)
 	return nil
 }
 
-// BodyCbor returns the original CBOR bytes of the epoch boundary block body.
-// This is used for body proof validation.
+// BodyCbor returns the original CBOR bytes of the epoch boundary block body,
+// sliced out of the block CBOR that DecodeStoreCbor already preserves. The
+// header's proof hashes exactly these bytes, so they are read back rather than
+// re-encoded.
 func (b *ByronEpochBoundaryBlock) BodyCbor() []byte {
-	return b.bodyRaw
+	var parts []cbor.RawMessage
+	if _, err := cbor.Decode(b.Cbor(), &parts); err != nil {
+		return nil
+	}
+	if len(parts) < 2 {
+		return nil
+	}
+	return []byte(parts[1])
 }
 
 func (ByronEpochBoundaryBlock) Type() int {

--- a/ledger/byron/merkle.go
+++ b/ledger/byron/merkle.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package byron
+
+import (
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// Byron merkle nodes are domain-separated by a leading tag byte so a leaf
+// hash can never be mistaken for a branch hash.
+const (
+	merkleLeafTag   byte = 0
+	merkleBranchTag byte = 1
+)
+
+// MerkleRoot computes the Byron merkle root over pre-encoded items, matching
+// cardano-ledger's `Cardano.Chain.Common.Merkle`.
+//
+// Items are the original CBOR bytes of each element, never a re-encoding: the
+// root has to match what the block producer hashed, and a round-trip through
+// our encoder is not guaranteed to reproduce those bytes.
+//
+// The empty tree hashes the empty byte string, and the tree is built by
+// splitting at the largest power of two below the item count, which makes it
+// left-heavy in the same way as the reference implementation.
+func MerkleRoot(items [][]byte) common.Blake2b256 {
+	if len(items) == 0 {
+		return common.Blake2b256Hash(nil)
+	}
+	return merkleNode(items)
+}
+
+func merkleNode(items [][]byte) common.Blake2b256 {
+	if len(items) == 1 {
+		return common.Blake2b256Hash(
+			append([]byte{merkleLeafTag}, items[0]...),
+		)
+	}
+	split := largestPowerOfTwoBelow(len(items))
+	left := merkleNode(items[:split])
+	right := merkleNode(items[split:])
+	combined := make([]byte, 0, 1+len(left)+len(right))
+	combined = append(combined, merkleBranchTag)
+	combined = append(combined, left[:]...)
+	combined = append(combined, right[:]...)
+	return common.Blake2b256Hash(combined)
+}
+
+// largestPowerOfTwoBelow returns the largest power of two strictly less than
+// n, which is where the reference implementation splits a node's items. n is
+// always at least 2 here, so the result is at least 1.
+func largestPowerOfTwoBelow(n int) int {
+	power := 1
+	for power*2 < n {
+		power *= 2
+	}
+	return power
+}

--- a/ledger/byron/merkle_test.go
+++ b/ledger/byron/merkle_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package byron_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+)
+
+// leaf and branch recompute the Byron merkle primitives directly from the
+// specification, so these tests check the tree shape independently rather
+// than by calling the implementation they are verifying.
+func leaf(item []byte) common.Blake2b256 {
+	return common.Blake2b256Hash(append([]byte{0}, item...))
+}
+
+func branch(l, r common.Blake2b256) common.Blake2b256 {
+	combined := []byte{1}
+	combined = append(combined, l[:]...)
+	combined = append(combined, r[:]...)
+	return common.Blake2b256Hash(combined)
+}
+
+// TestMerkleRootShape pins how items are combined. The split point is the
+// largest power of two below the item count, which makes odd trees left-heavy;
+// getting this wrong still produces a plausible-looking hash, so the structure
+// is asserted explicitly for each size.
+func TestMerkleRootShape(t *testing.T) {
+	a := []byte("a")
+	b := []byte("b")
+	c := []byte("c")
+	d := []byte("d")
+	e := []byte("e")
+
+	tests := []struct {
+		name  string
+		items [][]byte
+		want  common.Blake2b256
+	}{
+		{
+			name:  "empty hashes the empty string",
+			items: nil,
+			want:  common.Blake2b256Hash(nil),
+		},
+		{
+			name:  "single item is a bare leaf",
+			items: [][]byte{a},
+			want:  leaf(a),
+		},
+		{
+			name:  "two items split evenly",
+			items: [][]byte{a, b},
+			want:  branch(leaf(a), leaf(b)),
+		},
+		{
+			name:  "three items split at two",
+			items: [][]byte{a, b, c},
+			want:  branch(branch(leaf(a), leaf(b)), leaf(c)),
+		},
+		{
+			name:  "four items form a balanced tree",
+			items: [][]byte{a, b, c, d},
+			want:  branch(branch(leaf(a), leaf(b)), branch(leaf(c), leaf(d))),
+		},
+		{
+			name:  "five items split at four",
+			items: [][]byte{a, b, c, d, e},
+			want: branch(
+				branch(branch(leaf(a), leaf(b)), branch(leaf(c), leaf(d))),
+				leaf(e),
+			),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, byron.MerkleRoot(tc.items))
+		})
+	}
+}
+
+// TestMerkleRootOrderSensitive confirms the root depends on item order, which
+// is what stops transactions being reordered without detection.
+func TestMerkleRootOrderSensitive(t *testing.T) {
+	forward := byron.MerkleRoot([][]byte{[]byte("a"), []byte("b")})
+	reversed := byron.MerkleRoot([][]byte{[]byte("b"), []byte("a")})
+	assert.NotEqual(t, forward, reversed)
+}
+
+// TestMerkleRootLeafBranchDomainSeparation confirms a leaf can never collide
+// with a branch, which the differing tag bytes are there to guarantee.
+func TestMerkleRootLeafBranchDomainSeparation(t *testing.T) {
+	single := byron.MerkleRoot([][]byte{[]byte("x")})
+	// A one-item tree is a leaf; feeding the same bytes as a two-item tree
+	// must take the branch path and produce something different.
+	pair := byron.MerkleRoot([][]byte{[]byte("x"), []byte("x")})
+	assert.NotEqual(t, single, pair)
+}


### PR DESCRIPTION
## Problem

`NewByronMainBlockFromCbor` and `NewByronEpochBoundaryBlockFromCbor` accept a `common.VerifyConfig` and never read it — they decode and return. Shelley and later validate their body hash at decode; Byron validated nothing.

A Byron header, and therefore the block hash and slot, can be genuine while the body has been replaced. Callers accepting blocks from a source they do not control had no way to detect that.

Reproduced against the bundled mainnet Byron block: replacing the transaction payload with an empty one changes the encoding from 894 to 636 bytes while `Hash()` and `SlotNumber()` stay identical, and decoding succeeds. `TestByronMainBlockHeaderUnchangedByTampering` pins exactly this.

Found while hardening Bark archive block retrieval in dingo (blinklabs-io/dingo#2038, PR blinklabs-io/dingo#2990), where the archive chooses the response body and local verification has to establish block identity. Credit to @wolf31o2 for identifying the gap in review.

## Change

Recompute the header's body proof from the body:

- **Main blocks** — body proof is `[tx_proof, ssc_proof, dlg_proof, upd_proof]`, with `tx_proof = [tx_count, merkle_root, witnesses_hash]`. Validates the transaction count, the merkle root over transaction bodies, the hash over the witness list, and the delegation and update payload hashes.
- **Epoch boundary blocks** — no transactions, so a single hash covers the body. The EBB body now preserves its original CBOR, matching how the main block body already keeps `dlgPayloadRaw`/`updPayloadRaw`.

On by default, skipped via `SkipBodyHashValidation`, matching the other eras.

### Byron merkle roots

`byron.MerkleRoot` implements cardano-ledger's `Cardano.Chain.Common.Merkle`: leaves and branches carry distinct tag bytes (`0x00`/`0x01`), the empty tree hashes the empty string, and each node splits at the largest power of two below its item count — which makes odd trees left-heavy. Computed over preserved CBOR, never a re-encoding.

Two details that are easy to get wrong and are covered by tests:

- The **witness list is an indefinite-length array**. A definite-length array over identical elements hashes differently and would reject every real block.
- The **split point** produces a specific tree shape; a wrong one still yields a plausible-looking hash, so `TestMerkleRootShape` asserts the structure for 0–5 items by recomputing leaves and branches directly from the spec rather than by calling `MerkleRoot`.

## Tests

- `TestByronMainBlockBodyProofValidates` — the bundled mainnet block, which carries **two** transactions and so exercises merkle branch combination, not just the single-leaf case.
- `TestByronEpochBoundaryBlockBodyProofValidates` — a real testnet EBB.
- `TestByronMainBlockRejectsSubstitutedBody`, `TestByronEpochBoundaryBlockRejectsSubstitutedBody` — tamper regressions, asserting `ErrBodyProofMismatch`.
- `TestByronMainBlockSkipBodyHashValidation` — the escape hatch still decodes.
- `TestByronMainBlockHeaderUnchangedByTampering` — documents why the proof is needed: hash and slot survive a body substitution untouched.
- `TestMerkleRootShape`, `TestMerkleRootOrderSensitive`, `TestMerkleRootLeafBranchDomainSeparation`.

Validating against blocks produced by the reference implementation is what pins the recomputation — the real fixtures are the oracle, not our own encoder.

## Verification

- `make test` — 3544 passing, 0 failures
- `make lint` — 0 issues across all 9 targets
- `make format` — no changes to the added files
- Conformance suite passes, including the existing Byron EBB test that now decodes with validation enabled

## Note on the conformance table

`CLAUDE.md` asks that the conformance snapshot table be updated when counts change. I left it alone: my count of `^func Test` is 1500 against the table's recorded 3461, so the figures are derived by different methods and I would rather not overwrite the baseline with an incompatible number. Happy to update it if you tell me how that figure is produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate Byron block body proofs during decode to bind the body to the header and reject tampered bodies from untrusted sources. Enabled by default; set `common.VerifyConfig{SkipBodyHashValidation: true}` to bypass (same as Shelley+).

- New Features
  - `NewByronMainBlockFromCbor` and `NewByronEpochBoundaryBlockFromCbor` now recompute and validate header body proofs at decode.
  - Main blocks: verify tx count, Merkle root over tx bodies, witnesses hash, and `dlg`/`upd` payload hashes; EBBs: verify a single body hash with body CBOR derived from stored block bytes. Adds `byron.MerkleRoot` matching cardano-ledger (tagged leaves/branches; split at largest power of two) over preserved CBOR.

- Bug Fixes
  - Require preserved witness CBOR; missing witnesses now fail validation instead of hashing an empty list. Note: `ssc_proof` is not recomputed; changes limited to the SSC payload aren’t detected.

<sup>Written for commit 0d463350d991b362bcf4eaa24f00c59e93658f8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added verification of Byron block body proofs, including transaction, delegation, update, and epoch-boundary proofs.
  * Added Byron-specific Merkle root calculation.
  * Added an option to skip body-hash validation when decoding blocks.

* **Bug Fixes**
  * Byron blocks with substituted or tampered bodies are now rejected when validation is enabled.
  * Preserved body data for accurate epoch-boundary verification.

* **Documentation**
  * Clarified body validation behavior, proof formats, and security considerations when validation is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->