### PR TITLE
fix(ledger): reject invalid reward parameters

### DIFF
--- a/ledger/common/rewards.go
+++ b/ledger/common/rewards.go
@@ -135,9 +135,12 @@ func CalculateAdaPots(
 	params RewardParameters,
 	epochFees uint64,
 	totalBlocksInEpoch uint32,
-) AdaPots {
+) (AdaPots, error) {
 	// Calculate eta (pool performance factor)
-	eta := calculateEta(totalBlocksInEpoch, params)
+	eta, err := calculateEta(totalBlocksInEpoch, params)
+	if err != nil {
+		return AdaPots{}, err
+	}
 
 	// Calculate monetary expansion (rho * eta * reserves)
 	// rho is in millionths (3000 = 0.3%)
@@ -186,19 +189,18 @@ func CalculateAdaPots(
 		Rewards:  rewardPot.Uint64(),
 	}
 
-	return newPots
+	return newPots, nil
 }
 
 // calculateEta calculates the pool performance factor (η)
 // Following Amaru's approach: eta = min(1, blocks_produced / (epoch_length * active_slot_coeff))
-func calculateEta(totalBlocksInEpoch uint32, params RewardParameters) *big.Rat {
-	// Defensive guards
+func calculateEta(totalBlocksInEpoch uint32, params RewardParameters) (*big.Rat, error) {
 	activeSlotsCoeff := params.ActiveSlotsCoeff
-	if activeSlotsCoeff == nil {
-		activeSlotsCoeff = new(big.Rat).SetInt64(0) // Treat nil as zero
+	if activeSlotsCoeff == nil || activeSlotsCoeff.Sign() <= 0 {
+		return nil, errors.New("active slots coefficient must be positive")
 	}
 	if params.ExpectedSlotsPerEpoch == 0 {
-		return new(big.Rat).SetInt64(0) // Avoid division by zero
+		return nil, errors.New("expected slots per epoch must be positive")
 	}
 
 	// Calculate expected blocks: epoch_length * active_slot_coeff
@@ -217,7 +219,7 @@ func calculateEta(totalBlocksInEpoch uint32, params RewardParameters) *big.Rat {
 		eta = oneRat
 	}
 
-	return eta
+	return eta, nil
 }
 
 // calculatePoolPerformance calculates the apparent performance of a pool

--- a/ledger/common/rewards_test.go
+++ b/ledger/common/rewards_test.go
@@ -39,12 +39,13 @@ func TestCalculateAdaPots(t *testing.T) {
 	epochFees := uint64(1000000)        // 1 million ADA in fees
 	totalBlocksInEpoch := uint32(21600) // Expected blocks per epoch
 
-	newPots := common.CalculateAdaPots(
+	newPots, err := common.CalculateAdaPots(
 		currentPots,
 		params,
 		epochFees,
 		totalBlocksInEpoch,
 	)
+	require.NoError(t, err)
 
 	// Expected monetary expansion: 1000000000 * 0.003 * eta
 	// With Amaru approach: expected_blocks = 432000 * 0.05 = 21600

--- a/ledger/common/rewards_test.go
+++ b/ledger/common/rewards_test.go
@@ -64,6 +64,54 @@ func TestCalculateAdaPots(t *testing.T) {
 	assert.Equal(t, expectedRewards, newPots.Rewards)
 }
 
+func TestCalculateAdaPotsRejectsInvalidEtaParameters(t *testing.T) {
+	baseParams := common.RewardParameters{
+		ActiveSlotsCoeff:      big.NewRat(1, 20),
+		ExpectedSlotsPerEpoch: 432000,
+	}
+	currentPots := common.AdaPots{Reserves: 100, Treasury: 200, Rewards: 300}
+
+	tests := []struct {
+		name   string
+		modify func(*common.RewardParameters)
+	}{
+		{
+			name: "nil active slots coefficient",
+			modify: func(params *common.RewardParameters) {
+				params.ActiveSlotsCoeff = nil
+			},
+		},
+		{
+			name: "zero active slots coefficient",
+			modify: func(params *common.RewardParameters) {
+				params.ActiveSlotsCoeff = new(big.Rat)
+			},
+		},
+		{
+			name: "negative active slots coefficient",
+			modify: func(params *common.RewardParameters) {
+				params.ActiveSlotsCoeff = big.NewRat(-1, 20)
+			},
+		},
+		{
+			name: "zero expected slots per epoch",
+			modify: func(params *common.RewardParameters) {
+				params.ExpectedSlotsPerEpoch = 0
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			params := baseParams
+			tc.modify(&params)
+			pots, err := common.CalculateAdaPots(currentPots, params, 0, 0)
+			require.Error(t, err)
+			assert.Equal(t, common.AdaPots{}, pots)
+		})
+	}
+}
+
 func TestCalculateRewards(t *testing.T) {
 	// Setup test data
 	pots := common.AdaPots{

--- a/ledger/common/rewards_validation_test.go
+++ b/ledger/common/rewards_validation_test.go
@@ -380,17 +380,20 @@ func TestJavaReferenceScenarios(t *testing.T) {
 
 		// expected_blocks = 432000 * 0.05 = 21600
 		// With 21600 blocks (exactly expected), eta = min(1, 21600/21600) = 1
-		eta := calculateEta(21600, params)
+		eta, err := calculateEta(21600, params)
+		require.NoError(t, err)
 		etaFloat, _ := eta.Float64()
 		assert.Equal(t, 1.0, etaFloat)
 
 		// With 10800 blocks (half of expected), eta = 10800/21600 = 0.5
-		eta = calculateEta(10800, params)
+		eta, err = calculateEta(10800, params)
+		require.NoError(t, err)
 		etaFloat, _ = eta.Float64()
 		assert.Equal(t, 0.5, etaFloat)
 
 		// With 5400 blocks (quarter of expected), eta = 5400/21600 = 0.25
-		eta = calculateEta(5400, params)
+		eta, err = calculateEta(5400, params)
+		require.NoError(t, err)
 		etaFloat, _ = eta.Float64()
 		assert.Equal(t, 0.25, etaFloat)
 	})
@@ -451,12 +454,13 @@ func TestJavaReferenceScenarios(t *testing.T) {
 		// total_rewards = 1,500,000 + 1,000,000 = 2,500,000
 		// treasury_tax = 2,500,000 * 0.2 = 500,000
 		// available_rewards = 2,500,000 - 500,000 = 2,000,000
-		newPots := CalculateAdaPots(
+		newPots, err := CalculateAdaPots(
 			currentPots,
 			params,
 			1000000,
 			10800,
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t, uint64(1000000000-1500000), newPots.Reserves)
 		assert.Equal(t, uint64(200000000+500000), newPots.Treasury)
@@ -584,19 +588,22 @@ func TestAmaruCompatibility(t *testing.T) {
 		// Test case: 10800 blocks produced, expected calculation
 		// expected_blocks = 432000 * 0.05 = 21600
 		// eta = min(1, 10800/21600) = 0.5
-		eta := calculateEta(10800, params)
+		eta, err := calculateEta(10800, params)
+		require.NoError(t, err)
 		etaFloat, _ := eta.Float64()
 		assert.Equal(t, 0.5, etaFloat)
 
 		// Test case: 21600 blocks produced (exactly expected)
 		// eta = min(1, 21600/21600) = 1
-		eta = calculateEta(21600, params)
+		eta, err = calculateEta(21600, params)
+		require.NoError(t, err)
 		etaFloat, _ = eta.Float64()
 		assert.Equal(t, 1.0, etaFloat)
 
 		// Test case: 5400 blocks produced (quarter of expected)
 		// eta = min(1, 5400/21600) = 0.25
-		eta = calculateEta(5400, params)
+		eta, err = calculateEta(5400, params)
+		require.NoError(t, err)
 		etaFloat, _ = eta.Float64()
 		assert.Equal(t, 0.25, etaFloat)
 	})
@@ -664,12 +671,13 @@ func TestAmaruCompatibility(t *testing.T) {
 		// total_rewards = 1,500,000 + 1,000,000 = 2,500,000
 		// treasury_tax = 2,500,000 * 0.2 = 500,000
 		// available_rewards = 2,500,000 - 500,000 = 2,000,000
-		newPots := CalculateAdaPots(
+		newPots, err := CalculateAdaPots(
 			currentPots,
 			params,
 			1000000,
 			10800,
 		)
+		require.NoError(t, err)
 
 		assert.Equal(t, uint64(1000000000-1500000), newPots.Reserves)
 		assert.Equal(t, uint64(200000000+500000), newPots.Treasury)


### PR DESCRIPTION
Returns errors for missing or non-positive active-slot coefficients and expected epoch slots.

Tests: `go test ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject invalid reward parameters in ledger rewards to prevent wrong `eta` and pot calculations. We now return errors for bad `ActiveSlotsCoeff` or `ExpectedSlotsPerEpoch`.

- **Bug Fixes**
  - `calculateEta` returns an error when `ActiveSlotsCoeff` is nil/non-positive or `ExpectedSlotsPerEpoch` is zero.
  - `CalculateAdaPots` now returns `(AdaPots, error)`, propagates `eta` errors, and returns zero pots on error.
  - Tests add coverage for invalid parameters (nil/zero/negative `ActiveSlotsCoeff`, zero `ExpectedSlotsPerEpoch`) and assert no error for valid inputs.

- **Migration**
  - Update callers to handle errors from `CalculateAdaPots` and `calculateEta`.
  - Ensure `ActiveSlotsCoeff > 0` and `ExpectedSlotsPerEpoch > 0` before calling.

<sup>Written for commit a61998e10e18acb2998694a1cc888cfa70b1d495. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

