### PR TITLE
fix(ledger): render txInfoMint zero-ada entry at every protocol version

### DIFF
--- a/ledger/common/script/context.go
+++ b/ledger/common/script/context.go
@@ -103,9 +103,10 @@ type TxInfoV1 struct {
 	Data         KeyValuePairs[lcommon.Blake2b256, data.PlutusData]
 	Redeemers    KeyValuePairs[ScriptPurpose, Redeemer]
 	Id           lcommon.Blake2b256
-	// ProtocolMajor no longer affects the txInfoMint rendering, which matches
-	// cardano-ledger at every protocol version. Retained so existing callers
-	// that set it keep compiling.
+	// Deprecated: ProtocolMajor has no effect. The txInfoMint rendering matches
+	// cardano-ledger at every protocol version, so nothing reads this field. It
+	// is retained only so existing callers that assign it keep compiling, and
+	// will be removed in a future release.
 	ProtocolMajor uint
 }
 
@@ -259,9 +260,10 @@ type TxInfoV2 struct {
 	Redeemers       KeyValuePairs[ScriptPurpose, Redeemer]
 	Data            KeyValuePairs[lcommon.Blake2b256, data.PlutusData]
 	Id              lcommon.Blake2b256
-	// ProtocolMajor no longer affects the txInfoMint rendering, which matches
-	// cardano-ledger at every protocol version. Retained so existing callers
-	// that set it keep compiling.
+	// Deprecated: ProtocolMajor has no effect. The txInfoMint rendering matches
+	// cardano-ledger at every protocol version, so nothing reads this field. It
+	// is retained only so existing callers that assign it keep compiling, and
+	// will be removed in a future release.
 	ProtocolMajor uint
 }
 

--- a/ledger/common/script/context.go
+++ b/ledger/common/script/context.go
@@ -92,40 +92,38 @@ type TxInfo interface {
 }
 
 type TxInfoV1 struct {
-	Inputs        []ResolvedInput
-	Outputs       []lcommon.TransactionOutput
-	Fee           *big.Int
-	Mint          lcommon.MultiAsset[lcommon.MultiAssetTypeMint]
-	Certificates  []lcommon.Certificate
-	Withdrawals   Pairs[*lcommon.Address, *big.Int]
-	ValidRange    TimeRange
-	Signatories   []lcommon.Blake2b224
-	Data          KeyValuePairs[lcommon.Blake2b256, data.PlutusData]
-	Redeemers     KeyValuePairs[ScriptPurpose, Redeemer]
-	Id            lcommon.Blake2b256
+	Inputs       []ResolvedInput
+	Outputs      []lcommon.TransactionOutput
+	Fee          *big.Int
+	Mint         lcommon.MultiAsset[lcommon.MultiAssetTypeMint]
+	Certificates []lcommon.Certificate
+	Withdrawals  Pairs[*lcommon.Address, *big.Int]
+	ValidRange   TimeRange
+	Signatories  []lcommon.Blake2b224
+	Data         KeyValuePairs[lcommon.Blake2b256, data.PlutusData]
+	Redeemers    KeyValuePairs[ScriptPurpose, Redeemer]
+	Id           lcommon.Blake2b256
+	// ProtocolMajor no longer affects the txInfoMint rendering, which matches
+	// cardano-ledger at every protocol version. Retained so existing callers
+	// that set it keep compiling.
 	ProtocolMajor uint
 }
 
 func (TxInfoV1) isTxInfo() {}
 
