### PR TITLE
fix(ledger): reject unknown governance actions

### DIFF
--- a/ledger/common/testdata/governance.go
+++ b/ledger/common/testdata/governance.go
@@ -1,0 +1,30 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdata
+
+import (
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/plutigo/data"
+)
+
+// UnsupportedGovAction is a GovAction implementation that is not a known
+// governance action type.
+type UnsupportedGovAction struct {
+	common.GovActionBase
+}
+
+func (UnsupportedGovAction) ToPlutusData() data.PlutusData {
+	return data.NewConstr(0)
+}

--- a/ledger/conway/gov_constructors_test.go
+++ b/ledger/conway/gov_constructors_test.go
@@ -19,21 +19,19 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
-	"github.com/blinklabs-io/plutigo/data"
+	commontestdata "github.com/blinklabs-io/gouroboros/ledger/common/testdata"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// unsupportedGovAction satisfies common.GovAction (via the embedded
-// GovActionBase) but is not one of the known Conway action types, so
-// NewConwayGovAction must reject it rather than silently coerce it to
-// discriminant 0.
-type unsupportedGovAction struct {
-	common.GovActionBase
-}
-
-func (unsupportedGovAction) ToPlutusData() data.PlutusData {
-	return data.NewConstr(0)
+func TestUtxoValidateBootstrapAllowedGovActionsRejectsUnknown(t *testing.T) {
+	tx := &ConwayTransaction{}
+	tx.Body.TxProposalProcedures = []ConwayProposalProcedure{{
+		PPGovAction: ConwayGovAction{Action: commontestdata.UnsupportedGovAction{}},
+	}}
+	pp := &ConwayProtocolParameters{}
+	pp.ProtocolVersion.Major = common.ProtocolVersionConway
+	require.Error(t, UtxoValidateBootstrapAllowedGovActions(tx, 0, nil, pp))
 }
 
 func TestNewConwayParameterChangeGovAction(t *testing.T) {
@@ -132,14 +130,14 @@ func TestNewConwayGovActionRejectsInvalid(t *testing.T) {
 
 	// An action that satisfies common.GovAction but is not a known Conway type
 	// must be rejected rather than silently coerced to discriminant 0.
-	_, err = NewConwayGovAction(unsupportedGovAction{})
+	_, err = NewConwayGovAction(commontestdata.UnsupportedGovAction{})
 	require.Error(t, err)
 
 	// A typed-nil pointer must be rejected rather than matching its concrete
 	// case and wrapping a nil action, for both known and unsupported types.
 	_, err = NewConwayGovAction((*common.InfoGovAction)(nil))
 	require.Error(t, err)
-	_, err = NewConwayGovAction((*unsupportedGovAction)(nil))
+	_, err = NewConwayGovAction((*commontestdata.UnsupportedGovAction)(nil))
 	require.Error(t, err)
 
 	// NewConwayProposalProcedure propagates the error instead of producing a

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -271,10 +271,8 @@ func UtxoValidateBootstrapAllowedGovActions(
 			continue
 		}
 		// NOTE: closed-set type-switch over the 7 GovActionType constants in
-		// ledger/common/gov.go. Permissive default is intentional — matches
-		// cardano-ledger's deny-list semantics. New GovAction types added to
-		// common will fall into the default arm and be allowed at PV9; an
-		// explicit case must be added here to gate them.
+		// ledger/common/gov.go. Unknown GovAction implementations are rejected
+		// by the default arm; add an explicit case when a new action is supported.
 		switch govAction.(type) {
 		case *common.InfoGovAction:
 			// always allowed

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -299,9 +299,7 @@ func UtxoValidateBootstrapAllowedGovActions(
 				ActionType: common.GovActionTypeNewConstitution,
 			}
 		default:
-			// Any new GovAction type added to ledger/common is implicitly
-			// allowed here; this branch exists so the assumption is visible
-			// at the call site rather than only in the NOTE above.
+			return fmt.Errorf("unknown governance action type %T", govAction)
 		}
 	}
 	return nil
@@ -2342,12 +2340,14 @@ func UtxoValidateDelegation(
 	// DrepTypeAddrKeyHash/DrepTypeScriptHash (any other type returns an
 	// error from isDRepRegistered before this is reached), so the default
 	// case below is unreachable and does not fall back silently.
-	drepTypeToCredType := func(drepType int) uint {
+	drepTypeToCredType := func(drepType int) (uint, error) {
 		switch drepType {
+		case common.DrepTypeAddrKeyHash:
+			return common.CredentialTypeAddrKeyHash, nil
 		case common.DrepTypeScriptHash:
-			return common.CredentialTypeScriptHash
+			return common.CredentialTypeScriptHash, nil
 		default:
-			return common.CredentialTypeAddrKeyHash
+			return 0, InvalidDRepTypeError{DrepType: drepType}
 		}
 	}
 
@@ -2422,8 +2422,12 @@ func UtxoValidateDelegation(
 				return err
 			}
 			if !drepRegistered {
+				credType, err := drepTypeToCredType(c.Drep.Type)
+				if err != nil {
+					return err
+				}
 				return DelegateVoteToUnregisteredDRepError{DRepCredential: common.Credential{
-					CredType:   drepTypeToCredType(c.Drep.Type),
+					CredType:   credType,
 					Credential: common.NewBlake2b224(c.Drep.Credential),
 				}}
 			}
@@ -2443,8 +2447,12 @@ func UtxoValidateDelegation(
 				return err
 			}
 			if !drepRegistered {
+				credType, err := drepTypeToCredType(c.Drep.Type)
+				if err != nil {
+					return err
+				}
 				return DelegateVoteToUnregisteredDRepError{DRepCredential: common.Credential{
-					CredType:   drepTypeToCredType(c.Drep.Type),
+					CredType:   credType,
 					Credential: common.NewBlake2b224(c.Drep.Credential),
 				}}
 			}
@@ -2466,8 +2474,12 @@ func UtxoValidateDelegation(
 				return err
 			}
 			if !drepRegistered {
+				credType, err := drepTypeToCredType(c.Drep.Type)
+				if err != nil {
+					return err
+				}
 				return DelegateVoteToUnregisteredDRepError{DRepCredential: common.Credential{
-					CredType:   drepTypeToCredType(c.Drep.Type),
+					CredType:   credType,
 					Credential: common.NewBlake2b224(c.Drep.Credential),
 				}}
 			}
@@ -2485,8 +2497,12 @@ func UtxoValidateDelegation(
 				return err
 			}
 			if !drepRegistered {
+				credType, err := drepTypeToCredType(c.Drep.Type)
+				if err != nil {
+					return err
+				}
 				return DelegateVoteToUnregisteredDRepError{DRepCredential: common.Credential{
-					CredType:   drepTypeToCredType(c.Drep.Type),
+					CredType:   credType,
 					Credential: common.NewBlake2b224(c.Drep.Credential),
 				}}
 			}

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -34,18 +34,9 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
-	"github.com/blinklabs-io/plutigo/data"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-type unsupportedBootstrapGovAction struct {
-	common.GovActionBase
-}
-
-func (unsupportedBootstrapGovAction) ToPlutusData() data.PlutusData {
-	return data.NewConstr(0)
-}
 
 func makeConwayRewardAddress(
 	t *testing.T,
@@ -3467,15 +3458,6 @@ func TestUtxoValidateBootstrapAllowedGovActions(t *testing.T) {
 		}
 	})
 
-	t.Run("PV9 unknown action is rejected", func(t *testing.T) {
-		err := conway.UtxoValidateBootstrapAllowedGovActions(
-			mkTx(unsupportedBootstrapGovAction{}),
-			0,
-			nil,
-			mkPp(9),
-		)
-		require.Error(t, err)
-	})
 }
 
 func TestUtxoValidateBootstrapParameterGroups(t *testing.T) {

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -34,9 +34,18 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/blinklabs-io/plutigo/data"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type unsupportedBootstrapGovAction struct {
+	common.GovActionBase
+}
+
+func (unsupportedBootstrapGovAction) ToPlutusData() data.PlutusData {
+	return data.NewConstr(0)
+}
 
 func makeConwayRewardAddress(
 	t *testing.T,
@@ -3456,6 +3465,16 @@ func TestUtxoValidateBootstrapAllowedGovActions(t *testing.T) {
 		if bdErr.ActionType != common.GovActionTypeTreasuryWithdrawal {
 			t.Fatalf("got ActionType %d, want %d (TreasuryWithdrawal)", bdErr.ActionType, common.GovActionTypeTreasuryWithdrawal)
 		}
+	})
+
+	t.Run("PV9 unknown action is rejected", func(t *testing.T) {
+		err := conway.UtxoValidateBootstrapAllowedGovActions(
+			mkTx(unsupportedBootstrapGovAction{}),
+			0,
+			nil,
+			mkPp(9),
+		)
+		require.Error(t, err)
 	})
 }
 

--- a/ledger/dijkstra/rules.go
+++ b/ledger/dijkstra/rules.go
@@ -184,6 +184,7 @@ func UtxoValidateBootstrapAllowedGovActions(
 				ActionType: common.GovActionTypeNewConstitution,
 			}
 		default:
+			return fmt.Errorf("unknown governance action type %T", govAction)
 		}
 	}
 	return nil

