### PR TITLE
fix(ledger): reject unknown genesis network ids during CBOR marshal

### DIFF
--- a/ledger/shelley/genesis.go
+++ b/ledger/shelley/genesis.go
@@ -114,6 +114,11 @@ func (g ShelleyGenesis) MarshalCBOR() ([]byte, error) {
 		)
 	}
 
+	networkId, err := g.getNetworkId()
+	if err != nil {
+		return nil, err
+	}
+
 	slotLengthMs := &big.Rat{}
 	tmpData := []any{
 		[]any{
@@ -122,7 +127,7 @@ func (g ShelleyGenesis) MarshalCBOR() ([]byte, error) {
 			g.SystemStart.Nanosecond() * 1000,
 		},
 		g.NetworkMagic,
-		map[string]int{"Testnet": 0, "Mainnet": 1}[g.NetworkId],
+		networkId,
 		[]any{
 			g.ActiveSlotsCoeff.Num().Int64(),
 			g.ActiveSlotsCoeff.Denom().Int64(),

--- a/ledger/shelley/genesis_test.go
+++ b/ledger/shelley/genesis_test.go
@@ -23,6 +23,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
@@ -207,9 +210,7 @@ func TestGenesisMarshalCBORInvalidNetworkId(t *testing.T) {
 		NetworkId: "Regtest",
 	}
 	_, err := tmpGenesis.MarshalCBOR()
-	if err == nil {
-		t.Fatalf("expected error for invalid network ID, got nil")
-	}
+	require.Error(t, err)
 }
 
 // Confirms the getNetworkId() refactor preserves the original encoded
@@ -239,32 +240,16 @@ func TestGenesisMarshalCBORValidNetworkId(t *testing.T) {
 			},
 		}
 		cborData, err := tmpGenesis.MarshalCBOR()
-		if err != nil {
-			t.Fatalf(
-				"unexpected error marshaling %s genesis: %s",
-				testDef.networkId,
-				err,
-			)
-		}
+		require.NoError(t, err, "unexpected error marshaling %s genesis", testDef.networkId)
+
 		var decoded []any
-		if _, err := cbor.Decode(cborData, &decoded); err != nil {
-			t.Fatalf("unexpected error decoding CBOR: %s", err)
-		}
+		_, err = cbor.Decode(cborData, &decoded)
+		require.NoError(t, err, "unexpected error decoding CBOR")
+		require.Greater(t, len(decoded), 2, "decoded genesis has too few fields")
+
 		gotNetworkId, ok := decoded[2].(uint64)
-		if !ok {
-			t.Fatalf(
-				"expected network ID field to decode as uint64, got %T",
-				decoded[2],
-			)
-		}
-		if gotNetworkId != testDef.expectedNetworkIdCbor {
-			t.Fatalf(
-				"for %s, expected encoded network ID %d, got %d",
-				testDef.networkId,
-				testDef.expectedNetworkIdCbor,
-				gotNetworkId,
-			)
-		}
+		require.True(t, ok, "expected network ID field to decode as uint64, got %T", decoded[2])
+		assert.Equal(t, testDef.expectedNetworkIdCbor, gotNetworkId, "for %s", testDef.networkId)
 	}
 }
 