-func mintToPlutusData(
-	mint lcommon.MultiAsset[lcommon.MultiAssetTypeMint],
-	protocolMajor uint,
-) data.PlutusData {
-	if !lcommon.IsProtocolVersionAtLeast(
-		protocolMajor,
-		0,
-		lcommon.ProtocolVersionPlomin,
-	) {
-		return mint.ToPlutusData()
-	}
-	return mintWithZeroAda(mint)
-}
-
-// mintWithZeroAda renders PV10+ txInfoMint for PlutusV1/V2 as cardano-ledger
-// does: transMintValue m = transCoinToValue zero <> transMultiAsset m. That
-// prepends a zero-lovelace ada entry ({"":{"":0}}), even when nothing is
-// minted. PlutusV3 uses the V3 MintValue representation, so TxInfoV3 keeps
+// mintWithZeroAda renders txInfoMint for PlutusV1/V2 as cardano-ledger does:
+// transMintValue m = transCoinToValue zero <> transMultiAsset m. That prepends a
+// zero-lovelace ada entry ({"":{"":0}}), even when nothing is minted.
+//
+// This applies at every protocol version. cardano-ledger's transMintValue takes
+// no protocol version and has no branch, and Alonzo, Babbage and Conway all
+// route their V1/V2 txInfo through that one function. Gating it on PV10 made
+// every pre-Plomin script that inspects txInfoMint see a mint field one entry
+// short, so its execution cost diverged from the node that produced the block.
+//
+// PlutusV3 differs: Conway defines its own transMintValue as
+// PV3.UnsafeMintValue . PV1.getValue . transMultiAsset, dropping the ada entry
+// because V3 uses the MintValue representation. TxInfoV3 therefore keeps
 // t.Mint.ToPlutusData().
 func mintWithZeroAda(
 	mint lcommon.MultiAsset[lcommon.MultiAssetTypeMint],
@@ -175,7 +173,7 @@ func (t TxInfoV1) ToPlutusData() data.PlutusData {
 				CoinBigInt: t.Fee,
 			},
 		}.ToPlutusData(),
-		mintToPlutusData(t.Mint, t.ProtocolMajor),
+		mintWithZeroAda(t.Mint),
 		WithPartialCertificates{
 			t.Certificates,
 		}.ToPlutusData(),
@@ -261,7 +259,10 @@ type TxInfoV2 struct {
 	Redeemers       KeyValuePairs[ScriptPurpose, Redeemer]
 	Data            KeyValuePairs[lcommon.Blake2b256, data.PlutusData]
 	Id              lcommon.Blake2b256
-	ProtocolMajor   uint
+	// ProtocolMajor no longer affects the txInfoMint rendering, which matches
+	// cardano-ledger at every protocol version. Retained so existing callers
+	// that set it keep compiling.
+	ProtocolMajor uint
 }
 
 func (TxInfoV2) isTxInfo() {}
@@ -287,7 +288,7 @@ func (t TxInfoV2) ToPlutusData() data.PlutusData {
 				CoinBigInt: t.Fee,
 			},
 		}.ToPlutusData(),
-		mintToPlutusData(t.Mint, t.ProtocolMajor),
+		mintWithZeroAda(t.Mint),
 		WithPartialCertificates{
 			t.Certificates,
 		}.ToPlutusData(),

--- a/ledger/common/script/context_test.go
+++ b/ledger/common/script/context_test.go
@@ -18,7 +18,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -269,31 +268,6 @@ var scriptContextV1TestDefs = []struct {
 	},
 }
 
