### PR TITLE
feat(kes): forward-secure erasure (Zeroize + erase spent evolution on Update)

### DIFF
--- a/kes/kes_test.go
+++ b/kes/kes_test.go
@@ -144,6 +144,118 @@ func TestVerifySignedKES(t *testing.T) {
 	)
 }
 
+func TestUpdateErasesSpentKey(t *testing.T) {
+	sk, _, err := KeyGen(CardanoKesDepth, testSeed)
+	require.NoError(t, err, "KeyGen failed")
+
+	// Hold a reference to the original backing array so we can prove it was
+	// wiped after evolution (Zeroize sets sk.Data = nil).
+	oldData := sk.Data
+
+	sk1, err := Update(sk)
+	require.NoError(t, err, "Update failed")
+	require.Equal(t, uint64(1), sk1.Period, "evolved key wrong period")
+
+	// The spent predecessor must be erased and unusable.
+	require.Nil(t, sk.Data, "spent key Data not cleared")
+	require.Equal(
+		t,
+		make([]byte, len(oldData)),
+		oldData,
+		"spent key backing array not zeroed",
+	)
+	_, err = Sign(sk, 0, []byte("should fail"))
+	require.Error(t, err, "erased key must not sign")
+
+	// The evolved key must sign and verify at the new period.
+	message := []byte("test message at period 1")
+	sig, err := Sign(sk1, 1, message)
+	require.NoError(t, err, "evolved key sign failed")
+	require.True(
+		t,
+		VerifySignedKES(PublicKey(sk1), 1, message, sig),
+		"evolved signature failed to verify",
+	)
+}
+
+func TestZeroize(t *testing.T) {
+	sk, _, err := KeyGen(CardanoKesDepth, testSeed)
+	require.NoError(t, err, "KeyGen failed")
+
+	data := sk.Data
+	sk.Zeroize()
+
+	require.Nil(t, sk.Data, "Data not cleared after Zeroize")
+	require.Equal(
+		t,
+		make([]byte, len(data)),
+		data,
+		"backing array not zeroed after Zeroize",
+	)
+
+	_, err = Sign(sk, 0, []byte("x"))
+	require.Error(t, err, "zeroized key must not sign")
+	_, err = Update(sk)
+	require.Error(t, err, "zeroized key must not evolve")
+
+	// Zeroize on a nil key and a double Zeroize must not panic.
+	require.NotPanics(t, func() { sk.Zeroize() }, "double Zeroize panicked")
+	var nilKey *SecretKey
+	require.NotPanics(t, func() { nilKey.Zeroize() }, "nil Zeroize panicked")
+}
+
+func TestUpdateExhaustionUnchanged(t *testing.T) {
+	sk, _, err := KeyGen(CardanoKesDepth, testSeed)
+	require.NoError(t, err, "KeyGen failed")
+
+	maxPeriod := MaxPeriod(CardanoKesDepth)
+	// Evolve to the final valid period (maxPeriod - 1).
+	for range maxPeriod - 1 {
+		sk, err = Update(sk)
+		require.NoError(t, err, "Update failed during evolve chain")
+	}
+	require.Equal(t, maxPeriod-1, sk.Period, "did not reach final period")
+
+	// One more evolution is exhausted and must leave the key unchanged/usable.
+	before := append([]byte(nil), sk.Data...)
+	_, err = Update(sk)
+	require.Error(t, err, "expected exhaustion error")
+	require.NotNil(t, sk.Data, "exhausted Update must not erase the key")
+	require.Equal(t, before, sk.Data, "exhausted Update mutated the key")
+
+	// The key at the final period must still sign.
+	message := []byte("final period")
+	sig, err := Sign(sk, maxPeriod-1, message)
+	require.NoError(t, err, "sign at final period failed")
+	require.True(
+		t,
+		VerifySignedKES(PublicKey(sk), maxPeriod-1, message, sig),
+		"final period signature failed to verify",
+	)
+}
+
+func TestFullEvolveChainVerifies(t *testing.T) {
+	sk, pk, err := KeyGen(CardanoKesDepth, testSeed)
+	require.NoError(t, err, "KeyGen failed")
+
+	maxPeriod := MaxPeriod(CardanoKesDepth)
+	message := []byte("evolve chain message")
+	for period := range maxPeriod {
+		sig, err := Sign(sk, period, message)
+		require.NoErrorf(t, err, "sign failed at period %d", period)
+		require.Truef(
+			t,
+			VerifySignedKES(pk, period, message, sig),
+			"verify failed at period %d",
+			period,
+		)
+		if period < maxPeriod-1 {
+			sk, err = Update(sk)
+			require.NoErrorf(t, err, "update failed at period %d", period)
+		}
+	}
+}
+
 func TestHashPair(t *testing.T) {
 	left := make([]byte, PublicKeySize)
 	right := make([]byte, PublicKeySize)

--- a/kes/sign.go
+++ b/kes/sign.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"runtime"
 
 	"golang.org/x/crypto/blake2b"
 )
