### PR TITLE
feat(protocol): support node-to-client protocol version 21

### DIFF
--- a/protocol/localstatequery/client.go
+++ b/protocol/localstatequery/client.go
@@ -991,6 +991,46 @@ func (c *Client) GetPoolDistr(poolIds []any) (*PoolDistrResult, error) {
 	return &result, nil
 }
 
+// GetPoolDistr2 returns the ledger's pool stake distribution, which replaces
+// GetPoolDistr from node-to-client protocol version 21.
+//
+// Passing no pool IDs asks about every pool. The reply carries each pool's
+// total delegated stake and the total active stake across all pools, neither of
+// which GetPoolDistr returned.
+func (c *Client) GetPoolDistr2(
+	poolIds []ledger.PoolId,
+) (*PoolDistr2Result, error) {
+	c.Protocol.Logger().
+		Debug(fmt.Sprintf("calling GetPoolDistr2(poolIds: %+v)", poolIds),
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "client",
+			"connection_id", c.callbackContext.ConnectionId.String(),
+		)
+	c.busyMutex.Lock()
+	defer c.busyMutex.Unlock()
+	currentEra, err := c.getCurrentEra()
+	if err != nil {
+		return nil, err
+	}
+	// The pool filter is a StrictMaybe encoded as a list, so an empty list asks
+	// about every pool rather than about none.
+	poolFilter := []any{}
+	if len(poolIds) > 0 {
+		poolFilter = append(poolFilter, cbor.NewSetType(poolIds, true))
+	}
+	query := buildShelleyQuery(
+		currentEra,
+		QueryTypeShelleyPoolDistr2,
+		poolFilter,
+	)
+	var result PoolDistr2Result
+	if err := c.runQuery(query, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 // GetConstitution returns the current on-chain constitution (CIP-1694).
 //
 // Use this to read the constitution that governance actions are checked

--- a/protocol/localstatequery/client_test.go
+++ b/protocol/localstatequery/client_test.go
@@ -1356,9 +1356,9 @@ func TestGenesisConfigJSON(t *testing.T) {
 			MinUTxOValue:          1000000,
 			MinPoolCost:           340000000,
 		},
-		GenDelegs: []byte("mocked_cbor_data"),
-		Unknown1:  nil,
-		Unknown2:  nil,
+		GenDelegs:    []byte("mocked_cbor_data"),
+		InitialFunds: nil,
+		Staking:      nil,
 	}
 
 	// Marshal to JSON

--- a/protocol/localstatequery/genesis_config.go
+++ b/protocol/localstatequery/genesis_config.go
@@ -1,0 +1,344 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localstatequery
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+)
+
+// The GetGenesisConfig reply has two wire layouts, chosen by the negotiated
+// node-to-client protocol version. Up to version 20 the node emits a copy of an
+// older ledger serialisation it keeps for the purpose; from version 21 it emits
+// the ledger's current one.
+//
+// The layouts differ in arity at both levels, so the reply identifies itself
+// and the decoder does not need to be told which version was negotiated:
+//
+//	genesis record   15 fields -> 16 fields, gaining the extra config
+//	protocol params  18 fields -> 17 fields, the protocol version having become
+//	                              a nested pair rather than two adjacent fields
+//
+// Reading one layout as the other is not a near miss. The protocol parameters
+// sit in the middle of the genesis record, so a wrong guess shifts every
+// following field: the genesis delegates are read out of the protocol
+// parameters, and the decode either fails on a type mismatch or, worse,
+// succeeds with values that belong to other fields.
+const (
+	genesisConfigFieldsLegacy  = 15
+	genesisConfigFieldsCurrent = 16
+
+	genesisPParamsFieldsLegacy  = 18
+	genesisPParamsFieldsCurrent = 17
+)
+
+type GenesisConfigResult struct {
+	Start             SystemStartResult
+	NetworkMagic      int
+	NetworkId         uint8
+	ActiveSlotsCoeff  []any
+	SecurityParam     int
+	EpochLength       int
+	SlotsPerKESPeriod int
+	MaxKESEvolutions  int
+	SlotLength        int
+	UpdateQuorum      int
+	MaxLovelaceSupply int64
+	ProtocolParams    GenesisConfigResultProtocolParameters
+	// GenDelegs, InitialFunds and Staking are held as raw CBOR: they are maps
+	// with bytestring keys, which we can't parse yet.
+	GenDelegs    cbor.RawMessage
+	InitialFunds cbor.RawMessage
+	Staking      cbor.RawMessage
+	// ExtraConfig carries the optional injection configuration the ledger added
+	// alongside the version-21 encoding. It is nil when the reply used the
+	// legacy layout, which has no such field, and it doubles as the record's
+	// layout marker when re-encoding.
+	ExtraConfig cbor.RawMessage
+}
+
+func (g *GenesisConfigResult) UnmarshalCBOR(data []byte) error {
+	var fields []cbor.RawMessage
+	if _, err := cbor.Decode(data, &fields); err != nil {
+		return err
+	}
+	if len(fields) != genesisConfigFieldsLegacy &&
+		len(fields) != genesisConfigFieldsCurrent {
+		return fmt.Errorf(
+			"genesis config: expected %d or %d fields, got %d",
+			genesisConfigFieldsLegacy,
+			genesisConfigFieldsCurrent,
+			len(fields),
+		)
+	}
+	decoded := GenesisConfigResult{}
+	targets := []any{
+		&decoded.Start,
+		&decoded.NetworkMagic,
+		&decoded.NetworkId,
+		&decoded.ActiveSlotsCoeff,
+		&decoded.SecurityParam,
+		&decoded.EpochLength,
+		&decoded.SlotsPerKESPeriod,
+		&decoded.MaxKESEvolutions,
+		&decoded.SlotLength,
+		&decoded.UpdateQuorum,
+		&decoded.MaxLovelaceSupply,
+		&decoded.ProtocolParams,
+	}
+	for idx, target := range targets {
+		if _, err := cbor.Decode(fields[idx], target); err != nil {
+			return fmt.Errorf("genesis config field %d: %w", idx+1, err)
+		}
+	}
+	decoded.GenDelegs = fields[len(targets)]
+	decoded.InitialFunds = fields[len(targets)+1]
+	decoded.Staking = fields[len(targets)+2]
+	if len(fields) == genesisConfigFieldsCurrent {
+		decoded.ExtraConfig = fields[genesisConfigFieldsCurrent-1]
+	}
+	*g = decoded
+	return nil
+}
+
+func (g GenesisConfigResult) MarshalCBOR() ([]byte, error) {
+	// The protocol parameters are nested inside this record, so their layout is
+	// the record's to choose rather than their own.
+	pparams := g.ProtocolParams
+	pparams.legacyLayout = g.ExtraConfig == nil
+	fields := []any{
+		g.Start,
+		g.NetworkMagic,
+		g.NetworkId,
+		g.ActiveSlotsCoeff,
+		g.SecurityParam,
+		g.EpochLength,
+		g.SlotsPerKESPeriod,
+		g.MaxKESEvolutions,
+		g.SlotLength,
+		g.UpdateQuorum,
+		g.MaxLovelaceSupply,
+		pparams,
+		g.GenDelegs,
+		g.InitialFunds,
+		g.Staking,
+	}
+	if g.ExtraConfig != nil {
+		fields = append(fields, g.ExtraConfig)
+	}
+	return cbor.Encode(fields)
+}
+
+type GenesisConfigResultProtocolParameters struct {
+	MinFeeA               int
+	MinFeeB               int
+	MaxBlockBodySize      int
+	MaxTxSize             int
+	MaxBlockHeaderSize    int
+	KeyDeposit            int
+	PoolDeposit           int
+	EMax                  int
+	NOpt                  int
+	A0                    []int
+	Rho                   []int
+	Tau                   []int
+	DecentralizationParam []int
+	ExtraEntropy          any
+	ProtocolVersionMajor  int
+	ProtocolVersionMinor  int
+	MinUTxOValue          int
+	MinPoolCost           int
+	// legacyLayout records which of the two encodings this value was decoded
+	// from, so that re-encoding reproduces it. A value built in Go rather than
+	// decoded encodes as the current layout.
+	legacyLayout bool
+}
+
+// genesisPParamsLegacy is the layout sent up to node-to-client protocol version
+// 20, with the protocol version split across two adjacent fields.
+type genesisPParamsLegacy struct {
+	cbor.StructAsArray
+	MinFeeA               int
+	MinFeeB               int
+	MaxBlockBodySize      int
+	MaxTxSize             int
+	MaxBlockHeaderSize    int
+	KeyDeposit            int
+	PoolDeposit           int
+	EMax                  int
+	NOpt                  int
+	A0                    []int
+	Rho                   []int
+	Tau                   []int
+	DecentralizationParam []int
+	ExtraEntropy          any
+	ProtocolVersionMajor  int
+	ProtocolVersionMinor  int
+	MinUTxOValue          int
+	MinPoolCost           int
+}
+
+// genesisProtocolVersion is the nested pair the current layout uses in place of
+// the two adjacent fields.
+type genesisProtocolVersion struct {
+	cbor.StructAsArray
+	Major int
+	Minor int
+}
+
+// genesisPParamsCurrent is the layout sent from node-to-client protocol version
+// 21 onwards.
+type genesisPParamsCurrent struct {
+	cbor.StructAsArray
+	MinFeeA               int
+	MinFeeB               int
+	MaxBlockBodySize      int
+	MaxTxSize             int
+	MaxBlockHeaderSize    int
+	KeyDeposit            int
+	PoolDeposit           int
+	EMax                  int
+	NOpt                  int
+	A0                    []int
+	Rho                   []int
+	Tau                   []int
+	DecentralizationParam []int
+	ExtraEntropy          any
+	ProtocolVersion       genesisProtocolVersion
+	MinUTxOValue          int
+	MinPoolCost           int
+}
+
+func (p *GenesisConfigResultProtocolParameters) UnmarshalCBOR(
+	data []byte,
+) error {
+	listLen, err := cbor.ListLength(data)
+	if err != nil {
+		return err
+	}
+	switch listLen {
+	case genesisPParamsFieldsLegacy:
+		var tmp genesisPParamsLegacy
+		if _, err := cbor.Decode(data, &tmp); err != nil {
+			return err
+		}
+		*p = GenesisConfigResultProtocolParameters{
+			MinFeeA:               tmp.MinFeeA,
+			MinFeeB:               tmp.MinFeeB,
+			MaxBlockBodySize:      tmp.MaxBlockBodySize,
+			MaxTxSize:             tmp.MaxTxSize,
+			MaxBlockHeaderSize:    tmp.MaxBlockHeaderSize,
+			KeyDeposit:            tmp.KeyDeposit,
+			PoolDeposit:           tmp.PoolDeposit,
+			EMax:                  tmp.EMax,
+			NOpt:                  tmp.NOpt,
+			A0:                    tmp.A0,
+			Rho:                   tmp.Rho,
+			Tau:                   tmp.Tau,
+			DecentralizationParam: tmp.DecentralizationParam,
+			ExtraEntropy:          tmp.ExtraEntropy,
+			ProtocolVersionMajor:  tmp.ProtocolVersionMajor,
+			ProtocolVersionMinor:  tmp.ProtocolVersionMinor,
+			MinUTxOValue:          tmp.MinUTxOValue,
+			MinPoolCost:           tmp.MinPoolCost,
+			legacyLayout:          true,
+		}
+	case genesisPParamsFieldsCurrent:
+		var tmp genesisPParamsCurrent
+		if _, err := cbor.Decode(data, &tmp); err != nil {
+			return err
+		}
+		*p = GenesisConfigResultProtocolParameters{
+			MinFeeA:               tmp.MinFeeA,
+			MinFeeB:               tmp.MinFeeB,
+			MaxBlockBodySize:      tmp.MaxBlockBodySize,
+			MaxTxSize:             tmp.MaxTxSize,
+			MaxBlockHeaderSize:    tmp.MaxBlockHeaderSize,
+			KeyDeposit:            tmp.KeyDeposit,
+			PoolDeposit:           tmp.PoolDeposit,
+			EMax:                  tmp.EMax,
+			NOpt:                  tmp.NOpt,
+			A0:                    tmp.A0,
+			Rho:                   tmp.Rho,
+			Tau:                   tmp.Tau,
+			DecentralizationParam: tmp.DecentralizationParam,
+			ExtraEntropy:          tmp.ExtraEntropy,
+			ProtocolVersionMajor:  tmp.ProtocolVersion.Major,
+			ProtocolVersionMinor:  tmp.ProtocolVersion.Minor,
+			MinUTxOValue:          tmp.MinUTxOValue,
+			MinPoolCost:           tmp.MinPoolCost,
+		}
+	default:
+		return fmt.Errorf(
+			"genesis protocol parameters: expected %d or %d fields, got %d",
+			genesisPParamsFieldsLegacy,
+			genesisPParamsFieldsCurrent,
+			listLen,
+		)
+	}
+	return nil
+}
+
+func (p GenesisConfigResultProtocolParameters) MarshalCBOR() ([]byte, error) {
+	if p.legacyLayout {
+		return cbor.Encode(
+			genesisPParamsLegacy{
+				MinFeeA:               p.MinFeeA,
+				MinFeeB:               p.MinFeeB,
+				MaxBlockBodySize:      p.MaxBlockBodySize,
+				MaxTxSize:             p.MaxTxSize,
+				MaxBlockHeaderSize:    p.MaxBlockHeaderSize,
+				KeyDeposit:            p.KeyDeposit,
+				PoolDeposit:           p.PoolDeposit,
+				EMax:                  p.EMax,
+				NOpt:                  p.NOpt,
+				A0:                    p.A0,
+				Rho:                   p.Rho,
+				Tau:                   p.Tau,
+				DecentralizationParam: p.DecentralizationParam,
+				ExtraEntropy:          p.ExtraEntropy,
+				ProtocolVersionMajor:  p.ProtocolVersionMajor,
+				ProtocolVersionMinor:  p.ProtocolVersionMinor,
+				MinUTxOValue:          p.MinUTxOValue,
+				MinPoolCost:           p.MinPoolCost,
+			},
+		)
+	}
+	return cbor.Encode(
+		genesisPParamsCurrent{
+			MinFeeA:               p.MinFeeA,
+			MinFeeB:               p.MinFeeB,
+			MaxBlockBodySize:      p.MaxBlockBodySize,
+			MaxTxSize:             p.MaxTxSize,
+			MaxBlockHeaderSize:    p.MaxBlockHeaderSize,
+			KeyDeposit:            p.KeyDeposit,
+			PoolDeposit:           p.PoolDeposit,
+			EMax:                  p.EMax,
+			NOpt:                  p.NOpt,
+			A0:                    p.A0,
+			Rho:                   p.Rho,
+			Tau:                   p.Tau,
+			DecentralizationParam: p.DecentralizationParam,
+			ExtraEntropy:          p.ExtraEntropy,
+			ProtocolVersion: genesisProtocolVersion{
+				Major: p.ProtocolVersionMajor,
+				Minor: p.ProtocolVersionMinor,
+			},
+			MinUTxOValue: p.MinUTxOValue,
+			MinPoolCost:  p.MinPoolCost,
+		},
+	)
+}

