### PR TITLE
fix(mainnet): remove emurgo bootstrap peers

### DIFF
--- a/networks.go
+++ b/networks.go
@@ -28,10 +28,6 @@ var (
 				Port:    3001,
 			},
 			{
-				Address: "backbone.mainnet.emurgornd.com",
-				Port:    3001,
-			},
-			{
 				Address: "backbone.mainnet.cardanofoundation.org",
 				Port:    3001,
 			},


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unavailable Emurgo mainnet bootstrap peer to improve startup reliability. Previously nodes attempted backbone.mainnet.emurgornd.com:3001; now they connect only to IOG and Cardano Foundation backbones.

**Rollout**
- No operator action; this affects mainnet only and does not change custom peer lists.

<sup>Written for commit 465d1736510781efda2b027249cd5897d8b08694. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unavailable Cardano mainnet bootstrap connection to improve network startup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->