@@ -36,6 +37,42 @@ type SecretKey struct {
 	Period    uint64
 	Data      []byte // The raw key bytes
 	publicKey []byte // Cached public key (computed once, never changes)
+}
+
+// wipe overwrites the given buffer with zeros in a way the compiler is not
+// permitted to elide as a dead store.
+//
+// Go provides no guaranteed-secure zeroization primitive. This helper uses the
+// established best-effort pattern: the write loop lives in a //go:noinline
+// function (so the call site cannot prove the stores are dead and remove them)
+// and runtime.KeepAlive pins the backing array until the loop completes.
+//
+// CAVEAT: this only wipes THIS backing array. Go's garbage collector or stack
+// growth may have copied the secret elsewhere earlier in its lifetime; those
+// copies cannot be reached from here and are outside the guarantees of this
+// package. Callers needing stronger assurances should hold KES secrets in
+// mlock'd, non-GC-managed memory and wipe that buffer as well.
+//
+//go:noinline
+func wipe(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+	runtime.KeepAlive(b)
+}
+
+// Zeroize erases all secret material held by the key and renders it unusable.
+// After Zeroize, Sign and Update return an error for this key. The (public,
+// non-secret) cached public key is retained so PublicKey still works.
+//
+// See the wipe caveat regarding residual copies the Go runtime may have made.
+func (sk *SecretKey) Zeroize() {
+	if sk == nil {
+		return
+	}
+	wipe(sk.Data)
+	sk.Data = nil
+	sk.Period = 0
 }
 
 // secretKeySize returns the size of a KES secret key for a given depth
