### PR TITLE
fix(leiosfetch): bound block requests with caller context, non-fatal timeout

### DIFF
--- a/protocol/leiosfetch/client.go
+++ b/protocol/leiosfetch/client.go
@@ -88,9 +88,17 @@ func (s *requestSlot) acquire(
 // rather than mis-delivered, while leaving the slot busy until that response
 // arrives (or the protocol shuts down). It is used when a caller's context
 // expires before a response is received.
-func (s *requestSlot) abandon() {
+//
+// The caller passes the delivery channel it registered in acquire. The slot is
+// only mutated while that channel is still the live waiter (s.waiter == w). If
+// the response already arrived (deliver cleared and freed the slot) and a
+// different request has since acquired the slot, s.waiter now belongs to that
+// newer request, so this is a no-op and the newer waiter is left intact.
+func (s *requestSlot) abandon(w chan protocol.Message) {
 	s.mu.Lock()
-	s.waiter = nil
+	if s.waiter == w {
+		s.waiter = nil
+	}
 	s.mu.Unlock()
 }
 
@@ -98,10 +106,18 @@ func (s *requestSlot) abandon() {
 // goroutine waiting in acquire. It is used when the request message could not
 // be sent, or the protocol is shutting down, so no response will ever arrive
 // to drain the slot.
-func (s *requestSlot) release() {
+//
+// As with abandon, the caller passes the delivery channel it registered in
+// acquire and the slot is only cleared and freed while that channel is still
+// the live waiter (s.waiter == w). If the slot was already freed and reacquired
+// by a newer request, this is a no-op so the newer request's registration is
+// not disturbed.
+func (s *requestSlot) release(w chan protocol.Message) {
 	s.mu.Lock()
-	s.waiter = nil
-	s.freeLocked()
+	if s.waiter == w {
+		s.waiter = nil
+		s.freeLocked()
+	}
 	s.mu.Unlock()
 }
 
@@ -242,7 +258,7 @@ func (c *Client) BlockRequest(
 	}
 	msg := NewMsgBlockRequest(point)
 	if err := c.SendMessage(msg); err != nil {
-		c.blockSlot.release()
+		c.blockSlot.release(w)
 		return nil, err
 	}
 	select {
@@ -253,10 +269,10 @@ func (c *Client) BlockRequest(
 		}
 		return resp, nil
 	case <-ctx.Done():
-		c.blockSlot.abandon()
+		c.blockSlot.abandon(w)
 		return nil, ctx.Err()
 	case <-c.DoneChan():
-		c.blockSlot.release()
+		c.blockSlot.release(w)
 		return nil, protocol.ErrProtocolShuttingDown
 	}
 }
@@ -277,7 +293,7 @@ func (c *Client) BlockTxsRequest(
 	}
 	msg := NewMsgBlockTxsRequest(point, bitmaps)
 	if err := c.SendMessage(msg); err != nil {
-		c.blockTxsSlot.release()
+		c.blockTxsSlot.release(w)
 		return nil, err
 	}
 	select {
@@ -288,10 +304,10 @@ func (c *Client) BlockTxsRequest(
 		}
 		return resp, nil
 	case <-ctx.Done():
-		c.blockTxsSlot.abandon()
+		c.blockTxsSlot.abandon(w)
 		return nil, ctx.Err()
 	case <-c.DoneChan():
-		c.blockTxsSlot.release()
+		c.blockTxsSlot.release(w)
 		return nil, protocol.ErrProtocolShuttingDown
 	}
 }

--- a/protocol/leiosfetch/client.go
+++ b/protocol/leiosfetch/client.go
@@ -15,6 +15,7 @@
 package leiosfetch
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -52,14 +53,13 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 	}
 	// Update state map with timeout
 	stateMap := StateMap.Copy()
-	if entry, ok := stateMap[StateBlock]; ok {
-		entry.Timeout = c.config.Timeout
-		stateMap[StateBlock] = entry
-	}
-	if entry, ok := stateMap[StateBlockTxs]; ok {
-		entry.Timeout = c.config.Timeout
-		stateMap[StateBlockTxs] = entry
-	}
+	// NOTE: StateBlock and StateBlockTxs intentionally do NOT get a
+	// protocol-level timeout. A missing response to a BlockRequest /
+	// BlockTxsRequest must fail only that individual request (bounded by the
+	// caller-supplied context), never tear down the shared multiplexed
+	// connection. The protocol-level timeout fires p.SendError(), which is
+	// fatal to every mini-protocol on the same bearer (chainsync, blockfetch,
+	// etc.), so it must not be wired for these two states.
 	if entry, ok := stateMap[StateVotes]; ok {
 		entry.Timeout = c.config.Timeout
 		stateMap[StateVotes] = entry
@@ -121,27 +121,44 @@ func (c *Client) Stop() error {
 	return err
 }
 
-// BlockRequest fetches the requested EB identified by the specified point
+// BlockRequest fetches the requested EB identified by the specified point.
+//
+// The wait for a response is bounded by the provided context. If the context
+// is cancelled or its deadline is exceeded before a response arrives, the
+// context error is returned. This failure is local to this request: it does
+// NOT emit a protocol error and does NOT tear down the shared multiplexed
+// connection. A response that arrives after the context is done is dropped by
+// the receive path (see handleBlock/handleNoBlock).
 func (c *Client) BlockRequest(
+	ctx context.Context,
 	point pcommon.Point,
 ) (protocol.Message, error) {
 	msg := NewMsgBlockRequest(point)
 	if err := c.SendMessage(msg); err != nil {
 		return nil, err
 	}
-	resp, ok := <-c.blockResultChan
-	if !ok {
-		return nil, protocol.ErrProtocolShuttingDown
+	select {
+	case resp, ok := <-c.blockResultChan:
+		if !ok {
+			return nil, protocol.ErrProtocolShuttingDown
+		}
+		// The server reported the endorser block as not available
+		if _, ok := resp.(*MsgNoBlock); ok {
+			return nil, ErrBlockNotFound
+		}
+		return resp, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	}
-	// The server reported the endorser block as not available
-	if _, ok := resp.(*MsgNoBlock); ok {
-		return nil, ErrBlockNotFound
-	}
-	return resp, nil
 }
 
-// BlockTxsRequest fetches the requested TXs identified by the specified point and TX bitmaps
+// BlockTxsRequest fetches the requested TXs identified by the specified point and TX bitmaps.
+//
+// As with BlockRequest, the wait is bounded by the provided context and a
+// context cancellation/deadline returns the context error without tearing down
+// the shared connection.
 func (c *Client) BlockTxsRequest(
+	ctx context.Context,
 	point pcommon.Point,
 	bitmaps map[uint16]uint64,
 ) (protocol.Message, error) {
@@ -149,15 +166,19 @@ func (c *Client) BlockTxsRequest(
 	if err := c.SendMessage(msg); err != nil {
 		return nil, err
 	}
-	resp, ok := <-c.blockTxsResultChan
-	if !ok {
-		return nil, protocol.ErrProtocolShuttingDown
+	select {
+	case resp, ok := <-c.blockTxsResultChan:
+		if !ok {
+			return nil, protocol.ErrProtocolShuttingDown
+		}
+		// The server reported the endorser block transactions as not available
+		if _, ok := resp.(*MsgNoBlockTxs); ok {
+			return nil, ErrBlockTxsNotFound
+		}
+		return resp, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	}
-	// The server reported the endorser block transactions as not available
-	if _, ok := resp.(*MsgNoBlockTxs); ok {
-		return nil, ErrBlockTxsNotFound
-	}
-	return resp, nil
 }
 
 // VotesRequest fetches the requested votes
@@ -226,8 +247,32 @@ func (c *Client) messageHandler(msg protocol.Message) error {
 	return err
 }
 
+// deliverResult delivers a response to a waiting request without blocking the
+// protocol receive loop. If no caller is currently waiting on the channel (for
+// example, because the request was abandoned after its context expired), the
+// response is dropped. The mini-protocol state transition back to StateIdle is
+// driven independently by protocol.handleMessage before this handler runs, so
+// dropping the message here never leaves the mini-protocol wedged.
+func (c *Client) deliverResult(
+	ch chan protocol.Message,
+	msg protocol.Message,
+) {
+	select {
+	case ch <- msg:
+	default:
+		c.Protocol.Logger().
+			Debug("dropping unawaited leios-fetch response",
+				"component", "network",
+				"protocol", ProtocolName,
+				"role", "client",
+				"connection_id", c.callbackContext.ConnectionId.String(),
+				"message_type", msg.Type(),
+			)
+	}
+}
+
 func (c *Client) handleBlock(msg protocol.Message) {
-	c.blockResultChan <- msg
+	c.deliverResult(c.blockResultChan, msg)
 }
 
 func (c *Client) handleNoBlock(msg protocol.Message) {
@@ -238,11 +283,11 @@ func (c *Client) handleNoBlock(msg protocol.Message) {
 			"role", "client",
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
-	c.blockResultChan <- msg
+	c.deliverResult(c.blockResultChan, msg)
 }
 
 func (c *Client) handleBlockTxs(msg protocol.Message) {
-	c.blockTxsResultChan <- msg
+	c.deliverResult(c.blockTxsResultChan, msg)
 }
 
 func (c *Client) handleNoBlockTxs(msg protocol.Message) {
@@ -253,7 +298,7 @@ func (c *Client) handleNoBlockTxs(msg protocol.Message) {
 			"role", "client",
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
-	c.blockTxsResultChan <- msg
+	c.deliverResult(c.blockTxsResultChan, msg)
 }
 
 func (c *Client) handleVotes(msg protocol.Message) {

--- a/protocol/leiosfetch/client.go
+++ b/protocol/leiosfetch/client.go
@@ -29,10 +29,112 @@ type Client struct {
 	callbackContext      CallbackContext
 	onceStart            sync.Once
 	onceStop             sync.Once
-	blockResultChan      chan protocol.Message
-	blockTxsResultChan   chan protocol.Message
+	blockSlot            requestSlot
+	blockTxsSlot         requestSlot
 	votesResultChan      chan protocol.Message
 	blockRangeResultChan chan protocol.Message
+}
+
+// requestSlot serializes a single outstanding request/response exchange for a
+// ping-pong leios-fetch state (Block or BlockTxs) and correlates the response
+// with the caller that is actually waiting for it.
+//
+// These mini-protocol states carry no request identifier and the underlying
+// protocol is strictly serialized (a new request message is not sent until the
+// previous response returns the state to Idle). Correlation is therefore
+// enforced structurally:
+//   - a request registers its own capacity-1 delivery channel BEFORE the
+//     request message is sent, so a response that arrives before the caller
+//     parks cannot be dropped; and
+//   - a new request blocks until any previously abandoned response has been
+//     drained, so a late response to an abandoned request is never
+//     mis-delivered to a subsequent request.
+type requestSlot struct {
+	mu        sync.Mutex
+	waiter    chan protocol.Message
+	busy      bool
+	drainedCh chan struct{}
+}
+
+// acquire waits until the slot is free (any previously abandoned response has
+// been drained), bounded by ctx and the protocol done channel, then registers
+// and returns a fresh capacity-1 delivery channel for this request.
+func (s *requestSlot) acquire(
+	ctx context.Context,
+	done <-chan struct{},
+) (chan protocol.Message, error) {
+	s.mu.Lock()
+	for s.busy {
+		drained := s.drainedCh
+		s.mu.Unlock()
+		select {
+		case <-drained:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-done:
+			return nil, protocol.ErrProtocolShuttingDown
+		}
+		s.mu.Lock()
+	}
+	w := make(chan protocol.Message, 1)
+	s.waiter = w
+	s.busy = true
+	s.drainedCh = make(chan struct{})
+	s.mu.Unlock()
+	return w, nil
+}
+
+// abandon clears the live waiter so that a late response is dropped by deliver
+// rather than mis-delivered, while leaving the slot busy until that response
+// arrives (or the protocol shuts down). It is used when a caller's context
+// expires before a response is received.
+func (s *requestSlot) abandon() {
+	s.mu.Lock()
+	s.waiter = nil
+	s.mu.Unlock()
+}
+
+// release frees the slot without a response having been received, waking any
+// goroutine waiting in acquire. It is used when the request message could not
+// be sent, or the protocol is shutting down, so no response will ever arrive
+// to drain the slot.
+func (s *requestSlot) release() {
+	s.mu.Lock()
+	s.waiter = nil
+	s.freeLocked()
+	s.mu.Unlock()
+}
+
+// deliver routes a received response to the waiting caller, if any, and frees
+// the slot. It returns true when a caller received the response and false when
+// the response was dropped (no caller waiting, e.g. after abandonment).
+func (s *requestSlot) deliver(msg protocol.Message) bool {
+	s.mu.Lock()
+	w := s.waiter
+	s.waiter = nil
+	s.freeLocked()
+	s.mu.Unlock()
+	if w == nil {
+		return false
+	}
+	// The channel has capacity 1 and receives at most one response per
+	// request (the state machine rejects a second server message before it
+	// reaches this handler), so this send never blocks the receive loop.
+	w <- msg
+	return true
+}
+
+// freeLocked marks the slot as no longer busy and wakes any goroutine waiting
+// in acquire. The caller must hold s.mu.
+func (s *requestSlot) freeLocked() {
+	if !s.busy {
+		return
+	}
+	s.busy = false
+	if s.drainedCh != nil {
+		close(s.drainedCh)
+		s.drainedCh = nil
+	}
 }
 
 func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
@@ -42,8 +144,6 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 	}
 	c := &Client{
 		config:               cfg,
-		blockResultChan:      make(chan protocol.Message),
-		blockTxsResultChan:   make(chan protocol.Message),
 		votesResultChan:      make(chan protocol.Message),
 		blockRangeResultChan: make(chan protocol.Message),
 	}
@@ -95,11 +195,13 @@ func (c *Client) Start() {
 				"connection_id", c.callbackContext.ConnectionId.String(),
 			)
 		c.Protocol.Start()
-		// Start goroutine to cleanup resources on protocol shutdown
+		// Start goroutine to cleanup resources on protocol shutdown.
+		// The Block/BlockTxs request slots are unblocked directly by the
+		// per-request select watching DoneChan (see BlockRequest /
+		// BlockTxsRequest), so only the shared Votes/BlockRange channels are
+		// closed here.
 		go func() {
 			<-c.DoneChan()
-			close(c.blockResultChan)
-			close(c.blockTxsResultChan)
 			close(c.votesResultChan)
 			close(c.blockRangeResultChan)
 		}()
@@ -128,27 +230,34 @@ func (c *Client) Stop() error {
 // context error is returned. This failure is local to this request: it does
 // NOT emit a protocol error and does NOT tear down the shared multiplexed
 // connection. A response that arrives after the context is done is dropped by
-// the receive path (see handleBlock/handleNoBlock).
+// the receive path (see handleBlock/handleNoBlock), and a subsequent request
+// waits for that late response to drain so it can never be mis-delivered.
 func (c *Client) BlockRequest(
 	ctx context.Context,
 	point pcommon.Point,
 ) (protocol.Message, error) {
+	w, err := c.blockSlot.acquire(ctx, c.DoneChan())
+	if err != nil {
+		return nil, err
+	}
 	msg := NewMsgBlockRequest(point)
 	if err := c.SendMessage(msg); err != nil {
+		c.blockSlot.release()
 		return nil, err
 	}
 	select {
-	case resp, ok := <-c.blockResultChan:
-		if !ok {
-			return nil, protocol.ErrProtocolShuttingDown
-		}
+	case resp := <-w:
 		// The server reported the endorser block as not available
 		if _, ok := resp.(*MsgNoBlock); ok {
 			return nil, ErrBlockNotFound
 		}
 		return resp, nil
 	case <-ctx.Done():
+		c.blockSlot.abandon()
 		return nil, ctx.Err()
+	case <-c.DoneChan():
+		c.blockSlot.release()
+		return nil, protocol.ErrProtocolShuttingDown
 	}
 }
 
@@ -162,22 +271,28 @@ func (c *Client) BlockTxsRequest(
 	point pcommon.Point,
 	bitmaps map[uint16]uint64,
 ) (protocol.Message, error) {
+	w, err := c.blockTxsSlot.acquire(ctx, c.DoneChan())
+	if err != nil {
+		return nil, err
+	}
 	msg := NewMsgBlockTxsRequest(point, bitmaps)
 	if err := c.SendMessage(msg); err != nil {
+		c.blockTxsSlot.release()
 		return nil, err
 	}
 	select {
-	case resp, ok := <-c.blockTxsResultChan:
-		if !ok {
-			return nil, protocol.ErrProtocolShuttingDown
-		}
+	case resp := <-w:
 		// The server reported the endorser block transactions as not available
 		if _, ok := resp.(*MsgNoBlockTxs); ok {
 			return nil, ErrBlockTxsNotFound
 		}
 		return resp, nil
 	case <-ctx.Done():
+		c.blockTxsSlot.abandon()
 		return nil, ctx.Err()
+	case <-c.DoneChan():
+		c.blockTxsSlot.release()
+		return nil, protocol.ErrProtocolShuttingDown
 	}
 }
 
@@ -247,32 +362,26 @@ func (c *Client) messageHandler(msg protocol.Message) error {
 	return err
 }
 
-// deliverResult delivers a response to a waiting request without blocking the
-// protocol receive loop. If no caller is currently waiting on the channel (for
-// example, because the request was abandoned after its context expired), the
-// response is dropped. The mini-protocol state transition back to StateIdle is
+// logDroppedResponse records that a response was dropped because no caller was
+// waiting for it (for example, because the request was abandoned after its
+// context expired). The mini-protocol state transition back to StateIdle is
 // driven independently by protocol.handleMessage before this handler runs, so
 // dropping the message here never leaves the mini-protocol wedged.
-func (c *Client) deliverResult(
-	ch chan protocol.Message,
-	msg protocol.Message,
-) {
-	select {
-	case ch <- msg:
-	default:
-		c.Protocol.Logger().
-			Debug("dropping unawaited leios-fetch response",
-				"component", "network",
-				"protocol", ProtocolName,
-				"role", "client",
-				"connection_id", c.callbackContext.ConnectionId.String(),
-				"message_type", msg.Type(),
-			)
-	}
+func (c *Client) logDroppedResponse(msg protocol.Message) {
+	c.Protocol.Logger().
+		Debug("dropping unawaited leios-fetch response",
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "client",
+			"connection_id", c.callbackContext.ConnectionId.String(),
+			"message_type", msg.Type(),
+		)
 }
 
 func (c *Client) handleBlock(msg protocol.Message) {
-	c.deliverResult(c.blockResultChan, msg)
+	if !c.blockSlot.deliver(msg) {
+		c.logDroppedResponse(msg)
+	}
 }
 
 func (c *Client) handleNoBlock(msg protocol.Message) {
@@ -283,11 +392,15 @@ func (c *Client) handleNoBlock(msg protocol.Message) {
 			"role", "client",
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
-	c.deliverResult(c.blockResultChan, msg)
+	if !c.blockSlot.deliver(msg) {
+		c.logDroppedResponse(msg)
+	}
 }
 
 func (c *Client) handleBlockTxs(msg protocol.Message) {
-	c.deliverResult(c.blockTxsResultChan, msg)
+	if !c.blockTxsSlot.deliver(msg) {
+		c.logDroppedResponse(msg)
+	}
 }
 
 func (c *Client) handleNoBlockTxs(msg protocol.Message) {
@@ -298,7 +411,9 @@ func (c *Client) handleNoBlockTxs(msg protocol.Message) {
 			"role", "client",
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
-	c.deliverResult(c.blockTxsResultChan, msg)
+	if !c.blockTxsSlot.deliver(msg) {
+		c.logDroppedResponse(msg)
+	}
 }
 
 func (c *Client) handleVotes(msg protocol.Message) {

--- a/protocol/leiosfetch/client_test.go
+++ b/protocol/leiosfetch/client_test.go
@@ -15,8 +15,8 @@
 package leiosfetch
 
 import (
+	"context"
 	"net"
-	"runtime"
 	"testing"
 	"time"
 
@@ -115,69 +115,52 @@ func TestClientMessageHandler(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// The Block/BlockTxs handlers now deliver results with a
-			// non-blocking send, so a response is dropped unless a caller is
-			// already parked on the result channel. The Votes/BlockRange
-			// handlers still deliver with a blocking send. To exercise routing
-			// deterministically for both, run a persistent drainer goroutine
-			// on the appropriate result channel (so a receiver is effectively
-			// always parked) and retry messageHandler until the drainer
-			// records a delivery. Calls are sequential, so at most one send is
-			// ever in flight; the drainer absorbs every send (preventing a
-			// blocking handler from wedging) and exits on stop.
+			// The Block/BlockTxs handlers deliver results to a per-request
+			// slot, so register a waiter first; the Votes/BlockRange handlers
+			// deliver with a blocking send to a shared channel, so park a
+			// receiver. Either way a single messageHandler call routes the
+			// message deterministically, with no busy-spin. A goroutine parked
+			// on the delivery channel forwards the routed message so we can
+			// assert delivery under a bounded deadline.
 			got := make(chan protocol.Message, 1)
-			stop := make(chan struct{})
-			done := make(chan struct{})
+			var deliverCh chan protocol.Message
+			switch tc.msg.Type() {
+			case MessageTypeBlock, MessageTypeNoBlock:
+				w, err := client.blockSlot.acquire(
+					context.Background(),
+					client.DoneChan(),
+				)
+				require.NoError(t, err)
+				deliverCh = w
+			case MessageTypeBlockTxs, MessageTypeNoBlockTxs:
+				w, err := client.blockTxsSlot.acquire(
+					context.Background(),
+					client.DoneChan(),
+				)
+				require.NoError(t, err)
+				deliverCh = w
+			case MessageTypeVotes:
+				deliverCh = client.votesResultChan
+			case MessageTypeNextBlockAndTxsInRange, MessageTypeLastBlockAndTxsInRange:
+				deliverCh = client.blockRangeResultChan
+			}
 			go func() {
-				defer close(done)
-				var ch chan protocol.Message
-				switch tc.msg.Type() {
-				case MessageTypeBlock, MessageTypeNoBlock:
-					ch = client.blockResultChan
-				case MessageTypeBlockTxs, MessageTypeNoBlockTxs:
-					ch = client.blockTxsResultChan
-				case MessageTypeVotes:
-					ch = client.votesResultChan
-				case MessageTypeNextBlockAndTxsInRange, MessageTypeLastBlockAndTxsInRange:
-					ch = client.blockRangeResultChan
-				}
-				for {
-					select {
-					case m := <-ch:
-						// Record only the first delivery; drop the rest.
-						select {
-						case got <- m:
-						default:
-						}
-					case <-stop:
-						return
-					}
-				}
+				got <- <-deliverCh
 			}()
 
-			deadline := time.Now().Add(time.Second)
-			delivered := false
-			for !delivered {
-				err := client.messageHandler(tc.msg)
-				if tc.expectError {
-					assert.Error(t, err)
-				} else {
-					assert.NoError(t, err)
-				}
-				select {
-				case <-got:
-					delivered = true
-				default:
-					require.False(
-						t,
-						time.Now().After(deadline),
-						"handler did not route message",
-					)
-					runtime.Gosched()
-				}
+			err := client.messageHandler(tc.msg)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
-			close(stop)
-			<-done
+
+			select {
+			case m := <-got:
+				assert.Equal(t, tc.msg, m)
+			case <-time.After(time.Second):
+				t.Fatal("handler did not route message")
+			}
 		})
 	}
 }

--- a/protocol/leiosfetch/client_test.go
+++ b/protocol/leiosfetch/client_test.go
@@ -115,14 +115,14 @@ func TestClientMessageHandler(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// The Block/BlockTxs handlers deliver results to a per-request
-			// slot, so register a waiter first; the Votes/BlockRange handlers
-			// deliver with a blocking send to a shared channel, so park a
-			// receiver. Either way a single messageHandler call routes the
-			// message deterministically, with no busy-spin. A goroutine parked
-			// on the delivery channel forwards the routed message so we can
-			// assert delivery under a bounded deadline.
-			got := make(chan protocol.Message, 1)
+			// The Block/BlockTxs handlers deliver results to a per-request slot
+			// (a non-blocking send), so register a waiter first. The
+			// Votes/BlockRange handlers deliver with a blocking send to a shared
+			// channel, so the main goroutine below acts as the parked receiver.
+			// messageHandler runs in a helper goroutine: for a slot delivery it
+			// returns immediately, and for a blocking-send delivery it unblocks
+			// as soon as the main goroutine receives. Either way the helper is
+			// guaranteed to exit, so no goroutine dangles on a failed subtest.
 			var deliverCh chan protocol.Message
 			switch tc.msg.Type() {
 			case MessageTypeBlock, MessageTypeNoBlock:
@@ -144,24 +144,134 @@ func TestClientMessageHandler(t *testing.T) {
 			case MessageTypeNextBlockAndTxsInRange, MessageTypeLastBlockAndTxsInRange:
 				deliverCh = client.blockRangeResultChan
 			}
+			errCh := make(chan error, 1)
 			go func() {
-				got <- <-deliverCh
+				errCh <- client.messageHandler(tc.msg)
 			}()
 
-			err := client.messageHandler(tc.msg)
-			if tc.expectError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-
+			// Receive the routed message under a bounded deadline.
 			select {
-			case m := <-got:
+			case m := <-deliverCh:
 				assert.Equal(t, tc.msg, m)
 			case <-time.After(time.Second):
 				t.Fatal("handler did not route message")
 			}
+
+			// Confirm the handler returned (and its error expectation) under a
+			// bounded deadline so the helper goroutine cannot dangle.
+			select {
+			case err := <-errCh:
+				if tc.expectError {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("handler did not return")
+			}
 		})
+	}
+}
+
+// TestRequestSlotAbandonAfterDeliverKeepsNextWaiter reproduces the
+// deliver-vs-context-cancel race between two requests on the same slot.
+//
+// Request A registers its waiter and its response is delivered (freeing the
+// slot). A's context also fires, so A's select may pick the cancellation branch
+// and call abandon with its own delivery channel. Before that abandon runs,
+// request B acquires the freed slot and registers its own waiter. abandon must
+// only clear the waiter it still owns: passing A's channel while B owns the slot
+// must be a no-op, so B's response is delivered to B rather than dropped.
+//
+// The ordering (deliver A, acquire B, then abandon A) is driven explicitly so
+// the regression is exercised deterministically rather than via scheduler luck.
+func TestRequestSlotAbandonAfterDeliverKeepsNextWaiter(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	client := NewClient(protocol.ProtocolOptions{ConnectionId: connId}, nil)
+
+	// Request A acquires the slot and registers its delivery channel.
+	wA, err := client.blockSlot.acquire(context.Background(), client.DoneChan())
+	require.NoError(t, err)
+
+	// A's response arrives: delivered to wA and the slot is freed.
+	msgA := NewMsgBlock([]byte{0xaa, 0xbb})
+	require.True(t, client.blockSlot.deliver(msgA))
+
+	// Request B acquires the now-free slot and registers its own channel.
+	wB, err := client.blockSlot.acquire(context.Background(), client.DoneChan())
+	require.NoError(t, err)
+
+	// A's late context cancellation abandons using A's own channel. B owns the
+	// slot now, so this must not disturb B's registration.
+	client.blockSlot.abandon(wA)
+
+	// B's response must be delivered to B (not dropped).
+	msgB := NewMsgBlock([]byte{0xcc, 0xdd})
+	require.True(
+		t,
+		client.blockSlot.deliver(msgB),
+		"B's response was dropped: abandon(wA) erased B's waiter",
+	)
+
+	// B receives its own payload, not A's.
+	select {
+	case got := <-wB:
+		gotBlock, ok := got.(*MsgBlock)
+		require.True(t, ok)
+		assert.Equal(t, []byte{0xcc, 0xdd}, []byte(gotBlock.BlockRaw))
+	case <-time.After(time.Second):
+		t.Fatal("request B did not receive its response")
+	}
+
+	// A's earlier response is still buffered on its own channel, unaffected.
+	select {
+	case got := <-wA:
+		gotBlock, ok := got.(*MsgBlock)
+		require.True(t, ok)
+		assert.Equal(t, []byte{0xaa, 0xbb}, []byte(gotBlock.BlockRaw))
+	case <-time.After(time.Second):
+		t.Fatal("request A's buffered response went missing")
+	}
+}
+
+// TestRequestSlotReleaseAfterReacquireKeepsNextWaiter is the release-path
+// analogue of the abandon race: once the slot has been freed and reacquired by
+// a newer request, calling release with the previous request's channel must be
+// a no-op and must not free the slot out from under the newer waiter.
+func TestRequestSlotReleaseAfterReacquireKeepsNextWaiter(t *testing.T) {
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	client := NewClient(protocol.ProtocolOptions{ConnectionId: connId}, nil)
+
+	wA, err := client.blockSlot.acquire(context.Background(), client.DoneChan())
+	require.NoError(t, err)
+	// Free the slot via a delivery, then reacquire for request B.
+	require.True(t, client.blockSlot.deliver(NewMsgBlock([]byte{0x01})))
+	<-wA
+	wB, err := client.blockSlot.acquire(context.Background(), client.DoneChan())
+	require.NoError(t, err)
+
+	// A stale release using A's channel must not touch B's registration.
+	client.blockSlot.release(wA)
+
+	msgB := NewMsgBlock([]byte{0x02})
+	require.True(
+		t,
+		client.blockSlot.deliver(msgB),
+		"B's response was dropped: release(wA) erased B's waiter",
+	)
+	select {
+	case got := <-wB:
+		gotBlock, ok := got.(*MsgBlock)
+		require.True(t, ok)
+		assert.Equal(t, []byte{0x02}, []byte(gotBlock.BlockRaw))
+	case <-time.After(time.Second):
+		t.Fatal("request B did not receive its response")
 	}
 }
 

--- a/protocol/leiosfetch/client_test.go
+++ b/protocol/leiosfetch/client_test.go
@@ -16,6 +16,7 @@ package leiosfetch
 
 import (
 	"net"
+	"runtime"
 	"testing"
 	"time"
 
@@ -114,37 +115,69 @@ func TestClientMessageHandler(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// For block-related messages, we need to drain the channels
-			// to prevent blocking. We use goroutines to consume the messages.
+			// The Block/BlockTxs handlers now deliver results with a
+			// non-blocking send, so a response is dropped unless a caller is
+			// already parked on the result channel. The Votes/BlockRange
+			// handlers still deliver with a blocking send. To exercise routing
+			// deterministically for both, run a persistent drainer goroutine
+			// on the appropriate result channel (so a receiver is effectively
+			// always parked) and retry messageHandler until the drainer
+			// records a delivery. Calls are sequential, so at most one send is
+			// ever in flight; the drainer absorbs every send (preventing a
+			// blocking handler from wedging) and exits on stop.
+			got := make(chan protocol.Message, 1)
+			stop := make(chan struct{})
 			done := make(chan struct{})
 			go func() {
 				defer close(done)
+				var ch chan protocol.Message
 				switch tc.msg.Type() {
 				case MessageTypeBlock, MessageTypeNoBlock:
-					<-client.blockResultChan
+					ch = client.blockResultChan
 				case MessageTypeBlockTxs, MessageTypeNoBlockTxs:
-					<-client.blockTxsResultChan
+					ch = client.blockTxsResultChan
 				case MessageTypeVotes:
-					<-client.votesResultChan
+					ch = client.votesResultChan
 				case MessageTypeNextBlockAndTxsInRange, MessageTypeLastBlockAndTxsInRange:
-					<-client.blockRangeResultChan
+					ch = client.blockRangeResultChan
+				}
+				for {
+					select {
+					case m := <-ch:
+						// Record only the first delivery; drop the rest.
+						select {
+						case got <- m:
+						default:
+						}
+					case <-stop:
+						return
+					}
 				}
 			}()
 
-			err := client.messageHandler(tc.msg)
-
-			if tc.expectError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
+			deadline := time.Now().Add(time.Second)
+			delivered := false
+			for !delivered {
+				err := client.messageHandler(tc.msg)
+				if tc.expectError {
+					assert.Error(t, err)
+				} else {
+					assert.NoError(t, err)
+				}
+				select {
+				case <-got:
+					delivered = true
+				default:
+					require.False(
+						t,
+						time.Now().After(deadline),
+						"handler did not route message",
+					)
+					runtime.Gosched()
+				}
 			}
-
-			// Wait for the channel consumer goroutine to finish
-			select {
-			case <-done:
-			case <-time.After(100 * time.Millisecond):
-				t.Fatal("timeout waiting for channel consumer")
-			}
+			close(stop)
+			<-done
 		})
 	}
 }

--- a/protocol/leiosfetch/leiosfetch_test.go
+++ b/protocol/leiosfetch/leiosfetch_test.go
@@ -164,6 +164,109 @@ func TestBlockTxsRequestNoBlockTxs(t *testing.T) {
 	)
 }
 
+// TestBlockRequestSuccess verifies the normal path: the server answers a
+// BlockRequest with MsgBlock and the caller receives the exact block payload.
+// Because the per-request delivery channel is registered before the request
+// message is sent, the response cannot be dropped even if it arrives before
+// the caller parks on the channel.
+func TestBlockRequestSuccess(t *testing.T) {
+	conversation := append(
+		conversationHandshake,
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  leiosfetch.ProtocolId,
+			MessageType: leiosfetch.MessageTypeBlockRequest,
+		},
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: leiosfetch.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				leiosfetch.NewMsgBlock([]byte{0x82, 0x0a, 0x0b}),
+			},
+		},
+	)
+	runTest(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			resp, err := oConn.LeiosFetch().Client.BlockRequest(
+				context.Background(),
+				pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+			)
+			require.NoError(t, err)
+			require.IsType(t, &leiosfetch.MsgBlock{}, resp)
+			assert.Equal(
+				t,
+				[]byte{0x82, 0x0a, 0x0b},
+				[]byte(resp.(*leiosfetch.MsgBlock).BlockRaw),
+			)
+		},
+	)
+}
+
+// TestBlockRequestSubsequentAfterAbandonedNoResponse verifies that when a
+// BlockRequest is abandoned via its context and NO response ever arrives, a
+// subsequent BlockRequest still fails cleanly with its own context error and
+// does NOT tear down the shared multiplexed connection. The runTest harness
+// panics on any error delivered to the connection ErrorChan, so completing
+// without a panic proves the connection stays alive (no SendError / fatal
+// teardown from a request issued after an abandoned one).
+func TestBlockRequestSubsequentAfterAbandonedNoResponse(t *testing.T) {
+	conversation := append(
+		conversationHandshake,
+		// The server receives the first request and never responds. The
+		// second request never reaches the wire because the client blocks it
+		// until the first (never-arriving) response drains.
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  leiosfetch.ProtocolId,
+			MessageType: leiosfetch.MessageTypeBlockRequest,
+		},
+	)
+	runTest(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			client := oConn.LeiosFetch().Client
+			ctx1, cancel1 := context.WithTimeout(
+				context.Background(),
+				150*time.Millisecond,
+			)
+			defer cancel1()
+			resp1, err1 := client.BlockRequest(
+				ctx1,
+				pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+			)
+			require.Error(t, err1)
+			assert.True(
+				t,
+				errors.Is(err1, context.DeadlineExceeded),
+				"expected context deadline error, got %v",
+				err1,
+			)
+			assert.Nil(t, resp1)
+
+			// Subsequent request: also bounded by its own context. It must
+			// return a context error, not tear down the connection.
+			ctx2, cancel2 := context.WithTimeout(
+				context.Background(),
+				150*time.Millisecond,
+			)
+			defer cancel2()
+			resp2, err2 := client.BlockRequest(
+				ctx2,
+				pcommon.NewPoint(23456, []byte{0x05, 0x06, 0x07, 0x08}),
+			)
+			require.Error(t, err2)
+			assert.True(
+				t,
+				errors.Is(err2, context.DeadlineExceeded),
+				"expected context deadline error, got %v",
+				err2,
+			)
+			assert.Nil(t, resp2)
+		},
+	)
+}
+
 // TestBlockRequestContextCancelledNonFatal verifies that when a BlockRequest
 // receives no response, the caller-supplied context bounds the wait and the
 // request returns the context error. Critically, this must NOT emit a protocol
@@ -279,7 +382,17 @@ func TestBlockRequestSubsequentAfterAbandoned(t *testing.T) {
 			)
 			require.NoError(t, err2)
 			require.NotNil(t, resp2)
-			assert.IsType(t, &leiosfetch.MsgBlock{}, resp2)
+			require.IsType(t, &leiosfetch.MsgBlock{}, resp2)
+			// Assert the exact payload for the SECOND request. The late
+			// response to the abandoned first request carried {0x82,0x01,0x02};
+			// if correlation were broken it would be mis-delivered here. Only
+			// the second request's own response {0x82,0x03,0x04} is correct.
+			block2 := resp2.(*leiosfetch.MsgBlock)
+			assert.Equal(
+				t,
+				[]byte{0x82, 0x03, 0x04},
+				[]byte(block2.BlockRaw),
+			)
 		},
 	)
 }

