### PR TITLE
fix(ledger): prevent invalid Bech32 addresses from falling back to Base58

### DIFF
--- a/ledger/common/address.go
+++ b/ledger/common/address.go
@@ -21,6 +21,7 @@ import (
 	"hash/crc32"
 	"io"
 	"math/big"
+	"strings"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/plutigo/data"
@@ -86,18 +87,22 @@ type Address struct {
 	byronAddressAttr ByronAddressAttributes
 }
 
-// NewAddress returns an Address based on the provided bech32/base58 address string
-// It detects if the string has mixed case assumes it is a base58 encoded address
-// otherwise, it assumes it is bech32 encoded
+// NewAddress returns an Address based on the provided bech32/base58 address
+// string.
 func NewAddress(addr string) (Address, error) {
 	var decoded []byte
-	_, data, err := bech32.DecodeNoLimit(addr)
+	hrp, data, err := bech32.DecodeNoLimit(addr)
 	if err == nil {
 		decoded, err = bech32.ConvertBits(data, 5, 8, false)
 		if err != nil {
 			return Address{}, err
 		}
 	} else {
+		// A string with a known Shelley HRP was intended to be bech32. Do not
+		// reinterpret a checksum or mixed-case failure as a Byron address.
+		if hasShelleyAddressHRP(addr) {
+			return Address{}, fmt.Errorf("invalid bech32 address: %w", err)
+		}
 		// bech32 failed — try base58 (Byron addresses)
 		decoded = base58.Decode(addr)
 		if len(decoded) == 0 {
@@ -109,7 +114,29 @@ func NewAddress(addr string) (Address, error) {
 	if err != nil {
 		return Address{}, err
 	}
+	if hrp != "" && !strings.EqualFold(hrp, a.generateHRP()) {
+		return Address{}, fmt.Errorf(
+			"address HRP %q does not match expected HRP %q",
+			hrp,
+			a.generateHRP(),
+		)
+	}
 	return a, nil
+}
+
+func hasShelleyAddressHRP(addr string) bool {
+	lowerAddr := strings.ToLower(addr)
+	for _, prefix := range []string{
+		"addr1",
+		"addr_test1",
+		"stake1",
+		"stake_test1",
+	} {
+		if strings.HasPrefix(lowerAddr, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // NewAddressFromBytes returns an Address based on the raw bytes provided

--- a/ledger/common/address.go
+++ b/ledger/common/address.go
@@ -102,7 +102,7 @@ func NewAddress(addr string) (Address, error) {
 		// A string with a known Shelley HRP was intended to be bech32. Do not
 		// reinterpret a checksum or mixed-case failure as a Byron address.
 		if hasShelleyAddressHRP(addr) {
-			return Address{}, fmt.Errorf("invalid bech32 address: %w", err)
+			return Address{}, err
 		}
 		// bech32 failed — try base58 (Byron addresses)
 		decoded = base58.Decode(addr)

--- a/ledger/common/address.go
+++ b/ledger/common/address.go
@@ -92,6 +92,7 @@ type Address struct {
 func NewAddress(addr string) (Address, error) {
 	var decoded []byte
 	hrp, data, err := bech32.DecodeNoLimit(addr)
+	isBech32 := err == nil
 	if err == nil {
 		decoded, err = bech32.ConvertBits(data, 5, 8, false)
 		if err != nil {
@@ -114,29 +115,29 @@ func NewAddress(addr string) (Address, error) {
 	if err != nil {
 		return Address{}, err
 	}
-	if hrp != "" && !strings.EqualFold(hrp, a.generateHRP()) {
-		return Address{}, fmt.Errorf(
-			"address HRP %q does not match expected HRP %q",
-			hrp,
-			a.generateHRP(),
-		)
+	if isBech32 {
+		expectedHRP := a.generateHRP()
+		if !strings.EqualFold(hrp, expectedHRP) {
+			return Address{}, fmt.Errorf(
+				"address HRP %q does not match expected HRP %q",
+				hrp,
+				expectedHRP,
+			)
+		}
 	}
 	return a, nil
 }
 
 func hasShelleyAddressHRP(addr string) bool {
-	lowerAddr := strings.ToLower(addr)
-	for _, prefix := range []string{
-		"addr1",
-		"addr_test1",
-		"stake1",
-		"stake_test1",
-	} {
-		if strings.HasPrefix(lowerAddr, prefix) {
-			return true
-		}
-	}
-	return false
+	return hasFoldedPrefix(addr, "addr1") ||
+		hasFoldedPrefix(addr, "addr_test1") ||
+		hasFoldedPrefix(addr, "stake1") ||
+		hasFoldedPrefix(addr, "stake_test1")
+}
+
+func hasFoldedPrefix(value, prefix string) bool {
+	return len(value) >= len(prefix) &&
+		strings.EqualFold(value[:len(prefix)], prefix)
 }
 
 // NewAddressFromBytes returns an Address based on the raw bytes provided

--- a/ledger/common/address.go
+++ b/ledger/common/address.go
@@ -116,6 +116,11 @@ func NewAddress(addr string) (Address, error) {
 		return Address{}, err
 	}
 	if isBech32 {
+		if a.addressType == AddressTypeByron {
+			return Address{}, errors.New(
+				"byron addresses must use base58 encoding",
+			)
+		}
 		expectedHRP := a.generateHRP()
 		if !strings.EqualFold(hrp, expectedHRP) {
 			return Address{}, fmt.Errorf(

--- a/ledger/common/address_test.go
+++ b/ledger/common/address_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/internal/test"
 	"github.com/blinklabs-io/plutigo/data"
+	"github.com/btcsuite/btcd/btcutil/bech32"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1373,6 +1374,84 @@ func TestCIP0019_InvalidBech32Inputs(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+// TestNewAddressRejectsCorruptedShelleyAddress verifies that single-character
+// Bech32 corruptions cannot be accepted through the Byron Base58 fallback.
+func TestNewAddressRejectsCorruptedShelleyAddress(t *testing.T) {
+	paymentHash := make([]byte, AddressHashSize)
+	stakeHash := make([]byte, AddressHashSize)
+	for i := range paymentHash {
+		paymentHash[i] = 0xaa
+		stakeHash[i] = 0xbb
+	}
+	addr, err := NewAddressFromParts(
+		AddressTypeKeyKey,
+		AddressNetworkMainnet,
+		paymentHash,
+		stakeHash,
+	)
+	require.NoError(t, err)
+
+	encoded := addr.String()
+	separator := strings.LastIndexByte(encoded, '1')
+	require.Positive(t, separator)
+	const mutationCharacters = "qpzry9x8gf2tvdw0s3jn54khce6mua7l1"
+
+	// A Bech32 checksum detects every single-character substitution. Verify
+	// that none of those failures can be accepted through the Byron fallback.
+	for pos := separator + 1; pos < len(encoded)-6; pos++ {
+		for _, replacement := range mutationCharacters {
+			if byte(replacement) == encoded[pos] {
+				continue
+			}
+			corrupted := []byte(encoded)
+			corrupted[pos] = byte(replacement)
+			_, err := NewAddress(string(corrupted))
+			require.Error(
+				t,
+				err,
+				"accepted corruption at position %d with %q",
+				pos,
+				replacement,
+			)
+		}
+	}
+}
+
+// TestNewAddressValidatesBech32HRP verifies that the textual HRP agrees with
+// the address type and network encoded in the decoded header.
+func TestNewAddressValidatesBech32HRP(t *testing.T) {
+	const paymentAddress = "addr1q862w5ru0hpxl4r6vezgtegrfqve0dm2dp3yj2f7y4arrf223wd3fr6qcumc6873am478xnxmfp8lgpe6q6ju9ttjgns2xavze"
+	_, words, err := bech32.DecodeNoLimit(paymentAddress)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		hrp  string
+	}{
+		{
+			name: "payment address with stake HRP",
+			hrp:  "stake",
+		},
+		{
+			name: "mainnet address with testnet HRP",
+			hrp:  "addr_test",
+		},
+		{
+			name: "unknown HRP",
+			hrp:  "wrong",
+		},
+	}
+	for _, testDef := range tests {
+		t.Run(testDef.name, func(t *testing.T) {
+			encoded, err := bech32.Encode(testDef.hrp, words)
+			require.NoError(t, err)
+			_, err = NewAddress(encoded)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "does not match expected HRP")
 		})
 	}
 }

--- a/ledger/common/address_test.go
+++ b/ledger/common/address_test.go
@@ -1456,6 +1456,20 @@ func TestNewAddressValidatesBech32HRP(t *testing.T) {
 	}
 }
 
+// TestNewAddressRejectsBech32ByronAddress verifies that a Byron payload cannot
+// bypass its Base58-only encoding requirement by using a matching Bech32 HRP.
+func TestNewAddressRejectsBech32ByronAddress(t *testing.T) {
+	const byronAddress = "Ae2tdPwUPEYwFx4dmJheyNPPYXtvHbJLeCaA96o6Y2iiUL18cAt7AizN2zG"
+	const bech32ByronAddress = "addr_test1stvpskppsdvpcpyxtepdyde6mklt6hf2e7quwcxgfztszs5gnalwwccfrwsqqxhsrytd2vqclr3"
+
+	_, err := NewAddress(byronAddress)
+	require.NoError(t, err)
+
+	_, err = NewAddress(bech32ByronAddress)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "byron addresses must use base58 encoding")
+}
+
 func TestCIP0019_PaymentAndStakeAddressExtraction(t *testing.T) {
 	tests := []struct {
 		name              string


### PR DESCRIPTION
1. Prevent malformed Shelley addresses from being reinterpreted as Byron addresses and validate Bech32 HRPs against decoded address headers.
2. Recognized Shelley payment and stake address prefixes.
3. Returned Bech32 checksum and mixed-case errors directly.
4. Verified that the Bech32 prefix matches the decoded address type and network.
5. Preserved Base58 decoding for valid Byron addresses.
6. Added tests for single-character address corruption.
7. Added tests for incorrect network and address-type prefixes.
8. Optimized prefix detection to avoid unnecessary allocations.

Closes #1930 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent invalid Shelley `bech32` addresses from falling back to Byron `base58`, and reject `bech32`-encoded Byron addresses. Validate the HRP against the decoded address header and return clearer errors.

- **Bug Fixes**
  - If a Shelley HRP (`addr1`, `addr_test1`, `stake1`, `stake_test1`) is present, do not attempt `base58` fallback on `bech32` errors; return the checksum/mixed-case error.
  - Ensure the `bech32` HRP matches the decoded address type and network; provide a mismatch error with both HRPs.
  - Enforce Byron-only `base58`: reject `bech32`-encoded Byron addresses while preserving valid Byron `base58` decoding.
  - Add tests for single-character corruption and wrong HRPs; optimize case-insensitive prefix checks.

<sup>Written for commit fd2559d7f0c7c425df541d1238cd67d68f52e5a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for Shelley addresses.
  * Malformed addresses are now rejected instead of being misinterpreted.
  * Address network and type information is verified against the encoded format.
  * Address prefix matching is now case-insensitive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->