--- a/protocol/localstatequery/genesis_config_test.go
+++ b/protocol/localstatequery/genesis_config_test.go
@@ -1,0 +1,286 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localstatequery_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+)
+
+// GetGenesisConfig has two wire layouts. Node-to-client protocol version 21
+// (ShelleyNodeToClientVersion13) switched the reply from a vendored copy of an
+// older ledger serialisation to the ledger's current one. The two differ in
+// arity at both levels, which is what makes a single decoder possible:
+//
+//	ShelleyGenesis  15 fields (legacy)  ->  16 fields (adds sgExtraConfig)
+//	PParams         18 fields (legacy)  ->  17 fields (protocol version became
+//	                                        a nested pair rather than two
+//	                                        adjacent fields)
+//
+// A node that negotiates 21 or higher and still emits the legacy layout is not
+// merely returning stale field names: the client reads sgGenDelegs where the
+// node wrote sgProtocolParams, so every field from the protocol parameters
+// onwards is silently wrong.
+
+// genesisProtocolParamsLegacy is the pre-21 PParams layout, with the protocol
+// version occupying two adjacent fields.
+func genesisProtocolParamsLegacy() []any {
+	return []any{
+		44,             // minFeeA
+		155381,         // minFeeB
+		65536,          // maxBlockBodySize
+		16384,          // maxTxSize
+		1100,           // maxBlockHeaderSize
+		2000000,        // keyDeposit
+		500000000,      // poolDeposit
+		18,             // eMax
+		150,            // nOpt
+		[]any{3, 10},   // a0
+		[]any{3, 1000}, // rho
+		[]any{2, 10},   // tau
+		[]any{0, 1},    // decentralizationParam
+		[]any{0},       // extraEntropy (neutral nonce)
+		10,             // protocol version major
+		3,              // protocol version minor
+		1000000,        // minUTxOValue
+		340000000,      // minPoolCost
+	}
+}
+
+// genesisProtocolParamsCurrent is the same parameters in the layout a node
+// negotiating protocol version 21 or higher sends: one field shorter, with the
+// protocol version nested.
+func genesisProtocolParamsCurrent() []any {
+	legacy := genesisProtocolParamsLegacy()
+	current := make([]any, 0, len(legacy)-1)
+	current = append(current, legacy[:14]...)
+	current = append(current, []any{legacy[14], legacy[15]})
+	current = append(current, legacy[16:]...)
+	return current
+}
+
+func genesisConfigCommonPrefix(pparams []any) []any {
+	return []any{
+		[]any{2017, 254, 71856000000000}, // system start
+		42,                               // network magic
+		0,                                // network id
+		[]any{1, 20},                     // active slots coeff
+		2160,                             // security param
+		432000,                           // epoch length
+		129600,                           // slots per KES period
+		62,                               // max KES evolutions
+		1,                                // slot length
+		5,                                // update quorum
+		45000000000000000,                // max lovelace supply
+		pparams,
+		map[any]any{},                 // genesis delegates
+		[]any{},                       // initial funds
+		[]any{[]any{}, map[any]any{}}, // staking
+	}
+}
+
+func encodeGenesisConfigLegacy(t *testing.T) []byte {
+	t.Helper()
+	encoded, err := cbor.Encode(
+		genesisConfigCommonPrefix(genesisProtocolParamsLegacy()),
+	)
+	if err != nil {
+		t.Fatalf("encoding legacy genesis fixture: %v", err)
+	}
+	return encoded
+}
+
+func encodeGenesisConfigCurrent(t *testing.T) []byte {
+	t.Helper()
+	fields := genesisConfigCommonPrefix(genesisProtocolParamsCurrent())
+	// sgExtraConfig is a StrictMaybe, so an absent value is the empty list.
+	fields = append(fields, []any{})
+	encoded, err := cbor.Encode(fields)
+	if err != nil {
+		t.Fatalf("encoding current genesis fixture: %v", err)
+	}
+	return encoded
+}
+
+// assertGenesisConfigFields checks the fields that sit after the protocol
+// parameters, since those are the ones a mis-detected layout shifts.
+func assertGenesisConfigFields(
+	t *testing.T,
+	result localstatequery.GenesisConfigResult,
+) {
+	t.Helper()
+	if result.NetworkMagic != 42 {
+		t.Errorf("network magic: got %d, want 42", result.NetworkMagic)
+	}
+	if result.MaxLovelaceSupply != 45000000000000000 {
+		t.Errorf(
+			"max lovelace supply: got %d, want 45000000000000000",
+			result.MaxLovelaceSupply,
+		)
+	}
+	if result.ProtocolParams.MinFeeA != 44 {
+		t.Errorf("minFeeA: got %d, want 44", result.ProtocolParams.MinFeeA)
+	}
+	if result.ProtocolParams.ProtocolVersionMajor != 10 {
+		t.Errorf(
+			"protocol version major: got %d, want 10",
+			result.ProtocolParams.ProtocolVersionMajor,
+		)
+	}
+	if result.ProtocolParams.ProtocolVersionMinor != 3 {
+		t.Errorf(
+			"protocol version minor: got %d, want 3",
+			result.ProtocolParams.ProtocolVersionMinor,
+		)
+	}
+	if result.ProtocolParams.MinUTxOValue != 1000000 {
+		t.Errorf(
+			"minUTxOValue: got %d, want 1000000",
+			result.ProtocolParams.MinUTxOValue,
+		)
+	}
+	if result.ProtocolParams.MinPoolCost != 340000000 {
+		t.Errorf(
+			"minPoolCost: got %d, want 340000000",
+			result.ProtocolParams.MinPoolCost,
+		)
+	}
+	if len(result.GenDelegs) == 0 {
+		t.Error("genesis delegates were not decoded")
+	}
+}
+
+// TestGenesisConfigResultDecodesLegacyLayout pins the existing behaviour so the
+// version-21 work cannot regress clients talking to an older node.
+func TestGenesisConfigResultDecodesLegacyLayout(t *testing.T) {
+	var result localstatequery.GenesisConfigResult
+	if _, err := cbor.Decode(encodeGenesisConfigLegacy(t), &result); err != nil {
+		t.Fatalf("decoding legacy genesis config: %v", err)
+	}
+	assertGenesisConfigFields(t, result)
+	if result.ExtraConfig != nil {
+		t.Errorf(
+			"legacy layout carries no extra config, got %v",
+			result.ExtraConfig,
+		)
+	}
+}
+
+// TestGenesisConfigResultDecodesCurrentLayout covers the reply a node sends once
+// node-to-client protocol version 21 is negotiated.
+func TestGenesisConfigResultDecodesCurrentLayout(t *testing.T) {
+	var result localstatequery.GenesisConfigResult
+	if _, err := cbor.Decode(encodeGenesisConfigCurrent(t), &result); err != nil {
+		t.Fatalf("decoding current genesis config: %v", err)
+	}
+	assertGenesisConfigFields(t, result)
+	if result.ExtraConfig == nil {
+		t.Error("current layout carries extra config, got none")
+	}
+}
+
+// TestGenesisConfigResultRejectsUnknownArity keeps the decoder from quietly
+// accepting a record it cannot map, which would hand callers zero values that
+// look like real parameters.
+func TestGenesisConfigResultRejectsUnknownArity(t *testing.T) {
+	encoded, err := cbor.Encode([]any{1, 2, 3})
+	if err != nil {
+		t.Fatalf("encoding fixture: %v", err)
+	}
+	var result localstatequery.GenesisConfigResult
+	if _, err := cbor.Decode(encoded, &result); err == nil {
+		t.Error("expected an error for a genesis record of unknown arity")
+	}
+}
+
+// TestGenesisConfigProtocolParamsRejectsUnknownArity is the same guard one level
+// down, where a shifted decode is just as silent.
+func TestGenesisConfigProtocolParamsRejectsUnknownArity(t *testing.T) {
+	encoded, err := cbor.Encode([]any{1, 2, 3})
+	if err != nil {
+		t.Fatalf("encoding fixture: %v", err)
+	}
+	var result localstatequery.GenesisConfigResultProtocolParameters
+	if _, err := cbor.Decode(encoded, &result); err == nil {
+		t.Error("expected an error for protocol parameters of unknown arity")
+	}
+}
+
+// TestGenesisConfigResultRoundTripsLegacyLayout and its current-layout twin pin
+// the encoder to the layout the value was decoded from. Re-encoding a reply in
+// the other layout would corrupt it in exactly the way described above, and
+// byte equality is the only assertion that catches a field moving.
+func TestGenesisConfigResultRoundTripsLegacyLayout(t *testing.T) {
+	original := encodeGenesisConfigLegacy(t)
+	var result localstatequery.GenesisConfigResult
+	if _, err := cbor.Decode(original, &result); err != nil {
+		t.Fatalf("decoding legacy genesis config: %v", err)
+	}
+	reencoded, err := cbor.Encode(result)
+	if err != nil {
+		t.Fatalf("re-encoding legacy genesis config: %v", err)
+	}
+	if !bytes.Equal(original, reencoded) {
+		t.Errorf(
+			"legacy round trip changed the encoding:\n got %x\nwant %x",
+			reencoded,
+			original,
+		)
+	}
+}
+
+func TestGenesisConfigResultRoundTripsCurrentLayout(t *testing.T) {
+	original := encodeGenesisConfigCurrent(t)
+	var result localstatequery.GenesisConfigResult
+	if _, err := cbor.Decode(original, &result); err != nil {
+		t.Fatalf("decoding current genesis config: %v", err)
+	}
+	reencoded, err := cbor.Encode(result)
+	if err != nil {
+		t.Fatalf("re-encoding current genesis config: %v", err)
+	}
+	if !bytes.Equal(original, reencoded) {
+		t.Errorf(
+			"current round trip changed the encoding:\n got %x\nwant %x",
+			reencoded,
+			original,
+		)
+	}
+}
+
+// TestGenesisConfigProtocolParamsEncodeCurrentByDefault covers a value built in
+// Go rather than decoded: new callers should get the layout a node negotiating
+// version 21 or higher expects.
+func TestGenesisConfigProtocolParamsEncodeCurrentByDefault(t *testing.T) {
+	encoded, err := cbor.Encode(
+		localstatequery.GenesisConfigResultProtocolParameters{
+			ProtocolVersionMajor: 10,
+			ProtocolVersionMinor: 3,
+		},
+	)
+	if err != nil {
+		t.Fatalf("encoding protocol parameters: %v", err)
+	}
+	listLen, err := cbor.ListLength(encoded)
+	if err != nil {
+		t.Fatalf("reading list length: %v", err)
+	}
+	if listLen != 17 {
+		t.Errorf("expected the 17-field current layout, got %d fields", listLen)
+	}
+}