--- a/ledger/dijkstra/rules_test.go
+++ b/ledger/dijkstra/rules_test.go
@@ -21,24 +21,16 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/common/script"
+	commontestdata "github.com/blinklabs-io/gouroboros/ledger/common/testdata"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
-	"github.com/blinklabs-io/plutigo/data"
 	"github.com/stretchr/testify/require"
 )
-
-type unsupportedBootstrapGovAction struct {
-	common.GovActionBase
-}
-
-func (unsupportedBootstrapGovAction) ToPlutusData() data.PlutusData {
-	return data.NewConstr(0)
-}
 
 func TestUtxoValidateBootstrapAllowedGovActionsRejectsUnknown(t *testing.T) {
 	tx := &DijkstraTransaction{}
 	tx.Body.TxProposalProcedures = []DijkstraProposalProcedure{{
-		PPGovAction: DijkstraGovAction{Action: unsupportedBootstrapGovAction{}},
+		PPGovAction: DijkstraGovAction{Action: commontestdata.UnsupportedGovAction{}},
 	}}
 	pp := &DijkstraProtocolParameters{}
 	pp.ProtocolVersion.Major = common.ProtocolVersionConway

--- a/ledger/dijkstra/rules_test.go
+++ b/ledger/dijkstra/rules_test.go
@@ -23,8 +23,27 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/common/script"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/blinklabs-io/plutigo/data"
 	"github.com/stretchr/testify/require"
 )