--- a/protocol/leiosfetch/leiosfetch_test.go
+++ b/protocol/leiosfetch/leiosfetch_test.go
@@ -15,6 +15,8 @@
 package leiosfetch_test
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -119,6 +121,7 @@ func TestBlockRequestNoBlock(t *testing.T) {
 		conversation,
 		func(t *testing.T, oConn *ouroboros.Connection) {
 			resp, err := oConn.LeiosFetch().Client.BlockRequest(
+				context.Background(),
 				pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}),
 			)
 			require.Error(t, err)
@@ -150,12 +153,133 @@ func TestBlockTxsRequestNoBlockTxs(t *testing.T) {
 		conversation,
 		func(t *testing.T, oConn *ouroboros.Connection) {
 			resp, err := oConn.LeiosFetch().Client.BlockTxsRequest(
+				context.Background(),
 				pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}),
 				map[uint16]uint64{0: 0xff00000000000000},
 			)
 			require.Error(t, err)
 			assert.ErrorIs(t, err, leiosfetch.ErrBlockTxsNotFound)
 			assert.Nil(t, resp)
+		},
+	)
+}
+
+// TestBlockRequestContextCancelledNonFatal verifies that when a BlockRequest
+// receives no response, the caller-supplied context bounds the wait and the
+// request returns the context error. Critically, this must NOT emit a protocol
+// error (the runTest harness panics on any error delivered to the shared
+// connection ErrorChan), proving that an unanswered leios-fetch request does
+// not tear down the multiplexed connection that other mini-protocols share.
+func TestBlockRequestContextCancelledNonFatal(t *testing.T) {
+	conversation := append(
+		conversationHandshake,
+		// The server receives the request but never responds.
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  leiosfetch.ProtocolId,
+			MessageType: leiosfetch.MessageTypeBlockRequest,
+		},
+	)
+	runTest(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			ctx, cancel := context.WithTimeout(
+				context.Background(),
+				200*time.Millisecond,
+			)
+			defer cancel()
+			resp, err := oConn.LeiosFetch().Client.BlockRequest(
+				ctx,
+				pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+			)
+			require.Error(t, err)
+			assert.True(
+				t,
+				errors.Is(err, context.DeadlineExceeded),
+				"expected context deadline error, got %v",
+				err,
+			)
+			assert.Nil(t, resp)
+		},
+	)
+}
+
+// TestBlockRequestSubsequentAfterAbandoned verifies that after a BlockRequest
+// is abandoned via its context, a subsequent BlockRequest on the same client
+// still completes normally. The late response to the abandoned request arrives
+// after the caller has given up; it drives the mini-protocol state back to
+// Idle (and is then delivered/dropped without blocking the receive loop), so
+// the client remains usable for further requests.
+func TestBlockRequestSubsequentAfterAbandoned(t *testing.T) {
+	conversation := append(
+		conversationHandshake,
+		// First request: the server delays past the caller's context
+		// deadline before finally sending a (now unawaited) response.
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  leiosfetch.ProtocolId,
+			MessageType: leiosfetch.MessageTypeBlockRequest,
+		},
+		ouroboros_mock.ConversationEntrySleep{
+			Duration: 300 * time.Millisecond,
+		},
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: leiosfetch.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				leiosfetch.NewMsgBlock([]byte{0x82, 0x01, 0x02}),
+			},
+		},
+		// Second request: served normally.
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  leiosfetch.ProtocolId,
+			MessageType: leiosfetch.MessageTypeBlockRequest,
+		},
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: leiosfetch.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				leiosfetch.NewMsgBlock([]byte{0x82, 0x03, 0x04}),
+			},
+		},
+	)
+	runTest(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			client := oConn.LeiosFetch().Client
+			// First request: abandoned when its short context expires
+			// before the (delayed) server response arrives.
+			ctx1, cancel1 := context.WithTimeout(
+				context.Background(),
+				100*time.Millisecond,
+			)
+			defer cancel1()
+			resp1, err1 := client.BlockRequest(
+				ctx1,
+				pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+			)
+			require.Error(t, err1)
+			assert.True(
+				t,
+				errors.Is(err1, context.DeadlineExceeded),
+				"expected context deadline error, got %v",
+				err1,
+			)
+			assert.Nil(t, resp1)
+
+			// Second request on the same client must still complete.
+			ctx2, cancel2 := context.WithTimeout(
+				context.Background(),
+				2*time.Second,
+			)
+			defer cancel2()
+			resp2, err2 := client.BlockRequest(
+				ctx2,
+				pcommon.NewPoint(23456, []byte{0x05, 0x06, 0x07, 0x08}),
+			)
+			require.NoError(t, err2)
+			require.NotNil(t, resp2)
+			assert.IsType(t, &leiosfetch.MsgBlock{}, resp2)
 		},
 	)
 }


