### PR TITLE
fix(ledger): prune zero-quantity assets when decoding MultiAsset

### DIFF
--- a/ledger/common/common.go
+++ b/ledger/common/common.go
@@ -290,11 +290,48 @@ type multiAssetJson[T int64 | uint64 | *big.Int] struct {
 	Amount      string `json:"amount"`
 }
 
+// pruneZeroAssets removes zero-quantity assets, and any policy left with no
+// assets, matching cardano-ledger. Its Value decoder applies
+// pruneZeroMultiAsset (eras/mary/impl/src/Cardano/Ledger/Mary/Value.hs), so a
+// zero-quantity entry never reaches any ledger rule or the Plutus script
+// context. Keeping one makes a script that traverses the value do measurably
+// more work than the node that produced the block, so its execution cost
+// diverges.
+func pruneZeroAssets[T int64 | uint64 | *big.Int](
+	data map[Blake2b224]map[cbor.ByteString]T,
+) map[Blake2b224]map[cbor.ByteString]T {
+	if data == nil {
+		return nil
+	}
+	isZero := func(v T) bool {
+		switch tv := any(v).(type) {
+		case int64:
+			return tv == 0
+		case uint64:
+			return tv == 0
+		case *big.Int:
+			return tv == nil || tv.Sign() == 0
+		}
+		return false
+	}
+	for policy, assets := range data {
+		for name, qty := range assets {
+			if isZero(qty) {
+				delete(assets, name)
+			}
+		}
+		if len(assets) == 0 {
+			delete(data, policy)
+		}
+	}
+	return data
+}
+
 func (m *MultiAsset[T]) UnmarshalCBOR(data []byte) error {
 	var decoded map[Blake2b224]map[cbor.ByteString]T
 	m.duplicateMapKeys = false
 	if _, err := cbor.Decode(data, &decoded); err == nil {
-		m.data = decoded
+		m.data = pruneZeroAssets(decoded)
 		return nil
 	} else if !cbor.IsDuplicateMapKeyError(err) {
 		return err
@@ -310,7 +347,7 @@ func (m *MultiAsset[T]) UnmarshalCBOR(data []byte) error {
 	if _, err := cbor.DecodeLenient(data, &decoded); err != nil {
 		return err
 	}
-	m.data = decoded
+	m.data = pruneZeroAssets(decoded)
 	return nil
 }
 

--- a/ledger/common/common.go
+++ b/ledger/common/common.go
@@ -303,20 +303,9 @@ func pruneZeroAssets[T int64 | uint64 | *big.Int](
 	if data == nil {
 		return nil
 	}
-	isZero := func(v T) bool {
-		switch tv := any(v).(type) {
-		case int64:
-			return tv == 0
-		case uint64:
-			return tv == 0
-		case *big.Int:
-			return tv == nil || tv.Sign() == 0
-		}
-		return false
-	}
 	for policy, assets := range data {
 		for name, qty := range assets {
-			if isZero(qty) {
+			if amountIsZero(qty) {
 				delete(assets, name)
 			}
 		}

--- a/ledger/common/common_test.go
+++ b/ledger/common/common_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/internal/test"
 	"github.com/blinklabs-io/plutigo/data"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBlake2b256_MarshalCBOR_ZeroHash(t *testing.T) {
@@ -1498,4 +1499,54 @@ func TestMultiAssetUnmarshalDuplicateAssetNameLastWins(t *testing.T) {
 	if last == nil || last.Int64() != 9 {
 		t.Fatalf("expected last-wins asset 0xCC == 9, got %v", last)
 	}
+}
+
+// TestMultiAssetDecodePrunesZeroQuantities pins decode-time pruning of
+// zero-quantity assets, matching cardano-ledger. Its Value decoder applies
+// pruneZeroMultiAsset (eras/mary/impl/src/Cardano/Ledger/Mary/Value.hs), so a
+// zero entry never reaches a ledger rule or the Plutus script context.
+//
+// Keeping one is not cosmetic. A script that walks the value of an input or
+// output does measurably more work than the node that produced the block, so
+// its execution cost diverges and phase-2 validation rejects a transaction the
+// chain already accepted. Observed on preview: a burn left a zero-quantity
+// entry in an output, and every script in that transaction cost more than its
+// declared budget.
+func TestMultiAssetDecodePrunesZeroQuantities(t *testing.T) {
+	policyA := "1654dce4e3529f13b1b6f8b0cfb9e0cbd0b2a70b8bbcbcd0d0e0f1a2"
+	policyB := "3b8684b73e1b8f5c3206676d4dda66e96535b05d650c8de4105256d4"
+	mkPolicy := func(hexStr string) Blake2b224 {
+		raw, err := hex.DecodeString(hexStr)
+		require.NoError(t, err)
+		return NewBlake2b224(raw)
+	}
+
+	// One policy keeps a non-zero asset beside a zero one; the other has only a
+	// zero asset and must disappear entirely.
+	src := map[Blake2b224]map[cbor.ByteString]MultiAssetTypeOutput{
+		mkPolicy(policyA): {
+			cbor.NewByteString([]byte{0x55, 0x49}): big.NewInt(500),
+			cbor.NewByteString([]byte{0x46, 0x32}): big.NewInt(0),
+		},
+		mkPolicy(policyB): {
+			cbor.NewByteString([]byte{0x46, 0x32}): big.NewInt(0),
+		},
+	}
+	encoded, err := cbor.Encode(src)
+	require.NoError(t, err)
+
+	var ma MultiAsset[MultiAssetTypeOutput]
+	require.NoError(t, ma.UnmarshalCBOR(encoded))
+
+	policies := ma.Policies()
+	require.Len(t, policies, 1, "a policy left with no assets must be dropped")
+	assert.Equal(t, mkPolicy(policyA), policies[0])
+
+	assets := ma.Assets(policies[0])
+	require.Len(t, assets, 1, "the zero-quantity asset must be dropped")
+	assert.Equal(
+		t,
+		big.NewInt(500),
+		ma.Asset(policies[0], assets[0]),
+	)
 }

--- a/ledger/common/common_test.go
+++ b/ledger/common/common_test.go
@@ -1550,3 +1550,38 @@ func TestMultiAssetDecodePrunesZeroQuantities(t *testing.T) {
 		ma.Asset(policies[0], assets[0]),
 	)
 }
+
+// TestMultiAssetDecodePrunesZeroQuantitiesWithDuplicateKeys covers the lenient
+// decode path. Pre-Conway values may carry duplicate policy or asset keys, which
+// UnmarshalCBOR re-decodes with DecodeLenient on a last-wins basis, and that
+// path prunes too. Here the winning value is zero, so the asset and then its
+// now-empty policy must both disappear while the duplicate-key flag still
+// records that a Conway+ decoder has to reject the value.
+func TestMultiAssetDecodePrunesZeroQuantitiesWithDuplicateKeys(t *testing.T) {
+	policy, err := hex.DecodeString(
+		"1654dce4e3529f13b1b6f8b0cfb9e0cbd0b2a70b8bbcbcd0d0e0f1a2",
+	)
+	require.NoError(t, err)
+
+	// Hand-built because an encoder cannot emit a duplicate map key:
+	//   a1                       map(1)
+	//     581c <28-byte policy>
+	//     a2                     map(2), duplicate asset name
+	//       42 5549  1901f4      "UI" -> 500
+	//       42 5549  00          "UI" -> 0   (last wins)
+	encoded := []byte{0xa1, 0x58, 0x1c}
+	encoded = append(encoded, policy...)
+	encoded = append(encoded,
+		0xa2,
+		0x42, 0x55, 0x49, 0x19, 0x01, 0xf4,
+		0x42, 0x55, 0x49, 0x00,
+	)
+
+	var ma MultiAsset[MultiAssetTypeOutput]
+	require.NoError(t, ma.UnmarshalCBOR(encoded))
+
+	assert.True(t, ma.duplicateMapKeys,
+		"the duplicate key must still be recorded for Conway+ rejection")
+	assert.Empty(t, ma.Policies(),
+		"last-wins zero must be pruned, emptying and dropping the policy")
+}


### PR DESCRIPTION
cardano-ledger's `Value` decoder applies `pruneZeroMultiAsset`, at `eras/mary/impl/src/Cardano/Ledger/Mary/Value.hs`:

```haskell
pruneZeroMultiAsset . MultiAsset <$> decodeMap decCBOR (decodeMap decCBOR decodeAmount)

pruneZeroMultiAsset :: MultiAsset -> MultiAsset
pruneZeroMultiAsset = filterMultiAsset (\_ _ -> (/= 0))
```

So a zero-quantity asset never reaches a ledger rule or a Plutus script context. gouroboros kept them, putting an entry in the script context that the node which produced the block did not have.

That is not cosmetic. A script that walks the value of an input or output does strictly more work than the producer's node did, so its execution cost exceeds the budget declared in its redeemer, and phase-2 validation rejects a transaction the chain already accepted.

## Evidence

Preview transaction `3b2bddb3d46733581937eca1f89f682fd8a32b456fa6ec24920d7a0d56328b90` burns asset `3b8684b7...4632`, which leaves a zero-quantity entry in one of its outputs. Before this change every script in the transaction exceeded its declared budget by a constant, and the script that traverses values eight times over exceeded by eight times that constant:

| script | exact mem | declared mem | delta |
| --- | ---: | ---: | ---: |
| `b4c2f977` | 1177728 | 1171904 | +5824 |
| `3b8684b7` | 1247664 | 1241840 | +5824 |
| `b21f7e15` | 7796444 | 7749812 | +46632 (8 x 5824) |

The constant is the cost of traversing the one extra entry, which is why it is identical across unrelated scripts in the same transaction and scales with how often a script walks the value.

After this change, all twenty script evaluations across the four affected preview transactions match their declared budgets exactly, in both cpu and memory. A sample:

```
e6a72496  exact=(420033009, 1295390)   declared=(420033009, 1295390)
0e26570e  exact=(2200582223, 8365962)  declared=(2200582223, 8365962)
c805ae3e  exact=(1800466965, 6820806)  declared=(1800466965, 6820806)
1b0a4900  exact=(1131542483, 4046800)  declared=(1131542483, 4046800)
b21f7e15  exact=(2040854887, 7749812)  declared=(2040854887, 7749812)
```

Bit-for-bit agreement with the budgets cardano-node accepted on chain is the strongest available check: those budgets are what a Haskell node computed, and matching them exactly means the script context and the cost accounting both agree with it.

## Ruled out along the way

Recorded so the next person does not repeat the work: the cost model is byte-identical to the one the chain voted in at preview slot 701109, for both PlutusV1 (166 entries) and PlutusV2 (175 entries); the redeemer count and the spend redeemer to sorted-input index mapping are correct; removing whole context fields (reference inputs, signatories, redeemers, the mint ada entry) moves the cost by far more than the observed constant, so it was never a missing or extra field; and plutigo's accounting agrees with an independent Rust implementation exactly once the trailing slippage batch is charged.

## Scope

Pruning happens at decode, which is where cardano-ledger does it, so every consumer sees the same canonical value rather than only the script-context path. `MarshalCBOR` on types embedding `DecodeStoreCbor` still returns the original bytes, so re-serialising a decoded transaction is unaffected.

Testing: new `TestMultiAssetDecodePrunesZeroQuantities` covers a policy that keeps a non-zero asset beside a zero one and a policy left empty, which must disappear; it fails if pruning is removed. Full `go test ./...` and `golangci-lint run ./...` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prunes zero-quantity assets during MultiAsset decode to match `cardano-ledger`, so zero entries never reach ledger rules or Plutus contexts. This prevents inflated script costs and phase-2 rejections caused by extra entries.

- **Bug Fixes**
  - Drop zero-quantity assets and empty policies at decode in both strict and lenient paths, using `amountIsZero` for consistent checks across `int64`, `uint64`, and `*big.Int`.
  - Tests cover strict and lenient paths, including duplicate asset keys: last-wins zero amounts are pruned, empty policies removed, and duplicate keys still flagged for Conway+ rejection.

<sup>Written for commit 271f26b9a7deafff2f2b4f0602c1d7166efab172. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed zero-valued assets when decoding multi-asset data.
  * Removed empty asset policies after zero-valued assets are discarded.
  * Applied consistent cleanup for both standard and duplicate-key-tolerant decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->