+
+type unsupportedBootstrapGovAction struct {
+	common.GovActionBase
+}
+
+func (unsupportedBootstrapGovAction) ToPlutusData() data.PlutusData {
+	return data.NewConstr(0)
+}
+
+func TestUtxoValidateBootstrapAllowedGovActionsRejectsUnknown(t *testing.T) {
+	tx := &DijkstraTransaction{}
+	tx.Body.TxProposalProcedures = []DijkstraProposalProcedure{{
+		PPGovAction: DijkstraGovAction{Action: unsupportedBootstrapGovAction{}},
+	}}
+	pp := &DijkstraProtocolParameters{}
+	pp.ProtocolVersion.Major = common.ProtocolVersionConway
+	require.Error(t, UtxoValidateBootstrapAllowedGovActions(tx, 0, nil, pp))
+}
 
 func testGuardCredential() common.Credential {
 	var guardHash common.Blake2b224


### PR DESCRIPTION
Rejects unknown governance actions during bootstrap and uses explicit DRep credential-type matching.

Tests: `go test ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects unknown governance actions during bootstrap and enforces explicit DRep credential-type mapping. Prevents silent fallbacks and ensures accurate delegation validation.

- **Bug Fixes**
  - In `ledger/conway` and `ledger/dijkstra`, `UtxoValidateBootstrapAllowedGovActions` now errors on unknown `GovAction` implementations instead of allowing them.
  - In `UtxoValidateDelegation`, `drepTypeToCredType` maps only `AddrKeyHash` and `ScriptHash`; unknown types return an error, callers propagate it and build `DelegateVoteToUnregisteredDRepError` with the correct credential type.
  - Tests use a shared `ledger/common/testdata.UnsupportedGovAction` and cover rejection of unknown bootstrap actions in both ledgers.

<sup>Written for commit c430ad2e8c15c766a6fb2bc59ae503bcc41febef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

