### PR TITLE
fix(localstatequery): unwrap the QueryIfCurrent array in DebugChainDepState

### DIFF
--- a/protocol/localstatequery/client.go
+++ b/protocol/localstatequery/client.go
@@ -691,11 +691,20 @@ func (c *Client) DebugChainDepState() (*DebugChainDepStateResult, error) {
 		currentEra,
 		QueryTypeShelleyDebugChainDepState,
 	)
-	var result DebugChainDepStateResult
+	// The node answers a QueryIfCurrent query with a one-element array wrapping
+	// the result, as it does for every other Shelley query here. Decoding
+	// straight into DebugChainDepStateResult skips that layer and hands its
+	// UnmarshalCBOR the outer array, which it reports as "cannot unmarshal
+	// array into Go value of type struct { Version uint64; Inner RawMessage }"
+	// — the encodeVersion envelope it expects one level down.
+	result := []DebugChainDepStateResult{}
 	if err := c.runQuery(query, &result); err != nil {
 		return nil, err
 	}
-	return &result, nil
+	if len(result) == 0 {
+		return nil, errors.New("empty result from chain dep state query")
+	}
+	return &result[0], nil
 }
 
 // GetOpCertCounters returns the authoritative on-chain operational-certificate

--- a/protocol/localstatequery/client_test.go
+++ b/protocol/localstatequery/client_test.go
@@ -1385,3 +1385,65 @@ func TestGenesisConfigJSON(t *testing.T) {
 		t.Logf("Successfully validated the GenesisConfigResult after JSON marshalling and unmarshalling.")
 	}
 }
+
+// TestDebugChainDepState drives the real client against a mocked node answer,
+// which is the layer where the QueryIfCurrent unwrap lives.
+//
+// The unit tests in chain_dep_state_test.go hand DebugChainDepStateResult's
+// UnmarshalCBOR the inner encodeVersion envelope directly, so the decoder looked
+// correct in isolation while DebugChainDepState never unwrapped the one-element
+// array the node actually sends. GetOpCertCounters therefore failed against any
+// conformant node with "cbor: cannot unmarshal array into Go value of type
+// struct { Version uint64; Inner RawMessage }". Only a test that goes through
+// the client catches that, which is why this one lives here rather than beside
+// the decoder tests.
+func TestDebugChainDepState(t *testing.T) {
+	var expectedPool ledger.Blake2b224
+	for i := range expectedPool {
+		expectedPool[i] = 0x11
+	}
+
+	conversation := append(
+		conversationCurrentEra,
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  localstatequery.ProtocolId,
+			MessageType: localstatequery.MessageTypeQuery,
+		},
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: localstatequery.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				localstatequery.NewMsgResult(
+					// [[1, [slot, {pool: 3}, nonces...]]] — the Praos
+					// chain-dep-state inside the QueryIfCurrent wrapper the node
+					// puts on the wire.
+					test.DecodeHexString(
+						"8182008882011a0012d687a1581c111111111111111111111111" +
+							"1111111111111111111111111111111103820158200000000000" +
+							"0000000000000000000000000000000000000000000000000000" +
+							"0081008201582000000000000000000000000000000000000000" +
+							"00000000000000000000000000810081008100",
+					),
+				),
+			},
+		},
+	)
+	runTest(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			counters, err := oConn.LocalStateQuery().
+				Client.GetOpCertCounters()
+			// Without the QueryIfCurrent unwrap this is where the decode of the
+			// node's answer fails, so name it: the error is the whole signal.
+			require.NoError(t, err, "GetOpCertCounters against a mocked node")
+			require.Contains(
+				t,
+				counters,
+				expectedPool,
+				"pool must survive the unwrap into the counter map",
+			)
+			require.Equal(t, uint64(3), counters[expectedPool])
+		},
+	)
+}


### PR DESCRIPTION
Fixes #1965.

## The bug

A `QueryIfCurrent` answer wraps its result in a one-element array. That is why every other Shelley query in `client.go` decodes into a slice and takes the first element:

```go
// GetEpochNo
result := []int{}
return result[0], nil

// GetGenesisConfig
result := []GenesisConfigResult{}
```

`DebugChainDepState` decoded straight into the struct:

```go
var result DebugChainDepStateResult
if err := c.runQuery(query, &result); err != nil { ... }
return &result, nil
```

So `DebugChainDepStateResult.UnmarshalCBOR` was handed `[[version, inner]]` when it expects the `encodeVersion` envelope `[version, inner]` one level down. Against a real node:

```
cbor: cannot unmarshal array into Go value of type
struct { cbor.StructAsArray; Version uint64; Inner cbor.RawMessage }
```

`GetOpCertCounters` is a thin wrapper over this call, so **it has never worked against a conformant node**.

Neither side was otherwise at fault: the result type's decoder is correct, and `dingo`'s `queryShelleyDebugChainDepState` returns the standard `[]any{versionedChainDepState{…}}` wrapper.

## Why it survived

The tests in `chain_dep_state_test.go` build the inner envelope by hand and call the decoder directly:

```go
wire, err := cbor.Encode([]any{chainDepStateVersionPraos, inner})
var got DebugChainDepStateResult
_, err = cbor.Decode(wire, &got)
```

That exercises the decoder in isolation — where it is correct — and never the layer the client operates at. There was no client-level test for this query at all.

## The test

`TestDebugChainDepState` in `client_test.go` drives the real `Client` through `ouroboros-mock` with a `QueryIfCurrent`-wrapped payload, following the existing `TestGetEpochNo` pattern.

Verified it genuinely guards the fix — reverting only the `client.go` change:

```
--- FAIL: TestDebugChainDepState (0.47s)
    received unexpected error: cbor: cannot unmarshal array into Go value of type
    struct { cbor.StructAsArray; Version uint64; Inner cbor.RawMessage }
```

That is the same error seen against a live node, so the test reproduces the real failure rather than something adjacent. With the fix: `ok`.

## The length check

`if len(result) == 0` follows the precedent already used by the Dijkstra and Conway protocol-parameters queries in this file, rather than the unchecked `result[0]` of some older queries — an empty array from a peer would otherwise panic.

## Impact

Callers of `GetOpCertCounters` got an error instead of counters. In `dingo-operator` it backs the on-chain operational-certificate floor that rejects a delivered opcert numbered below the chain's. That check fails open by design, so the consequence was a silently inert safety check rather than a wrong decision — but it has never functioned.

Not version drift: `chain_dep_state.go` and `client.go` are identical between v0.191.2 and v0.192.2, and `main` is affected.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l` clean, and `go test ./protocol/localstatequery/...` green. Diff is two files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix decoding of `DebugChainDepState` by unwrapping the `QueryIfCurrent` one-element array to match the expected encodeVersion envelope. Restores `GetOpCertCounters` on conformant nodes and replaces a potential panic on empty responses with a clear error; fixes #1965.

- **Bug Fixes**
  - Decode into `[]DebugChainDepStateResult` and return the first item.
  - Return a clear error when the result is empty.
  - Add a client-level test using `ouroboros-mock` that reproduces the failure without the fix.

<sup>Written for commit 797d74f069d29d11e454b8448d34d7582f327cd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decoding of chain dependency state query responses.
  * Added a clear error when a query returns no results.
  * Correctly retrieves operational certificate counters from wrapped state data.

* **Tests**
  * Added coverage for successful chain dependency state decoding and counter retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->