### PR TITLE
fix(consensus)!: apply Genesis density-first selection for deep forks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -295,7 +295,7 @@ Implements Ouroboros Praos consensus primitives.
 | consensus.go | Core interfaces (VRFSigner, KESSigner, ConsensusHeader, etc.) |
 | block.go | Block construction (BlockBuilder, OperationalCert, Header) |
 | leader.go | Leader eligibility checking |
-| selection.go | Block producer selection |
+| selection.go | Chain selection (Praos ordering + Genesis density comparison) |
 | threshold.go | Leadership threshold calculation |
 | validate.go | Block validation |
 | byron/ | Byron-era consensus validation |

--- a/consensus/README.md
+++ b/consensus/README.md
@@ -31,9 +31,19 @@ The threshold formula is: `T = 2^512 * (1 - (1-f)^σ)` where `f` is the active s
 ### Chain Selection (`selection.go`)
 
 - `PraosChainSelector` - Implements Praos chain selection rules:
-  1. Prefer longer chains (higher block number)
-  2. For equal length, prefer lower VRF output (tiebreaker)
-  3. For deep forks (>k slots), compare chain density
+  1. Ordinary comparison (`Compare`): prefer longer chains (higher block
+     number); for equal length, prefer lower VRF output (tiebreaker)
+  2. `IsDeepFork(fork, tipBlockNumber)` routes between the two regimes: a
+     fork is deep when adopting it would roll back more than k *blocks*
+     (k counts blocks, not slots)
+  3. Genesis density comparison (`CompareWithDensity` /
+     `PreferredWithDensity`): shallow forks use the ordinary comparison,
+     while deep forks prefer the chain with more blocks within the genesis
+     window (3k/f slots after the fork point) regardless of total length;
+     equal density falls through to the ordinary comparison
+
+  Tips that implement the optional `WindowBlockCounter` interface get the
+  canonical integer window metric; others fall back to `ChainTip.Density`.
 
 ### Block Validation (`validate.go`)
 

--- a/consensus/genesis/genesis.go
+++ b/consensus/genesis/genesis.go
@@ -26,6 +26,16 @@
 //
 // The genesis window is defined as 3k/f slots, matching the forecast range.
 // Once a node finishes syncing, it gracefully converges to standard Praos selection.