--- a/protocol/localstatequery/pool_distr2_test.go
+++ b/protocol/localstatequery/pool_distr2_test.go
@@ -1,0 +1,191 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localstatequery_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+)
+
+// GetPoolDistr2 (Shelley sub-query 36) replaces GetPoolDistr from node-to-client
+// protocol version 21. cardano-cli sends it while computing a leadership
+// schedule, and a node that cannot even decode the query tag fails the whole
+// connection rather than the one query, so the caller sees a closed bearer.
+//
+// The result is the ledger's own pool distribution rather than the consensus
+// one, which carries two things the old result did not: the total stake
+// delegated to each pool, and the total active stake across all pools.
+
+func poolDistr2Fixture(t *testing.T) (poolId ledger.PoolId, vrfHash []byte) {
+	t.Helper()
+	rawPoolId, err := hex.DecodeString(
+		"1cb2c9bb54fb097fba58542c5adcf3a7d094db95e8b9c4e3d0bcbf1d",
+	)
+	if err != nil {
+		t.Fatalf("decoding pool id: %v", err)
+	}
+	rawVrf, err := hex.DecodeString(
+		"c0d1f9b040d2f6fd7fc8775d24753d6db4b0fb6846b76f0d8f4b8e8b96ed7d9a",
+	)
+	if err != nil {
+		t.Fatalf("decoding vrf hash: %v", err)
+	}
+	return ledger.PoolId(ledger.NewBlake2b224(rawPoolId)), rawVrf
+}
+
+// TestPoolDistr2QueryDecodesAllPools covers the SNothing pool filter, which the
+// ledger reads as "every pool".
+func TestPoolDistr2QueryDecodesAllPools(t *testing.T) {
+	encoded, err := cbor.Encode(
+		[]any{localstatequery.QueryTypeShelleyPoolDistr2, []any{}},
+	)
+	if err != nil {
+		t.Fatalf("encoding query: %v", err)
+	}
+	var query localstatequery.ShelleyPoolDistr2Query
+	if _, err := cbor.Decode(encoded, &query); err != nil {
+		t.Fatalf("decoding query: %v", err)
+	}
+	pools, all := query.PoolFilter()
+	if !all {
+		t.Errorf("an empty filter covers every pool, got %d pools", len(pools))
+	}
+}
+
+// TestPoolDistr2QueryDecodesPoolFilter covers the SJust case, where the caller
+// asks about specific pools.
+func TestPoolDistr2QueryDecodesPoolFilter(t *testing.T) {
+	poolId, _ := poolDistr2Fixture(t)
+	encoded, err := cbor.Encode(
+		[]any{
+			localstatequery.QueryTypeShelleyPoolDistr2,
+			[]any{cbor.NewSetType([]ledger.PoolId{poolId}, false)},
+		},
+	)
+	if err != nil {
+		t.Fatalf("encoding query: %v", err)
+	}
+	var query localstatequery.ShelleyPoolDistr2Query
+	if _, err := cbor.Decode(encoded, &query); err != nil {
+		t.Fatalf("decoding query: %v", err)
+	}
+	pools, all := query.PoolFilter()
+	if all {
+		t.Fatal("an explicit pool set does not cover every pool")
+	}
+	if len(pools) != 1 || pools[0] != poolId {
+		t.Errorf("pool filter: got %v, want [%v]", pools, poolId)
+	}
+}
+
+// TestPoolDistr2ResultDecodes pins the reply shape. The ledger's pool
+// distribution is a two-field record, and each pool's entry is a three-field
+// record; the old query's entry had no total-stake field, so a decoder written
+// for it reads the VRF hash out of the wrong slot.
+func TestPoolDistr2ResultDecodes(t *testing.T) {
+	poolId, vrfHash := poolDistr2Fixture(t)
+	encoded, err := cbor.Encode(
+		[]any{
+			map[any]any{
+				poolId: []any{
+					&cbor.Rat{Rat: big.NewRat(1, 3)},
+					4200000000,
+					vrfHash,
+				},
+			},
+			12600000000,
+		},
+	)
+	if err != nil {
+		t.Fatalf("encoding result: %v", err)
+	}
+	var result localstatequery.PoolDistr2Result
+	if _, err := cbor.Decode(encoded, &result); err != nil {
+		t.Fatalf("decoding result: %v", err)
+	}
+	if result.TotalActiveStake != 12600000000 {
+		t.Errorf(
+			"total active stake: got %d, want 12600000000",
+			result.TotalActiveStake,
+		)
+	}
+	stake, ok := result.Pools[poolId]
+	if !ok {
+		t.Fatalf("pool %v missing from the distribution", poolId)
+	}
+	if stake.StakeFraction == nil ||
+		stake.StakeFraction.Num().Int64() != 1 ||
+		stake.StakeFraction.Denom().Int64() != 3 {
+		t.Errorf("stake fraction: got %v, want 1/3", stake.StakeFraction)
+	}
+	if stake.TotalPoolStake != 4200000000 {
+		t.Errorf(
+			"total pool stake: got %d, want 4200000000",
+			stake.TotalPoolStake,
+		)
+	}
+	if !bytes.Equal(stake.VrfHash[:], vrfHash) {
+		t.Errorf("vrf hash: got %x, want %x", stake.VrfHash, vrfHash)
+	}
+}
+
+// TestPoolDistr2QueryIsDispatchable checks the query reaches a server through
+// the same table a real connection uses. Registering the result type without
+// registering the tag leaves the node failing the connection on decode.
+func TestPoolDistr2QueryIsDispatchable(t *testing.T) {
+	blockQuery, err := cbor.Encode(
+		[]any{localstatequery.QueryTypeShelleyPoolDistr2, []any{}},
+	)
+	if err != nil {
+		t.Fatalf("encoding query: %v", err)
+	}
+	// A Shelley leaf query travels wrapped in its era and block-query envelopes.
+	wrapped, err := cbor.Encode(
+		[]any{
+			localstatequery.QueryTypeBlock,
+			[]any{
+				localstatequery.QueryTypeShelley,
+				[]any{ledger.EraIdConway, cbor.RawMessage(blockQuery)},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("encoding wrapper: %v", err)
+	}
+	var query localstatequery.QueryWrapper
+	if _, err := cbor.Decode(wrapped, &query); err != nil {
+		t.Fatalf("decoding wrapped query: %v", err)
+	}
+	blockQ, ok := query.Query.(*localstatequery.BlockQuery)
+	if !ok {
+		t.Fatalf("expected a block query, got %T", query.Query)
+	}
+	shelleyQ, ok := blockQ.Query.(*localstatequery.ShelleyQuery)
+	if !ok {
+		t.Fatalf("expected a shelley query, got %T", blockQ.Query)
+	}
+	if _, ok := shelleyQ.Query.(*localstatequery.ShelleyPoolDistr2Query); !ok {
+		t.Errorf(
+			"expected a GetPoolDistr2 query, got %T",
+			shelleyQ.Query,
+		)
+	}
+}

--- a/protocol/localstatequery/queries.go
+++ b/protocol/localstatequery/queries.go
@@ -785,47 +785,8 @@ func (r *FilteredDelegationsAndRewardAccountsResult) UnmarshalCBOR(data []byte) 
 	return nil
 }
 
-type GenesisConfigResult struct {
-	cbor.StructAsArray
-	Start             SystemStartResult
-	NetworkMagic      int
-	NetworkId         uint8
-	ActiveSlotsCoeff  []any
-	SecurityParam     int
-	EpochLength       int
-	SlotsPerKESPeriod int
-	MaxKESEvolutions  int
-	SlotLength        int
-	UpdateQuorum      int
-	MaxLovelaceSupply int64
-	ProtocolParams    GenesisConfigResultProtocolParameters
-	// This value contains maps with bytestring keys, which we can't parse yet
-	GenDelegs cbor.RawMessage
-	Unknown1  any
-	Unknown2  any
-}
-
-type GenesisConfigResultProtocolParameters struct {
-	cbor.StructAsArray
-	MinFeeA               int
-	MinFeeB               int
-	MaxBlockBodySize      int
-	MaxTxSize             int
-	MaxBlockHeaderSize    int
-	KeyDeposit            int
-	PoolDeposit           int
-	EMax                  int
-	NOpt                  int
-	A0                    []int
-	Rho                   []int
-	Tau                   []int
-	DecentralizationParam []int
-	ExtraEntropy          any
-	ProtocolVersionMajor  int
-	ProtocolVersionMinor  int
-	MinUTxOValue          int
-	MinPoolCost           int
-}
+// GenesisConfigResult and GenesisConfigResultProtocolParameters are defined in
+// genesis_config.go, which carries the two wire layouts.
 
 // TODO (#864)
 type DebugNewEpochStateResult any

--- a/protocol/localstatequery/queries.go
+++ b/protocol/localstatequery/queries.go
@@ -80,6 +80,10 @@ const (
 	// GetLedgerPeerSnapshot (Shelley sub-query 34, NtC v19+ / cardano-node 10.7+).
 	// The v15+ wire layout includes a peer-kind byte: [34, peerKindTag].
 	QueryTypeShelleyGetLedgerPeerSnapshot = 34
+
+	// GetPoolDistr2 (Shelley sub-query 36) replaces GetPoolDistr from NtC v21.
+	// cardano-cli sends it while computing a leadership schedule.
+	QueryTypeShelleyPoolDistr2 = 36
 )
 
 // LedgerPeerKind selects which ledger peers the snapshot covers.
@@ -237,6 +241,7 @@ func shelleyQueryTypes() map[int]any {
 		QueryTypeShelleyPoolState:                           &ShelleyPoolStateQuery{},
 		QueryTypeShelleyStakeSnapshots:                      &ShelleyStakeSnapshotsQuery{},
 		QueryTypeShelleyPoolDistr:                           &ShelleyPoolDistrQuery{},
+		QueryTypeShelleyPoolDistr2:                          &ShelleyPoolDistr2Query{},
 		QueryTypeShelleyStakeDelegDeposits:                  &ShelleyStakeDelegDepositsQuery{},
 		// Conway governance queries
 		QueryTypeShelleyConstitution:           &ShelleyConstitutionQuery{},
@@ -478,6 +483,51 @@ func (q *ShelleyStakeSnapshotsQuery) PoolFilter() (pools []ledger.PoolId, all bo
 
 type ShelleyPoolDistrQuery struct {
 	simpleQueryBase
+}
+
+// ShelleyPoolDistr2Query is GetPoolDistr2 (Shelley sub-query 36), which
+// replaces GetPoolDistr from node-to-client protocol version 21. The wire form
+// is unchanged from its predecessor -- [36, poolFilter], where poolFilter is a
+// StrictMaybe of a pool-id set encoded as a list, so [] means "all pools" and
+// [ 258{poolids} ] restricts the result. Only the reply differs; see
+// PoolDistr2Result.
+type ShelleyPoolDistr2Query struct {
+	cbor.StructAsArray
+	Type  int
+	Pools []cbor.SetType[ledger.PoolId]
+}
+
+func (q *ShelleyPoolDistr2Query) UnmarshalCBOR(data []byte) error {
+	var tmp struct {
+		cbor.StructAsArray
+		Type  int
+		Pools []cbor.SetType[ledger.PoolId]
+	}
+	if _, err := cbor.Decode(data, &tmp); err != nil {
+		return err
+	}
+	// A StrictMaybe holds at most one value. Reject a malformed encoding that
+	// carries more than one set rather than silently dropping the extras.
+	if len(tmp.Pools) > 1 {
+		return fmt.Errorf(
+			"invalid GetPoolDistr2 pool filter: expected at most one pool set, got %d",
+			len(tmp.Pools),
+		)
+	}
+	q.Type = tmp.Type
+	q.Pools = tmp.Pools
+	return nil
+}
+
+// PoolFilter reports the pool IDs the query is restricted to. When all is true
+// the query covers every pool (the StrictMaybe was SNothing) and pools is nil;
+// when all is false only the returned pools are requested (which may be empty
+// for an explicit SJust of the empty set).
+func (q *ShelleyPoolDistr2Query) PoolFilter() (pools []ledger.PoolId, all bool) {
+	if len(q.Pools) == 0 {
+		return nil, true
+	}
+	return q.Pools[0].Items(), false
 }
 
 func decodeQuery(
@@ -1026,6 +1076,28 @@ type StakeSnapshotsResult struct {
 	TotalStakeMark uint64
 	TotalStakeSet  uint64
 	TotalStakeGo   uint64
+}
+
+// PoolDistr2Result is the GetPoolDistr2 reply: the ledger's own pool
+// distribution rather than the consensus one that GetPoolDistr returned.
+//
+// It carries two values its predecessor did not. Each pool's entry gains the
+// total stake delegated to it, alongside the fraction and VRF hash the old
+// entry held, and the record as a whole gains the total active stake across
+// all pools. Both are needed to check a pool's leader eligibility without
+// re-deriving the denominator.
+type PoolDistr2Result struct {
+	cbor.StructAsArray
+	Pools            map[ledger.PoolId]PoolDistr2IndividualStake
+	TotalActiveStake uint64
+}
+
+// PoolDistr2IndividualStake is one pool's entry in a GetPoolDistr2 reply.
+type PoolDistr2IndividualStake struct {
+	cbor.StructAsArray
+	StakeFraction  *cbor.Rat
+	TotalPoolStake uint64
+	VrfHash        ledger.Blake2b256
 }
 
 // PoolDistrResult represents the pool distribution result.

--- a/protocol/versions.go
+++ b/protocol/versions.go
@@ -188,6 +188,25 @@ var protocolVersions = map[uint16]ProtocolVersion{
 		EnableDijkstraEra:            true,
 		EnableLocalTxMonitorProtocol: true,
 	},
+	// Replaced the GetCurrentProtocolParams and GetGenesisConfig result
+	// encodings with the ledger's own, in place of the older serialisation the
+	// node had been vendoring. GetGenesisConfig changes shape on the wire; see
+	// GenesisConfigResult. GetCurrentProtocolParams does not, because the
+	// vendored encoding differs from the ledger's only up to Babbage, and a
+	// node that negotiates this version is past those eras. The eras and
+	// mini-protocols are unchanged from version 20.
+	(21 + ProtocolVersionNtCOffset): {
+		NewVersionDataFromCborFunc:   NewVersionDataNtC15andUpFromCbor,
+		EnableLocalQueryProtocol:     true,
+		EnableShelleyEra:             true,
+		EnableAllegraEra:             true,
+		EnableMaryEra:                true,
+		EnableAlonzoEra:              true,
+		EnableBabbageEra:             true,
+		EnableConwayEra:              true,
+		EnableDijkstraEra:            true,
+		EnableLocalTxMonitorProtocol: true,
+	},
 
 	//
 	// We don't bother supporting NtN protocol versions before 7 (when Alonzo was enabled)

--- a/protocol/versions_test.go
+++ b/protocol/versions_test.go
@@ -130,3 +130,43 @@ func TestGetProtocolVersionMapDMQNtCMithril(t *testing.T) {
 		})
 	}
 }
+
+// TestNtCVersion21Supported covers the handshake half of node-to-client
+// protocol version 21.
+//
+// cardano-cli gates several queries on the negotiated version rather than on
+// the reply it gets back, so a node that stops at 20 is refused before it can
+// answer anything — `query leadership-schedule` reports that it needs a newer
+// version and never sends the query.
+func TestNtCVersion21Supported(t *testing.T) {
+	const version = 21 + ProtocolVersionNtCOffset
+
+	assert.Contains(t, GetProtocolVersionsNtC(), uint16(version),
+		"version 21 must be offered during the handshake")
+
+	got := GetProtocolVersion(version)
+	require.NotNil(t, got.NewVersionDataFromCborFunc,
+		"version 21 needs the version data codec used from 15 onwards")
+
+	// Version 21 changes how two query results are serialised; it neither adds
+	// nor removes an era or a mini-protocol, so its capabilities are those of
+	// version 20.
+	previous := GetProtocolVersion(20 + ProtocolVersionNtCOffset)
+	assert.Equal(t, previous.EnableShelleyEra, got.EnableShelleyEra)
+	assert.Equal(t, previous.EnableAllegraEra, got.EnableAllegraEra)
+	assert.Equal(t, previous.EnableMaryEra, got.EnableMaryEra)
+	assert.Equal(t, previous.EnableAlonzoEra, got.EnableAlonzoEra)
+	assert.Equal(t, previous.EnableBabbageEra, got.EnableBabbageEra)
+	assert.Equal(t, previous.EnableConwayEra, got.EnableConwayEra)
+	assert.Equal(t, previous.EnableDijkstraEra, got.EnableDijkstraEra)
+	assert.Equal(
+		t,
+		previous.EnableLocalQueryProtocol,
+		got.EnableLocalQueryProtocol,
+	)
+	assert.Equal(
+		t,
+		previous.EnableLocalTxMonitorProtocol,
+		got.EnableLocalTxMonitorProtocol,
+	)
+}


### PR DESCRIPTION
## Why

`cardano-cli` gates queries on the *negotiated* node-to-client version rather than on the reply it gets back. gouroboros stops at version 20, so `cardano-cli query leadership-schedule` against a gouroboros-based node is refused during handshake and never sends a query at all — regardless of which queries the node actually implements.

This adds version 21 and the two wire changes that come with it.

## What version 21 actually changes

The upstream haddock for `NodeToClientV_21` says "new codecs for `PParams` and `CompactGenesis`". Reading the source, the practical breakdown is a little different, and worth stating because two of the three points are not what the description implies.

`NodeToClientV_21` maps to `ShelleyNodeToClientVersion13` ([`NetworkProtocolVersion.hs`](https://github.com/IntersectMBO/ouroboros-consensus/blob/main/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/NetworkProtocolVersion.hs)).

**1. `GetGenesisConfig` changes shape.** Up to version 20 the node emits a copy of an older ledger serialisation it vendors for the purpose; from 21 it emits the ledger's current one ([`Query.hs`](https://github.com/IntersectMBO/ouroboros-consensus/blob/main/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs), `genesisConfigEnDecoding`).

| | legacy (≤ 20) | current (≥ 21) |
|---|---|---|
| genesis record | 15 fields | 16 fields, gaining `sgExtraConfig` |
| nested protocol params | 18 fields | 17 fields, protocol version became a nested pair |

**2. `GetCurrentProtocolParams` does *not* change.** [`LegacyPParams.hs`](https://github.com/IntersectMBO/ouroboros-consensus/blob/main/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query/LegacyPParams.hs) delegates Conway and Dijkstra straight to `toCBOR`:

```haskell
instance ToCBOR (LegacyPParams ConwayEra) where
  toCBOR = toCBOR . unLegacyPParams
```

The two encodings diverge only up to Babbage, and a node negotiating version 21 is past those eras. So despite the version's own description, there is nothing to do here.

**3. `GetPoolDistr` is deprecated in favour of `GetPoolDistr2`** (Shelley sub-query 36), also gated at this version — `blockQueryIsSupportedOnVersion` has `GetPoolDistr{} -> (< v13)` and `GetPoolDistr2{} -> (>= v13)`. This is not mentioned in the version haddock; it surfaced only when a real `cardano-cli` got past the handshake and sent tag 36.

## How the genesis layouts are told apart

The two layouts differ in arity at both levels, so the reply identifies itself and the decoder does not need to be told which version was negotiated.

That property is load-bearing rather than merely convenient. The protocol parameters sit in the middle of the genesis record, so reading one layout as the other shifts every following field — the genesis delegates get read out of the protocol parameters — and the decode can *succeed* with values that belong to other fields. Both arities are checked, and a record of any other size is rejected rather than partially mapped.

The encoder reproduces whichever layout a value was decoded from. A value built in Go rather than decoded encodes as the current layout.

## Verification

- Both genesis layouts **round-trip byte-exact**. That is the assertion that catches a field moving; a field-by-field comparison would not.
- Mutation-tested, since a decoder that silently shifts is exactly the kind of bug that passes a happy-path test. Suppressing `ExtraConfig` and reading the protocol version from the wrong half of the nested pair each produced a failure naming the right field.
- Verified end-to-end against real `cardano-cli` on a DevNet, watching the failure boundary move:
  1. before — refused at handshake;
  2. after the version entry — `unknown Block query type: 36`;
  3. after `GetPoolDistr2` — query decodes and dispatches; the remaining gap is the downstream node's own handler.
- Full suite green, `golangci-lint` 0 issues, `modernize` clean.

## Breaking change

`GenesisConfigResult.Unknown1` and `.Unknown2` are renamed to `.InitialFunds` and `.Staking`, which is what the ledger calls them — the source now confirms what those fields hold. One test referenced them.

## Not included

`NodeToClientV_22` (SRV support in `GetBigLedgerPeerSnapshot`) and `NodeToClientV_23` (`QueryDRepDelegations`, plus block hash and NetworkMagic in the peer-snapshot encoding) each carry their own protocol changes and are left for separate changes. Adding those version entries without implementing the changes would advertise capabilities the node does not have, trading a clear handshake failure for a silent mis-decode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds node-to-client protocol version 21 and implements `GetPoolDistr2`, enabling `cardano-cli query leadership-schedule` to negotiate the handshake and run. Also adds dual-layout support for `GetGenesisConfig` so v21 replies decode correctly.

- **New Features**
  - Added NtC v21 in `protocol/versions.go` (same eras/protocols as v20).
  - Implemented `GetPoolDistr2` (Shelley sub-query 36) with new result types carrying pool stake fraction, total pool stake, and total active stake; added `Client.GetPoolDistr2`.
  - Added dual-layout decoding/encoding for `GetGenesisConfig` (15→16 fields; nested protocol version) without changing `GetCurrentProtocolParams`.
  - Registered query tag and decoders so dispatch succeeds; added tests for handshake, query decode, and round-trip encoding.

- **Migration**
  - `GenesisConfigResult.Unknown1` and `Unknown2` are renamed to `InitialFunds` and `Staking`. Update references if used.

<sup>Written for commit af6c560d0368111f0f59167c4e59c9f0af5c46a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Node-to-Client protocol version 21.
  * Added pool distribution queries with optional pool filters and detailed stake information.
  * Added compatibility for current and legacy genesis configuration formats.
* **Bug Fixes**
  * Improved handling and validation of protocol responses across supported formats.
* **Tests**
  * Added coverage for pool distribution queries, protocol compatibility, and genesis configuration encoding and decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->