### PR TITLE
fix(ledger): reject malformed fallback data

### DIFF
--- a/ledger/allegra/allegra.go
+++ b/ledger/allegra/allegra.go
@@ -355,8 +355,11 @@ func (t *AllegraTransaction) UnmarshalCBOR(cborData []byte) error {
 			}
 		} else {
 			// Fallback to old method for backward compatibility
-			metadata, err := common.DecodeAuxiliaryDataToMetadata(metadataRaw)
-			if err == nil && metadata != nil {
+			metadata, fallbackErr := common.DecodeAuxiliaryDataToMetadata(metadataRaw)
+			if fallbackErr != nil {
+				return fmt.Errorf("failed to decode auxiliary data: %w", fallbackErr)
+			}
+			if metadata != nil {
 				t.TxMetadata = metadata
 			}
 		}

--- a/ledger/allegra/allegra.go
+++ b/ledger/allegra/allegra.go
@@ -342,8 +342,8 @@ func (t *AllegraTransaction) UnmarshalCBOR(cborData []byte) error {
 	// Store raw auxiliary data bytes (including any scripts)
 	metadataRaw := []byte(txArray[2])
 	if len(metadataRaw) > 0 && metadataRaw[0] != 0xF6 &&
-		!(len(metadataRaw) == 1 &&
-			(metadataRaw[0] == 0xF4 || metadataRaw[0] == 0xF5)) {
+		(len(metadataRaw) != 1 ||
+			(metadataRaw[0] != 0xF4 && metadataRaw[0] != 0xF5)) {
 		// 0xF6 is CBOR null
 
 		// Decode auxiliary data
@@ -363,7 +363,7 @@ func (t *AllegraTransaction) UnmarshalCBOR(cborData []byte) error {
 					fallbackErr = errors.New("metadata fallback returned no metadata")
 				}
 				return fmt.Errorf(
-					"failed to decode auxiliary data: %w (metadata fallback: %v)",
+					"failed to decode auxiliary data: %w (metadata fallback: %w)",
 					err,
 					fallbackErr,
 				)

--- a/ledger/allegra/allegra.go
+++ b/ledger/allegra/allegra.go
@@ -341,7 +341,9 @@ func (t *AllegraTransaction) UnmarshalCBOR(cborData []byte) error {
 	// Handle metadata (component 3, index 2) - always present, but may be CBOR nil
 	// Store raw auxiliary data bytes (including any scripts)
 	metadataRaw := []byte(txArray[2])
-	if len(metadataRaw) > 0 && metadataRaw[0] != 0xF6 {
+	if len(metadataRaw) > 0 && metadataRaw[0] != 0xF6 &&
+		!(len(metadataRaw) == 1 &&
+			(metadataRaw[0] == 0xF4 || metadataRaw[0] == 0xF5)) {
 		// 0xF6 is CBOR null
 
 		// Decode auxiliary data
@@ -356,8 +358,15 @@ func (t *AllegraTransaction) UnmarshalCBOR(cborData []byte) error {
 		} else {
 			// Fallback to old method for backward compatibility
 			metadata, fallbackErr := common.DecodeAuxiliaryDataToMetadata(metadataRaw)
-			if fallbackErr != nil {
-				return fmt.Errorf("failed to decode auxiliary data: %w", fallbackErr)
+			if fallbackErr != nil || metadata == nil {
+				if fallbackErr == nil {
+					fallbackErr = errors.New("metadata fallback returned no metadata")
+				}
+				return fmt.Errorf(
+					"failed to decode auxiliary data: %w (metadata fallback: %v)",
+					err,
+					fallbackErr,
+				)
 			}
 			if metadata != nil {
 				t.TxMetadata = metadata

--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -818,8 +818,11 @@ func (t *AlonzoTransaction) UnmarshalCBOR(cborData []byte) error {
 			}
 		} else {
 			// Fallback to old method for backward compatibility
-			metadata, err := common.DecodeAuxiliaryDataToMetadata(metadataRaw)
-			if err == nil && metadata != nil {
+			metadata, fallbackErr := common.DecodeAuxiliaryDataToMetadata(metadataRaw)
+			if fallbackErr != nil {
+				return fmt.Errorf("failed to decode auxiliary data: %w", fallbackErr)
+			}
+			if metadata != nil {
 				t.TxMetadata = metadata
 			}
 		}

--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -805,8 +805,8 @@ func (t *AlonzoTransaction) UnmarshalCBOR(cborData []byte) error {
 	// Handle metadata (component 4, always present - either data or CBOR nil)
 	metadataRaw := []byte(txArray[3])
 	if len(metadataRaw) > 0 && metadataRaw[0] != 0xF6 &&
-		!(len(metadataRaw) == 1 &&
-			(metadataRaw[0] == 0xF4 || metadataRaw[0] == 0xF5)) {
+		(len(metadataRaw) != 1 ||
+			(metadataRaw[0] != 0xF4 && metadataRaw[0] != 0xF5)) {
 		// 0xF6 is CBOR null
 
 		// Decode auxiliary data
@@ -826,7 +826,7 @@ func (t *AlonzoTransaction) UnmarshalCBOR(cborData []byte) error {
 					fallbackErr = errors.New("metadata fallback returned no metadata")
 				}
 				return fmt.Errorf(
-					"failed to decode auxiliary data: %w (metadata fallback: %v)",
+					"failed to decode auxiliary data: %w (metadata fallback: %w)",
 					err,
 					fallbackErr,
 				)

--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -804,7 +804,9 @@ func (t *AlonzoTransaction) UnmarshalCBOR(cborData []byte) error {
 	}
 	// Handle metadata (component 4, always present - either data or CBOR nil)
 	metadataRaw := []byte(txArray[3])
-	if len(metadataRaw) > 0 && metadataRaw[0] != 0xF6 {
+	if len(metadataRaw) > 0 && metadataRaw[0] != 0xF6 &&
+		!(len(metadataRaw) == 1 &&
+			(metadataRaw[0] == 0xF4 || metadataRaw[0] == 0xF5)) {
 		// 0xF6 is CBOR null
 
 		// Decode auxiliary data
@@ -819,8 +821,15 @@ func (t *AlonzoTransaction) UnmarshalCBOR(cborData []byte) error {
 		} else {
 			// Fallback to old method for backward compatibility
 			metadata, fallbackErr := common.DecodeAuxiliaryDataToMetadata(metadataRaw)
-			if fallbackErr != nil {
-				return fmt.Errorf("failed to decode auxiliary data: %w", fallbackErr)
+			if fallbackErr != nil || metadata == nil {
+				if fallbackErr == nil {
+					fallbackErr = errors.New("metadata fallback returned no metadata")
+				}
+				return fmt.Errorf(
+					"failed to decode auxiliary data: %w (metadata fallback: %v)",
+					err,
+					fallbackErr,
+				)
 			}
 			if metadata != nil {
 				t.TxMetadata = metadata

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -74,7 +74,7 @@ func (b *BabbageBlock) UnmarshalCBOR(cborData []byte) error {
 		TransactionBodies      []BabbageTransactionBody
 		TransactionWitnessSets []BabbageTransactionWitnessSet
 		TransactionMetadataSet common.TransactionMetadataSet
-		InvalidTransactions    []any
+		InvalidTransactions    []uint64
 	}
 
 	var tmp tmpBabbageBlock
@@ -82,35 +82,14 @@ func (b *BabbageBlock) UnmarshalCBOR(cborData []byte) error {
 		return err
 	}
 
-	// Convert []any to []uint with validation
-	const maxReasonableIndex = 1000000 // Reasonable upper bound for transaction indices
+	// Convert the wire indices to the platform type without discarding values.
 	result := make([]uint, 0, len(tmp.InvalidTransactions))
-	for _, v := range tmp.InvalidTransactions {
-		switch val := v.(type) {
-		case uint:
-			if val > maxReasonableIndex {
-				continue // Skip unreasonably large indices
-			}
-			result = append(result, val)
-		case uint64:
-			if val > maxReasonableIndex {
-				continue // Skip unreasonably large indices
-			}
-			result = append(result, uint(val))
-		case int:
-			if val < 0 || val > maxReasonableIndex {
-				continue // Skip negative or unreasonably large indices
-			}
-			result = append(result, uint(val)) //nolint:gosec // bounds checked above
-		case int64:
-			if val < 0 || val > maxReasonableIndex {
-				continue // Skip negative or unreasonably large indices
-			}
-			result = append(result, uint(val)) //nolint:gosec // bounds checked above
-		default:
-			// Skip invalid types (strings, floats, etc.)
-			continue
+	for _, val := range tmp.InvalidTransactions {
+		converted := uint(val)
+		if uint64(converted) != val {
+			return fmt.Errorf("invalid transaction index %d overflows uint", val)
 		}
+		result = append(result, converted)
 	}
 	if len(result) == 0 {
 		b.InvalidTransactions = nil
@@ -1018,8 +997,11 @@ func (t *BabbageTransaction) UnmarshalCBOR(cborData []byte) error {
 			}
 		} else {
 			// Fallback to old method for backward compatibility
-			metadata, err := common.DecodeAuxiliaryDataToMetadata(metadataRaw)
-			if err == nil && metadata != nil {
+			metadata, fallbackErr := common.DecodeAuxiliaryDataToMetadata(metadataRaw)
+			if fallbackErr != nil {
+				return fmt.Errorf("failed to decode auxiliary data: %w", fallbackErr)
+			}
+			if metadata != nil {
 				t.TxMetadata = metadata
 			}
 		}

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -85,6 +85,13 @@ func (b *BabbageBlock) UnmarshalCBOR(cborData []byte) error {
 	// Convert the wire indices to the platform type without discarding values.
 	result := make([]uint, 0, len(tmp.InvalidTransactions))
 	for _, val := range tmp.InvalidTransactions {
+		if val >= uint64(len(tmp.TransactionBodies)) {
+			return fmt.Errorf(
+				"invalid transaction index %d outside transaction list length %d",
+				val,
+				len(tmp.TransactionBodies),
+			)
+		}
 		converted := uint(val)
 		if uint64(converted) != val {
 			return fmt.Errorf("invalid transaction index %d overflows uint", val)
@@ -983,7 +990,9 @@ func (t *BabbageTransaction) UnmarshalCBOR(cborData []byte) error {
 	}
 	// Handle metadata (component 4, always present - either data or CBOR nil)
 	metadataRaw := []byte(txArray[3])
-	if len(metadataRaw) > 0 && metadataRaw[0] != 0xF6 {
+	if len(metadataRaw) > 0 && metadataRaw[0] != 0xF6 &&
+		!(len(metadataRaw) == 1 &&
+			(metadataRaw[0] == 0xF4 || metadataRaw[0] == 0xF5)) {
 		// 0xF6 is CBOR null
 
 		// Decode auxiliary data
@@ -998,8 +1007,15 @@ func (t *BabbageTransaction) UnmarshalCBOR(cborData []byte) error {
 		} else {
 			// Fallback to old method for backward compatibility
 			metadata, fallbackErr := common.DecodeAuxiliaryDataToMetadata(metadataRaw)
-			if fallbackErr != nil {
-				return fmt.Errorf("failed to decode auxiliary data: %w", fallbackErr)
+			if fallbackErr != nil || metadata == nil {
+				if fallbackErr == nil {
+					fallbackErr = errors.New("metadata fallback returned no metadata")
+				}
+				return fmt.Errorf(
+					"failed to decode auxiliary data: %w (metadata fallback: %v)",
+					err,
+					fallbackErr,
+				)
 			}
 			if metadata != nil {
 				t.TxMetadata = metadata

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -991,8 +991,8 @@ func (t *BabbageTransaction) UnmarshalCBOR(cborData []byte) error {
 	// Handle metadata (component 4, always present - either data or CBOR nil)
 	metadataRaw := []byte(txArray[3])
 	if len(metadataRaw) > 0 && metadataRaw[0] != 0xF6 &&
-		!(len(metadataRaw) == 1 &&
-			(metadataRaw[0] == 0xF4 || metadataRaw[0] == 0xF5)) {
+		(len(metadataRaw) != 1 ||
+			(metadataRaw[0] != 0xF4 && metadataRaw[0] != 0xF5)) {
 		// 0xF6 is CBOR null
 
 		// Decode auxiliary data
@@ -1012,7 +1012,7 @@ func (t *BabbageTransaction) UnmarshalCBOR(cborData []byte) error {
 					fallbackErr = errors.New("metadata fallback returned no metadata")
 				}
 				return fmt.Errorf(
-					"failed to decode auxiliary data: %w (metadata fallback: %v)",
+					"failed to decode auxiliary data: %w (metadata fallback: %w)",
 					err,
 					fallbackErr,
 				)

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -87,6 +87,13 @@ func (b *ConwayBlock) UnmarshalCBOR(cborData []byte) error {
 	// Convert the wire indices to the platform type without discarding values.
 	result := make([]uint, 0, len(tmp.InvalidTransactions))
 	for _, val := range tmp.InvalidTransactions {
+		if val >= uint64(len(tmp.TransactionBodies)) {
+			return fmt.Errorf(
+				"invalid transaction index %d outside transaction list length %d",
+				val,
+				len(tmp.TransactionBodies),
+			)
+		}
 		converted := uint(val)
 		if uint64(converted) != val {
 			return fmt.Errorf("invalid transaction index %d overflows uint", val)
@@ -837,7 +844,9 @@ func (t *ConwayTransaction) UnmarshalCBOR(cborData []byte) error {
 	}
 	// Handle metadata (component 4, always present - either data or CBOR nil)
 	metadataRaw := []byte(txArray[3])
-	if len(metadataRaw) > 0 && metadataRaw[0] != 0xF6 {
+	if len(metadataRaw) > 0 && metadataRaw[0] != 0xF6 &&
+		!(len(metadataRaw) == 1 &&
+			(metadataRaw[0] == 0xF4 || metadataRaw[0] == 0xF5)) {
 		// 0xF6 is CBOR null
 
 		// Decode auxiliary data
@@ -852,8 +861,15 @@ func (t *ConwayTransaction) UnmarshalCBOR(cborData []byte) error {
 		} else {
 			// Fallback to old method for backward compatibility
 			metadata, fallbackErr := common.DecodeAuxiliaryDataToMetadata(metadataRaw)
-			if fallbackErr != nil {
-				return fmt.Errorf("failed to decode auxiliary data: %w", fallbackErr)
+			if fallbackErr != nil || metadata == nil {
+				if fallbackErr == nil {
+					fallbackErr = errors.New("metadata fallback returned no metadata")
+				}
+				return fmt.Errorf(
+					"failed to decode auxiliary data: %w (metadata fallback: %v)",
+					err,
+					fallbackErr,
+				)
 			}
 			if metadata != nil {
 				t.TxMetadata = metadata

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -76,7 +76,7 @@ func (b *ConwayBlock) UnmarshalCBOR(cborData []byte) error {
 		TransactionBodies      []ConwayTransactionBody
 		TransactionWitnessSets []ConwayTransactionWitnessSet
 		TransactionMetadataSet common.TransactionMetadataSet
-		InvalidTransactions    []any
+		InvalidTransactions    []uint64
 	}
 
 	var tmp tmpConwayBlock
@@ -84,35 +84,14 @@ func (b *ConwayBlock) UnmarshalCBOR(cborData []byte) error {
 		return err
 	}
 
-	// Convert []any to []uint with validation
-	const maxReasonableIndex = 1000000 // Reasonable upper bound for transaction indices
+	// Convert the wire indices to the platform type without discarding values.
 	result := make([]uint, 0, len(tmp.InvalidTransactions))
-	for _, v := range tmp.InvalidTransactions {
-		switch val := v.(type) {
-		case uint:
-			if val > maxReasonableIndex {
-				continue // Skip unreasonably large indices
-			}
-			result = append(result, val)
-		case uint64:
-			if val > maxReasonableIndex {
-				continue // Skip unreasonably large indices
-			}
-			result = append(result, uint(val))
-		case int:
-			if val < 0 || val > maxReasonableIndex {
-				continue // Skip negative or unreasonably large indices
-			}
-			result = append(result, uint(val)) //nolint:gosec // bounds checked above
-		case int64:
-			if val < 0 || val > maxReasonableIndex {
-				continue // Skip negative or unreasonably large indices
-			}
-			result = append(result, uint(val)) //nolint:gosec // bounds checked above
-		default:
-			// Skip invalid types (strings, floats, etc.)
-			continue
+	for _, val := range tmp.InvalidTransactions {
+		converted := uint(val)
+		if uint64(converted) != val {
+			return fmt.Errorf("invalid transaction index %d overflows uint", val)
 		}
+		result = append(result, converted)
 	}
 	if len(result) == 0 {
 		b.InvalidTransactions = nil
@@ -872,8 +851,11 @@ func (t *ConwayTransaction) UnmarshalCBOR(cborData []byte) error {
 			}
 		} else {
 			// Fallback to old method for backward compatibility
-			metadata, err := common.DecodeAuxiliaryDataToMetadata(metadataRaw)
-			if err == nil && metadata != nil {
+			metadata, fallbackErr := common.DecodeAuxiliaryDataToMetadata(metadataRaw)
+			if fallbackErr != nil {
+				return fmt.Errorf("failed to decode auxiliary data: %w", fallbackErr)
+			}
+			if metadata != nil {
 				t.TxMetadata = metadata
 			}
 		}

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -845,8 +845,8 @@ func (t *ConwayTransaction) UnmarshalCBOR(cborData []byte) error {
 	// Handle metadata (component 4, always present - either data or CBOR nil)
 	metadataRaw := []byte(txArray[3])
 	if len(metadataRaw) > 0 && metadataRaw[0] != 0xF6 &&
-		!(len(metadataRaw) == 1 &&
-			(metadataRaw[0] == 0xF4 || metadataRaw[0] == 0xF5)) {
+		(len(metadataRaw) != 1 ||
+			(metadataRaw[0] != 0xF4 && metadataRaw[0] != 0xF5)) {
 		// 0xF6 is CBOR null
 
 		// Decode auxiliary data
@@ -866,7 +866,7 @@ func (t *ConwayTransaction) UnmarshalCBOR(cborData []byte) error {
 					fallbackErr = errors.New("metadata fallback returned no metadata")
 				}
 				return fmt.Errorf(
-					"failed to decode auxiliary data: %w (metadata fallback: %v)",
+					"failed to decode auxiliary data: %w (metadata fallback: %w)",
 					err,
 					fallbackErr,
 				)

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -364,7 +364,9 @@ func (t *MaryTransaction) UnmarshalCBOR(cborData []byte) error {
 	// Handle metadata (component 3, index 2) - always present, but may be CBOR nil
 	// Handle metadata (component 3, index 2) - always present, but may be CBOR nil
 	metadataRaw := []byte(txArray[2])
-	if len(metadataRaw) > 0 && metadataRaw[0] != 0xF6 {
+	if len(metadataRaw) > 0 && metadataRaw[0] != 0xF6 &&
+		!(len(metadataRaw) == 1 &&
+			(metadataRaw[0] == 0xF4 || metadataRaw[0] == 0xF5)) {
 		// 0xF6 is CBOR null
 
 		// Decode auxiliary data
@@ -379,8 +381,15 @@ func (t *MaryTransaction) UnmarshalCBOR(cborData []byte) error {
 		} else {
 			// Fallback to old method for backward compatibility
 			metadata, fallbackErr := common.DecodeAuxiliaryDataToMetadata(metadataRaw)
-			if fallbackErr != nil {
-				return fmt.Errorf("failed to decode auxiliary data: %w", fallbackErr)
+			if fallbackErr != nil || metadata == nil {
+				if fallbackErr == nil {
+					fallbackErr = errors.New("metadata fallback returned no metadata")
+				}
+				return fmt.Errorf(
+					"failed to decode auxiliary data: %w (metadata fallback: %v)",
+					err,
+					fallbackErr,
+				)
 			}
 			if metadata != nil {
 				t.TxMetadata = metadata

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -378,8 +378,11 @@ func (t *MaryTransaction) UnmarshalCBOR(cborData []byte) error {
 			}
 		} else {
 			// Fallback to old method for backward compatibility
-			metadata, err := common.DecodeAuxiliaryDataToMetadata(metadataRaw)
-			if err == nil && metadata != nil {
+			metadata, fallbackErr := common.DecodeAuxiliaryDataToMetadata(metadataRaw)
+			if fallbackErr != nil {
+				return fmt.Errorf("failed to decode auxiliary data: %w", fallbackErr)
+			}
+			if metadata != nil {
 				t.TxMetadata = metadata
 			}
 		}

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -365,8 +365,8 @@ func (t *MaryTransaction) UnmarshalCBOR(cborData []byte) error {
 	// Handle metadata (component 3, index 2) - always present, but may be CBOR nil
 	metadataRaw := []byte(txArray[2])
 	if len(metadataRaw) > 0 && metadataRaw[0] != 0xF6 &&
-		!(len(metadataRaw) == 1 &&
-			(metadataRaw[0] == 0xF4 || metadataRaw[0] == 0xF5)) {
+		(len(metadataRaw) != 1 ||
+			(metadataRaw[0] != 0xF4 && metadataRaw[0] != 0xF5)) {
 		// 0xF6 is CBOR null
 
 		// Decode auxiliary data
@@ -386,7 +386,7 @@ func (t *MaryTransaction) UnmarshalCBOR(cborData []byte) error {
 					fallbackErr = errors.New("metadata fallback returned no metadata")
 				}
 				return fmt.Errorf(
-					"failed to decode auxiliary data: %w (metadata fallback: %v)",
+					"failed to decode auxiliary data: %w (metadata fallback: %w)",
 					err,
 					fallbackErr,
 				)

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -670,7 +670,9 @@ func (t *ShelleyTransaction) UnmarshalCBOR(cborData []byte) error {
 
 	// Handle metadata (component 3, index 2) - always present, but may be CBOR nil
 	metadataRaw := []byte(txArray[2])
-	if len(metadataRaw) > 0 && metadataRaw[0] != 0xF6 {
+	if len(metadataRaw) > 0 && metadataRaw[0] != 0xF6 &&
+		!(len(metadataRaw) == 1 &&
+			(metadataRaw[0] == 0xF4 || metadataRaw[0] == 0xF5)) {
 		// 0xF6 is CBOR null
 
 		// Decode auxiliary data
@@ -685,8 +687,15 @@ func (t *ShelleyTransaction) UnmarshalCBOR(cborData []byte) error {
 		} else {
 			// Fallback to old method for backward compatibility
 			metadata, fallbackErr := common.DecodeAuxiliaryDataToMetadata(metadataRaw)
-			if fallbackErr != nil {
-				return fmt.Errorf("failed to decode auxiliary data: %w", fallbackErr)
+			if fallbackErr != nil || metadata == nil {
+				if fallbackErr == nil {
+					fallbackErr = errors.New("metadata fallback returned no metadata")
+				}
+				return fmt.Errorf(
+					"failed to decode auxiliary data: %w (metadata fallback: %v)",
+					err,
+					fallbackErr,
+				)
 			}
 			if metadata != nil {
 				t.TxMetadata = metadata

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -671,8 +671,8 @@ func (t *ShelleyTransaction) UnmarshalCBOR(cborData []byte) error {
 	// Handle metadata (component 3, index 2) - always present, but may be CBOR nil
 	metadataRaw := []byte(txArray[2])
 	if len(metadataRaw) > 0 && metadataRaw[0] != 0xF6 &&
-		!(len(metadataRaw) == 1 &&
-			(metadataRaw[0] == 0xF4 || metadataRaw[0] == 0xF5)) {
+		(len(metadataRaw) != 1 ||
+			(metadataRaw[0] != 0xF4 && metadataRaw[0] != 0xF5)) {
 		// 0xF6 is CBOR null
 
 		// Decode auxiliary data
@@ -692,7 +692,7 @@ func (t *ShelleyTransaction) UnmarshalCBOR(cborData []byte) error {
 					fallbackErr = errors.New("metadata fallback returned no metadata")
 				}
 				return fmt.Errorf(
-					"failed to decode auxiliary data: %w (metadata fallback: %v)",
+					"failed to decode auxiliary data: %w (metadata fallback: %w)",
 					err,
 					fallbackErr,
 				)

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -684,8 +684,11 @@ func (t *ShelleyTransaction) UnmarshalCBOR(cborData []byte) error {
 			}
 		} else {
 			// Fallback to old method for backward compatibility
-			metadata, err := common.DecodeAuxiliaryDataToMetadata(metadataRaw)
-			if err == nil && metadata != nil {
+			metadata, fallbackErr := common.DecodeAuxiliaryDataToMetadata(metadataRaw)
+			if fallbackErr != nil {
+				return fmt.Errorf("failed to decode auxiliary data: %w", fallbackErr)
+			}
+			if metadata != nil {
 				t.TxMetadata = metadata
 			}
 		}


### PR DESCRIPTION
Rejects malformed invalid-transaction indices and propagates auxiliary-data decode failures across Shelley through Conway.

Tests: `go test ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject malformed fallback auxiliary metadata and invalid transaction indices across ledger eras. Tighten strict decode to fail fast and surface errors instead of skipping bad data.

- **Bug Fixes**
  - Babbage/Conway blocks: decode `InvalidTransactions` as `[]uint64`, require each index be within `TransactionBodies`, convert to `uint`, and error on overflow or out-of-bounds.
  - Shelley, Mary, Allegra, Alonzo, Babbage, Conway transactions: ignore CBOR `true`/`false`, and on fallback return errors from `common.DecodeAuxiliaryDataToMetadata` or when it returns no metadata; set `TxMetadata` only on successful decode.

<sup>Written for commit b008968017982329f18a4d8d1f7421dd0c0218a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