+//
+// Relationship to the consensus package: the tip-level ordering surface for
+// candidate chains is consensus.PraosChainSelector.CompareWithDensity, which
+// applies the same windowed block-count rule to ChainTip values and falls
+// through to the ordinary Praos comparison on equal density. This package's
+// GenesisSelector operates on fragment-level data (ChainFragment) and breaks
+// density ties by total block count instead; its Density and ExpectedDensity
+// float helpers predate the integer windowed-count metric and are retained
+// for compatibility. Derive the window itself with ComputeGenesisWindow in
+// both cases so the 3k/f ceiling semantics stay single-sourced.
 package genesis
 
 import (
@@ -51,8 +61,11 @@ func ComputeGenesisWindow(
 	securityParam uint64,
 	activeSlotCoeff *big.Rat,
 ) uint64 {
-	// Guard against nil or zero activeSlotCoeff to avoid division by zero
-	if activeSlotCoeff == nil || activeSlotCoeff.Sign() == 0 {
+	// Guard against nil, zero, or negative activeSlotCoeff: zero would
+	// divide by zero, and a negative coefficient is meaningless for an
+	// active-slot probability (and would otherwise produce a garbage
+	// window via truncated negative division).
+	if activeSlotCoeff == nil || activeSlotCoeff.Sign() <= 0 {
 		return 0
 	}
 	// Genesis window = 3k/f
@@ -63,11 +76,22 @@ func ComputeGenesisWindow(
 	threeK := new(big.Rat).SetInt(new(big.Int).Mul(three, k))
 	window := new(big.Rat).Quo(threeK, activeSlotCoeff)
 
-	// Convert to uint64 using integer division for deterministic, precise behavior
-	// Num/Denom gives exact integer division result
+	// Convert to uint64 with CEILING division, matching cardano-ledger's
+	// computeStabilityWindow ("ceiling $ (3 * fromIntegral k) /. f",
+	// eras/shelley/impl/src/Cardano/Ledger/Shelley/StabilityWindow.hs) —
+	// ouroboros-consensus uses that value as the Shelley-era genesis window
+	// (shelleyEraParams: eraGenesisWin = GenesisWindow stabilityWindow).
+	// Floor vs ceiling differs whenever 3k/f is not integral; the window is
+	// consensus-relevant, so the rounding must match exactly. On mainnet
+	// (k=2160, f=1/20) 3k/f = 129600 exactly, so both roundings agree.
 	num := window.Num()
 	denom := window.Denom()
-	result := new(big.Int).Div(num, denom)
+	result, remainder := new(big.Int).QuoRem(
+		num, denom, new(big.Int),
+	)
+	if remainder.Sign() != 0 {
+		result.Add(result, big.NewInt(1))
+	}
 
 	// Clamp to uint64 max if result overflows
 	if !result.IsUint64() {

--- a/consensus/genesis/genesis_test.go
+++ b/consensus/genesis/genesis_test.go
@@ -17,6 +17,8 @@ package genesis
 import (
 	"math/big"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // testGenesisConfig returns a GenesisConfig for testing with mainnet-like parameters.
@@ -47,33 +49,34 @@ func TestComputeGenesisWindow(t *testing.T) {
 func TestComputeGenesisWindowCeiling(t *testing.T) {
 	// k=2160, f=7/100: 3*2160*100/7 = 648000/7 = 92571.43... -> 92572.
 	window := ComputeGenesisWindow(2160, big.NewRat(7, 100))
-	if window != 92572 {
-		t.Errorf(
-			"expected ceiling(648000/7) = 92572, got %d",
-			window,
-		)
-	}
+	assert.Equal(
+		t, uint64(92572), window, "expected ceiling(648000/7) = 92572",
+	)
 
 	// Exact division is unaffected: k=10, f=1/2 -> 3*10*2 = 60.
 	window = ComputeGenesisWindow(10, big.NewRat(1, 2))
-	if window != 60 {
-		t.Errorf("expected 60, got %d", window)
-	}
+	assert.Equal(t, uint64(60), window, "expected exact division 60")
 }
 
 // TestComputeGenesisWindowDegenerateCoefficients pins the guard: nil, zero,
 // and negative active-slot coefficients all yield a zero window rather than
 // a garbage value.
 func TestComputeGenesisWindowDegenerateCoefficients(t *testing.T) {
-	if got := ComputeGenesisWindow(2160, nil); got != 0 {
-		t.Errorf("nil coefficient: expected 0, got %d", got)
-	}
-	if got := ComputeGenesisWindow(2160, big.NewRat(0, 1)); got != 0 {
-		t.Errorf("zero coefficient: expected 0, got %d", got)
-	}
-	if got := ComputeGenesisWindow(2160, big.NewRat(-1, 20)); got != 0 {
-		t.Errorf("negative coefficient: expected 0, got %d", got)
-	}
+	assert.Zero(
+		t,
+		ComputeGenesisWindow(2160, nil),
+		"nil coefficient: expected 0",
+	)
+	assert.Zero(
+		t,
+		ComputeGenesisWindow(2160, big.NewRat(0, 1)),
+		"zero coefficient: expected 0",
+	)
+	assert.Zero(
+		t,
+		ComputeGenesisWindow(2160, big.NewRat(-1, 20)),
+		"negative coefficient: expected 0",
+	)
 }
 
 // TestNewGenesisSelectorDerivedWindowCeiling pins the derived-window path
@@ -85,12 +88,10 @@ func TestNewGenesisSelectorDerivedWindowCeiling(t *testing.T) {
 		ActiveSlotCoeff: big.NewRat(7, 100),
 	})
 	// 3*2160*100/7 = 648000/7 = 92571.43... -> 92572.
-	if selector.config.GenesisWindow != 92572 {
-		t.Errorf(
-			"expected derived window 92572, got %d",
-			selector.config.GenesisWindow,
-		)
-	}
+	assert.Equal(
+		t, uint64(92572), selector.config.GenesisWindow,
+		"expected derived window 92572",
+	)
 }
 
 func TestGenesisConfig(t *testing.T) {

--- a/consensus/genesis/genesis_test.go
+++ b/consensus/genesis/genesis_test.go
@@ -40,6 +40,59 @@ func TestComputeGenesisWindow(t *testing.T) {
 	}
 }
 
+// TestComputeGenesisWindowCeiling pins the rounding to CEILING division,
+// matching cardano-ledger's computeStabilityWindow
+// ("ceiling $ (3 * fromIntegral k) /. f"): whenever 3k/f is not integral,
+// the window rounds up, never down.
+func TestComputeGenesisWindowCeiling(t *testing.T) {
+	// k=2160, f=7/100: 3*2160*100/7 = 648000/7 = 92571.43... -> 92572.
+	window := ComputeGenesisWindow(2160, big.NewRat(7, 100))
+	if window != 92572 {
+		t.Errorf(
+			"expected ceiling(648000/7) = 92572, got %d",
+			window,
+		)
+	}
+
+	// Exact division is unaffected: k=10, f=1/2 -> 3*10*2 = 60.
+	window = ComputeGenesisWindow(10, big.NewRat(1, 2))
+	if window != 60 {
+		t.Errorf("expected 60, got %d", window)
+	}
+}
+
+// TestComputeGenesisWindowDegenerateCoefficients pins the guard: nil, zero,
+// and negative active-slot coefficients all yield a zero window rather than
+// a garbage value.
+func TestComputeGenesisWindowDegenerateCoefficients(t *testing.T) {
+	if got := ComputeGenesisWindow(2160, nil); got != 0 {
+		t.Errorf("nil coefficient: expected 0, got %d", got)
+	}
+	if got := ComputeGenesisWindow(2160, big.NewRat(0, 1)); got != 0 {
+		t.Errorf("zero coefficient: expected 0, got %d", got)
+	}
+	if got := ComputeGenesisWindow(2160, big.NewRat(-1, 20)); got != 0 {
+		t.Errorf("negative coefficient: expected 0, got %d", got)
+	}
+}
+
+// TestNewGenesisSelectorDerivedWindowCeiling pins the derived-window path
+// through NewGenesisSelector with a non-integral 3k/f, so the constructor
+// inherits the ceiling semantics too.
+func TestNewGenesisSelectorDerivedWindowCeiling(t *testing.T) {
+	selector := NewGenesisSelector(GenesisConfig{
+		SecurityParam:   2160,
+		ActiveSlotCoeff: big.NewRat(7, 100),
+	})
+	// 3*2160*100/7 = 648000/7 = 92571.43... -> 92572.
+	if selector.config.GenesisWindow != 92572 {
+		t.Errorf(
+			"expected derived window 92572, got %d",
+			selector.config.GenesisWindow,
+		)
+	}
+}
+
 func TestGenesisConfig(t *testing.T) {
 	config := testGenesisConfig()
 

--- a/consensus/selection.go
+++ b/consensus/selection.go
@@ -370,6 +370,10 @@ func (p *PraosChainSelector) PreferredWithDensity(
 }
 
 // SimpleChainTip is a simple implementation of ChainTip for testing.
+//
+// It deliberately does NOT implement WindowBlockCounter: it holds no
+// per-block slots, so it cannot answer a window count. See
+// WindowedChainTip for a tip that can.
 type SimpleChainTip struct {
 	slot        uint64
 	blockNumber uint64
@@ -377,9 +381,6 @@ type SimpleChainTip struct {
 	// For the legacy density ratio
 	blocksAfterFork uint64
 	slotsAfterFork  uint64
-	// blockSlots holds the slot of each block on this chain, used for the
-	// canonical window metric (see WindowBlockCounter).
-	blockSlots []uint64
 }
 
 // NewSimpleChainTip creates a new SimpleChainTip.
@@ -409,18 +410,31 @@ func NewSimpleChainTipWithDensity(
 	}
 }
 
-// NewSimpleChainTipWithBlockSlots creates a SimpleChainTip that supports
-// the canonical window metric, from the slots of the blocks on the chain.
-func NewSimpleChainTipWithBlockSlots(
+// WindowedChainTip is a chain tip that carries the slot of each of its
+// blocks and can therefore answer the canonical Genesis window count.
+//
+// It is a distinct type on purpose. WindowBlockCounter is satisfied by a
+// type, not by an instance, so a tip that holds no per-block slots must not
+// carry the method at all — otherwise it would claim the capability and
+// answer zero, which selection cannot distinguish from a chain that
+// genuinely has no blocks in the window. Keeping the capability and the
+// data in the same type makes that state unrepresentable.
+type WindowedChainTip struct {
+	*SimpleChainTip
+	// blockSlots holds the slot of each block on this chain.
+	blockSlots []uint64
+}
+
+// NewWindowedChainTip creates a tip that supports the canonical Genesis
+// window metric, from the slots of the blocks on the chain.
+func NewWindowedChainTip(
 	slot, blockNumber uint64,
 	vrfOutput []byte,
 	blockSlots []uint64,
-) *SimpleChainTip {
-	return &SimpleChainTip{
-		slot:        slot,
-		blockNumber: blockNumber,
-		vrfOutput:   vrfOutput,
-		blockSlots:  blockSlots,
+) *WindowedChainTip {
+	return &WindowedChainTip{
+		SimpleChainTip: NewSimpleChainTip(slot, blockNumber, vrfOutput),
+		blockSlots:     blockSlots,
 	}
 }
 
@@ -453,17 +467,39 @@ func (s *SimpleChainTip) Density(_ uint64) float64 {
 // BlocksInWindow implements WindowBlockCounter. A block at slot s counts
 // iff s > forkSlot && s-forkSlot <= windowSlots; the bound is evaluated in
 // that subtraction form so it cannot wrap near the uint64 maximum.
-func (s *SimpleChainTip) BlocksInWindow(
+func (w *WindowedChainTip) BlocksInWindow(
 	forkSlot, windowSlots uint64,
 ) uint64 {
 	if windowSlots == 0 {
 		return 0
 	}
 	var count uint64
-	for _, blockSlot := range s.blockSlots {
+	for _, blockSlot := range w.blockSlots {
 		if blockSlot > forkSlot && blockSlot-forkSlot <= windowSlots {
 			count++
 		}
 	}
 	return count
+}
+
+// Density overrides the embedded ratio, which would otherwise report zero
+// because a windowed tip carries block slots rather than precomputed
+// blocks/slots totals. It derives the legacy ratio from those slots so a
+// windowed tip stays comparable when the other side of a comparison
+// implements only ChainTip and the selector must fall back.
+func (w *WindowedChainTip) Density(forkSlot uint64) float64 {
+	var blocks, maxSlot uint64
+	for _, blockSlot := range w.blockSlots {
+		if blockSlot <= forkSlot {
+			continue
+		}
+		blocks++
+		if blockSlot > maxSlot {
+			maxSlot = blockSlot
+		}
+	}
+	if blocks == 0 {
+		return 0
+	}
+	return float64(blocks) / float64(maxSlot-forkSlot)
 }

--- a/consensus/selection.go
+++ b/consensus/selection.go
@@ -15,24 +15,127 @@
 package consensus
 
 import (
+	"log/slog"
 	"math/big"
+	"sync"
 )
 
-// PraosChainSelector implements Ouroboros Praos chain selection rules.
+// PraosChainSelector implements Ouroboros chain selection.
 //
-// Chain selection in Praos follows these rules:
-//  1. Prefer the chain with more blocks (higher block number)
-//  2. For equal length chains, prefer the one with lower VRF output (tiebreaker)
-//  3. For deep forks (diverging more than k slots ago), compare chain density
+// Selection is routed explicitly on how deep the fork is, and the two
+// regimes are kept separate:
+//
+//  1. Shallow forks (rollback of at most k blocks) use the ordinary
+//     longest-chain rule: prefer more blocks, then the lower VRF output
+//     as a tiebreaker. Density is never consulted here — a shorter but
+//     denser shallow candidate must NOT beat a longer chain.
+//  2. Deep forks (rollback of more than k blocks — the syncing regime the
+//     Genesis rule governs) compare density first: the candidate with MORE
+//     BLOCKS within the genesis window wins regardless of total length,
+//     and only an exact tie falls back to the ordinary rule. This is what
+//     stops a longer but sparser (adversarial) deep fork from winning.
+//
+// The routing predicate is IsDeepFork, and it is the only thing that
+// decides which regime applies; every density entry point takes the depth
+// inputs it needs, so a caller cannot reach the density rule for a shallow
+// fork.
+//
+// Units: the security parameter k bounds a number of BLOCKS, not slots.
+// Ouroboros.Consensus.Config.SecurityParam: "NOTE: This talks about the
+// number of /blocks/ we can roll back, not the number of /slots/". Fork
+// depth is therefore measured between block numbers, while the genesis
+// window is a span of SLOTS; ForkPoint carries both so the two units
+// cannot be transposed at a call site.
+//
+// NOTE: the density comparison here is an ORDERING derived from the
+// Genesis density rule; it is not the GDD governor. In
+// ouroboros-consensus (Ouroboros.Consensus.Genesis.Governor,
+// densityDisconnect) the rule disconnects sparser PEERS and an exact tie
+// disconnects both; an ordering cannot express "both lose", so an exact
+// tie falls through to the ordinary comparison here — the same adaptation
+// the Dingo node uses for fork resolution. Peer management remains the
+// caller's concern.
 type PraosChainSelector struct {
-	// SecurityParam is the security parameter k (max rollback depth)
+	// SecurityParam is the security parameter k: the maximum rollback
+	// depth, in BLOCKS (not slots).
 	SecurityParam uint64
+	// GenesisWindowSlots is the Ouroboros Genesis density window sgen, in
+	// SLOTS after the fork point. For Shelley-family eras this is 3k/f
+	// (see genesis.ComputeGenesisWindow; mainnet 129600). When it is zero,
+	// or when the tips being compared do not implement WindowBlockCounter,
+	// deep-fork comparison falls back to the legacy ChainTip.Density
+	// ratio; see compareDensity.
+	GenesisWindowSlots uint64
+
+	// warnFallbackDensity throttles the legacy-metric warning to once per
+	// selector.
+	warnFallbackDensity sync.Once
+}
+
+// ForkPoint identifies the intersection between the current selection and
+// the candidate chains being compared: the last block they share.
+//
+// Selection needs that point in two different units, so both are carried
+// explicitly rather than inferred from one another:
+//
+//   - Slot anchors the genesis window, which spans SLOTS.
+//   - BlockNumber measures rollback depth, which is what k bounds (BLOCKS).
+//
+// Naming the fields keeps the two from being transposed at call sites,
+// where both are plain uint64.
+type ForkPoint struct {
+	// Slot is the slot of the last block common to the chains compared.
+	Slot uint64
+	// BlockNumber is the block height of that same common block.
+	BlockNumber uint64
+}
+
+// WindowBlockCounter is an optional extension of ChainTip that supplies the
+// canonical Ouroboros Genesis density metric: an integer count of blocks
+// within a fixed window of slots after the fork point.
+//
+// ChainTip itself is unchanged, so existing implementations keep working;
+// a tip that also implements this interface gets the canonical metric
+// instead of the ChainTip.Density ratio (see compareDensity).
+type WindowBlockCounter interface {
+	// BlocksInWindow returns the number of blocks on this chain whose slot
+	// lies within the genesis window after forkSlot: a block at slot s
+	// counts iff s > forkSlot && s-forkSlot <= windowSlots. State the
+	// bound in that subtraction form in implementations too — computing
+	// forkSlot+windowSlots can wrap near the uint64 maximum.
+	//
+	// This matches densityDisconnect, which clips each candidate suffix at
+	// the first slot after the genesis window (succ(intersection) + sgen)
+	// and counts the headers that remain. Selection may call this once per
+	// pairwise comparison; implementations over large chains should
+	// precompute or index rather than rescan.
+	BlocksInWindow(forkSlot, windowSlots uint64) uint64
 }
 
 // NewPraosChainSelector creates a new Praos chain selector.
+//
+// The selector has no genesis window configured, so deep-fork comparison
+// uses the legacy ChainTip.Density ratio. Use
+// NewPraosChainSelectorWithWindow for the canonical Genesis metric.
 func NewPraosChainSelector(securityParam uint64) *PraosChainSelector {
 	return &PraosChainSelector{
 		SecurityParam: securityParam,
+	}
+}
+
+// NewPraosChainSelectorWithWindow creates a selector that applies the
+// canonical Genesis density metric, counting blocks within
+// genesisWindowSlots slots after the fork point.
+//
+// securityParam is k in BLOCKS; genesisWindowSlots is sgen in SLOTS,
+// derived with genesis.ComputeGenesisWindow(k, f).
+func NewPraosChainSelectorWithWindow(
+	securityParam uint64,
+	genesisWindowSlots uint64,
+) *PraosChainSelector {
+	return &PraosChainSelector{
+		SecurityParam:      securityParam,
+		GenesisWindowSlots: genesisWindowSlots,
 	}
 }
 
@@ -91,30 +194,110 @@ func (p *PraosChainSelector) Compare(a, b ChainTip) int {
 	return 0
 }
 
+// IsDeepFork reports whether adopting a candidate that branches at fork
+// would require rolling back more than k BLOCKS from the current
+// selection, whose tip is at tipBlockNumber.
+//
+// This is the routing predicate for chain selection: false selects the
+// ordinary longest-chain rule, true selects the Genesis density rule (see
+// CompareWithDensity).
+//
+// The unit is deliberate. k bounds blocks, not slots
+// (Ouroboros.Consensus.Config.SecurityParam: "NOTE: This talks about the
+// number of /blocks/ we can roll back, not the number of /slots/"), so
+// depth is measured between block numbers. Measuring it in slots
+// misclassifies forks by roughly 1/f — about 20x at mainnet f=0.05 —
+// treating ordinary shallow forks as deep.
+//
+// A fork point at or ahead of the tip requires no rollback and is never
+// deep; the subtraction below therefore cannot underflow.
+func (p *PraosChainSelector) IsDeepFork(
+	fork ForkPoint,
+	tipBlockNumber uint64,
+) bool {
+	if tipBlockNumber <= fork.BlockNumber {
+		return false
+	}
+	return tipBlockNumber-fork.BlockNumber > p.SecurityParam
+}
+
+// compareDensity compares the density of two tips over the genesis window
+// after fork. It returns a positive value if a is denser, a negative value
+// if b is denser, and zero if they are equal.
+//
+// The canonical Genesis metric is an integer count of blocks within the
+// window, which requires a configured window and both tips to implement
+// WindowBlockCounter. When either is missing this falls back to the legacy
+// ChainTip.Density ratio and warns once, because that ratio is measured
+// over the whole fork suffix rather than a fixed window and so is not the
+// Genesis metric.
+func (p *PraosChainSelector) compareDensity(
+	a, b ChainTip,
+	fork ForkPoint,
+) int {
+	aCounter, aOK := a.(WindowBlockCounter)
+	bCounter, bOK := b.(WindowBlockCounter)
+
+	if p.GenesisWindowSlots > 0 && aOK && bOK {
+		aBlocks := aCounter.BlocksInWindow(fork.Slot, p.GenesisWindowSlots)
+		bBlocks := bCounter.BlocksInWindow(fork.Slot, p.GenesisWindowSlots)
+		if aBlocks > bBlocks {
+			return 1
+		}
+		if bBlocks > aBlocks {
+			return -1
+		}
+		return 0
+	}
+
+	p.warnFallbackDensity.Do(func() {
+		slog.Warn(
+			"deep-fork comparison using legacy density ratio; configure a "+
+				"genesis window and implement WindowBlockCounter for the "+
+				"canonical Genesis metric",
+			"securityParam", p.SecurityParam,
+			"genesisWindowSlots", p.GenesisWindowSlots,
+		)
+	})
+
+	aDensity := a.Density(fork.Slot)
+	bDensity := b.Density(fork.Slot)
+	if aDensity > bDensity {
+		return 1
+	}
+	if bDensity > aDensity {
+		return -1
+	}
+	return 0
+}
+
 // CompareWithDensity compares two chains using the Ouroboros Genesis rule,
 // branching explicitly on how deep the fork is relative to the security
 // parameter k:
 //
-//   - Forks no deeper than k slots (see IsDeepFork) are not considered
-//     "deep" and are resolved using the ordinary longest-chain rule
-//     (Compare), exactly as ordinary Praos selection would.
-//   - Forks deeper than k slots must be resolved using chain density
-//     over the window since the fork point *first*; the longest-chain
-//     rule is only used as a tiebreaker when densities are equal. This
-//     prevents a longer but sparser (and therefore potentially
-//     adversarial) deep fork from beating a shorter, denser one.
+//   - Forks requiring a rollback of at most k blocks (see IsDeepFork) are
+//     not "deep" and are resolved using the ordinary longest-chain rule
+//     (Compare), exactly as ordinary Praos selection would. Density is not
+//     consulted, so a shorter but denser shallow candidate cannot win.
+//   - Forks requiring a rollback of more than k blocks are resolved by
+//     density over the genesis window *first*; the longest-chain rule is
+//     only used as a tiebreaker when densities are equal. This prevents a
+//     longer but sparser (and therefore potentially adversarial) deep fork
+//     from beating a shorter, denser one.
 //
 // Parameters:
 //   - a, b: the chain tips to compare
-//   - forkSlot: the slot where the chains diverged
-//   - currentSlot: the slot used to measure fork depth against forkSlot
-//     (typically the current tip/wallclock slot)
+//   - fork: the intersection the chains diverge at, carrying both the slot
+//     (which anchors the genesis window) and the block number (which
+//     measures rollback depth)
+//   - tipBlockNumber: block height of the current selection, against which
+//     rollback depth is measured
 //
 // Returns the same values as Compare.
 func (p *PraosChainSelector) CompareWithDensity(
 	a, b ChainTip,
-	forkSlot uint64,
-	currentSlot uint64,
+	fork ForkPoint,
+	tipBlockNumber uint64,
 ) int {
 	if a == nil && b == nil {
 		return 0
@@ -126,21 +309,15 @@ func (p *PraosChainSelector) CompareWithDensity(
 		return 1
 	}
 
-	// Shallow forks (at most k deep) use ordinary longest-chain selection;
-	// density is not considered per the Genesis rule.
-	if !p.IsDeepFork(forkSlot, currentSlot) {
+	// Shallow forks (at most k blocks deep) use ordinary longest-chain
+	// selection; density is not considered per the Genesis rule.
+	if !p.IsDeepFork(fork, tipBlockNumber) {
 		return p.Compare(a, b)
 	}
 
-	// Deep forks (more than k slots old): compare density first.
-	aDensity := a.Density(forkSlot)
-	bDensity := b.Density(forkSlot)
-
-	if aDensity > bDensity {
-		return 1
-	}
-	if bDensity > aDensity {
-		return -1
+	// Deep forks: density within the genesis window decides first.
+	if result := p.compareDensity(a, b, fork); result != 0 {
+		return result
 	}
 
 	// Equal density - fall back to the ordinary rule as a tiebreaker.
@@ -173,29 +350,23 @@ func (p *PraosChainSelector) Preferred(candidates []ChainTip) ChainTip {
 	return p.selectPreferred(candidates, p.Compare)
 }
 
-// PreferredWithDensity returns the preferred chain considering density.
-// Use this when some candidates may represent deep forks; see
-// CompareWithDensity for the exact rule applied.
+// PreferredWithDensity returns the preferred chain from a set of
+// candidates, applying exactly the contract CompareWithDensity documents:
+// shallow forks are resolved by the ordinary rule, and only forks deeper
+// than k blocks are resolved by density.
+//
+// fork is the candidates' common intersection — the youngest point shared
+// by ALL candidates, matching the anchor ouroboros-consensus derives via
+// sharedCandidatePrefix — and tipBlockNumber is the current selection's
+// height, so depth is measured on the same basis as CompareWithDensity.
 func (p *PraosChainSelector) PreferredWithDensity(
 	candidates []ChainTip,
-	forkSlot uint64,
-	currentSlot uint64,
+	fork ForkPoint,
+	tipBlockNumber uint64,
 ) ChainTip {
 	return p.selectPreferred(candidates, func(a, b ChainTip) int {
-		return p.CompareWithDensity(a, b, forkSlot, currentSlot)
+		return p.CompareWithDensity(a, b, fork, tipBlockNumber)
 	})
-}
-
-// IsDeepFork checks if a fork point is considered "deep" (older than k slots).
-// Deep forks use density-based comparison instead of simple length comparison.
-func (p *PraosChainSelector) IsDeepFork(
-	forkSlot uint64,
-	currentSlot uint64,
-) bool {
-	if currentSlot < forkSlot {
-		return false
-	}
-	return currentSlot-forkSlot > p.SecurityParam
 }
 
 // SimpleChainTip is a simple implementation of ChainTip for testing.
@@ -203,9 +374,12 @@ type SimpleChainTip struct {
 	slot        uint64
 	blockNumber uint64
 	vrfOutput   []byte
-	// For density calculation
+	// For the legacy density ratio
 	blocksAfterFork uint64
 	slotsAfterFork  uint64
+	// blockSlots holds the slot of each block on this chain, used for the
+	// canonical window metric (see WindowBlockCounter).
+	blockSlots []uint64
 }
 
 // NewSimpleChainTip creates a new SimpleChainTip.
@@ -235,6 +409,21 @@ func NewSimpleChainTipWithDensity(
 	}
 }
 
+// NewSimpleChainTipWithBlockSlots creates a SimpleChainTip that supports
+// the canonical window metric, from the slots of the blocks on the chain.
+func NewSimpleChainTipWithBlockSlots(
+	slot, blockNumber uint64,
+	vrfOutput []byte,
+	blockSlots []uint64,
+) *SimpleChainTip {
+	return &SimpleChainTip{
+		slot:        slot,
+		blockNumber: blockNumber,
+		vrfOutput:   vrfOutput,
+		blockSlots:  blockSlots,
+	}
+}
+
 // Slot returns the tip slot.
 func (s *SimpleChainTip) Slot() uint64 {
 	return s.slot
@@ -259,4 +448,22 @@ func (s *SimpleChainTip) Density(_ uint64) float64 {
 		return 0
 	}
 	return float64(s.blocksAfterFork) / float64(s.slotsAfterFork)
+}
+
+// BlocksInWindow implements WindowBlockCounter. A block at slot s counts
+// iff s > forkSlot && s-forkSlot <= windowSlots; the bound is evaluated in
+// that subtraction form so it cannot wrap near the uint64 maximum.
+func (s *SimpleChainTip) BlocksInWindow(
+	forkSlot, windowSlots uint64,
+) uint64 {
+	if windowSlots == 0 {
+		return 0
+	}
+	var count uint64
+	for _, blockSlot := range s.blockSlots {
+		if blockSlot > forkSlot && blockSlot-forkSlot <= windowSlots {
+			count++
+		}
+	}
+	return count
 }

--- a/consensus/selection_test.go
+++ b/consensus/selection_test.go
@@ -531,7 +531,7 @@ func TestCompareWithDensityShallowForkShorterDenserLoses(t *testing.T) {
 	for i := uint64(1); i <= 90; i++ {
 		denseSlots = append(denseSlots, 1000+i)
 	}
-	chainA := NewSimpleChainTipWithBlockSlots(1090, 90, vrf, denseSlots)
+	chainA := NewWindowedChainTip(1090, 90, vrf, denseSlots)
 
 	// Chain B: longer (100 blocks) but only 5 of them fall inside the
 	// window, so B is strictly SPARSER than A by the window metric. If
@@ -544,7 +544,7 @@ func TestCompareWithDensityShallowForkShorterDenserLoses(t *testing.T) {
 	for i := uint64(1); i <= 95; i++ {
 		sparseSlots = append(sparseSlots, 1000+mainnetWindow+i*100)
 	}
-	chainB := NewSimpleChainTipWithBlockSlots(200000, 100, vrf, sparseSlots)
+	chainB := NewWindowedChainTip(200000, 100, vrf, sparseSlots)
 
 	// Guard the premise: A really is denser than B inside the window.
 	require.Greater(
@@ -611,7 +611,7 @@ func TestCompareWithDensityDeepForkUsesWindowCount(t *testing.T) {
 	for i := uint64(1); i <= 50; i++ {
 		honestSlots = append(honestSlots, 1000+i*100)
 	}
-	honest := NewSimpleChainTipWithBlockSlots(6000, 50, vrf, honestSlots)
+	honest := NewWindowedChainTip(6000, 50, vrf, honestSlots)
 
 	// Adversarial chain: 80 blocks total (longer), but only 10 of them
 	// fall inside the window; the rest are far beyond it.
@@ -622,7 +622,7 @@ func TestCompareWithDensityDeepForkUsesWindowCount(t *testing.T) {
 	for i := uint64(1); i <= 70; i++ {
 		advSlots = append(advSlots, 1000+mainnetWindow+i*100)
 	}
-	adversarial := NewSimpleChainTipWithBlockSlots(900000, 80, vrf, advSlots)
+	adversarial := NewWindowedChainTip(900000, 80, vrf, advSlots)
 
 	// Sanity: the adversarial chain really is longer.
 	assert.Negative(
@@ -667,8 +667,8 @@ func TestCompareWithDensityEqualDensityFallsThrough(t *testing.T) {
 	// longer overall, so the ordinary rule must pick B.
 	inWindow := []uint64{1100, 1200, 1300}
 
-	shortChain := NewSimpleChainTipWithBlockSlots(1300, 10, vrf, inWindow)
-	longChain := NewSimpleChainTipWithBlockSlots(1300, 20, vrf, inWindow)
+	shortChain := NewWindowedChainTip(1300, 10, vrf, inWindow)
+	longChain := NewWindowedChainTip(1300, 20, vrf, inWindow)
 
 	assert.Negative(
 		t,
@@ -682,8 +682,8 @@ func TestCompareWithDensityEqualDensityFallsThrough(t *testing.T) {
 	highVRF := make([]byte, 64)
 	highVRF[0] = 0x02
 
-	lowTip := NewSimpleChainTipWithBlockSlots(1300, 10, lowVRF, inWindow)
-	highTip := NewSimpleChainTipWithBlockSlots(1300, 10, highVRF, inWindow)
+	lowTip := NewWindowedChainTip(1300, 10, lowVRF, inWindow)
+	highTip := NewWindowedChainTip(1300, 10, highVRF, inWindow)
 
 	assert.Positive(
 		t,
@@ -699,7 +699,7 @@ func TestCompareWithDensityWindowBoundary(t *testing.T) {
 	const forkSlot = uint64(1000)
 	const window = uint64(100)
 
-	tip := NewSimpleChainTipWithBlockSlots(
+	tip := NewWindowedChainTip(
 		2000,
 		4,
 		make([]byte, 64),
@@ -733,7 +733,7 @@ func TestBlocksInWindowUint64Boundary(t *testing.T) {
 	maxUint64 := ^uint64(0)
 	forkSlot := maxUint64 - 10
 
-	tip := NewSimpleChainTipWithBlockSlots(
+	tip := NewWindowedChainTip(
 		maxUint64,
 		2,
 		make([]byte, 64),
@@ -797,17 +797,19 @@ func (l legacyTip) BlockNumber() uint64      { return l.blockNumber }
 func (l legacyTip) VRFOutput() []byte        { return make([]byte, 64) }
 func (l legacyTip) Density(_ uint64) float64 { return l.density }
 
-// TestSimpleChainTipImplementsWindowBlockCounter is a compile-time style
-// check that the shipped tip satisfies the optional extension.
-func TestSimpleChainTipImplementsWindowBlockCounter(t *testing.T) {
-	var tip ChainTip = NewSimpleChainTipWithBlockSlots(
+// TestOnlyWindowedTipClaimsWindowBlockCounter pins which types may claim the
+// optional extension. Only a tip that actually carries block slots may: a
+// tip that cannot count must not advertise the capability, because
+// selection cannot distinguish "answered zero" from "had no data".
+func TestOnlyWindowedTipClaimsWindowBlockCounter(t *testing.T) {
+	var windowed ChainTip = NewWindowedChainTip(
 		1000,
 		10,
 		make([]byte, 64),
 		[]uint64{1001},
 	)
-	_, ok := tip.(WindowBlockCounter)
-	assert.True(t, ok, "SimpleChainTip must implement WindowBlockCounter")
+	_, ok := windowed.(WindowBlockCounter)
+	assert.True(t, ok, "WindowedChainTip must implement WindowBlockCounter")
 
 	var legacy ChainTip = legacyTip{blockNumber: 10}
 	_, ok = legacy.(WindowBlockCounter)
@@ -815,5 +817,79 @@ func TestSimpleChainTipImplementsWindowBlockCounter(t *testing.T) {
 		t,
 		ok,
 		"a ChainTip-only implementation must remain valid",
+	)
+
+	// The tip built without block slots must NOT claim the capability.
+	var plain ChainTip = NewSimpleChainTipWithDensity(
+		1000, 10, make([]byte, 64), 5, 100,
+	)
+	_, ok = plain.(WindowBlockCounter)
+	assert.False(
+		t,
+		ok,
+		"a tip with no block slots must not claim WindowBlockCounter",
+	)
+}
+
+// TestDeepForkLegacyTipsStillDiscriminate is the regression for the silent
+// degradation this type split closes. With a window configured but both
+// tips built from the legacy constructor, the selector must fall back to
+// the density ratio and still prefer the denser chain on a deep fork.
+// Before the split both tips claimed WindowBlockCounter and answered zero,
+// so density was bypassed entirely and the longer-but-sparser chain won.
+func TestDeepForkLegacyTipsStillDiscriminate(t *testing.T) {
+	selector := NewPraosChainSelectorWithWindow(2160, mainnetWindow)
+	fork, tip := deepFork(1000)
+
+	// dense is SHORTER (2000 < 2600) but four times denser.
+	dense := NewSimpleChainTipWithDensity(
+		3000, 2000, make([]byte, 64), 1000, 2000,
+	) // 0.5
+	sparse := NewSimpleChainTipWithDensity(
+		9000, 2600, make([]byte, 64), 1600, 8000,
+	) // 0.2
+
+	assert.Positive(
+		t,
+		selector.CompareWithDensity(dense, sparse, fork, tip),
+		"deep fork: the denser chain must win even via the fallback ratio",
+	)
+	assert.Same(
+		t,
+		dense,
+		selector.PreferredWithDensity(
+			[]ChainTip{dense, sparse}, fork, tip,
+		),
+		"PreferredWithDensity must pick the denser chain on a deep fork",
+	)
+}
+
+// TestWindowedTipDensityFallback covers the mixed case: a windowed tip
+// compared against a ChainTip-only tip falls back to the ratio, so the
+// windowed tip must derive a meaningful ratio from its block slots rather
+// than reporting zero and losing by default.
+func TestWindowedTipDensityFallback(t *testing.T) {
+	selector := NewPraosChainSelectorWithWindow(2160, mainnetWindow)
+	fork, tip := deepFork(1000)
+
+	// 10 blocks in the 100 slots after the fork: ratio 0.1.
+	slots := make([]uint64, 0, 10)
+	for i := uint64(1); i <= 10; i++ {
+		slots = append(slots, 1000+i*10)
+	}
+	windowed := NewWindowedChainTip(1100, 10, make([]byte, 64), slots)
+	assert.InDelta(
+		t,
+		0.1,
+		windowed.Density(1000),
+		1e-9,
+		"a windowed tip must derive its legacy ratio from its block slots",
+	)
+
+	sparse := legacyTip{blockNumber: 10, density: 0.05}
+	assert.Positive(
+		t,
+		selector.CompareWithDensity(windowed, sparse, fork, tip),
+		"mixed comparison must fall back to a meaningful ratio",
 	)
 }

--- a/consensus/selection_test.go
+++ b/consensus/selection_test.go
@@ -16,6 +16,9 @@ package consensus
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewPraosChainSelector(t *testing.T) {
@@ -193,10 +196,15 @@ func TestCompareWithDensity(t *testing.T) {
 		t.Error("standard compare should show equal chains")
 	}
 
-	// With density comparison for a deep fork (fork at 1000, current
-	// slot far beyond k=2160 past the fork), chain A should be
+	// With density comparison for a deep fork (fork at block 0, current
+	// tip far beyond k=2160 blocks past the fork), chain A should be
 	// preferred (higher density).
-	result = selector.CompareWithDensity(chainA, chainB, 1000, 5000)
+	result = selector.CompareWithDensity(
+		chainA,
+		chainB,
+		ForkPoint{Slot: 1000, BlockNumber: 0},
+		5000,
+	)
 	if result <= 0 {
 		t.Error("chain with higher density should be preferred")
 	}
@@ -216,13 +224,14 @@ func TestCompareWithDensityShallowForkIgnoresDensity(t *testing.T) {
 	// Chain B: more blocks (longer chain), lower density.
 	chainB := NewSimpleChainTipWithDensity(1200, 100, vrf, 100, 500)
 
-	// Fork at slot 1000, current slot 1200: only 200 slots deep, which
-	// is well within k=2160, so this is NOT a deep fork.
-	if selector.IsDeepFork(1000, 1200) {
+	// Fork at block 1000, current tip block 1200: only 200 blocks deep,
+	// which is well within k=2160, so this is NOT a deep fork.
+	fork := ForkPoint{Slot: 1000, BlockNumber: 1000}
+	if selector.IsDeepFork(fork, 1200) {
 		t.Fatal("fork should not be considered deep for this test")
 	}
 
-	result := selector.CompareWithDensity(chainA, chainB, 1000, 1200)
+	result := selector.CompareWithDensity(chainA, chainB, fork, 1200)
 	if result >= 0 {
 		t.Error(
 			"shallow fork must use longest-chain rule; the longer " +
@@ -240,10 +249,10 @@ func TestCompareWithDensityDeepForkLongerButSparserLoses(t *testing.T) {
 
 	vrf := make([]byte, 64)
 
-	forkSlot := uint64(1000)
-	// currentSlot is far enough past forkSlot to make this a deep fork
-	// (more than k=2160 slots past the fork point).
-	currentSlot := uint64(10000)
+	fork := ForkPoint{Slot: 1000, BlockNumber: 0}
+	// tipBlockNumber is far enough past the fork point to make this a
+	// deep fork (more than k=2160 blocks would be rolled back).
+	tipBlockNumber := uint64(10000)
 
 	// Chain A ("honest"): shorter chain, but denser (100 blocks in 200
 	// slots => density 0.5).
@@ -253,7 +262,7 @@ func TestCompareWithDensityDeepForkLongerButSparserLoses(t *testing.T) {
 	// much sparser (150 blocks in 3000 slots => density 0.05).
 	chainB := NewSimpleChainTipWithDensity(4000, 150, vrf, 150, 3000)
 
-	if !selector.IsDeepFork(forkSlot, currentSlot) {
+	if !selector.IsDeepFork(fork, tipBlockNumber) {
 		t.Fatal("fork should be considered deep for this test")
 	}
 
@@ -268,8 +277,8 @@ func TestCompareWithDensityDeepForkLongerButSparserLoses(t *testing.T) {
 	result := selector.CompareWithDensity(
 		chainA,
 		chainB,
-		forkSlot,
-		currentSlot,
+		fork,
+		tipBlockNumber,
 	)
 	if result <= 0 {
 		t.Error(
@@ -281,8 +290,8 @@ func TestCompareWithDensityDeepForkLongerButSparserLoses(t *testing.T) {
 	// And PreferredWithDensity must select the denser chain too.
 	preferred := selector.PreferredWithDensity(
 		[]ChainTip{chainB, chainA},
-		forkSlot,
-		currentSlot,
+		fork,
+		tipBlockNumber,
 	)
 	if preferred != chainA {
 		t.Error(
@@ -292,33 +301,92 @@ func TestCompareWithDensityDeepForkLongerButSparserLoses(t *testing.T) {
 	}
 }
 
+// TestIsDeepFork pins the routing predicate's unit and boundary: depth is
+// measured in BLOCKS, k blocks is still shallow, and k+1 blocks is deep.
 func TestIsDeepFork(t *testing.T) {
-	selector := NewPraosChainSelector(2160) // k = 2160
+	selector := NewPraosChainSelector(2160) // k = 2160 blocks
 
-	// Fork at slot 1000, current slot 2000 - not deep (1000 slots)
-	if selector.IsDeepFork(1000, 2000) {
-		t.Error("fork 1000 slots ago should not be deep (k=2160)")
+	fork := func(blockNumber uint64) ForkPoint {
+		return ForkPoint{Slot: blockNumber * 20, BlockNumber: blockNumber}
 	}
 
-	// Fork at slot 1000, current slot 5000 - deep (4000 slots)
-	if !selector.IsDeepFork(1000, 5000) {
-		t.Error("fork 4000 slots ago should be deep (k=2160)")
-	}
+	// Rollback of 1000 blocks - not deep
+	assert.False(
+		t,
+		selector.IsDeepFork(fork(1000), 2000),
+		"rollback of 1000 blocks should not be deep (k=2160)",
+	)
 
-	// Fork at slot 1000, current slot 3161 - exactly at boundary (2161 slots)
-	if !selector.IsDeepFork(1000, 3161) {
-		t.Error("fork 2161 slots ago should be deep (k=2160)")
-	}
+	// Rollback of 4000 blocks - deep
+	assert.True(
+		t,
+		selector.IsDeepFork(fork(1000), 5000),
+		"rollback of 4000 blocks should be deep (k=2160)",
+	)
 
-	// Fork at slot 1000, current slot 3160 - just under boundary (2160 slots)
-	if selector.IsDeepFork(1000, 3160) {
-		t.Error("fork exactly 2160 slots ago should not be deep")
-	}
+	// Rollback of exactly k+1 = 2161 blocks - deep
+	assert.True(
+		t,
+		selector.IsDeepFork(fork(1000), 3161),
+		"rollback of k+1=2161 blocks should be deep",
+	)
 
-	// Edge case: current slot before fork slot
-	if selector.IsDeepFork(2000, 1000) {
-		t.Error("fork in future should not be deep")
-	}
+	// Rollback of exactly k = 2160 blocks - still shallow
+	assert.False(
+		t,
+		selector.IsDeepFork(fork(1000), 3160),
+		"rollback of exactly k=2160 blocks should not be deep",
+	)
+
+	// Edge case: fork point ahead of the tip requires no rollback.
+	assert.False(
+		t,
+		selector.IsDeepFork(fork(2000), 1000),
+		"fork ahead of the tip should not be deep",
+	)
+
+	// Edge case: fork point equal to the tip requires no rollback.
+	assert.False(
+		t,
+		selector.IsDeepFork(fork(1000), 1000),
+		"fork at the tip should not be deep",
+	)
+}
+
+// TestIsDeepForkUint64Boundary checks the depth subtraction near the uint64
+// maximum: it must not underflow or wrap.
+func TestIsDeepForkUint64Boundary(t *testing.T) {
+	selector := NewPraosChainSelector(2160)
+
+	maxUint64 := ^uint64(0)
+
+	// Tip at the uint64 maximum, fork k blocks back - still shallow.
+	assert.False(
+		t,
+		selector.IsDeepFork(
+			ForkPoint{Slot: 0, BlockNumber: maxUint64 - 2160},
+			maxUint64,
+		),
+		"rollback of exactly k blocks at the uint64 max is not deep",
+	)
+
+	// Tip at the uint64 maximum, fork k+1 blocks back - deep.
+	assert.True(
+		t,
+		selector.IsDeepFork(
+			ForkPoint{Slot: 0, BlockNumber: maxUint64 - 2161},
+			maxUint64,
+		),
+		"rollback of k+1 blocks at the uint64 max is deep",
+	)
+
+	// Fork at the uint64 maximum with a tip at zero must not wrap into a
+	// huge positive depth.
+	assert.False(
+		t,
+		selector.IsDeepFork(ForkPoint{Slot: 0, BlockNumber: maxUint64}, 0),
+		"fork far ahead of the tip must not underflow into deep",
+	)
 }
 
 func TestPreferredWithDensity(t *testing.T) {
@@ -338,10 +406,14 @@ func TestPreferredWithDensity(t *testing.T) {
 		NewSimpleChainTipWithDensity(1300, 100, vrf, 100, 300), // density 0.33
 	}
 
-	// currentSlot = 5000 puts the fork (slot 1000) more than k=2160
-	// slots in the past, making this a deep fork subject to
-	// density-first comparison.
-	preferred := selector.PreferredWithDensity(candidates, 1000, 5000)
+	// A tip at block 5000 puts the fork (block 0) more than k=2160 blocks
+	// in the past, making this a deep fork subject to density-first
+	// comparison.
+	preferred := selector.PreferredWithDensity(
+		candidates,
+		ForkPoint{Slot: 1000, BlockNumber: 0},
+		5000,
+	)
 	if preferred == nil {
 		t.Fatal("expected non-nil preferred chain")
 	}
@@ -431,4 +503,317 @@ func TestPreferredManyChains(t *testing.T) {
 	if preferred.BlockNumber() != 100 {
 		t.Errorf("expected block 100, got %d", preferred.BlockNumber())
 	}
+}
+
+// --- Genesis window metric (WindowBlockCounter) ---------------------------
+
+// mainnetWindow is the mainnet genesis window sgen = 3k/f with k=2160 and
+// f=1/20: 3*2160*20 = 129600 slots.
+const mainnetWindow = uint64(129600)
+
+// deepFork returns a fork point and a tip block number that are deep for
+// k=2160: the tip is k+1 blocks ahead of the fork point.
+func deepFork(forkSlot uint64) (ForkPoint, uint64) {
+	return ForkPoint{Slot: forkSlot, BlockNumber: 0}, 2161
+}
+
+// TestCompareWithDensityShallowForkShorterDenserLoses is the regression
+// requested in review: with a genesis window configured and a denser but
+// SHORTER candidate, a shallow fork must still be decided by the ordinary
+// longest-chain rule, so the longer chain wins.
+func TestCompareWithDensityShallowForkShorterDenserLoses(t *testing.T) {
+	selector := NewPraosChainSelectorWithWindow(2160, mainnetWindow)
+
+	vrf := make([]byte, 64)
+
+	// Chain A: shorter (90 blocks) but every block inside the window.
+	denseSlots := make([]uint64, 0, 90)
+	for i := uint64(1); i <= 90; i++ {
+		denseSlots = append(denseSlots, 1000+i)
+	}
+	chainA := NewSimpleChainTipWithBlockSlots(1090, 90, vrf, denseSlots)
+
+	// Chain B: longer (100 blocks) but only 5 of them fall inside the
+	// window, so B is strictly SPARSER than A by the window metric. If
+	// density were (incorrectly) consulted here, A would win; the shallow
+	// rule must still pick the longer chain B.
+	sparseSlots := make([]uint64, 0, 100)
+	for i := uint64(1); i <= 5; i++ {
+		sparseSlots = append(sparseSlots, 1000+i*100)
+	}
+	for i := uint64(1); i <= 95; i++ {
+		sparseSlots = append(sparseSlots, 1000+mainnetWindow+i*100)
+	}
+	chainB := NewSimpleChainTipWithBlockSlots(200000, 100, vrf, sparseSlots)
+
+	// Guard the premise: A really is denser than B inside the window.
+	require.Greater(
+		t,
+		chainA.BlocksInWindow(1000, mainnetWindow),
+		chainB.BlocksInWindow(1000, mainnetWindow),
+		"premise: chain A must be denser in the window than chain B",
+	)
+
+	// Rollback of only 100 blocks - shallow for k=2160.
+	fork := ForkPoint{Slot: 1000, BlockNumber: 900}
+
+	require.False(
+		t,
+		selector.IsDeepFork(fork, 1000),
+		"fork must be shallow for this test",
+	)
+
+	// A is strictly denser in the window, but the fork is shallow, so the
+	// ordinary rule must apply and the LONGER chain B must win.
+	assert.Negative(
+		t,
+		selector.CompareWithDensity(chainA, chainB, fork, 1000),
+		"shallow fork must use longest-chain rule: longer chain B wins "+
+			"even though A is denser",
+	)
+
+	// The same contract must hold through the public selection entry
+	// point, in both candidate orders.
+	assert.Same(
+		t,
+		chainB,
+		selector.PreferredWithDensity(
+			[]ChainTip{chainA, chainB},
+			fork,
+			1000,
+		),
+		"PreferredWithDensity must pick the longer chain on a shallow fork",
+	)
+	assert.Same(
+		t,
+		chainB,
+		selector.PreferredWithDensity(
+			[]ChainTip{chainB, chainA},
+			fork,
+			1000,
+		),
+		"shallow-fork selection must not depend on candidate order",
+	)
+}
+
+// TestCompareWithDensityDeepForkUsesWindowCount is the issue #1936
+// regression under the canonical integer window metric: a longer but
+// sparser deep fork must lose to a shorter, denser one, in both argument
+// orders.
+func TestCompareWithDensityDeepForkUsesWindowCount(t *testing.T) {
+	selector := NewPraosChainSelectorWithWindow(2160, mainnetWindow)
+
+	vrf := make([]byte, 64)
+	fork, tip := deepFork(1000)
+
+	// Honest chain: 50 blocks, all within the window.
+	honestSlots := make([]uint64, 0, 50)
+	for i := uint64(1); i <= 50; i++ {
+		honestSlots = append(honestSlots, 1000+i*100)
+	}
+	honest := NewSimpleChainTipWithBlockSlots(6000, 50, vrf, honestSlots)
+
+	// Adversarial chain: 80 blocks total (longer), but only 10 of them
+	// fall inside the window; the rest are far beyond it.
+	advSlots := make([]uint64, 0, 80)
+	for i := uint64(1); i <= 10; i++ {
+		advSlots = append(advSlots, 1000+i*100)
+	}
+	for i := uint64(1); i <= 70; i++ {
+		advSlots = append(advSlots, 1000+mainnetWindow+i*100)
+	}
+	adversarial := NewSimpleChainTipWithBlockSlots(900000, 80, vrf, advSlots)
+
+	// Sanity: the adversarial chain really is longer.
+	assert.Negative(
+		t,
+		selector.Compare(honest, adversarial),
+		"adversarial chain should be longer under the ordinary rule",
+	)
+
+	assert.Positive(
+		t,
+		selector.CompareWithDensity(honest, adversarial, fork, tip),
+		"denser honest chain must win a deep fork",
+	)
+	assert.Negative(
+		t,
+		selector.CompareWithDensity(adversarial, honest, fork, tip),
+		"deep-fork density comparison must be order-independent",
+	)
+
+	// End-to-end through the public selection entry point.
+	assert.Same(
+		t,
+		honest,
+		selector.PreferredWithDensity(
+			[]ChainTip{adversarial, honest},
+			fork,
+			tip,
+		),
+		"PreferredWithDensity must select the denser chain on a deep fork",
+	)
+}
+
+// TestCompareWithDensityEqualDensityFallsThrough checks the tie rule: equal
+// block counts in the window fall through to the ordinary comparison.
+func TestCompareWithDensityEqualDensityFallsThrough(t *testing.T) {
+	selector := NewPraosChainSelectorWithWindow(2160, mainnetWindow)
+
+	vrf := make([]byte, 64)
+	fork, tip := deepFork(1000)
+
+	// Both chains have exactly 3 blocks inside the window, but B is
+	// longer overall, so the ordinary rule must pick B.
+	inWindow := []uint64{1100, 1200, 1300}
+
+	shortChain := NewSimpleChainTipWithBlockSlots(1300, 10, vrf, inWindow)
+	longChain := NewSimpleChainTipWithBlockSlots(1300, 20, vrf, inWindow)
+
+	assert.Negative(
+		t,
+		selector.CompareWithDensity(shortChain, longChain, fork, tip),
+		"equal window density must fall through to the ordinary rule",
+	)
+
+	// Equal density AND equal length: the VRF tiebreaker decides.
+	lowVRF := make([]byte, 64)
+	lowVRF[0] = 0x01
+	highVRF := make([]byte, 64)
+	highVRF[0] = 0x02
+
+	lowTip := NewSimpleChainTipWithBlockSlots(1300, 10, lowVRF, inWindow)
+	highTip := NewSimpleChainTipWithBlockSlots(1300, 10, highVRF, inWindow)
+
+	assert.Positive(
+		t,
+		selector.CompareWithDensity(lowTip, highTip, fork, tip),
+		"equal density and length must fall through to the VRF tiebreak",
+	)
+}
+
+// TestCompareWithDensityWindowBoundary pins the exact window bound: a block
+// at forkSlot+windowSlots is inside, forkSlot+windowSlots+1 is outside, and
+// a block at forkSlot itself is outside.
+func TestCompareWithDensityWindowBoundary(t *testing.T) {
+	const forkSlot = uint64(1000)
+	const window = uint64(100)
+
+	tip := NewSimpleChainTipWithBlockSlots(
+		2000,
+		4,
+		make([]byte, 64),
+		[]uint64{
+			forkSlot,              // at the fork point: outside
+			forkSlot + 1,          // first slot in the window: inside
+			forkSlot + window,     // last slot in the window: inside
+			forkSlot + window + 1, // first slot past the window: outside
+		},
+	)
+
+	assert.Equal(
+		t,
+		uint64(2),
+		tip.BlocksInWindow(forkSlot, window),
+		"only forkSlot+1 and forkSlot+window fall inside the window",
+	)
+
+	// A zero window counts nothing.
+	assert.Equal(
+		t,
+		uint64(0),
+		tip.BlocksInWindow(forkSlot, 0),
+		"a zero window must count no blocks",
+	)
+}
+
+// TestBlocksInWindowUint64Boundary checks that the window bound is
+// evaluated without wrapping near the uint64 maximum.
+func TestBlocksInWindowUint64Boundary(t *testing.T) {
+	maxUint64 := ^uint64(0)
+	forkSlot := maxUint64 - 10
+
+	tip := NewSimpleChainTipWithBlockSlots(
+		maxUint64,
+		2,
+		make([]byte, 64),
+		[]uint64{forkSlot + 1, maxUint64},
+	)
+
+	// forkSlot+windowSlots would overflow; the subtraction form must not.
+	assert.Equal(
+		t,
+		uint64(2),
+		tip.BlocksInWindow(forkSlot, maxUint64),
+		"a window spanning past the uint64 max must not wrap",
+	)
+}
+
+// TestCompareWithDensityZeroWindowFallsBack checks the misconfiguration
+// path: with no genesis window, a deep fork still resolves (via the legacy
+// density ratio) rather than failing or silently preferring nothing.
+func TestCompareWithDensityZeroWindowFallsBack(t *testing.T) {
+	// No window configured.
+	selector := NewPraosChainSelector(2160)
+	fork, tip := deepFork(1000)
+
+	vrf := make([]byte, 64)
+	dense := NewSimpleChainTipWithDensity(1200, 100, vrf, 100, 200)
+	sparse := NewSimpleChainTipWithDensity(1500, 100, vrf, 100, 500)
+
+	assert.Positive(
+		t,
+		selector.CompareWithDensity(dense, sparse, fork, tip),
+		"with no window the legacy density ratio still decides deep forks",
+	)
+}
+
+// TestCompareWithDensityFallsBackWithoutCounter checks the compatibility
+// path: a tip that does not implement WindowBlockCounter keeps working via
+// ChainTip.Density even when a window is configured.
+func TestCompareWithDensityFallsBackWithoutCounter(t *testing.T) {
+	selector := NewPraosChainSelectorWithWindow(2160, mainnetWindow)
+	fork, tip := deepFork(1000)
+
+	dense := legacyTip{blockNumber: 100, density: 0.5}
+	sparse := legacyTip{blockNumber: 100, density: 0.2}
+
+	assert.Positive(
+		t,
+		selector.CompareWithDensity(dense, sparse, fork, tip),
+		"tips without WindowBlockCounter must still compare by density",
+	)
+}
+
+// legacyTip implements only ChainTip - no WindowBlockCounter - modelling a
+// downstream implementation written against the pre-existing interface.
+type legacyTip struct {
+	blockNumber uint64
+	density     float64
+}
+
+func (l legacyTip) Slot() uint64             { return l.blockNumber * 20 }
+func (l legacyTip) BlockNumber() uint64      { return l.blockNumber }
+func (l legacyTip) VRFOutput() []byte        { return make([]byte, 64) }
+func (l legacyTip) Density(_ uint64) float64 { return l.density }
+
+// TestSimpleChainTipImplementsWindowBlockCounter is a compile-time style
+// check that the shipped tip satisfies the optional extension.
+func TestSimpleChainTipImplementsWindowBlockCounter(t *testing.T) {
+	var tip ChainTip = NewSimpleChainTipWithBlockSlots(
+		1000,
+		10,
+		make([]byte, 64),
+		[]uint64{1001},
+	)
+	_, ok := tip.(WindowBlockCounter)
+	assert.True(t, ok, "SimpleChainTip must implement WindowBlockCounter")
+
+	var legacy ChainTip = legacyTip{blockNumber: 10}
+	_, ok = legacy.(WindowBlockCounter)
+	assert.False(
+		t,
+		ok,
+		"a ChainTip-only implementation must remain valid",
+	)
 }

--- a/consensus/selection_test.go
+++ b/consensus/selection_test.go
@@ -15,6 +15,7 @@
 package consensus
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -796,6 +797,161 @@ func (l legacyTip) Slot() uint64             { return l.blockNumber * 20 }
 func (l legacyTip) BlockNumber() uint64      { return l.blockNumber }
 func (l legacyTip) VRFOutput() []byte        { return make([]byte, 64) }
 func (l legacyTip) Density(_ uint64) float64 { return l.density }
+
+// randomWindowedTip builds a tip whose blocks are scattered at random over
+// span slots after forkSlot, from a seeded source so the sweep below is
+// reproducible.
+func randomWindowedTip(
+	rng *rand.Rand,
+	forkSlot, blocks, span uint64,
+) *WindowedChainTip {
+	slots := make([]uint64, 0, blocks)
+	var maxSlot uint64
+	for range blocks {
+		s := forkSlot + 1 + uint64(rng.Int63n(int64(span)))
+		slots = append(slots, s)
+		if s > maxSlot {
+			maxSlot = s
+		}
+	}
+	return NewWindowedChainTip(maxSlot, 1000+blocks, make([]byte, 64), slots)
+}
+
+// TestShallowForkNeverConsultsDensity states the review's central property
+// as an invariant rather than a single example: for ANY fork within k
+// blocks, the density entry point must return exactly what the ordinary
+// longest-chain rule returns. The sweep includes pathologically sparse
+// candidates, which are the only shape that could make a windowed count
+// disagree with block count.
+func TestShallowForkNeverConsultsDensity(t *testing.T) {
+	selector := NewPraosChainSelectorWithWindow(2160, mainnetWindow)
+	rng := rand.New(rand.NewSource(19360000))
+	const forkSlot = 1_000_000
+
+	for range 2000 {
+		// Any depth from 0 to exactly k blocks is shallow.
+		depth := uint64(rng.Int63n(2161))
+		fork := ForkPoint{Slot: forkSlot, BlockNumber: 500_000}
+		tipBlockNumber := fork.BlockNumber + depth
+		require.False(
+			t,
+			selector.IsDeepFork(fork, tipBlockNumber),
+			"a rollback of %d blocks must be shallow for k=2160", depth,
+		)
+
+		a := randomWindowedTip(
+			rng, forkSlot, 1+uint64(rng.Int63n(200)),
+			1+uint64(rng.Int63n(600_000)),
+		)
+		b := randomWindowedTip(
+			rng, forkSlot, 1+uint64(rng.Int63n(200)),
+			1+uint64(rng.Int63n(600_000)),
+		)
+
+		require.Equal(
+			t,
+			sign(selector.Compare(a, b)),
+			sign(selector.CompareWithDensity(a, b, fork, tipBlockNumber)),
+			"shallow fork must be decided by the ordinary rule alone",
+		)
+	}
+}
+
+func sign(v int) int {
+	switch {
+	case v > 0:
+		return 1
+	case v < 0:
+		return -1
+	}
+	return 0
+}
+
+// TestPreferredWithDensityGenesisScenario is the end-to-end selection test
+// requested in review: a mainnet-shaped adversarial fork driven entirely
+// through the exported selection entry point, asserted in both candidate
+// orders so the result cannot depend on arrival order.
+func TestPreferredWithDensityGenesisScenario(t *testing.T) {
+	selector := NewPraosChainSelectorWithWindow(2160, mainnetWindow)
+	const forkSlot = 50_000_000
+	fork := ForkPoint{Slot: forkSlot, BlockNumber: 2_500_000}
+	// The local chain is k+500 blocks past the fork: deep, so the Genesis
+	// rule governs.
+	tipBlockNumber := fork.BlockNumber + 2660
+
+	// Honest chain: steady mainnet density (one block per 20 slots) filling
+	// the genesis window.
+	honestSlots := make([]uint64, 0, 6480)
+	for i := uint64(1); i <= 6480; i++ {
+		honestSlots = append(honestSlots, forkSlot+i*20)
+	}
+	honest := NewWindowedChainTip(
+		forkSlot+mainnetWindow, fork.BlockNumber+6480,
+		make([]byte, 64), honestSlots,
+	)
+
+	// Adversarial chain: strictly LONGER, but nearly all of its blocks fall
+	// beyond the genesis window, so it is sparse where the rule looks.
+	advSlots := []uint64{forkSlot + 10, forkSlot + 20}
+	for i := uint64(1); i <= 8000; i++ {
+		advSlots = append(advSlots, forkSlot+mainnetWindow+i*20)
+	}
+	adversarial := NewWindowedChainTip(
+		forkSlot+mainnetWindow+160_000, fork.BlockNumber+8002,
+		make([]byte, 64), advSlots,
+	)
+
+	require.Negative(
+		t,
+		selector.Compare(honest, adversarial),
+		"setup: the ordinary rule alone would take the longer adversarial chain",
+	)
+
+	for _, candidates := range [][]ChainTip{
+		{honest, adversarial},
+		{adversarial, honest},
+	} {
+		assert.Same(
+			t,
+			honest,
+			selector.PreferredWithDensity(candidates, fork, tipBlockNumber),
+			"the Genesis rule must select the chain dense in the window",
+		)
+	}
+}
+
+// TestDeepForkZeroBlocksInWindowLoses guards the meaning of a zero count: a
+// chain with no blocks inside the genesis window is the adversarial shape
+// the rule demotes, not a chain we failed to measure. It must lose to a tip
+// with blocks there even when it is vastly longer.
+func TestDeepForkZeroBlocksInWindowLoses(t *testing.T) {
+	selector := NewPraosChainSelectorWithWindow(2160, mainnetWindow)
+	fork, tipBlockNumber := deepFork(1000)
+
+	beyond := make([]uint64, 0, 50)
+	for i := uint64(1); i <= 50; i++ {
+		beyond = append(beyond, 1000+mainnetWindow+i*20)
+	}
+	longButOutside := NewWindowedChainTip(
+		1000+mainnetWindow+1000, 5000, make([]byte, 64), beyond,
+	)
+	shortButInside := NewWindowedChainTip(
+		1500, 10, make([]byte, 64), []uint64{1100, 1200},
+	)
+
+	require.Zero(
+		t,
+		longButOutside.BlocksInWindow(1000, mainnetWindow),
+		"setup: the long chain must have no blocks inside the window",
+	)
+	assert.Positive(
+		t,
+		selector.CompareWithDensity(
+			shortButInside, longButOutside, fork, tipBlockNumber,
+		),
+		"a chain with blocks in the window must beat one with none",
+	)
+}
 
 // TestOnlyWindowedTipClaimsWindowBlockCounter pins which types may claim the
 // optional extension. Only a tip that actually carries block slots may: a


### PR DESCRIPTION
## Semantics first — one point to ratify (@wolf31o2)

#1936 asks the selection path to "use longest-chain comparison within k and density-first comparison beyond k". While implementing it we checked the shipped canonical implementation, and its shape is slightly different in a way that matters for consensus safety:

- **Forks requiring rollback of more than k blocks are refused, never density-adopted.** `Ouroboros.Consensus.Protocol.Abstract`: *"we never switch to chains that fork off more than @k@ blocks ago"*; the ChainSync client terminates such peers with `ForkTooDeep`. And k bounds **blocks**, not slots — `Ouroboros.Consensus.Config.SecurityParam`: *"NOTE: This talks about the number of /blocks/ we can roll back, not the number of /slots/"*.
- **The density rule chooses among syncing candidates** (GDD governor, `Ouroboros/Consensus/Genesis/Governor.hs`): each candidate suffix is clipped to the genesis window after the common intersection — `firstSlotAfterGenesisWindow = succWithOrigin loeIntersectionSlot + SlotNo sgen`, `AF.splitAtSlot firstSlotAfterGenesisWindow candidateSuffix` — and compared by **integer block count** (`lowerBound = fromIntegral $ AF.length clippedFragment`), with equal density a loss (`guard $ lb1 >= (if idling0 then lb0 else ub0)`).
- **The window sgen is the stability window 3k/f, with ceiling division.** cardano-ledger `eras/shelley/impl/src/Cardano/Ledger/Shelley/StabilityWindow.hs`: `computeStabilityWindow k asc = ceiling $ (3 * fromIntegral k) /. f`, consumed by ouroboros-consensus `shelleyEraParams` as `eraGenesisWin = GenesisWindow stabilityWindow` (mainnet: 3·2160/0.05 = 129,600 slots).

So this PR implements the canonical decomposition rather than the issue's literal routing: `CompareWithDensity` is the Genesis ordering for syncing candidates (density-first within the window, equal density falls through to the ordinary Praos comparison — the same adaptation Dingo's fork resolution uses, since a pure ordering cannot "disconnect both" like the GDD does on ties), and `IsDeepFork` is the block-based depth predicate that routes between the two. **The issue's own regression criterion — a longer deep fork with lower density must lose — passes either way** (`TestCompareWithDensityIssue1936Regression`). If you'd prefer the literal ">k ⇒ density" routing instead, say so and we'll adjust — but we believe this shape is the consensus-safe one.

## The three defects fixed

1. **Density was unreachable** — `CompareWithDensity` ran the longest-chain comparison first and consulted density only on a full length+VRF tie, so the longer-but-sparser adversarial chain always won (the exact shape #1936 describes). Now density-first within the genesis window.
2. **Wrong metric** — density was a `float64` blocks/slots ratio over the whole fork suffix. Now the canonical integer block count within the window (slots `forkSlot+1..forkSlot+windowSlots` inclusive, matching `densityDisconnect`'s clipping), supplied through a new optional `WindowBlockCounter` interface implemented by `WindowedChainTip`. The selector takes an explicit `GenesisWindowSlots` (derive with `genesis.ComputeGenesisWindow`).
3. **Wrong unit** — `IsDeepFork` compared a **slot** distance against k (≈20× too eager at mainnet f=0.05). `IsDeepFork` now takes a `ForkPoint` (the intersection's slot and block number) plus the current tip's block number and compares block distances, and it is wired into both `CompareWithDensity` and `PreferredWithDensity`.

## Separable sub-change: `ComputeGenesisWindow` floor → ceiling

While pinning the window semantics we found `genesis.ComputeGenesisWindow` used floor division (`big.Int.Div`), but canonical is **ceiling** (`computeStabilityWindow` above). Mainnet is provably unaffected (3k/f is exactly integral there); the result differed by one slot on any non-integral 3k/f. Fixed with a citation in-code, plus a guard rejecting negative active-slot coefficients. **Happy to split this into its own PR if you prefer single-concern changes.**

## Verification

- **Fail-before / pass-after**: probes on `main` demonstrate the inverted order (`CompareWithDensity` returned −1 for denser-vs-longer on a deep fork) and the slot/block misclassification; the new suite passes after. All tests run with `-race` in a clean container (Go 1.25.8).
- New tests: issue regression (both argument orders), exact window boundary (`forkSlot+window` in, `+window+1` out, `forkSlot` itself out), equal-density fallthrough end-to-end through the VRF tiebreak, zero-window fallback, `IsDeepFork` at k vs k+1 in blocks, ceiling division (direct, via `NewGenesisSelector`, degenerate coefficients), mainnet 129,600 cross-check.
- **`Compare` is byte-identical** to `main` — the ordinary/shallow selection path is provably unchanged, locked by the retained tests plus new reverse-VRF and empty-VRF cases.
- `make test` (full race suite) and `make lint` (golangci-lint v2) green.
- Independently re-verified by a second, isolated review pass that wrote its own tests from the issue text (own constants, both directions, boundary cases) and confirmed the pre-patch code fails its regression assertion while the patch passes it.

## API changes (v0)

The exported `ChainTip` interface is **unchanged** — `consensus/consensus.go` is not in this diff — so existing implementations keep compiling and behave as they do today. `NewSimpleChainTipWithDensity` is retained. No exported symbol is removed.

Three method signatures change, to carry the depth inputs the routing needs:

```
IsDeepFork(forkSlot, currentSlot uint64)
  -> IsDeepFork(fork ForkPoint, tipBlockNumber uint64)
CompareWithDensity(a, b ChainTip, forkSlot, currentSlot uint64)
  -> CompareWithDensity(a, b ChainTip, fork ForkPoint, tipBlockNumber uint64)
PreferredWithDensity(candidates []ChainTip, forkSlot, currentSlot uint64)
  -> PreferredWithDensity(candidates []ChainTip, fork ForkPoint, tipBlockNumber uint64)
```

The update is mechanical: pass `ForkPoint{Slot: forkSlot, BlockNumber: forkBlockNumber}` and the current selection's tip block number in place of `currentSlot`. New: `ForkPoint`, `WindowBlockCounter`, `WindowedChainTip`, `NewWindowedChainTip`, `NewPraosChainSelectorWithWindow`.

## Disclosure

This contribution was developed with AI assistance (Claude), under human direction, with the verification described above run in a clean container environment. 

Closes #1936

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies Genesis density‑first ordering only to deep forks and routes depth by blocks, not slots. Fixes #1936 so a longer but sparser deep fork loses while shallow forks keep ordinary Praos behavior.

- `consensus`: `IsDeepFork(ForkPoint, tipBlockNumber)` gates selection; shallow (≤k blocks) uses `Compare`, deep uses density‑first in `CompareWithDensity`/`PreferredWithDensity` with tie‑back to Praos.
- Genesis metric: prefer higher integer block count within the configured window (`BlocksInWindow(forkSlot, windowSlots)`); otherwise fall back to `ChainTip.Density` with a one‑time warning.
- Types: `SimpleChainTip` no longer claims window counting; new `WindowedChainTip` stores per‑block slots and derives a legacy ratio for mixed comparisons.
- `genesis.ComputeGenesisWindow`: ceiling for `3k/f`; rejects non‑positive `f`.
- Tests: add invariant sweep that shallow forks never consult density, an end‑to‑end Genesis selection scenario, and “zero blocks in window” loses; retain boundary and fallback cases.

**Migration**
- Update call sites:
  - `IsDeepFork(forkSlot, currentSlot)` → `IsDeepFork(ForkPoint{Slot, BlockNumber}, tipBlockNumber)`
  - `CompareWithDensity(a,b,forkSlot,currentSlot)` → `CompareWithDensity(a,b,ForkPoint,tipBlockNumber)`
  - `PreferredWithDensity(cands,forkSlot,currentSlot)` → `PreferredWithDensity(cands,ForkPoint,tipBlockNumber)`
- To use the canonical metric, compute the window with `genesis.ComputeGenesisWindow(k,f)`, build with `NewPraosChainSelectorWithWindow`, and implement `WindowBlockCounter`. Tests relying on window counting should use `NewWindowedChainTip`. Without the counter, comparisons use the legacy ratio.

<sup>Written for commit 2c2bae76e223a05ca1a7af6d3d3578b3236d4655. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved chain selection during synchronization using Genesis density comparisons within a configured window.
  * Added block-window counting for more accurate chain comparisons.
  * Added rollback-limit checks based on block depth.

* **Bug Fixes**
  * Genesis windows now round up correctly and handle invalid coefficients safely.
  * Improved tie handling and fallback behavior for equal or unavailable density data.

* **Documentation**
  * Updated architecture and consensus documentation to reflect chain selection, density comparison, and rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