-func expectedPrePV10Cbor(t *testing.T, name string, pv10Cbor string) string {
-	t.Helper()
-	// The table stores the PV10+ expectation. Pre-PV10 is the same context with
-	// the zero-ADA mint entry removed.
-	replacements := map[string][2]string{
-		"SimpleSend": {
-			"182aa140a1400080",
-			"182aa080",
-		},
-		"Mint": {
-			"182aa340a14000",
-			"182aa2",
-		},
-	}
-	replacement, ok := replacements[name]
-	if !ok {
-		t.Fatalf("missing pre-PV10 expected CBOR replacement for %q", name)
-	}
-	ret := strings.Replace(pv10Cbor, replacement[0], replacement[1], 1)
-	if ret == pv10Cbor {
-		t.Fatalf("pre-PV10 expected CBOR replacement did not match for %q", name)
-	}
-	return ret
-}
-
 func TestScriptContextV1(t *testing.T) {
 	for _, testDef := range scriptContextV1TestDefs {
 		t.Run(
@@ -325,13 +299,25 @@ func TestScriptContextV1(t *testing.T) {
 					expectedCbor  string
 				}{
 					{
+						// The V1/V2 txInfoMint rendering does not depend on the
+						// protocol version: cardano-ledger's transMintValue is
+						// ungated, so a pre-Plomin major must produce the same
+						// zero-ada entry as PV10+.
 						name:          "PV9",
 						protocolMajor: common.ProtocolVersionConway,
-						expectedCbor: expectedPrePV10Cbor(
-							t,
-							testDef.name,
-							testDef.expectedCbor,
-						),
+						expectedCbor:  testDef.expectedCbor,
+					},
+					{
+						// Babbage-era major, and the zero value left by a caller
+						// that never assigns ProtocolMajor.
+						name:          "PV8",
+						protocolMajor: 8,
+						expectedCbor:  testDef.expectedCbor,
+					},
+					{
+						name:          "unset major",
+						protocolMajor: 0,
+						expectedCbor:  testDef.expectedCbor,
 					},
 					{
 						name:          "PV10",
@@ -431,13 +417,25 @@ func TestScriptContextV2(t *testing.T) {
 					expectedCbor  string
 				}{
 					{
+						// The V1/V2 txInfoMint rendering does not depend on the
+						// protocol version: cardano-ledger's transMintValue is
+						// ungated, so a pre-Plomin major must produce the same
+						// zero-ada entry as PV10+.
 						name:          "PV9",
 						protocolMajor: common.ProtocolVersionConway,
-						expectedCbor: expectedPrePV10Cbor(
-							t,
-							testDef.name,
-							testDef.expectedCbor,
-						),
+						expectedCbor:  testDef.expectedCbor,
+					},
+					{
+						// Babbage-era major, and the zero value left by a caller
+						// that never assigns ProtocolMajor.
+						name:          "PV8",
+						protocolMajor: 8,
+						expectedCbor:  testDef.expectedCbor,
+					},
+					{
+						name:          "unset major",
+						protocolMajor: 0,
+						expectedCbor:  testDef.expectedCbor,
 					},
 					{
 						name:          "PV10",

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -2156,7 +2156,6 @@ func UtxoValidatePlutusScripts(
 				if err != nil {
 					return ScriptContextConstructionError{Err: err}
 				}
-				txInfoV2.ProtocolMajor = conwayPparams.ProtocolVersion.Major
 				txInfoV2Built = true
 			}
 			// Build V1V2 context
@@ -2189,7 +2188,6 @@ func UtxoValidatePlutusScripts(
 				if err != nil {
 					return ScriptContextConstructionError{Err: err}
 				}
-				txInfoV1.ProtocolMajor = conwayPparams.ProtocolVersion.Major
 				txInfoV1Built = true
 			}
 			// Build V1V2 context

--- a/ledger/dijkstra/rules.go
+++ b/ledger/dijkstra/rules.go
@@ -545,7 +545,6 @@ func validateGuardingPlutusScripts(
 				if err != nil {
 					return conway.ScriptContextConstructionError{Err: err}
 				}
-				txInfoV2.ProtocolMajor = pp.ProtocolVersion.Major
 				txInfoV2Built = true
 			}
 			ctx := script.NewScriptContextV1V2(txInfoV2, purpose)
@@ -579,7 +578,6 @@ func validateGuardingPlutusScripts(
 				if err != nil {
 					return conway.ScriptContextConstructionError{Err: err}
 				}
-				txInfoV1.ProtocolMajor = pp.ProtocolVersion.Major
 				txInfoV1Built = true
 			}
 			ctx := script.NewScriptContextV1V2(txInfoV1, purpose)


### PR DESCRIPTION
cardano-ledger's `transMintValue` is `transCoinToValue zero <> transMultiAsset m`. It takes no protocol version and has no branch, and Alonzo, Babbage and Conway all route their PlutusV1/V2 txInfo through that one function, so the zero-lovelace ada entry is present in every era. Gating it on PV10 (#1796) gave every pre-Plomin script that inspects `txInfoMint` a mint field one entry short, so its execution cost diverged from the node that produced the block.

Scripts that never touch `txInfoMint` were unaffected, which is why this stayed hidden: it only shows up as a small ex-unit discrepancy on minting policies and on spend validators that inspect the mint field.

## Evidence

Measured against real preview block data, replaying transactions through the ledger and comparing three independently derived numbers: the budget declared in the on-chain redeemer, the cost an independent evaluator (aiken) computes when it builds the script context itself from the transaction, and the cost computed from the context this library builds.

PlutusV2 mint script `0190b78a` at slot 900626:

| context | cpu | mem |
| --- | ---: | ---: |
| gated, before this change | 81035425 | 266300 |
| ungated, after this change | 103596585 | 335560 |
| aiken, building its own context | 103596585 | 335560 |
| declared on chain | 121311159 | 335560 |

Exact agreement on both cpu and mem between the fixed rendering and the independent evaluator, and the memory matches the declared budget exactly.

PlutusV2 spend script `d174c198` at slot 917220, which also inspects the mint field, moves from 563982 mem to 580626 mem, and 580626 is both the declared value and what aiken computes from its own context.

Three further scripts in the same blocks that do not inspect `txInfoMint` (`5251b103`, `a258f896`, `2618e94c`) already matched their declared memory exactly and are unchanged by this patch, which is the control.

Two negative results, recorded so they are not retried: adding the datum to `txInfoData` for an inline-datum input moves the same script to 570806, the wrong direction, so inline datums correctly stay out of `txInfoData`; and applying both changes overshoots to 587450.

## Scope

PlutusV3 is unaffected. Conway defines its own `transMintValue` as `PV3.UnsafeMintValue . PV1.getValue . transMultiAsset`, dropping the ada entry because V3 uses the MintValue representation, and `TxInfoV3` keeps `t.Mint.ToPlutusData()`.

`TxInfoV1.ProtocolMajor` and `TxInfoV2.ProtocolMajor` no longer affect any rendering. They are retained rather than removed so existing callers that assign them keep compiling; blinklabs-io/dingo#3125 sets them.

Testing: the PV9 cases in `context_test.go` now expect the same CBOR as PV10, since the rendering is version independent, and PV8 and unset-major cases are added. Full `go test ./...` and `golangci-lint run ./...` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always render the zero-ADA entry in `txInfoMint` for Plutus V1/V2 at every protocol version to match `cardano-ledger`, fixing ex-unit mismatches for pre-Plomin scripts. `ProtocolMajor` in `TxInfoV1/V2` is now deprecated and no longer set internally.

- **Bug Fixes**
  - Removed PV10 gating; `mintWithZeroAda` is used for V1/V2 regardless of `ProtocolMajor`.
  - Plutus V3 unchanged (uses MintValue; no ADA entry).
  - Tests updated: PV8, PV9, and unset-major expect the same CBOR as PV10; removed the pre-PV10 path.

- **Refactors**
  - Marked `TxInfoV1.ProtocolMajor` and `TxInfoV2.ProtocolMajor` as Deprecated and stopped assigning them in `ledger/conway` and `ledger/dijkstra` rules.

<sup>Written for commit ac45cb456eea5b0d7934dede89c66aca810e70c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Plutus V1 and V2 transaction context serialization to consistently include the zero-Ada mint entry across protocol versions.
  * Updated serialization behavior for older and unspecified protocol versions to match current-format output.
* **Tests**
  * Updated transaction context coverage to verify consistent mint serialization across supported protocol versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->