--- a/ledger/shelley/genesis_test.go
+++ b/ledger/shelley/genesis_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 )
@@ -208,6 +209,62 @@ func TestGenesisMarshalCBORInvalidNetworkId(t *testing.T) {
 	_, err := tmpGenesis.MarshalCBOR()
 	if err == nil {
 		t.Fatalf("expected error for invalid network ID, got nil")
+	}
+}
+
+// Confirms the getNetworkId() refactor preserves the original encoded
+// values (Testnet=0, Mainnet=1) for valid network ids.
+func TestGenesisMarshalCBORValidNetworkId(t *testing.T) {
+	testDefs := []struct {
+		networkId             string
+		expectedNetworkIdCbor uint64
+	}{
+		{networkId: "Testnet", expectedNetworkIdCbor: 0},
+		{networkId: "Mainnet", expectedNetworkIdCbor: 1},
+	}
+	for _, testDef := range testDefs {
+		tmpGenesis := shelley.ShelleyGenesis{
+			NetworkId: testDef.networkId,
+			ActiveSlotsCoeff: common.GenesisRat{
+				Rat: big.NewRat(5, 100),
+			},
+			SlotLength: common.GenesisRat{
+				Rat: big.NewRat(1, 1),
+			},
+			ProtocolParameters: shelley.ShelleyGenesisProtocolParams{
+				A0:               &common.GenesisRat{Rat: big.NewRat(3, 10)},
+				Rho:              &common.GenesisRat{Rat: big.NewRat(3, 1000)},
+				Tau:              &common.GenesisRat{Rat: big.NewRat(2, 10)},
+				Decentralization: &common.GenesisRat{Rat: big.NewRat(1, 1)},
+			},
+		}
+		cborData, err := tmpGenesis.MarshalCBOR()
+		if err != nil {
+			t.Fatalf(
+				"unexpected error marshaling %s genesis: %s",
+				testDef.networkId,
+				err,
+			)
+		}
+		var decoded []any
+		if _, err := cbor.Decode(cborData, &decoded); err != nil {
+			t.Fatalf("unexpected error decoding CBOR: %s", err)
+		}
+		gotNetworkId, ok := decoded[2].(uint64)
+		if !ok {
+			t.Fatalf(
+				"expected network ID field to decode as uint64, got %T",
+				decoded[2],
+			)
+		}
+		if gotNetworkId != testDef.expectedNetworkIdCbor {
+			t.Fatalf(
+				"for %s, expected encoded network ID %d, got %d",
+				testDef.networkId,
+				testDef.expectedNetworkIdCbor,
+				gotNetworkId,
+			)
+		}
 	}
 }
 

--- a/ledger/shelley/genesis_test.go
+++ b/ledger/shelley/genesis_test.go
@@ -199,6 +199,18 @@ func TestGenesisFromJson(t *testing.T) {
 	}
 }
 
+// Guards against a regression where an unrecognized NetworkId silently
+// encoded as testnet instead of returning an error.
+func TestGenesisMarshalCBORInvalidNetworkId(t *testing.T) {
+	tmpGenesis := shelley.ShelleyGenesis{
+		NetworkId: "Regtest",
+	}
+	_, err := tmpGenesis.MarshalCBOR()
+	if err == nil {
+		t.Fatalf("expected error for invalid network ID, got nil")
+	}
+}
+
 func TestGenesisUtxos(t *testing.T) {
 	testHexAddr := "000045183c1dcaeb0ca5cf583a68b9e31a6301bcbde487065bd35b955a98ba9d3061e1bd15749cc857e94b30583c120e3255adb93b44681bad"
 	testAmount := uint64(120_000_000_000_000)


### PR DESCRIPTION
1. Replaced the unchecked network ID lookup with the existing `getNetworkId()` validator, returning an error for unsupported values.
2. Added `TestGenesisMarshalCBORInvalidNetworkId` for verifying `MarshalCBOR` errors on a bogus network ID (e.g. `"Regtest"`).
3. Added `TestGenesisMarshalCBORValidNetworkId` to verify Testnet/Mainnet still encode to 0/1 after the `getNetworkId()` refactor.

Closes #1871 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject unknown Shelley genesis network IDs during CBOR marshal to prevent silently encoding to Testnet. Tests decode CBOR to confirm Testnet/Mainnet still encode to 0/1 and invalid IDs return errors.

- **Bug Fixes**
  - Use `getNetworkId()` for validation and error on unsupported values.
  - Add CBOR decoding tests with `github.com/blinklabs-io/gouroboros/cbor`; fix nilaway issues in test code.

<sup>Written for commit 59253c56c47c05ec3d5743fdd48baa9408c0753e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid network identifiers now produce an error instead of being silently encoded as a default value.
  * Valid testnet and mainnet identifiers are encoded consistently with their expected numeric values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->