### PR TITLE
fix: harden field-reported issues

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -19,24 +19,24 @@ jobs:
           # the fuzz target (no /... wildcards).
           - {package: "./cbor", fuzz: "FuzzDecode$"}
           - {package: "./cbor", fuzz: "FuzzDecodeStruct$"}
-          - {package: "./ledger", fuzz: "FuzzNewBlockFromCbor"}
-          - {package: "./ledger", fuzz: "FuzzNewTransactionFromCbor"}
-          - {package: "./ledger/common", fuzz: "FuzzMultiAsset"}
-          - {package: "./ledger/common", fuzz: "FuzzValue"}
-          - {package: "./ledger/common", fuzz: "FuzzNewAddressFromBytes"}
+          - {package: "./ledger", fuzz: "FuzzNewBlockFromCbor$"}
+          - {package: "./ledger", fuzz: "FuzzNewTransactionFromCbor$"}
+          - {package: "./ledger/common", fuzz: "FuzzMultiAsset$"}
+          - {package: "./ledger/common", fuzz: "FuzzValue$"}
+          - {package: "./ledger/common", fuzz: "FuzzNewAddressFromBytes$"}
           - {package: "./ledger/common", fuzz: "FuzzNewAddress$"}
-          - {package: "./ledger/common", fuzz: "FuzzNewScriptHashFromBech32"}
-          - {package: "./kes", fuzz: "FuzzVerifySignedKES"}
-          - {package: "./kes", fuzz: "FuzzNewSumKesFromBytes"}
+          - {package: "./ledger/common", fuzz: "FuzzNewScriptHashFromBech32$"}
+          - {package: "./kes", fuzz: "FuzzVerifySignedKES$"}
+          - {package: "./kes", fuzz: "FuzzNewSumKesFromBytes$"}
           - {package: "./vrf", fuzz: "FuzzVerify$"}
           - {package: "./vrf", fuzz: "FuzzVerifyAndHash$"}
-          - {package: "./vrf", fuzz: "FuzzProofToHash"}
+          - {package: "./vrf", fuzz: "FuzzProofToHash$"}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
         with:
-          go-version: 1.26.x
+          go-version: '1.26.x'
 
       - name: Run fuzz test
         run: |

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -33,6 +33,8 @@ jobs:
           - {package: "./vrf", fuzz: "FuzzProofToHash$"}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
         with:

--- a/ledger/byron/block_test.go
+++ b/ledger/byron/block_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestByronBlock_CborRoundTrip_UsingCborEncode(t *testing.T) {
@@ -93,14 +94,10 @@ func TestByronBlock_CborRoundTrip_UsingCborEncode(t *testing.T) {
 func TestByronEpochBoundaryBlockNullHeader(t *testing.T) {
 	// [null, [], []]: an EBB block whose header is CBOR null
 	dataBytes, err := hex.DecodeString("83f68080")
-	if err != nil {
-		t.Fatalf("Failed to decode hex string into CBOR bytes: %v", err)
-	}
+	require.NoError(t, err, "Failed to decode hex string into CBOR bytes: %v", err)
 	var block byron.ByronEpochBoundaryBlock
 	err = block.UnmarshalCBOR(dataBytes)
-	if err == nil {
-		t.Fatal("expected error decoding EBB block with null header, got none")
-	}
+	require.Error(t, err, "expected error decoding EBB block with null header, got none")
 }
 
 func TestByronTransaction_Utxorpc(t *testing.T) {

--- a/ledger/common/certs.go
+++ b/ledger/common/certs.go
@@ -691,6 +691,13 @@ func (p *PoolRegistrationCertificate) UnmarshalJSON(data []byte) error {
 		if err != nil {
 			return fmt.Errorf("invalid operator key: %w", err)
 		}
+		if len(opBytes) != Blake2b224Size {
+			return fmt.Errorf(
+				"invalid operator key length: expected %d, got %d",
+				Blake2b224Size,
+				len(opBytes),
+			)
+		}
 		p.Operator = PoolKeyHash(opBytes)
 	}
 

--- a/ledger/common/certs_test.go
+++ b/ledger/common/certs_test.go
@@ -275,6 +275,12 @@ func TestPoolRegistrationCertificateLeiosKey(t *testing.T) {
 	})
 }
 
+func TestPoolRegistrationCertificateRejectsShortOperatorKey(t *testing.T) {
+	var cert PoolRegistrationCertificate
+	err := json.Unmarshal([]byte(`{"publicKey":"01"}`), &cert)
+	require.Error(t, err)
+}
+
 func TestLeiosKeyRejectsInvalidLengths(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/protocol/messagesubmission/messages_test.go
+++ b/protocol/messagesubmission/messages_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/protocol"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestMsgInitEncoding tests MsgInit message encoding
@@ -218,7 +219,8 @@ func TestMsgReplyMessagesLegacyEncodingDecodes(t *testing.T) {
 	parsed, err := NewMsgFromCbor(uint(MessageTypeReplyMessages), data)
 	assert.NoError(t, err)
 	decoded, ok := parsed.(*MsgReplyMessages)
-	assert.True(t, ok)
+	require.True(t, ok)
+	require.NotEmpty(t, decoded.Messages)
 	assert.Equal(t, []byte("id1"), decoded.Messages[0].MessageID)
 	assert.Equal(t, []byte("id1"), decoded.Messages[0].Payload.MessageID)
 }


### PR DESCRIPTION
Fixes the reported test assertion, pool key parsing, and fuzz workflow issues.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened validation and tests, and tightened fuzz workflow selectors to prevent false matches. This blocks invalid pool operator keys and catches decoding issues earlier.

- **Bug Fixes**
  - Validate `PoolRegistrationCertificate` operator key length equals `Blake2b224Size`; return a clear error on mismatch.
  - Strengthen decoding tests in `ledger/byron` and `protocol/messagesubmission` using `require` and explicit checks (null header error, non-empty messages).
  - Tighten `.github/workflows/fuzz.yml` by anchoring fuzz target names with `$`, quoting Go version, and setting `actions/checkout` `persist-credentials: false`.

<sup>Written for commit 63147aeeabd4bfbb73f1df058ae0f3b814a8ca5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Pool registration certificates with invalid operator key lengths are now rejected during JSON decoding.
  - Improved error handling for malformed blockchain data and legacy message responses.

- **Testing & Reliability**
  - Expanded regression coverage for invalid certificates, malformed headers, and legacy message decoding.
  - Improved fuzz testing accuracy across ledger, KES, VRF, and common components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->