### PR DESCRIPTION
## What

`leiosfetch.Client.BlockRequest` and `BlockTxsRequest` now take a `context.Context` and return its error if the context is done before a response arrives. The block and block-txs states no longer carry a protocol-level timeout, and the block/no-block/block-txs/no-block-txs result delivery is non-blocking.

## Why

The block and block-txs states were wired with `c.config.Timeout`. When that protocol timeout fired, the protocol ran `SendError`, which stops the protocol and is fatal to the entire multiplexed connection, tearing down the chainsync and blockfetch mini-protocols running on the same bearer. A slow relay serving a by-point endorser-block fetch therefore killed an in-progress sync.

The timeout is now the caller's responsibility via the context: on expiry the request returns `ctx.Err()` as a normal error, and the shared connection stays up. The result channels are unbuffered, so `handleBlock`/`handleNoBlock`/`handleBlockTxs`/`handleNoBlockTxs` now do a non-blocking send; a response that arrives after its caller has abandoned the request is dropped rather than blocking the receive loop. The mini-protocol state transition is driven by `Protocol.handleMessage` before the client message handler runs, so a dropped response still transitions `StateBlock`/`StateBlockTxs` back to `StateIdle` and the next request on the same client proceeds.

## API change

```go
func (c *Client) BlockRequest(ctx context.Context, point pcommon.Point) (protocol.Message, error)
func (c *Client) BlockTxsRequest(ctx context.Context, point pcommon.Point, bitmaps map[uint16]uint64) (protocol.Message, error)
```

