### PR TITLE
fix(protocol): reject unknown DMQ reasons

### DIFF
--- a/protocol/common/dmq.go
+++ b/protocol/common/dmq.go
@@ -331,24 +331,26 @@ func (r RejectReasonData) RejectReasonType() uint8 {
 }
 
 // ToRejectReasonData converts any RejectReason implementation into a concrete RejectReasonData.
-func ToRejectReasonData(rr RejectReason) RejectReasonData {
+func ToRejectReasonData(rr RejectReason) (RejectReasonData, error) {
 	if rr == nil {
-		return RejectReasonData{Type: 3}
+		return RejectReasonData{}, errors.New("reject reason is nil")
 	}
 	switch v := rr.(type) {
 	case InvalidReason:
-		return RejectReasonData{Type: 0, Message: v.Message}
+		return RejectReasonData{Type: 0, Message: v.Message}, nil
 	case AlreadyReceivedReason:
-		return RejectReasonData{Type: 1}
+		return RejectReasonData{Type: 1}, nil
 	case ExpiredReason:
-		return RejectReasonData{Type: 2}
+		return RejectReasonData{Type: 2}, nil
 	case OtherReason:
-		return RejectReasonData{Type: 3, Message: v.Message}
+		return RejectReasonData{Type: 3, Message: v.Message}, nil
 	case RejectReasonData:
-		return v
+		if v.Type > 3 {
+			return RejectReasonData{}, fmt.Errorf("reject reason type out of range: %d", v.Type)
+		}
+		return v, nil
 	default:
-		// Fallback: encode as OtherReason with type 3
-		return RejectReasonData{Type: 3}
+		return RejectReasonData{}, fmt.Errorf("unsupported reject reason type %T", rr)
 	}
 }
 
@@ -406,17 +408,17 @@ func (r *RejectReasonData) UnmarshalCBOR(data []byte) error {
 
 // FromRejectReasonData converts RejectReasonData back to a concrete public API type.
 // This is used during decoding to reconstruct the public RejectReason interface type.
-func FromRejectReasonData(data RejectReasonData) RejectReason {
+func FromRejectReasonData(data RejectReasonData) (RejectReason, error) {
 	switch data.Type {
 	case 0:
-		return InvalidReason{Message: data.Message}
+		return InvalidReason{Message: data.Message}, nil
 	case 1:
-		return AlreadyReceivedReason{}
+		return AlreadyReceivedReason{}, nil
 	case 2:
-		return ExpiredReason{}
+		return ExpiredReason{}, nil
 	case 3:
-		return OtherReason{Message: data.Message}
+		return OtherReason{Message: data.Message}, nil
 	default:
-		return OtherReason{Message: data.Message}
+		return nil, fmt.Errorf("unknown reject reason type: %d", data.Type)
 	}
 }

--- a/protocol/common/dmq.go
+++ b/protocol/common/dmq.go
@@ -346,9 +346,37 @@ func ToRejectReasonData(rr RejectReason) (RejectReasonData, error) {
 		return RejectReasonData{Type: 3, Message: v.Message}, nil
 	case RejectReasonData:
 		if v.Type > 3 {
-			return RejectReasonData{}, fmt.Errorf("reject reason type out of range: %d", v.Type)
+			return RejectReasonData{}, fmt.Errorf(
+				"reject reason type out of range: %d",
+				v.Type,
+			)
 		}
 		return v, nil
+	case *InvalidReason:
+		if v == nil {
+			return RejectReasonData{}, errors.New("reject reason is nil")
+		}
+		return RejectReasonData{Type: 0, Message: v.Message}, nil
+	case *AlreadyReceivedReason:
+		if v == nil {
+			return RejectReasonData{}, errors.New("reject reason is nil")
+		}
+		return RejectReasonData{Type: 1}, nil
+	case *ExpiredReason:
+		if v == nil {
+			return RejectReasonData{}, errors.New("reject reason is nil")
+		}
+		return RejectReasonData{Type: 2}, nil
+	case *OtherReason:
+		if v == nil {
+			return RejectReasonData{}, errors.New("reject reason is nil")
+		}
+		return RejectReasonData{Type: 3, Message: v.Message}, nil
+	case *RejectReasonData:
+		if v == nil {
+			return RejectReasonData{}, errors.New("reject reason is nil")
+		}
+		return ToRejectReasonData(*v)
 	default:
 		return RejectReasonData{}, fmt.Errorf("unsupported reject reason type %T", rr)
 	}

--- a/protocol/localmessagesubmission/client.go
+++ b/protocol/localmessagesubmission/client.go
@@ -182,7 +182,10 @@ func (c *Client) handleRejectMessage(msg protocol.Message) error {
 		)
 	if c.config.RejectMessageFunc != nil {
 		// Convert concrete RejectReasonData back to a RejectReason interface expected by the callback.
-		rr := pcommon.FromRejectReasonData(msgReject.Reason)
+		rr, err := pcommon.FromRejectReasonData(msgReject.Reason)
+		if err != nil {
+			return err
+		}
 		c.config.RejectMessageFunc(c.callbackContext, rr)
 	}
 	return nil

--- a/protocol/localmessagesubmission/messages.go
+++ b/protocol/localmessagesubmission/messages.go
@@ -67,7 +67,6 @@ type MsgRejectMessage struct {
 }
 
 // NewMsgRejectMessage creates a new MsgRejectMessage
-
 func NewMsgRejectMessage(reason pcommon.RejectReason) (*MsgRejectMessage, error) {
 	reasonData, err := pcommon.ToRejectReasonData(reason)
 	if err != nil {

--- a/protocol/localmessagesubmission/messages.go
+++ b/protocol/localmessagesubmission/messages.go
@@ -67,13 +67,18 @@ type MsgRejectMessage struct {
 }
 
 // NewMsgRejectMessage creates a new MsgRejectMessage
-func NewMsgRejectMessage(reason pcommon.RejectReason) *MsgRejectMessage {
+
+func NewMsgRejectMessage(reason pcommon.RejectReason) (*MsgRejectMessage, error) {
+	reasonData, err := pcommon.ToRejectReasonData(reason)
+	if err != nil {
+		return nil, err
+	}
 	return &MsgRejectMessage{
 		MessageBase: protocol.MessageBase{
 			MessageType: MessageTypeRejectMessage,
 		},
-		Reason: pcommon.ToRejectReasonData(reason),
-	}
+		Reason: reasonData,
+	}, nil
 }
 
 // MsgDone represents the protocol completion message

--- a/protocol/localmessagesubmission/messages_test.go
+++ b/protocol/localmessagesubmission/messages_test.go
@@ -166,7 +166,8 @@ func TestMsgRejectMessageEncoding(t *testing.T) {
 		Message: "Invalid signature",
 	}
 
-	msg := NewMsgRejectMessage(invalidReason)
+	msg, err := NewMsgRejectMessage(invalidReason)
+	assert.NoError(t, err)
 
 	assert.Equal(t, uint8(MessageTypeRejectMessage), msg.Type())
 	assert.NotNil(t, msg.Reason)
@@ -176,7 +177,8 @@ func TestMsgRejectMessageEncoding(t *testing.T) {
 	data, err := cbor.Encode(msg)
 	assert.NoError(t, err)
 	// Recreate the same message and re-encode
-	msg2 := NewMsgRejectMessage(invalidReason)
+	msg2, err := NewMsgRejectMessage(invalidReason)
+	assert.NoError(t, err)
 	data2, err := cbor.Encode(msg2)
 	assert.NoError(t, err)
 	assert.Equal(t, data, data2)
@@ -189,7 +191,8 @@ func TestMsgRejectMessageEncoding(t *testing.T) {
 		t.Fatalf("expected *MsgRejectMessage, got %T", parsed)
 	}
 	// Convert back to public API type and check fields
-	rr := pcommon.FromRejectReasonData(parsedMsg.Reason)
+	rr, err := pcommon.FromRejectReasonData(parsedMsg.Reason)
+	assert.NoError(t, err)
 	inv, ok := rr.(pcommon.InvalidReason)
 	if !ok {
 		t.Fatalf("expected InvalidReason, got %T", rr)
@@ -201,7 +204,8 @@ func TestMsgRejectMessageEncoding(t *testing.T) {
 func TestMsgRejectMessageAlreadyReceived(t *testing.T) {
 	reason := pcommon.AlreadyReceivedReason{}
 
-	msg := NewMsgRejectMessage(reason)
+	msg, err := NewMsgRejectMessage(reason)
+	assert.NoError(t, err)
 
 	assert.Equal(t, uint8(1), msg.Reason.RejectReasonType())
 }
@@ -210,7 +214,8 @@ func TestMsgRejectMessageAlreadyReceived(t *testing.T) {
 func TestMsgRejectMessageExpired(t *testing.T) {
 	reason := pcommon.ExpiredReason{}
 
-	msg := NewMsgRejectMessage(reason)
+	msg, err := NewMsgRejectMessage(reason)
+	assert.NoError(t, err)
 
 	assert.Equal(t, uint8(2), msg.Reason.RejectReasonType())
 }
@@ -221,7 +226,8 @@ func TestMsgRejectMessageOther(t *testing.T) {
 		Message: "Some other reason",
 	}
 
-	msg := NewMsgRejectMessage(reason)
+	msg, err := NewMsgRejectMessage(reason)
+	assert.NoError(t, err)
 
 	assert.Equal(t, uint8(3), msg.Reason.RejectReasonType())
 }

--- a/protocol/localmessagesubmission/messages_test.go
+++ b/protocol/localmessagesubmission/messages_test.go
@@ -21,7 +21,12 @@ import (
 	"github.com/blinklabs-io/gouroboros/protocol"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type unsupportedRejectReason struct{}
+
+func (unsupportedRejectReason) RejectReasonType() uint8 { return 99 }
 
 // TestMsgSubmitMessageType tests MsgSubmitMessage type and field access
 func TestMsgSubmitMessageType(t *testing.T) {
@@ -76,10 +81,10 @@ func TestMsgSubmitMessageCBORRoundTrip(t *testing.T) {
 	}
 
 	data, err := cbor.Encode(msg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	parsed, err := NewMsgFromCbor(uint(MessageTypeSubmitMessage), data)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Type assertion and deep field equality checks
 	parsedMsg, ok := parsed.(*MsgSubmitMessage)
@@ -140,7 +145,7 @@ func TestMsgSubmitMessageCBORRoundTrip(t *testing.T) {
 
 	// Deterministic re-encode
 	reencoded, err := cbor.Encode(parsedMsg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, data, reencoded)
 }
 
@@ -154,9 +159,9 @@ func TestMsgAcceptMessageEncoding(t *testing.T) {
 
 	assert.Equal(t, uint8(MessageTypeAcceptMessage), msg.Type())
 	data, err := cbor.Encode(msg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	parsed, err := NewMsgFromCbor(uint(MessageTypeAcceptMessage), data)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, uint8(MessageTypeAcceptMessage), parsed.Type())
 }
 
@@ -167,7 +172,7 @@ func TestMsgRejectMessageEncoding(t *testing.T) {
 	}
 
 	msg, err := NewMsgRejectMessage(invalidReason)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, uint8(MessageTypeRejectMessage), msg.Type())
 	assert.NotNil(t, msg.Reason)
@@ -175,24 +180,24 @@ func TestMsgRejectMessageEncoding(t *testing.T) {
 
 	// Verify deterministic encoding: two equivalent messages should encode identically.
 	data, err := cbor.Encode(msg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// Recreate the same message and re-encode
 	msg2, err := NewMsgRejectMessage(invalidReason)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	data2, err := cbor.Encode(msg2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, data, data2)
 
 	// Verify decode round-trip preserves Reason
 	parsed, err := NewMsgFromCbor(uint(MessageTypeRejectMessage), data)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	parsedMsg, ok := parsed.(*MsgRejectMessage)
 	if !ok {
 		t.Fatalf("expected *MsgRejectMessage, got %T", parsed)
 	}
 	// Convert back to public API type and check fields
 	rr, err := pcommon.FromRejectReasonData(parsedMsg.Reason)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	inv, ok := rr.(pcommon.InvalidReason)
 	if !ok {
 		t.Fatalf("expected InvalidReason, got %T", rr)
@@ -205,7 +210,7 @@ func TestMsgRejectMessageAlreadyReceived(t *testing.T) {
 	reason := pcommon.AlreadyReceivedReason{}
 
 	msg, err := NewMsgRejectMessage(reason)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, uint8(1), msg.Reason.RejectReasonType())
 }
@@ -215,7 +220,7 @@ func TestMsgRejectMessageExpired(t *testing.T) {
 	reason := pcommon.ExpiredReason{}
 
 	msg, err := NewMsgRejectMessage(reason)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, uint8(2), msg.Reason.RejectReasonType())
 }
@@ -227,9 +232,26 @@ func TestMsgRejectMessageOther(t *testing.T) {
 	}
 
 	msg, err := NewMsgRejectMessage(reason)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, uint8(3), msg.Reason.RejectReasonType())
+}
+
+func TestMsgRejectMessageRejectsUnsupportedReasons(t *testing.T) {
+	_, err := NewMsgRejectMessage(nil)
+	require.Error(t, err)
+
+	_, err = NewMsgRejectMessage(unsupportedRejectReason{})
+	require.Error(t, err)
+
+	_, err = NewMsgRejectMessage((*pcommon.InvalidReason)(nil))
+	require.Error(t, err)
+
+	_, err = NewMsgRejectMessage(&pcommon.InvalidReason{Message: "invalid"})
+	require.NoError(t, err)
+
+	_, err = pcommon.FromRejectReasonData(pcommon.RejectReasonData{Type: 4})
+	require.Error(t, err)
 }
 
 // TestMsgDoneEncoding tests MsgDone encoding

--- a/protocol/localmessagesubmission/server.go
+++ b/protocol/localmessagesubmission/server.go
@@ -115,9 +115,12 @@ func (s *Server) handleSubmitMessage(msg protocol.Message) error {
 				"connection_id", s.callbackContext.ConnectionId.String(),
 				"error", err,
 			)
-		rejectMsg := NewMsgRejectMessage(
+		rejectMsg, err := NewMsgRejectMessage(
 			pcommon.OtherReason{Message: err.Error()},
 		)
+		if err != nil {
+			return err
+		}
 		return s.SendMessage(rejectMsg)
 	}
 
@@ -132,9 +135,12 @@ func (s *Server) handleSubmitMessage(msg protocol.Message) error {
 					"connection_id", s.callbackContext.ConnectionId.String(),
 					"error", err,
 				)
-			rejectMsg := NewMsgRejectMessage(
+			rejectMsg, err := NewMsgRejectMessage(
 				pcommon.InvalidReason{Message: err.Error()},
 			)
+			if err != nil {
+				return err
+			}
 			return s.SendMessage(rejectMsg)
 		}
 	}
@@ -148,9 +154,12 @@ func (s *Server) handleSubmitMessage(msg protocol.Message) error {
 					"connection_id", s.callbackContext.ConnectionId.String(),
 					"error", err,
 				)
-			rejectMsg := NewMsgRejectMessage(
+			rejectMsg, err := NewMsgRejectMessage(
 				pcommon.InvalidReason{Message: err.Error()},
 			)
+			if err != nil {
+				return err
+			}
 			return s.SendMessage(rejectMsg)
 		}
 	}
@@ -172,7 +181,10 @@ func (s *Server) handleSubmitMessage(msg protocol.Message) error {
 				"connection_id", s.callbackContext.ConnectionId.String(),
 				"reason", reason,
 			)
-		rejectMsg := NewMsgRejectMessage(reason)
+		rejectMsg, err := NewMsgRejectMessage(reason)
+		if err != nil {
+			return err
+		}
 		if err := s.SendMessage(rejectMsg); err != nil {
 			return err
 		}


### PR DESCRIPTION
Rejects nil, unsupported, and out-of-range DMQ reject reasons instead of mapping them to `OtherReason`.

Tests: `go test ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject unknown DMQ reject reasons instead of coercing to `OtherReason`. Adds strict validation in conversion helpers and message builder; client/server now surface these errors, and tests cover failure cases.

- **Bug Fixes**
  - In `protocol/common`, `pcommon.ToRejectReasonData` and `pcommon.FromRejectReasonData` now return errors for nil, unsupported types, and `Type > 3` (pointer forms validated too).
  - In `protocol/localmessagesubmission`, `NewMsgRejectMessage` returns an error on invalid input; client (`handleRejectMessage`) and server (`handleSubmitMessage`) check and propagate these errors.
  - Tests added for invalid/unsupported reasons and unknown types.

- **Migration**
  - Handle errors from `pcommon.ToRejectReasonData`, `pcommon.FromRejectReasonData`, and `NewMsgRejectMessage`.
  - Only use DMQ reason types 0–3 (`Invalid`, `AlreadyReceived`, `Expired`, `Other`).

<sup>Written for commit d5184587674fc4d478ad3fc85a43146468874507. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reject messages now validate rejection reasons before being created or processed.
  - Unknown or unsupported rejection reason types return clear errors instead of being silently converted.
  - Invalid rejection messages are no longer sent or passed to rejection callbacks.
- **Reliability**
  - Added handling for missing or invalid rejection data across message submission workflows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->