### PR TITLE
fix(ledger): parse Leios genesis extra config safely

### DIFF
--- a/ledger/conway/genesis.go
+++ b/ledger/conway/genesis.go
@@ -41,6 +41,10 @@ type ConwayGenesis struct {
 	Committee                  ConwayGenesisCommittee            `json:"committee"`
 	Delegs                     ConwayGenesisDelegs               `json:"delegs"`
 	InitialDReps               ConwayGenesisInitialDReps         `json:"initialDReps"`
+	// ExtraConfig carries the Leios prototype's Conway genesis injection
+	// (delegs/initialDReps overrides); captured raw so the strict decoder
+	// accepts it. Empty on the current Musashi network.
+	ExtraConfig json.RawMessage `json:"extraConfig,omitempty"`
 }
 
 type ConwayGenesisPoolVotingThresholds struct {

--- a/ledger/conway/genesis.go
+++ b/ledger/conway/genesis.go
@@ -41,9 +41,9 @@ type ConwayGenesis struct {
 	Committee                  ConwayGenesisCommittee            `json:"committee"`
 	Delegs                     ConwayGenesisDelegs               `json:"delegs"`
 	InitialDReps               ConwayGenesisInitialDReps         `json:"initialDReps"`
-	// ExtraConfig carries the Leios prototype's Conway genesis injection
-	// (delegs/initialDReps overrides); captured raw so the strict decoder
-	// accepts it. Empty on the current Musashi network.
+	// ExtraConfig carries the optional prototype genesis injection. Conway's
+	// current Musashi configuration leaves it empty, but it must be accepted by
+	// the strict decoder when present.
 	ExtraConfig json.RawMessage `json:"extraConfig,omitempty"`
 }
 

--- a/ledger/conway/genesis_test.go
+++ b/ledger/conway/genesis_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const conwayGenesisConfig = `
@@ -544,4 +545,12 @@ func TestNewConwayGenesisFromReader(t *testing.T) {
 			actual,
 		)
 	}
+}
+
+func TestNewConwayGenesisAcceptsExtraConfig(t *testing.T) {
+	genesis, err := conway.NewConwayGenesisFromReader(
+		strings.NewReader(`{"extraConfig":{"delegs":{},"initialDReps":{}}}`),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, genesis.ExtraConfig)
 }

--- a/ledger/shelley/genesis.go
+++ b/ledger/shelley/genesis.go
@@ -15,13 +15,13 @@
 package shelley
 
 import (
+	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
 	"math/big"
 	"os"
-	"reflect"
 	"time"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -45,6 +45,21 @@ type ShelleyGenesis struct {
 	GenDelegs          map[string]map[string]string `json:"genDelegs"`
 	InitialFunds       map[string]uint64            `json:"initialFunds"`
 	Staking            GenesisStaking               `json:"staking"`
+	// ExtraConfig carries the Musashi/Leios prototype genesis injection block.
+	// On that network the top-level initialFunds/staking are empty and the
+	// initial UTxOs, stake delegations and pool registrations are provided
+	// here instead. It is merged at read time by GenesisUtxos/InitialPools and is
+	// deliberately not folded into the marshalled fields, so the genesis hash is
+	// unaffected by parsing.
+	ExtraConfig *ShelleyGenesisExtraConfig `json:"extraConfig,omitempty" cbor:"-"`
+	// rawInitialFunds/rawStaking snapshot the values exactly as they appeared in
+	// the source document, before any extraConfig injection is folded in. CBOR
+	// encoding uses these so that parsing a genesis containing extraConfig never
+	// changes the bytes MarshalCBOR emits, and therefore never changes the
+	// genesis hash or the derived initial nonce.
+	rawInitialFunds map[string]uint64
+	rawStaking      GenesisStaking
+	rawCaptured     bool
 }
 
 type GenesisStaking struct {
@@ -52,7 +67,206 @@ type GenesisStaking struct {
 	Stake map[string]string                             `json:"stake"`
 }
 
+// ShelleyGenesisExtraConfig models the Leios prototype's genesis "extraConfig"
+// injection. Every field is captured so the strict genesis decoder accepts the
+// block; pool sub-fields not needed for ledger bootstrap are kept as raw JSON.
+type ShelleyGenesisExtraConfig struct {
+	InitialFunds     shelleyExtraFunds `json:"initialFunds"`
+	StakeCredentials shelleyExtraCreds `json:"stakeCredentials"`
+	StakePools       shelleyExtraPools `json:"stakePools"`
+}
+
+type shelleyExtraFunds struct {
+	Data map[string]uint64 `json:"data"`
+}
+
+type shelleyExtraCreds struct {
+	Data map[string]string `json:"data"`
+}
+
+type shelleyExtraPools struct {
+	Data map[string]ShelleyGenesisExtraPool `json:"data"`
+}
+
+type ShelleyGenesisExtraPool struct {
+	Vrf            string                      `json:"vrf"`
+	Pledge         uint64                      `json:"pledge"`
+	Cost           uint64                      `json:"cost"`
+	Margin         json.RawMessage             `json:"margin"`
+	LeiosKey       json.RawMessage             `json:"leiosKey"`
+	Metadata       json.RawMessage             `json:"metadata"`
+	Owners         json.RawMessage             `json:"owners"`
+	Relays         json.RawMessage             `json:"relays"`
+	PoolId         string                      `json:"poolId"`
+	AccountAddress shelleyExtraPoolAccountAddr `json:"accountAddress"`
+	// Unknown retains any pool property this package does not model, so an
+	// upstream addition does not break parsing under DisallowUnknownFields.
+	Unknown map[string]json.RawMessage `json:"-"`
+}
+
+// UnmarshalJSON decodes the pool fields this package uses and retains every
+// other property verbatim. The genesis decoder runs with DisallowUnknownFields,
+// so without this a new pool field added upstream would fail the whole parse;
+// keeping the remainder as raw JSON also means nothing is silently discarded.
+func (p *ShelleyGenesisExtraPool) UnmarshalJSON(data []byte) error {
+	type alias ShelleyGenesisExtraPool
+	var known alias
+	dec := json.NewDecoder(bytes.NewReader(data))
+	// no DisallowUnknownFields here: unknown properties are captured below
+	if err := dec.Decode(&known); err != nil {
+		return err
+	}
+	*p = ShelleyGenesisExtraPool(known)
+	var all map[string]json.RawMessage
+	if err := json.Unmarshal(data, &all); err != nil {
+		return err
+	}
+	for _, k := range []string{
+		"vrf", "pledge", "cost", "margin", "leiosKey",
+		"metadata", "owners", "relays", "poolId", "accountAddress",
+	} {
+		delete(all, k)
+	}
+	if len(all) > 0 {
+		p.Unknown = all
+	}
+	return nil
+}
+
+type shelleyExtraPoolAccountAddr struct {
+	Credential shelleyExtraPoolCredential `json:"credential"`
+	Network    string                     `json:"network"`
+}
+
+type shelleyExtraPoolCredential struct {
+	KeyHash    string `json:"keyHash"`
+	ScriptHash string `json:"scriptHash"`
+}
+
+// effectiveInitialFunds returns the initial funds the ledger should bootstrap
+// from: the standard top-level map, plus any carried in the extraConfig
+// injection block. It deliberately does NOT write into g.InitialFunds, because
+// that field is emitted by MarshalCBOR and mutating it would change the
+// re-encoded genesis bytes and therefore the genesis hash / initial nonce.
+// captureRaw snapshots the as-parsed maps so MarshalCBOR can reproduce the
+// source encoding regardless of any extraConfig folding done afterwards.
+func (g *ShelleyGenesis) captureRaw() {
+	g.rawInitialFunds = g.InitialFunds
+	g.rawStaking = g.Staking
+	g.rawCaptured = true
+}
+
+// applyExtraConfig folds the prototype extraConfig injection into the standard
+// InitialFunds/Staking fields so every existing consumer of those fields works
+// unchanged. captureRaw must have run first; MarshalCBOR uses the snapshot.
+func (g *ShelleyGenesis) applyExtraConfig() error {
+	if g.ExtraConfig == nil {
+		return nil
+	}
+	if f := g.effectiveInitialFunds(); len(f) > 0 {
+		g.InitialFunds = f
+	}
+	if st := g.effectiveStake(); len(st) > 0 {
+		g.Staking.Stake = st
+	}
+	pools, err := g.effectivePools()
+	if err != nil {
+		return err
+	}
+	if len(pools) > 0 {
+		g.Staking.Pools = pools
+	}
+	return nil
+}
+
+func (g *ShelleyGenesis) effectiveInitialFunds() map[string]uint64 {
+	if g.ExtraConfig == nil || len(g.ExtraConfig.InitialFunds.Data) == 0 {
+		return g.InitialFunds
+	}
+	out := make(map[string]uint64, len(g.InitialFunds)+len(g.ExtraConfig.InitialFunds.Data))
+	for k, v := range g.InitialFunds {
+		out[k] = v
+	}
+	for k, v := range g.ExtraConfig.InitialFunds.Data {
+		out[k] = v
+	}
+	return out
+}
+
+// effectiveStake returns the stake-credential -> pool delegations to bootstrap,
+// merging the extraConfig injection over the standard staking map. Same
+// no-mutation rule as effectiveInitialFunds.
+func (g *ShelleyGenesis) effectiveStake() map[string]string {
+	if g.ExtraConfig == nil || len(g.ExtraConfig.StakeCredentials.Data) == 0 {
+		return g.Staking.Stake
+	}
+	out := make(map[string]string, len(g.Staking.Stake)+len(g.ExtraConfig.StakeCredentials.Data))
+	for k, v := range g.Staking.Stake {
+		out[k] = v
+	}
+	for k, v := range g.ExtraConfig.StakeCredentials.Data {
+		out[k] = v
+	}
+	return out
+}
+
+// effectivePools returns the genesis pool registrations to bootstrap, merging
+// the extraConfig injection over the standard staking pools. Same no-mutation
+// rule as effectiveInitialFunds.
+func (g *ShelleyGenesis) effectivePools() (map[string]common.PoolRegistrationCertificate, error) {
+	if g.ExtraConfig == nil || len(g.ExtraConfig.StakePools.Data) == 0 {
+		return g.Staking.Pools, nil
+	}
+	out := make(map[string]common.PoolRegistrationCertificate, len(g.Staking.Pools)+len(g.ExtraConfig.StakePools.Data))
+	for k, v := range g.Staking.Pools {
+		out[k] = v
+	}
+	for poolId, ep := range g.ExtraConfig.StakePools.Data {
+		opBytes, err := hex.DecodeString(poolId)
+		if err != nil {
+			return nil, err
+		}
+		if len(opBytes) != common.Blake2b224Size {
+			return nil, errors.New("invalid extraConfig pool operator length")
+		}
+		vrfBytes, err := hex.DecodeString(ep.Vrf)
+		if err != nil {
+			return nil, err
+		}
+		if len(vrfBytes) != common.Blake2b256Size {
+			return nil, errors.New("invalid extraConfig pool vrf length")
+		}
+		var reward common.AddrKeyHash
+		if kh := ep.AccountAddress.Credential.KeyHash; kh != "" {
+			rewardBytes, err := hex.DecodeString(kh)
+			if err != nil {
+				return nil, err
+			}
+			if len(rewardBytes) != common.Blake2b224Size {
+				return nil, errors.New("invalid extraConfig pool reward account length")
+			}
+			reward = common.Blake2b224(rewardBytes)
+		}
+		out[poolId] = common.PoolRegistrationCertificate{
+			Operator:      common.Blake2b224(opBytes),
+			VrfKeyHash:    common.NewBlake2b256(vrfBytes),
+			Pledge:        ep.Pledge,
+			Cost:          ep.Cost,
+			Margin:        common.NewGenesisRat(0, 1),
+			RewardAccount: reward,
+		}
+	}
+	return out, nil
+}
+
 func (g ShelleyGenesis) MarshalCBOR() ([]byte, error) {
+	// Encode the genesis exactly as parsed. Any extraConfig injection folded
+	// into InitialFunds/Staking is bootstrap-only state and must not alter the
+	// encoded form, or the genesis hash (and initial nonce) would change.
+	if g.rawCaptured {
+		g.InitialFunds = g.rawInitialFunds
+		g.Staking = g.rawStaking
+	}
 	genDelegs := map[cbor.ByteString][]cbor.ByteString{}
 	for k, v := range g.GenDelegs {
 		keyBytes, err := hex.DecodeString(k)
@@ -213,7 +427,7 @@ func convertPoolRelays(relays []common.PoolRelay) []any {
 
 func (g *ShelleyGenesis) GenesisUtxos() ([]common.Utxo, error) {
 	ret := []common.Utxo{}
-	for address, amount := range g.InitialFunds {
+	for address, amount := range g.effectiveInitialFunds() {
 		addrBytes, err := hex.DecodeString(address)
 		if err != nil {
 			return nil, err
@@ -254,7 +468,12 @@ func (g *ShelleyGenesis) InitialPools() (map[string]common.PoolRegistrationCerti
 	pools := make(map[string]common.PoolRegistrationCertificate)
 	poolStake := make(map[string][]common.Address)
 
-	if reflect.DeepEqual(g.Staking, GenesisStaking{}) {
+	effStake := g.effectiveStake()
+	effPools, err := g.effectivePools()
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(effStake) == 0 && len(effPools) == 0 {
 		return pools, poolStake, nil
 	}
 
@@ -264,7 +483,7 @@ func (g *ShelleyGenesis) InitialPools() (map[string]common.PoolRegistrationCerti
 	}
 
 	// Process all stake addresses
-	for stakeAddr, poolId := range g.Staking.Stake {
+	for stakeAddr, poolId := range effStake {
 		stakeKey, err := hex.DecodeString(stakeAddr)
 		if err != nil {
 			return nil, nil, errors.New("failed to decode stake key")
@@ -284,7 +503,7 @@ func (g *ShelleyGenesis) InitialPools() (map[string]common.PoolRegistrationCerti
 	}
 
 	// Process all stake pools
-	for poolId, pool := range g.Staking.Pools {
+	for poolId, pool := range effPools {
 		operatorBytes, err := hex.DecodeString(poolId)
 		if err != nil {
 			return nil, nil, errors.New("failed to decode pool ID")
@@ -424,6 +643,10 @@ func NewShelleyGenesisFromReader(r io.Reader) (ShelleyGenesis, error) {
 	dec := json.NewDecoder(r)
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&ret); err != nil {
+		return ret, err
+	}
+	ret.captureRaw()
+	if err := ret.applyExtraConfig(); err != nil {
 		return ret, err
 	}
 	return ret, nil

--- a/ledger/shelley/genesis.go
+++ b/ledger/shelley/genesis.go
@@ -19,6 +19,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"math/big"
 	"os"
@@ -189,16 +190,72 @@ func (g *ShelleyGenesis) effectivePools() (map[string]common.PoolRegistrationCer
 			return nil, errors.New("invalid extraConfig pool vrf length")
 		}
 
-		var rewardAccount common.AddrKeyHash
-		if keyHash := extraPool.AccountAddress.Credential.KeyHash; keyHash != "" {
-			reward, err := hex.DecodeString(keyHash)
-			if err != nil {
-				return nil, err
+		credential := extraPool.AccountAddress.Credential
+		if credential.ScriptHash != "" {
+			return nil, errors.New(
+				"extraConfig pool reward account script credentials are not supported",
+			)
+		}
+		if credential.KeyHash == "" {
+			return nil, errors.New(
+				"extraConfig pool reward account key hash is required",
+			)
+		}
+		reward, err := hex.DecodeString(credential.KeyHash)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"invalid extraConfig pool reward account key hash: %w",
+				err,
+			)
+		}
+		if len(reward) != common.Blake2b224Size {
+			return nil, errors.New("invalid extraConfig pool reward account length")
+		}
+		rewardAccount := common.Blake2b224(reward)
+
+		var leiosKey *common.LeiosKey
+		if err := decodeExtraPoolField(
+			extraPool.LeiosKey,
+			"leiosKey",
+			&leiosKey,
+		); err != nil {
+			return nil, err
+		}
+
+		var metadata *common.PoolMetadata
+		if err := decodeExtraPoolField(
+			extraPool.Metadata,
+			"metadata",
+			&metadata,
+		); err != nil {
+			return nil, err
+		}
+
+		var owners []common.AddrKeyHash
+		if err := decodeExtraPoolField(
+			extraPool.Owners,
+			"owners",
+			&owners,
+		); err != nil {
+			return nil, err
+		}
+
+		var relays []common.PoolRelay
+		if err := decodeExtraPoolField(
+			extraPool.Relays,
+			"relays",
+			&relays,
+		); err != nil {
+			return nil, err
+		}
+		for idx := range relays {
+			if err := validateExtraPoolRelay(relays[idx]); err != nil {
+				return nil, fmt.Errorf(
+					"invalid extraConfig pool relays[%d]: %w",
+					idx,
+					err,
+				)
 			}
-			if len(reward) != common.Blake2b224Size {
-				return nil, errors.New("invalid extraConfig pool reward account length")
-			}
-			rewardAccount = common.Blake2b224(reward)
 		}
 
 		margin := common.NewGenesisRat(0, 1)
@@ -211,13 +268,73 @@ func (g *ShelleyGenesis) effectivePools() (map[string]common.PoolRegistrationCer
 		out[poolID] = common.PoolRegistrationCertificate{
 			Operator:      common.Blake2b224(operator),
 			VrfKeyHash:    common.NewBlake2b256(vrf),
+			LeiosKey:      leiosKey,
 			Pledge:        extraPool.Pledge,
 			Cost:          extraPool.Cost,
 			Margin:        margin,
 			RewardAccount: rewardAccount,
+			PoolOwners:    owners,
+			Relays:        relays,
+			PoolMetadata:  metadata,
 		}
 	}
 	return out, nil
+}
+
+func decodeExtraPoolField(
+	raw json.RawMessage,
+	name string,
+	dest any,
+) error {
+	data := bytes.TrimSpace(raw)
+	if len(data) == 0 || bytes.Equal(data, []byte("null")) {
+		return nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dest); err != nil {
+		return fmt.Errorf(
+			"invalid extraConfig pool %s: %w",
+			name,
+			err,
+		)
+	}
+	var trailing any
+	if err := dec.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return fmt.Errorf(
+			"invalid extraConfig pool %s: trailing JSON value",
+			name,
+		)
+	}
+	return nil
+}
+
+func validateExtraPoolRelay(relay common.PoolRelay) error {
+	switch relay.Type {
+	case common.PoolRelayTypeSingleHostAddress:
+		if relay.Hostname != nil {
+			return errors.New("single-host-address relay cannot have hostname")
+		}
+	case common.PoolRelayTypeSingleHostName:
+		if relay.Hostname == nil || *relay.Hostname == "" {
+			return errors.New("single-host-name relay requires hostname")
+		}
+		if relay.Ipv4 != nil || relay.Ipv6 != nil {
+			return errors.New("single-host-name relay cannot have IP addresses")
+		}
+	case common.PoolRelayTypeMultiHostName:
+		if relay.Hostname == nil || *relay.Hostname == "" {
+			return errors.New("multi-host-name relay requires hostname")
+		}
+		if relay.Port != nil || relay.Ipv4 != nil || relay.Ipv6 != nil {
+			return errors.New(
+				"multi-host-name relay cannot have port or IP addresses",
+			)
+		}
+	default:
+		return fmt.Errorf("unsupported relay type %d", relay.Type)
+	}
+	return nil
 }
 
 func (g ShelleyGenesis) MarshalCBOR() ([]byte, error) {
@@ -466,6 +583,7 @@ func (g *ShelleyGenesis) InitialPools() (map[string]common.PoolRegistrationCerti
 		pools[poolId] = common.PoolRegistrationCertificate{
 			Operator:      common.Blake2b224(operatorBytes),
 			VrfKeyHash:    pool.VrfKeyHash,
+			LeiosKey:      pool.LeiosKey,
 			Pledge:        pool.Pledge,
 			Cost:          pool.Cost,
 			Margin:        pool.Margin,
@@ -530,6 +648,7 @@ func (g *ShelleyGenesis) PoolById(
 	return &common.PoolRegistrationCertificate{
 		Operator:      common.Blake2b224(operatorBytes),
 		VrfKeyHash:    pool.VrfKeyHash,
+		LeiosKey:      pool.LeiosKey,
 		Pledge:        pool.Pledge,
 		Cost:          pool.Cost,
 		Margin:        pool.Margin,

--- a/ledger/shelley/genesis.go
+++ b/ledger/shelley/genesis.go
@@ -45,21 +45,10 @@ type ShelleyGenesis struct {
 	GenDelegs          map[string]map[string]string `json:"genDelegs"`
 	InitialFunds       map[string]uint64            `json:"initialFunds"`
 	Staking            GenesisStaking               `json:"staking"`
-	// ExtraConfig carries the Musashi/Leios prototype genesis injection block.
-	// On that network the top-level initialFunds/staking are empty and the
-	// initial UTxOs, stake delegations and pool registrations are provided
-	// here instead. It is merged at read time by GenesisUtxos/InitialPools and is
-	// deliberately not folded into the marshalled fields, so the genesis hash is
-	// unaffected by parsing.
+	// ExtraConfig carries the Musashi genesis injection block. Its values are
+	// applied by the bootstrap helpers, but are not part of the Shelley genesis
+	// CBOR encoding.
 	ExtraConfig *ShelleyGenesisExtraConfig `json:"extraConfig,omitempty" cbor:"-"`
-	// rawInitialFunds/rawStaking snapshot the values exactly as they appeared in
-	// the source document, before any extraConfig injection is folded in. CBOR
-	// encoding uses these so that parsing a genesis containing extraConfig never
-	// changes the bytes MarshalCBOR emits, and therefore never changes the
-	// genesis hash or the derived initial nonce.
-	rawInitialFunds map[string]uint64
-	rawStaking      GenesisStaking
-	rawCaptured     bool
 }
 
 type GenesisStaking struct {
@@ -67,9 +56,8 @@ type GenesisStaking struct {
 	Stake map[string]string                             `json:"stake"`
 }
 
-// ShelleyGenesisExtraConfig models the Leios prototype's genesis "extraConfig"
-// injection. Every field is captured so the strict genesis decoder accepts the
-// block; pool sub-fields not needed for ledger bootstrap are kept as raw JSON.
+// ShelleyGenesisExtraConfig contains the bootstrap values injected by the
+// Musashi Leios prototype genesis.
 type ShelleyGenesisExtraConfig struct {
 	InitialFunds     shelleyExtraFunds `json:"initialFunds"`
 	StakeCredentials shelleyExtraCreds `json:"stakeCredentials"`
@@ -88,6 +76,7 @@ type shelleyExtraPools struct {
 	Data map[string]ShelleyGenesisExtraPool `json:"data"`
 }
 
+// ShelleyGenesisExtraPool is an injected initial pool registration.
 type ShelleyGenesisExtraPool struct {
 	Vrf            string                      `json:"vrf"`
 	Pledge         uint64                      `json:"pledge"`
@@ -99,33 +88,29 @@ type ShelleyGenesisExtraPool struct {
 	Relays         json.RawMessage             `json:"relays"`
 	PoolId         string                      `json:"poolId"`
 	AccountAddress shelleyExtraPoolAccountAddr `json:"accountAddress"`
-	// Unknown retains any pool property this package does not model, so an
-	// upstream addition does not break parsing under DisallowUnknownFields.
-	Unknown map[string]json.RawMessage `json:"-"`
+	Unknown        map[string]json.RawMessage  `json:"-"`
 }
 
-// UnmarshalJSON decodes the pool fields this package uses and retains every
-// other property verbatim. The genesis decoder runs with DisallowUnknownFields,
-// so without this a new pool field added upstream would fail the whole parse;
-// keeping the remainder as raw JSON also means nothing is silently discarded.
+// UnmarshalJSON retains unmodelled pool properties. This lets the strict
+// top-level genesis decoder continue to accept future Musashi pool fields.
 func (p *ShelleyGenesisExtraPool) UnmarshalJSON(data []byte) error {
-	type alias ShelleyGenesisExtraPool
-	var known alias
+	type extraPool ShelleyGenesisExtraPool
+	var known extraPool
 	dec := json.NewDecoder(bytes.NewReader(data))
-	// no DisallowUnknownFields here: unknown properties are captured below
 	if err := dec.Decode(&known); err != nil {
 		return err
 	}
 	*p = ShelleyGenesisExtraPool(known)
+
 	var all map[string]json.RawMessage
 	if err := json.Unmarshal(data, &all); err != nil {
 		return err
 	}
-	for _, k := range []string{
-		"vrf", "pledge", "cost", "margin", "leiosKey",
-		"metadata", "owners", "relays", "poolId", "accountAddress",
+	for _, key := range []string{
+		"vrf", "pledge", "cost", "margin", "leiosKey", "metadata",
+		"owners", "relays", "poolId", "accountAddress",
 	} {
-		delete(all, k)
+		delete(all, key)
 	}
 	if len(all) > 0 {
 		p.Unknown = all
@@ -143,130 +128,99 @@ type shelleyExtraPoolCredential struct {
 	ScriptHash string `json:"scriptHash"`
 }
 
-// effectiveInitialFunds returns the initial funds the ledger should bootstrap
-// from: the standard top-level map, plus any carried in the extraConfig
-// injection block. It deliberately does NOT write into g.InitialFunds, because
-// that field is emitted by MarshalCBOR and mutating it would change the
-// re-encoded genesis bytes and therefore the genesis hash / initial nonce.
-// captureRaw snapshots the as-parsed maps so MarshalCBOR can reproduce the
-// source encoding regardless of any extraConfig folding done afterwards.
-func (g *ShelleyGenesis) captureRaw() {
-	g.rawInitialFunds = g.InitialFunds
-	g.rawStaking = g.Staking
-	g.rawCaptured = true
-}
-
-// applyExtraConfig folds the prototype extraConfig injection into the standard
-// InitialFunds/Staking fields so every existing consumer of those fields works
-// unchanged. captureRaw must have run first; MarshalCBOR uses the snapshot.
-func (g *ShelleyGenesis) applyExtraConfig() error {
-	if g.ExtraConfig == nil {
-		return nil
-	}
-	if f := g.effectiveInitialFunds(); len(f) > 0 {
-		g.InitialFunds = f
-	}
-	if st := g.effectiveStake(); len(st) > 0 {
-		g.Staking.Stake = st
-	}
-	pools, err := g.effectivePools()
-	if err != nil {
-		return err
-	}
-	if len(pools) > 0 {
-		g.Staking.Pools = pools
-	}
-	return nil
-}
-
 func (g *ShelleyGenesis) effectiveInitialFunds() map[string]uint64 {
 	if g.ExtraConfig == nil || len(g.ExtraConfig.InitialFunds.Data) == 0 {
 		return g.InitialFunds
 	}
-	out := make(map[string]uint64, len(g.InitialFunds)+len(g.ExtraConfig.InitialFunds.Data))
-	for k, v := range g.InitialFunds {
-		out[k] = v
+	out := make(
+		map[string]uint64,
+		len(g.InitialFunds)+len(g.ExtraConfig.InitialFunds.Data),
+	)
+	for key, amount := range g.InitialFunds {
+		out[key] = amount
 	}
-	for k, v := range g.ExtraConfig.InitialFunds.Data {
-		out[k] = v
+	for key, amount := range g.ExtraConfig.InitialFunds.Data {
+		out[key] = amount
 	}
 	return out
 }
 
-// effectiveStake returns the stake-credential -> pool delegations to bootstrap,
-// merging the extraConfig injection over the standard staking map. Same
-// no-mutation rule as effectiveInitialFunds.
 func (g *ShelleyGenesis) effectiveStake() map[string]string {
 	if g.ExtraConfig == nil || len(g.ExtraConfig.StakeCredentials.Data) == 0 {
 		return g.Staking.Stake
 	}
-	out := make(map[string]string, len(g.Staking.Stake)+len(g.ExtraConfig.StakeCredentials.Data))
-	for k, v := range g.Staking.Stake {
-		out[k] = v
+	out := make(
+		map[string]string,
+		len(g.Staking.Stake)+len(g.ExtraConfig.StakeCredentials.Data),
+	)
+	for credential, poolID := range g.Staking.Stake {
+		out[credential] = poolID
 	}
-	for k, v := range g.ExtraConfig.StakeCredentials.Data {
-		out[k] = v
+	for credential, poolID := range g.ExtraConfig.StakeCredentials.Data {
+		out[credential] = poolID
 	}
 	return out
 }
 
-// effectivePools returns the genesis pool registrations to bootstrap, merging
-// the extraConfig injection over the standard staking pools. Same no-mutation
-// rule as effectiveInitialFunds.
 func (g *ShelleyGenesis) effectivePools() (map[string]common.PoolRegistrationCertificate, error) {
 	if g.ExtraConfig == nil || len(g.ExtraConfig.StakePools.Data) == 0 {
 		return g.Staking.Pools, nil
 	}
-	out := make(map[string]common.PoolRegistrationCertificate, len(g.Staking.Pools)+len(g.ExtraConfig.StakePools.Data))
-	for k, v := range g.Staking.Pools {
-		out[k] = v
+	out := make(
+		map[string]common.PoolRegistrationCertificate,
+		len(g.Staking.Pools)+len(g.ExtraConfig.StakePools.Data),
+	)
+	for poolID, pool := range g.Staking.Pools {
+		out[poolID] = pool
 	}
-	for poolId, ep := range g.ExtraConfig.StakePools.Data {
-		opBytes, err := hex.DecodeString(poolId)
+	for poolID, extraPool := range g.ExtraConfig.StakePools.Data {
+		operator, err := hex.DecodeString(poolID)
 		if err != nil {
 			return nil, err
 		}
-		if len(opBytes) != common.Blake2b224Size {
+		if len(operator) != common.Blake2b224Size {
 			return nil, errors.New("invalid extraConfig pool operator length")
 		}
-		vrfBytes, err := hex.DecodeString(ep.Vrf)
+		vrf, err := hex.DecodeString(extraPool.Vrf)
 		if err != nil {
 			return nil, err
 		}
-		if len(vrfBytes) != common.Blake2b256Size {
+		if len(vrf) != common.Blake2b256Size {
 			return nil, errors.New("invalid extraConfig pool vrf length")
 		}
-		var reward common.AddrKeyHash
-		if kh := ep.AccountAddress.Credential.KeyHash; kh != "" {
-			rewardBytes, err := hex.DecodeString(kh)
+
+		var rewardAccount common.AddrKeyHash
+		if keyHash := extraPool.AccountAddress.Credential.KeyHash; keyHash != "" {
+			reward, err := hex.DecodeString(keyHash)
 			if err != nil {
 				return nil, err
 			}
-			if len(rewardBytes) != common.Blake2b224Size {
+			if len(reward) != common.Blake2b224Size {
 				return nil, errors.New("invalid extraConfig pool reward account length")
 			}
-			reward = common.Blake2b224(rewardBytes)
+			rewardAccount = common.Blake2b224(reward)
 		}
-		out[poolId] = common.PoolRegistrationCertificate{
-			Operator:      common.Blake2b224(opBytes),
-			VrfKeyHash:    common.NewBlake2b256(vrfBytes),
-			Pledge:        ep.Pledge,
-			Cost:          ep.Cost,
-			Margin:        common.NewGenesisRat(0, 1),
-			RewardAccount: reward,
+
+		margin := common.NewGenesisRat(0, 1)
+		if marginJSON := bytes.TrimSpace(extraPool.Margin); len(marginJSON) > 0 &&
+			!bytes.Equal(marginJSON, []byte("null")) {
+			if err := margin.UnmarshalJSON(extraPool.Margin); err != nil {
+				return nil, err
+			}
+		}
+		out[poolID] = common.PoolRegistrationCertificate{
+			Operator:      common.Blake2b224(operator),
+			VrfKeyHash:    common.NewBlake2b256(vrf),
+			Pledge:        extraPool.Pledge,
+			Cost:          extraPool.Cost,
+			Margin:        margin,
+			RewardAccount: rewardAccount,
 		}
 	}
 	return out, nil
 }
 
 func (g ShelleyGenesis) MarshalCBOR() ([]byte, error) {
-	// Encode the genesis exactly as parsed. Any extraConfig injection folded
-	// into InitialFunds/Staking is bootstrap-only state and must not alter the
-	// encoded form, or the genesis hash (and initial nonce) would change.
-	if g.rawCaptured {
-		g.InitialFunds = g.rawInitialFunds
-		g.Staking = g.rawStaking
-	}
 	genDelegs := map[cbor.ByteString][]cbor.ByteString{}
 	for k, v := range g.GenDelegs {
 		keyBytes, err := hex.DecodeString(k)
@@ -468,12 +422,12 @@ func (g *ShelleyGenesis) InitialPools() (map[string]common.PoolRegistrationCerti
 	pools := make(map[string]common.PoolRegistrationCertificate)
 	poolStake := make(map[string][]common.Address)
 
-	effStake := g.effectiveStake()
-	effPools, err := g.effectivePools()
+	effectiveStake := g.effectiveStake()
+	effectivePools, err := g.effectivePools()
 	if err != nil {
 		return nil, nil, err
 	}
-	if len(effStake) == 0 && len(effPools) == 0 {
+	if len(effectiveStake) == 0 && len(effectivePools) == 0 {
 		return pools, poolStake, nil
 	}
 
@@ -483,7 +437,7 @@ func (g *ShelleyGenesis) InitialPools() (map[string]common.PoolRegistrationCerti
 	}
 
 	// Process all stake addresses
-	for stakeAddr, poolId := range effStake {
+	for stakeAddr, poolId := range effectiveStake {
 		stakeKey, err := hex.DecodeString(stakeAddr)
 		if err != nil {
 			return nil, nil, errors.New("failed to decode stake key")
@@ -503,7 +457,7 @@ func (g *ShelleyGenesis) InitialPools() (map[string]common.PoolRegistrationCerti
 	}
 
 	// Process all stake pools
-	for poolId, pool := range effPools {
+	for poolId, pool := range effectivePools {
 		operatorBytes, err := hex.DecodeString(poolId)
 		if err != nil {
 			return nil, nil, errors.New("failed to decode pool ID")
@@ -532,7 +486,11 @@ func (g *ShelleyGenesis) PoolById(
 		return nil, nil, errors.New("invalid pool ID length")
 	}
 
-	pool, exists := g.Staking.Pools[poolId]
+	effectivePools, err := g.effectivePools()
+	if err != nil {
+		return nil, nil, err
+	}
+	pool, exists := effectivePools[poolId]
 	if !exists {
 		return nil, nil, errors.New("pool  not found")
 	}
@@ -543,7 +501,7 @@ func (g *ShelleyGenesis) PoolById(
 	}
 
 	var delegators []common.Address
-	for stakeAddr, pId := range g.Staking.Stake {
+	for stakeAddr, pId := range g.effectiveStake() {
 		if pId == poolId {
 			stakeKey, err := hex.DecodeString(stakeAddr)
 			if err != nil {
@@ -643,10 +601,6 @@ func NewShelleyGenesisFromReader(r io.Reader) (ShelleyGenesis, error) {
 	dec := json.NewDecoder(r)
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&ret); err != nil {
-		return ret, err
-	}
-	ret.captureRaw()
-	if err := ret.applyExtraConfig(); err != nil {
 		return ret, err
 	}
 	return ret, nil

--- a/ledger/shelley/genesis_test.go
+++ b/ledger/shelley/genesis_test.go
@@ -203,6 +203,110 @@ func TestGenesisFromJson(t *testing.T) {
 	}
 }
 
+func TestGenesisExtraConfig(t *testing.T) {
+	const extraConfig = `,
+  "extraConfig": {
+    "initialFunds": {
+      "data": {
+        "000045183c1dcaeb0ca5cf583a68b9e31a6301bcbde487065bd35b955a98ba9d3061e1bd15749cc857e94b30583c120e3255adb93b44681bad": 120000000000000
+      }
+    },
+    "stakeCredentials": {
+      "data": {
+        "24632b71152f31516054075897d0d4ababc33204f8a8661136d49e36": "0aedc455785463235311c990f68742c9043cd79af09ab31c2ba5e195"
+      }
+    },
+    "stakePools": {
+      "data": {
+        "0aedc455785463235311c990f68742c9043cd79af09ab31c2ba5e195": {
+          "vrf": "eb53a17fbad9b7ea0bcf1e1ea89355305600d593b426dfc3084a924d8877d47e",
+          "pledge": 1000000,
+          "cost": 340000000,
+          "margin": 0.05,
+          "accountAddress": {
+            "credential": {
+              "keyHash": "6079cde665c2035b8d9ac8929307bdd7f20a51e678e9d4a5e39ace3a"
+            },
+            "network": "Mainnet"
+          },
+          "futurePoolField": true
+        }
+      }
+    }
+  }
+}`
+
+	baseConfig := strings.TrimSpace(shelleyGenesisConfig)
+	extraConfigGenesis := strings.TrimSuffix(baseConfig, "}") + extraConfig
+	genesis, err := shelley.NewShelleyGenesisFromReader(
+		strings.NewReader(extraConfigGenesis),
+	)
+	require.NoError(t, err)
+
+	// The injection is effective for bootstrap consumers without changing the
+	// public Shelley fields that determine the standard genesis CBOR encoding.
+	require.Empty(t, genesis.InitialFunds)
+	require.Empty(t, genesis.Staking.Pools)
+	require.Empty(t, genesis.Staking.Stake)
+
+	utxos, err := genesis.GenesisUtxos()
+	require.NoError(t, err)
+	require.Len(t, utxos, 1)
+	assert.Equal(t, "120000000000000", utxos[0].Output.Amount().String())
+
+	pools, delegators, err := genesis.InitialPools()
+	require.NoError(t, err)
+	require.Len(t, pools, 1)
+	require.Len(
+		t,
+		delegators["0aedc455785463235311c990f68742c9043cd79af09ab31c2ba5e195"],
+		1,
+	)
+	pool := pools["0aedc455785463235311c990f68742c9043cd79af09ab31c2ba5e195"]
+	assert.Zero(t, pool.Margin.Rat.Cmp(big.NewRat(1, 20)))
+
+	poolByID, _, err := genesis.PoolById(
+		"0aedc455785463235311c990f68742c9043cd79af09ab31c2ba5e195",
+	)
+	require.NoError(t, err)
+	assert.Zero(t, poolByID.Margin.Rat.Cmp(big.NewRat(1, 20)))
+
+	baseGenesis, err := shelley.NewShelleyGenesisFromReader(
+		strings.NewReader(shelleyGenesisConfig),
+	)
+	require.NoError(t, err)
+	baseCbor, err := baseGenesis.MarshalCBOR()
+	require.NoError(t, err)
+	extraCbor, err := genesis.MarshalCBOR()
+	require.NoError(t, err)
+	assert.Equal(t, baseCbor, extraCbor)
+}
+
+func TestGenesisMarshalCBORReflectsPostParseMutation(t *testing.T) {
+	genesis, err := shelley.NewShelleyGenesisFromReader(
+		strings.NewReader(shelleyGenesisConfig),
+	)
+	require.NoError(t, err)
+
+	before, err := genesis.MarshalCBOR()
+	require.NoError(t, err)
+	genesis.InitialFunds = map[string]uint64{
+		"000045183c1dcaeb0ca5cf583a68b9e31a6301bcbde487065bd35b955a98ba9d3061e1bd15749cc857e94b30583c120e3255adb93b44681bad": 1,
+	}
+	after, err := genesis.MarshalCBOR()
+	require.NoError(t, err)
+	assert.NotEqual(t, before, after)
+
+	genesis.Staking = shelley.GenesisStaking{
+		Stake: map[string]string{
+			"24632b71152f31516054075897d0d4ababc33204f8a8661136d49e36": "0aedc455785463235311c990f68742c9043cd79af09ab31c2ba5e195",
+		},
+	}
+	afterStakingMutation, err := genesis.MarshalCBOR()
+	require.NoError(t, err)
+	assert.NotEqual(t, after, afterStakingMutation)
+}
+
 // Guards against a regression where an unrecognized NetworkId silently
 // encoded as testnet instead of returning an error.
 func TestGenesisMarshalCBORInvalidNetworkId(t *testing.T) {

--- a/ledger/shelley/genesis_test.go
+++ b/ledger/shelley/genesis_test.go
@@ -282,6 +282,236 @@ func TestGenesisExtraConfig(t *testing.T) {
 	assert.Equal(t, baseCbor, extraCbor)
 }
 
+func TestGenesisExtraConfigPoolFields(t *testing.T) {
+	const (
+		poolID = "0aedc455785463235311c990f68742c9043cd79af09ab31c2ba5e195"
+		vrf    = "eb53a17fbad9b7ea0bcf1e1ea89355305600d593b426dfc3084a924d8877d47e"
+		reward = "6079cde665c2035b8d9ac8929307bdd7f20a51e678e9d4a5e39ace3a"
+		owner  = "24632b71152f31516054075897d0d4ababc33204f8a8661136d49e36"
+	)
+	publicKey := strings.Repeat("A", common.LeiosBlsPublicKeySize)
+	proof := strings.Repeat("B", common.LeiosBlsPossessionProofSize)
+	metadataHash := common.NewBlake2b256(
+		[]byte(strings.Repeat("M", common.Blake2b256Size)),
+	)
+	poolJSON := map[string]any{
+		"vrf":    vrf,
+		"pledge": uint64(1_000_000),
+		"cost":   uint64(340_000_000),
+		"margin": 0.05,
+		"accountAddress": map[string]any{
+			"credential": map[string]any{"keyHash": reward},
+			"network":    "Mainnet",
+		},
+		"leiosKey": map[string]any{
+			"publicKey":       []byte(publicKey),
+			"possessionProof": []byte(proof),
+		},
+		"metadata": map[string]any{
+			"url":  "https://example.com/pool.json",
+			"hash": metadataHash,
+		},
+		"owners": []string{owner},
+		"relays": []map[string]any{
+			{
+				"type": 0,
+				"port": 3001,
+				"ipv4": "192.0.2.1",
+				"ipv6": "2001:db8::1",
+			},
+			{"type": 1, "port": 3002, "hostname": "relay.example.com"},
+			{"type": 2, "hostname": "_pool._tcp.example.com"},
+		},
+	}
+
+	genesis, err := genesisWithExtraPool(poolID, poolJSON)
+	require.NoError(t, err)
+	pools, _, err := genesis.InitialPools()
+	require.NoError(t, err)
+	require.Contains(t, pools, poolID)
+	pool := pools[poolID]
+	require.NotNil(t, pool.LeiosKey)
+	assert.Equal(t, []byte(publicKey), pool.LeiosKey.PublicKey)
+	assert.Equal(t, []byte(proof), pool.LeiosKey.PossessionProof)
+	assert.Equal(t, common.NewBlake2b224(mustHex(t, reward)), pool.RewardAccount)
+	assert.Equal(
+		t,
+		[]common.AddrKeyHash{common.NewBlake2b224(mustHex(t, owner))},
+		pool.PoolOwners,
+	)
+	require.Len(t, pool.Relays, 3)
+	assert.Equal(t, common.PoolRelayTypeSingleHostAddress, pool.Relays[0].Type)
+	require.NotNil(t, pool.Relays[0].Port)
+	assert.Equal(t, uint32(3001), *pool.Relays[0].Port)
+	require.NotNil(t, pool.Relays[0].Ipv4)
+	assert.Equal(t, "192.0.2.1", pool.Relays[0].Ipv4.String())
+	require.NotNil(t, pool.Relays[0].Ipv6)
+	assert.Equal(t, "2001:db8::1", pool.Relays[0].Ipv6.String())
+	assert.Equal(t, common.PoolRelayTypeSingleHostName, pool.Relays[1].Type)
+	require.NotNil(t, pool.Relays[1].Hostname)
+	assert.Equal(t, "relay.example.com", *pool.Relays[1].Hostname)
+	assert.Equal(t, common.PoolRelayTypeMultiHostName, pool.Relays[2].Type)
+	require.NotNil(t, pool.Relays[2].Hostname)
+	assert.Equal(t, "_pool._tcp.example.com", *pool.Relays[2].Hostname)
+	require.NotNil(t, pool.PoolMetadata)
+	assert.Equal(t, "https://example.com/pool.json", pool.PoolMetadata.Url)
+	assert.Equal(t, metadataHash, pool.PoolMetadata.Hash)
+
+	poolByID, _, err := genesis.PoolById(poolID)
+	require.NoError(t, err)
+	assert.Equal(t, pool.LeiosKey, poolByID.LeiosKey)
+	assert.Equal(t, pool.PoolOwners, poolByID.PoolOwners)
+	assert.Equal(t, pool.Relays, poolByID.Relays)
+	assert.Equal(t, pool.PoolMetadata, poolByID.PoolMetadata)
+}
+
+func TestGenesisExtraConfigPoolFieldValidation(t *testing.T) {
+	const (
+		poolID = "0aedc455785463235311c990f68742c9043cd79af09ab31c2ba5e195"
+		vrf    = "eb53a17fbad9b7ea0bcf1e1ea89355305600d593b426dfc3084a924d8877d47e"
+		reward = "6079cde665c2035b8d9ac8929307bdd7f20a51e678e9d4a5e39ace3a"
+	)
+	validPool := func() map[string]any {
+		return map[string]any{
+			"vrf": vrf,
+			"accountAddress": map[string]any{
+				"credential": map[string]any{"keyHash": reward},
+				"network":    "Mainnet",
+			},
+		}
+	}
+	tests := []struct {
+		name      string
+		mutate    func(map[string]any)
+		errString string
+	}{
+		{
+			name: "script reward credential",
+			mutate: func(pool map[string]any) {
+				pool["accountAddress"] = map[string]any{
+					"credential": map[string]any{"scriptHash": reward},
+					"network":    "Mainnet",
+				}
+			},
+			errString: "script credentials are not supported",
+		},
+		{
+			name: "missing reward credential",
+			mutate: func(pool map[string]any) {
+				pool["accountAddress"] = map[string]any{
+					"credential": map[string]any{},
+					"network":    "Mainnet",
+				}
+			},
+			errString: "reward account key hash is required",
+		},
+		{
+			name: "invalid reward key hash",
+			mutate: func(pool map[string]any) {
+				pool["accountAddress"] = map[string]any{
+					"credential": map[string]any{"keyHash": "01"},
+					"network":    "Mainnet",
+				}
+			},
+			errString: "invalid extraConfig pool reward account length",
+		},
+		{
+			name: "invalid Leios key length",
+			mutate: func(pool map[string]any) {
+				pool["leiosKey"] = map[string]any{
+					"publicKey":       []byte{1},
+					"possessionProof": make([]byte, common.LeiosBlsPossessionProofSize),
+				}
+			},
+			errString: "invalid Leios BLS public key length",
+		},
+		{
+			name: "invalid metadata hash",
+			mutate: func(pool map[string]any) {
+				pool["metadata"] = map[string]any{
+					"url":  "https://example.com",
+					"hash": "01",
+				}
+			},
+			errString: "invalid blake2b-256 hash",
+		},
+		{
+			name: "invalid owner hash",
+			mutate: func(pool map[string]any) {
+				pool["owners"] = []string{"01"}
+			},
+			errString: "invalid blake2b-224 hash",
+		},
+		{
+			name: "unsupported relay type",
+			mutate: func(pool map[string]any) {
+				pool["relays"] = []map[string]any{{"type": 3}}
+			},
+			errString: "unsupported relay type 3",
+		},
+		{
+			name: "invalid single-host-address fields",
+			mutate: func(pool map[string]any) {
+				pool["relays"] = []map[string]any{{
+					"type": 0, "hostname": "example.com",
+				}}
+			},
+			errString: "single-host-address relay cannot have hostname",
+		},
+		{
+			name: "missing single-host-name hostname",
+			mutate: func(pool map[string]any) {
+				pool["relays"] = []map[string]any{{"type": 1}}
+			},
+			errString: "single-host-name relay requires hostname",
+		},
+		{
+			name: "invalid multi-host relay fields",
+			mutate: func(pool map[string]any) {
+				pool["relays"] = []map[string]any{{
+					"type": 2, "hostname": "example.com", "port": 3001,
+				}}
+			},
+			errString: "multi-host-name relay cannot have port",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pool := validPool()
+			test.mutate(pool)
+			genesis, err := genesisWithExtraPool(poolID, pool)
+			require.NoError(t, err)
+			_, _, err = genesis.InitialPools()
+			require.ErrorContains(t, err, test.errString)
+		})
+	}
+}
+
+func genesisWithExtraPool(
+	poolID string,
+	pool map[string]any,
+) (shelley.ShelleyGenesis, error) {
+	extraConfig, err := json.Marshal(map[string]any{
+		"stakePools": map[string]any{
+			"data": map[string]any{poolID: pool},
+		},
+	})
+	if err != nil {
+		return shelley.ShelleyGenesis{}, err
+	}
+	baseConfig := strings.TrimSpace(shelleyGenesisConfig)
+	config := strings.TrimSuffix(baseConfig, "}") +
+		`,"extraConfig":` + string(extraConfig) + `}`
+	return shelley.NewShelleyGenesisFromReader(strings.NewReader(config))
+}
+
+func mustHex(t *testing.T, value string) []byte {
+	t.Helper()
+	decoded, err := hex.DecodeString(value)
+	require.NoError(t, err)
+	return decoded
+}
+
 func TestGenesisMarshalCBORReflectsPostParseMutation(t *testing.T) {
 	genesis, err := shelley.NewShelleyGenesisFromReader(
 		strings.NewReader(shelleyGenesisConfig),


### PR DESCRIPTION
Closes #1969 

## Summary

Accept and apply the Musashi/Leios genesis extraConfig injection without changing Shelley genesis CBOR or existing genesis mutation semantics.

This branch preserves the original PR implementation as the first commit, retaining the original author and DCO sign-off. The second commit fixes the decoded-value equality regression, post-parse MarshalCBOR mutation regression, pool margin loss, Conway strict decoding coverage, and adds regression tests.

## Validation

- make test
- make lint
- go test ./...
- go build ./...


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Safely accept Musashi/Leios genesis `extraConfig` and apply its funds, stake credentials, and pools in bootstrap helpers without changing Shelley genesis CBOR. Previously strict decoders rejected `extraConfig`; now they accept it, preserve unknown pool fields, and keep the original genesis hash/initial nonce.

- Adds `extraConfig` to `ledger/shelley` (typed `ShelleyGenesis.ExtraConfig`) and `ledger/conway` (raw `ConwayGenesis.ExtraConfig`); strict JSON decoding accepts it when present.
- Merges `extraConfig` values into `GenesisUtxos`, `InitialPools`, and `PoolById`; public Shelley fields remain unchanged to preserve CBOR, but pool data now includes `LeiosKey` when provided.
- `MarshalCBOR` re-encodes byte-identically to parsed input; mutations of public fields affect CBOR, while `extraConfig` does not.
- Validates pool operator/VRF/reward account sizes, parses margin, checks relay field consistency, rejects script reward credentials, and retains unmodelled pool properties for forward compatibility.
- Adds tests for `extraConfig` acceptance (Shelley and Conway), CBOR stability, post-parse mutation behavior, Leios key/metadata/relays handling, and invalid field cases.

<sup>Written for commit eb1b44ea98272a2f768867e7eed6cd57c509d5f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