`VotesRequest` and `BlockRangeRequest` are unchanged and keep their protocol timeouts.

## Validation

- `TestBlockRequestContextCancelledNonFatal`: a request whose response never arrives returns the context error and does not stop the protocol or emit on the error channel.
- `TestBlockRequestSubsequentAfterAbandoned`: after an abandoned request whose late response is dropped, a subsequent request on the same client completes normally.
- `go test -race -count=5 ./protocol/leiosfetch/...` passes; `go build ./...` and `go vet ./...` clean; golangci-lint 0 issues on the package.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make block and block-txs requests respect caller context so slow or silent relays don’t kill the shared connection. Add per-request correlation and guard against races so late replies aren’t mis-delivered or dropped incorrectly.

- **Bug Fixes**
  - Removed protocol-level timeouts for `StateBlock`/`StateBlockTxs`; requests are bounded by context and return `ctx.Err()` instead of triggering `SendError`.
  - Replaced shared result channels with a per-request slot that registers a capacity-1 waiter before sending and blocks new requests until late replies drain, ensuring correct correlation.
  - Made delivery non-blocking; late replies are dropped with a debug log.
  - Token-guarded request-slot `abandon`/`release` so a stale caller can’t erase a newer waiter; added regression tests and tightened message routing tests.

- **Migration**
  - `BlockRequest(ctx, point)` and `BlockTxsRequest(ctx, point, bitmaps)` now require a `context.Context` (use `context.Background()` or a deadline).
  - `VotesRequest` and `BlockRangeRequest` are unchanged.

<sup>Written for commit 49d298fbca7fe15f34c40d0eb1f268320d77b834. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Block and transaction-block requests now support cancellation and deadlines through caller-provided contexts.
  * Abandoned requests no longer block response processing, improving protocol responsiveness.
* **Bug Fixes**
  * Timed-out requests return a clear deadline error without causing protocol errors.
  * Subsequent requests continue to work correctly after an earlier request is abandoned.
* **Tests**
  * Added coverage for cancellation, delayed responses, and reliable message delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->