@@ -172,6 +209,9 @@ func Sign(sk *SecretKey, period uint64, message []byte) ([]byte, error) {
 	if sk == nil {
 		return nil, errors.New("secret key is nil")
 	}
+	if sk.Data == nil {
+		return nil, errors.New("secret key has been erased")
+	}
 
 	maxPeriod := uint64(1) << sk.Depth
 	if period >= maxPeriod {
@@ -261,10 +301,25 @@ func signInternal(
 }
 
 // Update evolves the secret key to the next period.
-// Returns the updated key, or error if key is exhausted.
+// Returns the evolved key, or an error if the key is exhausted, erased or nil.
+//
+// Update is forward-secure: it consumes the input key IN PLACE. On success the
+// spent predecessor (sk) is erased (its secret material zeroized, sk.Data set to
+// nil) so it can no longer sign, and the returned key is the only usable one.
+// The evolved key's own backing array is derived so it retains no period-N leaf
+// material. On the exhausted/erased/nil paths sk is left unchanged.
+//
+// Migration note: earlier revisions returned the evolved key WITHOUT erasing the
+// input, leaving the caller holding a still-signable copy of the spent period.
+// The established call pattern `sk, err = kes.Update(sk)` is unaffected — it
+// overwrites the reference that Update has already erased. Callers must not
+// retain or reuse the pre-Update *SecretKey.
 func Update(sk *SecretKey) (*SecretKey, error) {
 	if sk == nil {
 		return nil, errors.New("secret key is nil")
+	}
+	if sk.Data == nil {
+		return nil, errors.New("secret key has been erased")
 	}
 
 	maxPeriod := uint64(1) << sk.Depth
@@ -278,21 +333,30 @@ func Update(sk *SecretKey) (*SecretKey, error) {
 		)
 	}
 
-	// Create a copy of the key data
+	// Derive the evolved key into a fresh backing array. updateInternal
+	// overwrites the spent leaf and zeroes any used seed within this copy, so
+	// the evolved key holds no material from period sk.Period.
 	newData := make([]byte, len(sk.Data))
 	copy(newData, sk.Data)
 
-	err := updateInternal(sk.Depth, sk.Period, newData)
-	if err != nil {
+	if err := updateInternal(sk.Depth, sk.Period, newData); err != nil {
+		// Don't leak partially-derived secret material on failure.
+		wipe(newData)
 		return nil, err
 	}
 
-	return &SecretKey{
+	evolved := &SecretKey{
 		Depth:     sk.Depth,
 		Period:    newPeriod,
 		Data:      newData,
 		publicKey: sk.publicKey, // Preserve the cached public key (it never changes)
-	}, nil
+	}
+
+	// Forward security: erase the spent predecessor in place so the
+	// pre-evolution key can no longer produce signatures.
+	sk.Zeroize()
+
+	return evolved, nil
 }
 
 // updateInternal recursively updates the secret key
@@ -300,9 +364,7 @@ func updateInternal(depth uint64, period uint64, data []byte) error {
 	if depth == 0 {
 		// At depth 0, zero out the old key for forward security.
 		// This ensures compromising future keys doesn't reveal past signing capability.
-		for i := range kesEd25519KeySize {
-			data[i] = 0
-		}
+		wipe(data[0:kesEd25519KeySize])
 		return nil
 	}
 
@@ -325,9 +387,7 @@ func updateInternal(depth uint64, period uint64, data []byte) error {
 		}
 
 		// Zero out the seed (it's been used)
-		for i := range 32 {
-			data[seedOffset+i] = 0
-		}
+		wipe(data[seedOffset : seedOffset+32])
 
 		return nil
 	} else {


### PR DESCRIPTION
Adds `SecretKey.Zeroize()` — a barrier-safe wipe of all KES secret material that renders the key unusable — and makes `Update` forward-secure by erasing the spent predecessor in place before returning the evolved key. `Sign` and `Update` now reject an erased key.

- `Update` consumes its input `*SecretKey` (erases it); the `sk, err = kes.Update(sk)` reassignment pattern used by all current consumers is unaffected — callers must not reuse the pre-`Update` key.
- Inline zeroing in `updateInternal` replaced with the barrier-safe `wipe`.
- No wire-format change: `KeyGen`/`Sign`/`Verify`/serialization and all byte layouts are unchanged; opcerts and node-served keys still validate and the conformance vectors pass unchanged.

Tests: spent-key erasure after `Update` (old bytes zeroed, old key can't sign, evolved key verifies), `Zeroize` behavior, exhaustion unchanged, full 0→63 evolve chain verifies.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds forward-secure erasure to KES keys. `Update` now zeroizes and invalidates the spent key, and `SecretKey.Zeroize()` securely wipes secret material; erased keys cannot sign or evolve. No wire-format changes.

- **New Features**
  - Added `SecretKey.Zeroize()` to wipe secret material while keeping the cached public key.
  - Made `Update` forward-secure: derives the new key in a fresh buffer and erases the predecessor in place; `Sign`/`Update` return errors for erased keys.
  - Introduced a barrier-safe `wipe` helper (`//go:noinline` + `runtime.KeepAlive`).

- **Migration**
  - Keep using `sk, err = kes.Update(sk)`; do not reuse or retain references to the pre-`Update` key.
  - Handle new errors when operating on an erased key.

<sup>Written for commit 8b59d413640886e0938d628c40da0a5e91bf417f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit secret-key zeroization, clearing sensitive key material while retaining the public key.
  * Signing and key updates are now rejected after a key has been erased.
  * Key evolution now securely erases predecessor and temporary key data.

* **Bug Fixes**
  * Improved handling of exhausted key updates while preserving final-period behavior.
  * Added safe handling for repeated or empty zeroization requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->