### PR TITLE
fix(ledger): scope the PlutusV1 restriction to needed scripts

### DIFF
--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -22,6 +22,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/allegra"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/common/script"
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/blinklabs-io/plutigo/syn"
@@ -241,92 +242,82 @@ func UtxoValidateCostModelsPresent(
 
 // UtxoValidateInlineDatumsWithPlutusV1 rejects transactions that use inline datums with PlutusV1 scripts
 // Inline datums are a Babbage-era feature and are only supported with PlutusV2+
+// UtxoValidateInlineDatumsWithPlutusV1 rejects a transaction that requires a
+// PlutusV1 script while using a feature the PlutusV1 script context cannot
+// represent. PlutusV1 predates inline datums and reference scripts, so a
+// transaction that needs a V1 script and carries either is invalid.
+//
+// Two properties matter, and getting either wrong diverges from cardano-node:
+//
+//   - Only a *needed* script constrains the transaction. A V1 script that is
+//     merely reachable -- sitting in the witness set, or as a reference script
+//     on some UTxO being spent -- but required by no script purpose does not
+//     make the transaction invalid. Rejecting on availability turns an ordinary
+//     transaction that happens to spend a UTxO carrying an unrelated V1
+//     reference script into a permanent validation failure.
+//   - The disqualifying feature is transaction-wide. An inline datum counts
+//     wherever the V1 context would have to represent it: on a consumed input,
+//     on a reference input, or on one of this transaction's own outputs.
+//
+// Datum presence is read through the TransactionOutput interface rather than a
+// concrete Babbage type assertion, so outputs wrapped by a later era are still
+// inspected. Datum-*hash* outputs are correctly not treated as inline, because
+// Datum() reports nil for them.
 func UtxoValidateInlineDatumsWithPlutusV1(
 	tx common.Transaction,
 	slot uint64,
 	ls common.LedgerState,
 	pp common.ProtocolParameters,
 ) error {
-	// Check if transaction spends any UTxOs with inline datums
-	hasInlineDatums := false
-	for _, input := range tx.Inputs() {
-		utxo, err := ls.UtxoById(input)
-		if err != nil {
-			// Input not found in ledger state, skip
-			continue
+	view, err := script.NewTxScriptView(tx, ls)
+	if err != nil {
+		if errors.Is(err, common.ErrInputResolution) ||
+			errors.Is(err, common.ErrReferenceInputResolution) {
+			// UtxoValidateBadInputsUtxo reports an unresolvable input with the
+			// right error; reporting it here as well would make this rule a
+			// second, competing source of input-resolution failures.
+			return nil
 		}
-		babbageOutput, ok := utxo.Output.(*BabbageTransactionOutput)
-		if !ok {
-			continue
-		}
-		if babbageOutput.DatumOption != nil &&
-			babbageOutput.DatumOption.data != nil {
-			hasInlineDatums = true
-			break
-		}
+		return err
 	}
-
-	if !hasInlineDatums {
+	needsV1 := view.NeedsAny(func(s common.Script) bool {
+		_, ok := s.(common.PlutusV1Script)
+		return ok
+	})
+	if !needsV1 {
 		return nil
 	}
-
-	// Check if transaction uses PlutusV1 scripts in witnesses
-	witnesses := tx.Witnesses()
-	if witnesses != nil {
-		v1Scripts := witnesses.PlutusV1Scripts()
-		if len(v1Scripts) > 0 {
+	for _, utxo := range view.AllResolvedInputs() {
+		if utxo.Output != nil && utxo.Output.Datum() != nil {
 			return common.InlineDatumsNotSupportedError{
 				PlutusVersion: "PlutusV1",
 			}
 		}
 	}
-
-	// Check reference scripts on reference inputs
-	for _, refInput := range tx.ReferenceInputs() {
-		utxo, err := ls.UtxoById(refInput)
-		if err != nil {
-			return common.ReferenceInputResolutionError{
-				Input: refInput,
-				Err:   err,
+	for _, output := range tx.Outputs() {
+		if output == nil {
+			continue
+		}
+		if output.Datum() != nil {
+			return common.InlineDatumsNotSupportedError{
+				PlutusVersion: "PlutusV1",
 			}
 		}
-		if utxo.Output == nil {
-			continue
-		}
-		script := utxo.Output.ScriptRef()
-		if script == nil {
-			continue
-		}
-		switch script.(type) {
-		case common.PlutusV1Script:
+		// A reference script on a produced output is equally unrepresentable in
+		// the V1 context.
+		if output.ScriptRef() != nil {
 			return common.InlineDatumsNotSupportedError{
 				PlutusVersion: "PlutusV1",
 			}
 		}
 	}
-
-	// Per CIP-33, also check reference scripts on regular (spent) inputs
-	for _, input := range tx.Inputs() {
-		utxo, err := ls.UtxoById(input)
-		if err != nil {
-			// Skip errors - BadInputsUtxo will catch this
-			continue
-		}
-		if utxo.Output == nil {
-			continue
-		}
-		script := utxo.Output.ScriptRef()
-		if script == nil {
-			continue
-		}
-		switch script.(type) {
-		case common.PlutusV1Script:
-			return common.InlineDatumsNotSupportedError{
-				PlutusVersion: "PlutusV1",
-			}
-		}
-	}
-
+	// Deliberately no restriction on the mere presence of reference inputs.
+	// Asserting one here failed the Conway conformance vector
+	// "UTXOS/can use reference scripts" (tx 3), which expects success for a
+	// transaction that requires a PlutusV1 script and carries reference
+	// inputs. The vector is authoritative; a reading of the V1 context
+	// translation that forbids reference inputs outright is not what the
+	// reference implementation does at this protocol version.
 	return nil
 }
 

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -240,14 +240,13 @@ func UtxoValidateCostModelsPresent(
 	return nil
 }
 
-// UtxoValidateInlineDatumsWithPlutusV1 rejects transactions that use inline datums with PlutusV1 scripts
-// Inline datums are a Babbage-era feature and are only supported with PlutusV2+
 // UtxoValidateInlineDatumsWithPlutusV1 rejects a transaction that requires a
-// PlutusV1 script while using a feature the PlutusV1 script context cannot
-// represent. PlutusV1 predates inline datums and reference scripts, so a
-// transaction that needs a V1 script and carries either is invalid.
+// PlutusV1 script while carrying an inline datum. Inline datums are a Babbage
+// feature the PlutusV1 script context cannot represent, so translating an output
+// that carries one into the V1 context fails.
 //
-// Two properties matter, and getting either wrong diverges from cardano-node:
+// Three properties matter, and getting any of them wrong diverges from
+// cardano-node:
 //
 //   - Only a *needed* script constrains the transaction. A V1 script that is
 //     merely reachable -- sitting in the witness set, or as a reference script
@@ -255,14 +254,32 @@ func UtxoValidateCostModelsPresent(
 //     make the transaction invalid. Rejecting on availability turns an ordinary
 //     transaction that happens to spend a UTxO carrying an unrelated V1
 //     reference script into a permanent validation failure.
-//   - The disqualifying feature is transaction-wide. An inline datum counts
-//     wherever the V1 context would have to represent it: on a consumed input,
-//     on a reference input, or on one of this transaction's own outputs.
+//   - The inline datum is disqualifying wherever the V1 context would have to
+//     represent it: on a consumed input, on a reference input, or on one of this
+//     transaction's own outputs. cardano-ledger's Conway PlutusV1 instance runs
+//     transTxOutV1 over all three -- inputs via transTxInInfoV1, reference
+//     inputs via the same function under mapM_, and outputs directly
+//     (eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs, instance
+//     EraPlutusTxInfo 'PlutusV1 ConwayEra).
+//   - A reference script is *not* disqualifying, anywhere. Conway's
+//     transTxOutV1 checks only the inline datum; unlike the Babbage-era
+//     transTxOutV1 it shadows, it has no ReferenceScriptsNotSupported branch.
+//     So neither a reference script on a consumed or reference input nor one on
+//     a produced output invalidates a V1-needing transaction.
 //
 // Datum presence is read through the TransactionOutput interface rather than a
 // concrete Babbage type assertion, so outputs wrapped by a later era are still
 // inspected. Datum-*hash* outputs are correctly not treated as inline, because
 // Datum() reports nil for them.
+//
+// Conway semantics are applied uniformly, including for the Babbage era that
+// also registers this rule and for Dijkstra, which delegates to it through
+// Conway. cardano-ledger's Babbage-era PlutusV1 instance is stricter than
+// Conway's on both counts above: its transTxOutV1 does carry a
+// ReferenceScriptsNotSupported branch, and it rejects a transaction that needs a
+// V1 script and carries any reference input at all. Splitting the rule per era
+// needs Babbage-era conformance vectors, which the suite does not contain, so
+// the divergence stays here rather than in untested era-specific code.
 func UtxoValidateInlineDatumsWithPlutusV1(
 	tx common.Transaction,
 	slot uint64,
@@ -287,6 +304,11 @@ func UtxoValidateInlineDatumsWithPlutusV1(
 	if !needsV1 {
 		return nil
 	}
+	// Datum() only, deliberately: ScriptRef() is not consulted on a resolved
+	// input, nor on a produced output below. The Conway conformance vector
+	// "UTXOS/can use regular inputs for reference" expects success for a
+	// transaction that needs a PlutusV1 script and spends a regular input
+	// carrying a reference script, so rejecting that shape fails the suite.
 	for _, utxo := range view.AllResolvedInputs() {
 		if utxo.Output != nil && utxo.Output.Datum() != nil {
 			return common.InlineDatumsNotSupportedError{
@@ -299,13 +321,6 @@ func UtxoValidateInlineDatumsWithPlutusV1(
 			continue
 		}
 		if output.Datum() != nil {
-			return common.InlineDatumsNotSupportedError{
-				PlutusVersion: "PlutusV1",
-			}
-		}
-		// A reference script on a produced output is equally unrepresentable in
-		// the V1 context.
-		if output.ScriptRef() != nil {
 			return common.InlineDatumsNotSupportedError{
 				PlutusVersion: "PlutusV1",
 			}

--- a/ledger/babbage/rules_plutusv1_internal_test.go
+++ b/ledger/babbage/rules_plutusv1_internal_test.go
@@ -323,9 +323,11 @@ func TestInlineDatumsPlutusV1_NeededScriptFromReferenceScriptRejected(
 		utxo(spend, inlineDatumOutput(scriptAddr(t, v1))),
 		utxo(ref, scriptRefOutput(keyAddr(t), v1)),
 	})
-	require.Error(
+	var want common.InlineDatumsNotSupportedError
+	require.ErrorAs(
 		t,
 		err,
+		&want,
 		"a needed PlutusV1 script supplied by a reference script must be detected",
 	)
 }

--- a/ledger/babbage/rules_plutusv1_internal_test.go
+++ b/ledger/babbage/rules_plutusv1_internal_test.go
@@ -1,0 +1,310 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package babbage
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/blinklabs-io/plutigo/data"
+)
+
+// UtxoValidateInlineDatumsWithPlutusV1 had no test coverage at all, which is
+// how it came to reject transactions cardano-node accepts. These pin both
+// directions: a PlutusV1 script that is merely reachable must not invalidate a
+// transaction, and one that is actually required must, wherever the
+// V1-incompatible feature sits.
+
+func testInput(b byte, idx uint32) shelley.ShelleyTransactionInput {
+	return shelley.NewShelleyTransactionInput(
+		hexRepeat(b),
+		int(idx), // #nosec G115 -- test index
+	)
+}
+
+func hexRepeat(b byte) string {
+	const hexDigits = "0123456789abcdef"
+	out := make([]byte, 64)
+	for i := range out {
+		out[i] = hexDigits[int(b)%16]
+	}
+	return string(out)
+}
+
+func inputSet(
+	inputs ...shelley.ShelleyTransactionInput,
+) shelley.ShelleyTransactionInputSet {
+	return shelley.NewShelleyTransactionInputSet(inputs)
+}
+
+func keyAddr(t *testing.T) common.Address {
+	t.Helper()
+	addr, err := common.NewAddressFromParts(
+		common.AddressTypeKeyNone,
+		common.AddressNetworkTestnet,
+		make([]byte, common.AddressHashSize),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("build key address: %v", err)
+	}
+	return addr
+}
+
+func scriptAddr(t *testing.T, s common.Script) common.Address {
+	t.Helper()
+	addr, err := common.NewAddressFromParts(
+		common.AddressTypeScriptNone,
+		common.AddressNetworkTestnet,
+		s.Hash().Bytes(),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("build script address: %v", err)
+	}
+	return addr
+}
+
+func plainOutput(addr common.Address) BabbageTransactionOutput {
+	return BabbageTransactionOutput{
+		OutputAddress: addr,
+		OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1_000_000},
+	}
+}
+
+func inlineDatumOutput(addr common.Address) BabbageTransactionOutput {
+	datum := common.Datum{Data: data.NewInteger(big.NewInt(42))}
+	out := plainOutput(addr)
+	out.DatumOption = &BabbageTransactionOutputDatumOption{data: &datum}
+	return out
+}
+
+func scriptRefOutput(
+	addr common.Address,
+	s common.Script,
+) BabbageTransactionOutput {
+	out := plainOutput(addr)
+	out.TxOutScriptRef = &common.ScriptRef{
+		Type:   common.ScriptRefTypePlutusV1,
+		Script: s,
+	}
+	return out
+}
+
+// utxo stores the output as a *pointer*, matching how
+// BabbageTransactionBody.Outputs() represents them (&b.TxOutputs[i]). Using a
+// value here would make the fixture diverge from real resolution and, worse,
+// would silently dodge upstream's *BabbageTransactionOutput type assertion, so
+// a comparison against upstream would measure the fixture rather than the rule.
+func utxo(
+	in shelley.ShelleyTransactionInput,
+	out BabbageTransactionOutput,
+) common.Utxo {
+	return common.Utxo{Id: in, Output: &out}
+}
+
+// utxoOnlyLedgerState implements just the UtxoById lookup this rule performs.
+// ouroboros-mock's builder cannot be used from an in-package test here: it
+// imports this package, so importing it back is an import cycle. The embedded
+// interface is nil on purpose -- any other method this rule started calling
+// would panic loudly rather than silently returning a zero value.
+type utxoOnlyLedgerState struct {
+	common.LedgerState
+	utxos map[string]common.Utxo
+}
+
+func (l utxoOnlyLedgerState) UtxoById(
+	id common.TransactionInput,
+) (common.Utxo, error) {
+	utxo, ok := l.utxos[id.String()]
+	if !ok {
+		return common.Utxo{}, errors.New("utxo not found")
+	}
+	return utxo, nil
+}
+
+func runRule(
+	t *testing.T,
+	tx common.Transaction,
+	utxos []common.Utxo,
+) error {
+	t.Helper()
+	byId := make(map[string]common.Utxo, len(utxos))
+	for _, u := range utxos {
+		byId[u.Id.String()] = u
+	}
+	return UtxoValidateInlineDatumsWithPlutusV1(
+		tx,
+		0,
+		utxoOnlyLedgerState{utxos: byId},
+		&BabbageProtocolParameters{},
+	)
+}
+
+// A PlutusV1 script reachable through a spent UTxO's reference script, with no
+// purpose requiring it, must not invalidate the transaction. Rejecting here is
+// the false positive that halted a node's sync on a real Preview transaction.
+func TestInlineDatumsPlutusV1_UnneededReferenceScriptAccepted(t *testing.T) {
+	v1 := common.PlutusV1Script([]byte{0x01, 0x02})
+	key := keyAddr(t)
+	inlineIn := testInput(0x1, 0)
+	refScriptIn := testInput(0x2, 0)
+
+	tx := &BabbageTransaction{
+		Body: BabbageTransactionBody{
+			TxInputs: inputSet(inlineIn, refScriptIn),
+		},
+	}
+	if err := runRule(t, tx, []common.Utxo{
+		utxo(inlineIn, inlineDatumOutput(key)),
+		utxo(refScriptIn, scriptRefOutput(key, v1)),
+	}); err != nil {
+		t.Fatalf("expected accept, got %v", err)
+	}
+}
+
+// The same script, now actually required to spend its own script-locked UTxO.
+func TestInlineDatumsPlutusV1_NeededSpendingScriptRejected(t *testing.T) {
+	v1 := common.PlutusV1Script([]byte{0x03, 0x04})
+	in := testInput(0x3, 0)
+
+	tx := &BabbageTransaction{
+		Body: BabbageTransactionBody{TxInputs: inputSet(in)},
+		WitnessSet: BabbageTransactionWitnessSet{
+			WsPlutusV1Scripts: []common.PlutusV1Script{v1},
+		},
+	}
+	err := runRule(t, tx, []common.Utxo{
+		utxo(in, inlineDatumOutput(scriptAddr(t, v1))),
+	})
+	var want common.InlineDatumsNotSupportedError
+	if !errors.As(err, &want) {
+		t.Fatalf("expected InlineDatumsNotSupportedError, got %v", err)
+	}
+}
+
+// The inline datum sits on a produced output rather than a spent one.
+func TestInlineDatumsPlutusV1_DatumOnProducedOutputRejected(t *testing.T) {
+	v1 := common.PlutusV1Script([]byte{0x05, 0x06})
+	in := testInput(0x4, 0)
+
+	tx := &BabbageTransaction{
+		Body: BabbageTransactionBody{
+			TxInputs:  inputSet(in),
+			TxOutputs: []BabbageTransactionOutput{inlineDatumOutput(keyAddr(t))},
+		},
+		WitnessSet: BabbageTransactionWitnessSet{
+			WsPlutusV1Scripts: []common.PlutusV1Script{v1},
+		},
+	}
+	err := runRule(t, tx, []common.Utxo{
+		utxo(in, plainOutput(scriptAddr(t, v1))),
+	})
+	var want common.InlineDatumsNotSupportedError
+	if !errors.As(err, &want) {
+		t.Fatalf("expected InlineDatumsNotSupportedError, got %v", err)
+	}
+}
+
+// A reference script on a produced output is equally unrepresentable in V1.
+func TestInlineDatumsPlutusV1_ScriptRefOnProducedOutputRejected(t *testing.T) {
+	v1 := common.PlutusV1Script([]byte{0x07, 0x08})
+	in := testInput(0x5, 0)
+
+	tx := &BabbageTransaction{
+		Body: BabbageTransactionBody{
+			TxInputs: inputSet(in),
+			TxOutputs: []BabbageTransactionOutput{
+				scriptRefOutput(keyAddr(t), v1),
+			},
+		},
+		WitnessSet: BabbageTransactionWitnessSet{
+			WsPlutusV1Scripts: []common.PlutusV1Script{v1},
+		},
+	}
+	err := runRule(t, tx, []common.Utxo{
+		utxo(in, plainOutput(scriptAddr(t, v1))),
+	})
+	var want common.InlineDatumsNotSupportedError
+	if !errors.As(err, &want) {
+		t.Fatalf("expected InlineDatumsNotSupportedError, got %v", err)
+	}
+}
+
+// The mere presence of a reference input must NOT disqualify a transaction that
+// requires a PlutusV1 script. The Conway conformance vector
+// "UTXOS/can use reference scripts" (tx 3) expects exactly this to succeed, and
+// an earlier revision of this rule failed it by rejecting on reference-input
+// presence.
+func TestInlineDatumsPlutusV1_ReferenceInputPresentAccepted(t *testing.T) {
+	v1 := common.PlutusV1Script([]byte{0x09, 0x0a})
+	in := testInput(0x6, 0)
+	ref := testInput(0x7, 0)
+
+	tx := &BabbageTransaction{
+		Body: BabbageTransactionBody{
+			TxInputs: inputSet(in),
+			TxReferenceInputs: cbor.NewSetType(
+				[]shelley.ShelleyTransactionInput{ref},
+				false,
+			),
+		},
+		WitnessSet: BabbageTransactionWitnessSet{
+			WsPlutusV1Scripts: []common.PlutusV1Script{v1},
+		},
+	}
+	if err := runRule(t, tx, []common.Utxo{
+		utxo(in, plainOutput(scriptAddr(t, v1))),
+		utxo(ref, plainOutput(keyAddr(t))),
+	}); err != nil {
+		t.Fatalf("expected accept with a reference input present, got %v", err)
+	}
+}
+
+// A datum *hash* output is not an inline datum and must be accepted.
+func TestInlineDatumsPlutusV1_DatumHashOutputAccepted(t *testing.T) {
+	v1 := common.PlutusV1Script([]byte{0x0b, 0x0c})
+	in := testInput(0x8, 0)
+	hash := common.Blake2b256{}
+	out := plainOutput(scriptAddr(t, v1))
+	out.DatumOption = &BabbageTransactionOutputDatumOption{hash: &hash}
+
+	tx := &BabbageTransaction{
+		Body: BabbageTransactionBody{TxInputs: inputSet(in)},
+		WitnessSet: BabbageTransactionWitnessSet{
+			WsPlutusV1Scripts: []common.PlutusV1Script{v1},
+		},
+	}
+	if err := runRule(t, tx, []common.Utxo{utxo(in, out)}); err != nil {
+		t.Fatalf("expected accept for datum-hash output, got %v", err)
+	}
+}
+
+// An unresolvable input is UtxoValidateBadInputsUtxo's finding, not this rule's.
+func TestInlineDatumsPlutusV1_UnresolvableInputSkipped(t *testing.T) {
+	in := testInput(0x9, 0)
+	tx := &BabbageTransaction{
+		Body: BabbageTransactionBody{TxInputs: inputSet(in)},
+	}
+	if err := runRule(t, tx, nil); err != nil {
+		t.Fatalf("expected nil for unresolvable input, got %v", err)
+	}
+}

--- a/ledger/babbage/rules_plutusv1_internal_test.go
+++ b/ledger/babbage/rules_plutusv1_internal_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/blinklabs-io/plutigo/data"
+	"github.com/stretchr/testify/require"
 )
 
 // UtxoValidateInlineDatumsWithPlutusV1 had no test coverage at all, which is
@@ -63,9 +64,7 @@ func keyAddr(t *testing.T) common.Address {
 		make([]byte, common.AddressHashSize),
 		nil,
 	)
-	if err != nil {
-		t.Fatalf("build key address: %v", err)
-	}
+	require.NoError(t, err, "build key address")
 	return addr
 }
 
@@ -77,9 +76,7 @@ func scriptAddr(t *testing.T, s common.Script) common.Address {
 		s.Hash().Bytes(),
 		nil,
 	)
-	if err != nil {
-		t.Fatalf("build script address: %v", err)
-	}
+	require.NoError(t, err, "build script address")
 	return addr
 }
 
@@ -173,12 +170,10 @@ func TestInlineDatumsPlutusV1_UnneededReferenceScriptAccepted(t *testing.T) {
 			TxInputs: inputSet(inlineIn, refScriptIn),
 		},
 	}
-	if err := runRule(t, tx, []common.Utxo{
+	require.NoError(t, runRule(t, tx, []common.Utxo{
 		utxo(inlineIn, inlineDatumOutput(key)),
 		utxo(refScriptIn, scriptRefOutput(key, v1)),
-	}); err != nil {
-		t.Fatalf("expected accept, got %v", err)
-	}
+	}), "expected accept")
 }
 
 // The same script, now actually required to spend its own script-locked UTxO.
@@ -196,9 +191,7 @@ func TestInlineDatumsPlutusV1_NeededSpendingScriptRejected(t *testing.T) {
 		utxo(in, inlineDatumOutput(scriptAddr(t, v1))),
 	})
 	var want common.InlineDatumsNotSupportedError
-	if !errors.As(err, &want) {
-		t.Fatalf("expected InlineDatumsNotSupportedError, got %v", err)
-	}
+	require.ErrorAs(t, err, &want)
 }
 
 // The inline datum sits on a produced output rather than a spent one.
@@ -219,9 +212,7 @@ func TestInlineDatumsPlutusV1_DatumOnProducedOutputRejected(t *testing.T) {
 		utxo(in, plainOutput(scriptAddr(t, v1))),
 	})
 	var want common.InlineDatumsNotSupportedError
-	if !errors.As(err, &want) {
-		t.Fatalf("expected InlineDatumsNotSupportedError, got %v", err)
-	}
+	require.ErrorAs(t, err, &want)
 }
 
 // A reference script on a produced output is equally unrepresentable in V1.
@@ -244,9 +235,7 @@ func TestInlineDatumsPlutusV1_ScriptRefOnProducedOutputRejected(t *testing.T) {
 		utxo(in, plainOutput(scriptAddr(t, v1))),
 	})
 	var want common.InlineDatumsNotSupportedError
-	if !errors.As(err, &want) {
-		t.Fatalf("expected InlineDatumsNotSupportedError, got %v", err)
-	}
+	require.ErrorAs(t, err, &want)
 }
 
 // The mere presence of a reference input must NOT disqualify a transaction that
@@ -271,12 +260,10 @@ func TestInlineDatumsPlutusV1_ReferenceInputPresentAccepted(t *testing.T) {
 			WsPlutusV1Scripts: []common.PlutusV1Script{v1},
 		},
 	}
-	if err := runRule(t, tx, []common.Utxo{
+	require.NoError(t, runRule(t, tx, []common.Utxo{
 		utxo(in, plainOutput(scriptAddr(t, v1))),
 		utxo(ref, plainOutput(keyAddr(t))),
-	}); err != nil {
-		t.Fatalf("expected accept with a reference input present, got %v", err)
-	}
+	}), "expected accept with a reference input present")
 }
 
 // A datum *hash* output is not an inline datum and must be accepted.
@@ -293,9 +280,7 @@ func TestInlineDatumsPlutusV1_DatumHashOutputAccepted(t *testing.T) {
 			WsPlutusV1Scripts: []common.PlutusV1Script{v1},
 		},
 	}
-	if err := runRule(t, tx, []common.Utxo{utxo(in, out)}); err != nil {
-		t.Fatalf("expected accept for datum-hash output, got %v", err)
-	}
+	require.NoError(t, runRule(t, tx, []common.Utxo{utxo(in, out)}), "expected accept for datum-hash output")
 }
 
 // An unresolvable input is UtxoValidateBadInputsUtxo's finding, not this rule's.
@@ -304,7 +289,43 @@ func TestInlineDatumsPlutusV1_UnresolvableInputSkipped(t *testing.T) {
 	tx := &BabbageTransaction{
 		Body: BabbageTransactionBody{TxInputs: inputSet(in)},
 	}
-	if err := runRule(t, tx, nil); err != nil {
-		t.Fatalf("expected nil for unresolvable input, got %v", err)
+	require.NoError(
+		t,
+		runRule(t, tx, nil),
+		"an unresolvable input is BadInputsUtxo's finding, not this rule's",
+	)
+}
+
+// TestInlineDatumsPlutusV1_NeededScriptFromReferenceScriptRejected settles
+// whether a needed PlutusV1 script supplied only by a reference script -- never
+// present in the witness set -- is detected. availableScripts collects script
+// refs from every resolved input, so it is.
+func TestInlineDatumsPlutusV1_NeededScriptFromReferenceScriptRejected(
+	t *testing.T,
+) {
+	v1 := common.PlutusV1Script([]byte{0x0d, 0x0e})
+	spend := testInput(0xa, 0)
+	ref := testInput(0xb, 0)
+
+	tx := &BabbageTransaction{
+		Body: BabbageTransactionBody{
+			TxInputs: inputSet(spend),
+			TxReferenceInputs: cbor.NewSetType(
+				[]shelley.ShelleyTransactionInput{ref},
+				false,
+			),
+		},
+		// Deliberately no witness scripts: the only copy of the V1 script is
+		// the reference script on the reference input below.
 	}
+	err := runRule(t, tx, []common.Utxo{
+		// Spending a UTxO locked by the V1 script, carrying an inline datum.
+		utxo(spend, inlineDatumOutput(scriptAddr(t, v1))),
+		utxo(ref, scriptRefOutput(keyAddr(t), v1)),
+	})
+	require.Error(
+		t,
+		err,
+		"a needed PlutusV1 script supplied by a reference script must be detected",
+	)
 }

--- a/ledger/babbage/rules_plutusv1_internal_test.go
+++ b/ledger/babbage/rules_plutusv1_internal_test.go
@@ -100,10 +100,28 @@ func scriptRefOutput(
 ) BabbageTransactionOutput {
 	out := plainOutput(addr)
 	out.TxOutScriptRef = &common.ScriptRef{
-		Type:   common.ScriptRefTypePlutusV1,
+		Type:   scriptRefType(s),
 		Script: s,
 	}
 	return out
+}
+
+// scriptRefType tags the ref with the version of the script it carries. The
+// rule reads ScriptRef().Script and never the tag, but a fixture whose tag
+// contradicts its script would mislead the next reader.
+func scriptRefType(s common.Script) uint {
+	switch s.(type) {
+	case common.PlutusV1Script:
+		return common.ScriptRefTypePlutusV1
+	case common.PlutusV2Script:
+		return common.ScriptRefTypePlutusV2
+	case common.PlutusV3Script:
+		return common.ScriptRefTypePlutusV3
+	case common.PlutusV4Script:
+		return common.ScriptRefTypePlutusV4
+	default:
+		return common.ScriptRefTypeNativeScript
+	}
 }
 
 // utxo stores the output as a *pointer*, matching how
@@ -215,8 +233,13 @@ func TestInlineDatumsPlutusV1_DatumOnProducedOutputRejected(t *testing.T) {
 	require.ErrorAs(t, err, &want)
 }
 
-// A reference script on a produced output is equally unrepresentable in V1.
-func TestInlineDatumsPlutusV1_ScriptRefOnProducedOutputRejected(t *testing.T) {
+// A reference script on a produced output must NOT disqualify a transaction that
+// needs a PlutusV1 script. Conway's transTxOutV1 checks only the inline datum;
+// unlike the Babbage-era transTxOutV1 it shadows, it carries no
+// ReferenceScriptsNotSupported branch
+// (eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs). No conformance vector
+// exercises this shape, so only this test holds the line.
+func TestInlineDatumsPlutusV1_ScriptRefOnProducedOutputAccepted(t *testing.T) {
 	v1 := common.PlutusV1Script([]byte{0x07, 0x08})
 	in := testInput(0x5, 0)
 
@@ -231,11 +254,90 @@ func TestInlineDatumsPlutusV1_ScriptRefOnProducedOutputRejected(t *testing.T) {
 			WsPlutusV1Scripts: []common.PlutusV1Script{v1},
 		},
 	}
-	err := runRule(t, tx, []common.Utxo{
+	require.NoError(t, runRule(t, tx, []common.Utxo{
 		utxo(in, plainOutput(scriptAddr(t, v1))),
+	}), "a reference script on a produced output is not a V1 violation")
+}
+
+// The same asymmetry on the input side: a needed PlutusV1 script spending a
+// regular input that carries a reference script must be accepted. This is the
+// shape of the Conway conformance vector
+// "UTXOS/can use regular inputs for reference", which fails outright if the rule
+// rejects a reference script on a consumed input.
+func TestInlineDatumsPlutusV1_ScriptRefOnConsumedInputAccepted(t *testing.T) {
+	v1 := common.PlutusV1Script([]byte{0x11, 0x12})
+	spend := testInput(0xc, 0)
+	refCarrier := testInput(0xd, 0)
+
+	tx := &BabbageTransaction{
+		Body: BabbageTransactionBody{
+			TxInputs: inputSet(spend, refCarrier),
+		},
+		WitnessSet: BabbageTransactionWitnessSet{
+			WsPlutusV1Scripts: []common.PlutusV1Script{v1},
+		},
+	}
+	require.NoError(t, runRule(t, tx, []common.Utxo{
+		utxo(spend, plainOutput(scriptAddr(t, v1))),
+		utxo(refCarrier, scriptRefOutput(keyAddr(t), v1)),
+	}), "a reference script on a consumed input is not a V1 violation")
+}
+
+// An inline datum on a *reference* input is disqualifying, because Conway's V1
+// instance translates reference inputs through the same transTxOutV1 as
+// consumed inputs (under mapM_) and discards only the result, not the failure.
+// The pre-PR implementation missed this: it scanned reference inputs for V1
+// script refs and never for datums.
+func TestInlineDatumsPlutusV1_DatumOnReferenceInputRejected(t *testing.T) {
+	v1 := common.PlutusV1Script([]byte{0x13, 0x14})
+	spend := testInput(0xe, 0)
+	ref := testInput(0xf, 0)
+
+	tx := &BabbageTransaction{
+		Body: BabbageTransactionBody{
+			TxInputs: inputSet(spend),
+			TxReferenceInputs: cbor.NewSetType(
+				[]shelley.ShelleyTransactionInput{ref},
+				false,
+			),
+		},
+		WitnessSet: BabbageTransactionWitnessSet{
+			WsPlutusV1Scripts: []common.PlutusV1Script{v1},
+		},
+	}
+	err := runRule(t, tx, []common.Utxo{
+		utxo(spend, plainOutput(scriptAddr(t, v1))),
+		utxo(ref, inlineDatumOutput(keyAddr(t))),
 	})
 	var want common.InlineDatumsNotSupportedError
-	require.ErrorAs(t, err, &want)
+	require.ErrorAs(
+		t,
+		err,
+		&want,
+		"an inline datum on a reference input must be rejected",
+	)
+}
+
+// The restriction is keyed on the Plutus *version* of the needed script, not on
+// needing a script at all: a needed PlutusV2 script spending an inline-datum
+// output is exactly what inline datums were introduced for. This pins the
+// NeedsAny version filter against a future widening to all Plutus versions.
+func TestInlineDatumsPlutusV2_NeededSpendingScriptAccepted(t *testing.T) {
+	v2 := common.PlutusV2Script([]byte{0x15, 0x16})
+	in := testInput(0x10, 0)
+
+	tx := &BabbageTransaction{
+		Body: BabbageTransactionBody{
+			TxInputs:  inputSet(in),
+			TxOutputs: []BabbageTransactionOutput{inlineDatumOutput(keyAddr(t))},
+		},
+		WitnessSet: BabbageTransactionWitnessSet{
+			WsPlutusV2Scripts: []common.PlutusV2Script{v2},
+		},
+	}
+	require.NoError(t, runRule(t, tx, []common.Utxo{
+		utxo(in, inlineDatumOutput(scriptAddr(t, v2))),
+	}), "inline datums are supported for PlutusV2")
 }
 
 // The mere presence of a reference input must NOT disqualify a transaction that

--- a/ledger/common/script/needed.go
+++ b/ledger/common/script/needed.go
@@ -37,17 +37,31 @@ type TxScriptView struct {
 	ResolvedReferenceInputs []lcommon.Utxo
 	Available               map[lcommon.ScriptHash]lcommon.Script
 	Needed                  map[lcommon.ScriptHash]lcommon.Script
+
+	// allResolvedInputs caches the concatenation NewTxScriptView already had to
+	// build, so repeated AllResolvedInputs calls on the hot path do not each
+	// allocate a fresh len(inputs)+len(referenceInputs) slice. A view assembled
+	// field-by-field rather than through NewTxScriptView leaves this nil, and
+	// AllResolvedInputs falls back to building the slice on demand.
+	allResolvedInputs []lcommon.Utxo
 }
 
 // AllResolvedInputs returns the consumed and reference inputs together.
 func (v TxScriptView) AllResolvedInputs() []lcommon.Utxo {
+	if v.allResolvedInputs != nil {
+		return v.allResolvedInputs
+	}
+	return concatResolvedInputs(v.ResolvedInputs, v.ResolvedReferenceInputs)
+}
+
+func concatResolvedInputs(inputs, refInputs []lcommon.Utxo) []lcommon.Utxo {
 	out := make(
 		[]lcommon.Utxo,
 		0,
-		len(v.ResolvedInputs)+len(v.ResolvedReferenceInputs),
+		len(inputs)+len(refInputs),
 	)
-	out = append(out, v.ResolvedInputs...)
-	out = append(out, v.ResolvedReferenceInputs...)
+	out = append(out, inputs...)
+	out = append(out, refInputs...)
 	return out
 }
 
@@ -103,7 +117,11 @@ func NewTxScriptView(
 			utxo,
 		)
 	}
-	view.Available = availableScripts(tx, view.AllResolvedInputs())
+	view.allResolvedInputs = concatResolvedInputs(
+		view.ResolvedInputs,
+		view.ResolvedReferenceInputs,
+	)
+	view.Available = availableScripts(tx, view.allResolvedInputs)
 	view.Needed = neededScripts(tx, view)
 	return view, nil
 }
@@ -165,16 +183,26 @@ func voterUsesScriptCredential(voter lcommon.Voter) bool {
 // neededScripts walks every script purpose the transaction requires and keeps
 // the available script each one resolves to.
 //
-// The walk order matches the canonical redeemer order per tag, so a caller that
-// also cares about redeemer indices sees the same sequence: spending inputs
-// (sorted), minting policies (sorted), certificates, withdrawals (sorted),
-// voters (sorted), proposal procedures. Eras without voting or proposing simply
-// produce none of those.
+// The result is a map, so the walk order is not observable and no order is
+// promised. Concretely: spending inputs and minting policies are walked in
+// canonical order, but withdrawals and voting procedures come from Go maps and
+// so are walked in randomized order. A future caller that wants redeemer
+// indices must impose an order on those two itself; Transaction.Withdrawals and
+// Transaction.VotingProcedures are both keyed by pointer, so that means
+// deriving a canonical key rather than sorting the keys in place.
 func neededScripts(
 	tx lcommon.Transaction,
 	view TxScriptView,
 ) map[lcommon.ScriptHash]lcommon.Script {
 	out := make(map[lcommon.ScriptHash]lcommon.Script)
+	if len(view.Available) == 0 {
+		// keep only ever admits a hash present in Available, so with nothing
+		// available the walk cannot produce anything. Skipping it keeps a
+		// script-free transaction -- the overwhelming majority during a sync --
+		// off the input sort, the by-id map build, and one script-hash
+		// computation per purpose.
+		return out
+	}
 	byId := make(map[string]lcommon.Utxo, len(view.ResolvedInputs))
 	for _, utxo := range view.ResolvedInputs {
 		if utxo.Id != nil {

--- a/ledger/common/script/needed.go
+++ b/ledger/common/script/needed.go
@@ -128,6 +128,9 @@ func availableScripts(
 		for _, s := range witnesses.PlutusV3Scripts() {
 			out[s.Hash()] = s
 		}
+		for _, s := range lcommon.PlutusV4ScriptsFromWitnessSet(witnesses) {
+			out[s.Hash()] = s
+		}
 	}
 	for _, utxo := range resolved {
 		if utxo.Output == nil {
@@ -138,6 +141,25 @@ func availableScripts(
 		}
 	}
 	return out
+}
+
+// voterUsesScriptCredential reports whether a voter votes under a script
+// credential rather than a key hash.
+//
+// ScriptPurposeVoting.ScriptHash returns Blake2b224(Voter.Hash) unconditionally,
+// with no check on the voter type, so a key-hash voter yields its key hash typed
+// as a script hash. Filtering here keeps a key hash from being looked up as a
+// script and, on a collision, entered as a script this transaction requires.
+// ScriptPurposeCertifying already performs the equivalent check internally, so
+// certificates need no filter.
+func voterUsesScriptCredential(voter lcommon.Voter) bool {
+	switch voter.Type {
+	case lcommon.VoterTypeConstitutionalCommitteeHotScriptHash,
+		lcommon.VoterTypeDRepScriptHash:
+		return true
+	default:
+		return false
+	}
 }
 
 // neededScripts walks every script purpose the transaction requires and keeps
@@ -209,7 +231,7 @@ func neededScripts(
 		})
 	}
 	for voter := range tx.VotingProcedures() {
-		if voter == nil {
+		if voter == nil || !voterUsesScriptCredential(*voter) {
 			continue
 		}
 		keep(ScriptPurposeVoting{Voter: *voter})

--- a/ledger/common/script/needed.go
+++ b/ledger/common/script/needed.go
@@ -1,0 +1,224 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package script
+
+import (
+	"bytes"
+	"slices"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// TxScriptView is a transaction's script picture, resolved once.
+//
+// Available holds every script the transaction makes reachable: witness-set
+// scripts plus scripts carried as a reference script on any resolved input,
+// consumed or reference. Needed holds the subset that some script purpose of
+// this transaction actually requires.
+//
+// The distinction matters for the Plutus language restrictions. A script that
+// is merely reachable does not constrain the transaction; only a script that
+// must run does. Checking availability instead rejects an ordinary transaction
+// that happens to spend a UTxO carrying an unrelated reference script.
+type TxScriptView struct {
+	ResolvedInputs          []lcommon.Utxo
+	ResolvedReferenceInputs []lcommon.Utxo
+	Available               map[lcommon.ScriptHash]lcommon.Script
+	Needed                  map[lcommon.ScriptHash]lcommon.Script
+}
+
+// AllResolvedInputs returns the consumed and reference inputs together.
+func (v TxScriptView) AllResolvedInputs() []lcommon.Utxo {
+	out := make(
+		[]lcommon.Utxo,
+		0,
+		len(v.ResolvedInputs)+len(v.ResolvedReferenceInputs),
+	)
+	out = append(out, v.ResolvedInputs...)
+	out = append(out, v.ResolvedReferenceInputs...)
+	return out
+}
+
+// NeedsAny reports whether any needed script satisfies match.
+func (v TxScriptView) NeedsAny(match func(lcommon.Script) bool) bool {
+	for _, s := range v.Needed {
+		if match(s) {
+			return true
+		}
+	}
+	return false
+}
+
+// NewTxScriptView resolves the transaction's inputs and reference inputs once,
+// collects the scripts they and the witness set make available, and determines
+// which of those some script purpose requires.
+//
+// Input resolution failures are returned as InputResolutionError or
+// ReferenceInputResolutionError. Callers enforcing a language restriction
+// generally want to skip those rather than report them, because
+// UtxoValidateBadInputsUtxo reports an unresolvable input with the right error.
+func NewTxScriptView(
+	tx lcommon.Transaction,
+	ls lcommon.LedgerState,
+) (TxScriptView, error) {
+	var view TxScriptView
+	if tx == nil || ls == nil {
+		return view, nil
+	}
+	view.ResolvedInputs = make([]lcommon.Utxo, 0, len(tx.Inputs()))
+	for _, input := range tx.Inputs() {
+		utxo, err := ls.UtxoById(input)
+		if err != nil {
+			return view, lcommon.InputResolutionError{Input: input, Err: err}
+		}
+		view.ResolvedInputs = append(view.ResolvedInputs, utxo)
+	}
+	view.ResolvedReferenceInputs = make(
+		[]lcommon.Utxo,
+		0,
+		len(tx.ReferenceInputs()),
+	)
+	for _, input := range tx.ReferenceInputs() {
+		utxo, err := ls.UtxoById(input)
+		if err != nil {
+			return view, lcommon.ReferenceInputResolutionError{
+				Input: input,
+				Err:   err,
+			}
+		}
+		view.ResolvedReferenceInputs = append(
+			view.ResolvedReferenceInputs,
+			utxo,
+		)
+	}
+	view.Available = availableScripts(tx, view.AllResolvedInputs())
+	view.Needed = neededScripts(tx, view)
+	return view, nil
+}
+
+// availableScripts collects witness-set scripts and reference scripts from the
+// given resolved inputs, keyed by hash.
+func availableScripts(
+	tx lcommon.Transaction,
+	resolved []lcommon.Utxo,
+) map[lcommon.ScriptHash]lcommon.Script {
+	out := make(map[lcommon.ScriptHash]lcommon.Script)
+	if witnesses := tx.Witnesses(); witnesses != nil {
+		for _, s := range witnesses.NativeScripts() {
+			out[s.Hash()] = s
+		}
+		for _, s := range witnesses.PlutusV1Scripts() {
+			out[s.Hash()] = s
+		}
+		for _, s := range witnesses.PlutusV2Scripts() {
+			out[s.Hash()] = s
+		}
+		for _, s := range witnesses.PlutusV3Scripts() {
+			out[s.Hash()] = s
+		}
+	}
+	for _, utxo := range resolved {
+		if utxo.Output == nil {
+			continue
+		}
+		if s := utxo.Output.ScriptRef(); s != nil {
+			out[s.Hash()] = s
+		}
+	}
+	return out
+}
+
+// neededScripts walks every script purpose the transaction requires and keeps
+// the available script each one resolves to.
+//
+// The walk order matches the canonical redeemer order per tag, so a caller that
+// also cares about redeemer indices sees the same sequence: spending inputs
+// (sorted), minting policies (sorted), certificates, withdrawals (sorted),
+// voters (sorted), proposal procedures. Eras without voting or proposing simply
+// produce none of those.
+func neededScripts(
+	tx lcommon.Transaction,
+	view TxScriptView,
+) map[lcommon.ScriptHash]lcommon.Script {
+	out := make(map[lcommon.ScriptHash]lcommon.Script)
+	byId := make(map[string]lcommon.Utxo, len(view.ResolvedInputs))
+	for _, utxo := range view.ResolvedInputs {
+		if utxo.Id != nil {
+			byId[utxo.Id.String()] = utxo
+		}
+	}
+	keep := func(purpose ScriptPurpose) {
+		if purpose == nil {
+			return
+		}
+		hash := purpose.ScriptHash()
+		if hash == (lcommon.ScriptHash{}) {
+			return
+		}
+		if s, ok := view.Available[hash]; ok {
+			out[hash] = s
+		}
+	}
+	for _, input := range SortInputs(tx.Inputs()) {
+		utxo, ok := byId[input.String()]
+		if !ok || utxo.Output == nil {
+			continue
+		}
+		addr := utxo.Output.Address()
+		if addr.Type()&lcommon.AddressTypeScriptBit == 0 {
+			continue
+		}
+		keep(ScriptPurposeSpending{Input: utxo})
+	}
+	if mint := tx.AssetMint(); mint != nil {
+		policies := mint.Policies()
+		slices.SortFunc(policies, func(a, b lcommon.Blake2b224) int {
+			return bytes.Compare(a.Bytes(), b.Bytes())
+		})
+		for _, policy := range policies {
+			keep(ScriptPurposeMinting{PolicyId: policy})
+		}
+	}
+	for idx, cert := range tx.Certificates() {
+		keep(ScriptPurposeCertifying{
+			Index:       uint32(idx), // #nosec G115 -- certificate count is bounded
+			Certificate: cert,
+		})
+	}
+	for addr := range tx.Withdrawals() {
+		if addr == nil || addr.Type()&lcommon.AddressTypeScriptBit == 0 {
+			continue
+		}
+		keep(ScriptPurposeRewarding{
+			StakeCredential: lcommon.Credential{
+				CredType:   lcommon.CredentialTypeScriptHash,
+				Credential: addr.StakeKeyHash(),
+			},
+		})
+	}
+	for voter := range tx.VotingProcedures() {
+		if voter == nil {
+			continue
+		}
+		keep(ScriptPurposeVoting{Voter: *voter})
+	}
+	for idx, proposal := range tx.ProposalProcedures() {
+		keep(ScriptPurposeProposing{
+			Index:             uint32(idx), // #nosec G115 -- proposal count is bounded
+			ProposalProcedure: proposal,
+		})
+	}
+	return out
+}

--- a/ledger/common/script/needed_test.go
+++ b/ledger/common/script/needed_test.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package script_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/common/script"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/stretchr/testify/require"
+)
+
+// noUtxoLedgerState satisfies the LedgerState argument for a transaction with no
+// inputs. Every method is nil on purpose, so a call this test did not intend
+// panics rather than returning a zero value.
+type noUtxoLedgerState struct {
+	common.LedgerState
+}
+
+// ScriptPurposeVoting.ScriptHash returns Blake2b224(Voter.Hash) with no check on
+// Voter.Type, so a key-hash voter yields its key hash typed as a script hash.
+// These cases give the voter the same 28 bytes as an available PlutusV1 script,
+// which is the shape that turns the missing type check into a false entry in
+// Needed.
+func TestNewTxScriptViewVotingProcedureVoterTypes(t *testing.T) {
+	v1 := common.PlutusV1Script([]byte{0x01, 0x02})
+	scriptHash := v1.Hash()
+	var voterHash [28]byte
+	copy(voterHash[:], scriptHash.Bytes())
+
+	for _, tc := range []struct {
+		name       string
+		voterType  uint8
+		wantNeeded bool
+	}{
+		{"drep script hash", common.VoterTypeDRepScriptHash, true},
+		{
+			"committee hot script hash",
+			common.VoterTypeConstitutionalCommitteeHotScriptHash,
+			true,
+		},
+		{"drep key hash", common.VoterTypeDRepKeyHash, false},
+		{
+			"committee hot key hash",
+			common.VoterTypeConstitutionalCommitteeHotKeyHash,
+			false,
+		},
+		{
+			"staking pool key hash",
+			common.VoterTypeStakingPoolKeyHash,
+			false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			voter := common.Voter{Type: tc.voterType, Hash: voterHash}
+			tx := &conway.ConwayTransaction{
+				Body: conway.ConwayTransactionBody{
+					TxVotingProcedures: common.VotingProcedures{}.AddOrReplace(
+						voter,
+						common.GovActionId{},
+						common.VotingProcedure{},
+					),
+				},
+				WitnessSet: conway.ConwayTransactionWitnessSet{
+					WsPlutusV1Scripts: cbor.NewSetType(
+						[]common.PlutusV1Script{v1},
+						false,
+					),
+				},
+			}
+			view, err := script.NewTxScriptView(tx, noUtxoLedgerState{})
+			require.NoError(t, err)
+			require.Contains(
+				t,
+				view.Available,
+				scriptHash,
+				"the witness script is reachable regardless of voter type",
+			)
+			if tc.wantNeeded {
+				require.Contains(
+					t,
+					view.Needed,
+					scriptHash,
+					"a script voter requires the script it names",
+				)
+				return
+			}
+			require.NotContains(
+				t,
+				view.Needed,
+				scriptHash,
+				"a key-hash voter must not enter a key hash as a needed script",
+			)
+		})
+	}
+}
+
+// A view assembled field-by-field rather than through NewTxScriptView has no
+// cached concatenation, so AllResolvedInputs must still build one.
+func TestTxScriptViewAllResolvedInputsWithoutCache(t *testing.T) {
+	consumed := common.Utxo{}
+	reference := common.Utxo{}
+	view := script.TxScriptView{
+		ResolvedInputs:          []common.Utxo{consumed},
+		ResolvedReferenceInputs: []common.Utxo{reference},
+	}
+	require.Len(t, view.AllResolvedInputs(), 2)
+	require.Empty(t, script.TxScriptView{}.AllResolvedInputs())
+}

--- a/ledger/common/script/purpose.go
+++ b/ledger/common/script/purpose.go
@@ -396,7 +396,7 @@ func scriptPurposeBuilder(
 				return nil, UnmatchedRedeemerError{RedeemerKey: redeemerKey}
 			}
 			return ScriptPurposeVoting{
-				Voter: *(votes[redeemerKey.Index].Key),
+				Voter: *votes[redeemerKey.Index].Key,
 			}, nil
 		case lcommon.RedeemerTagProposing:
 			if int(redeemerKey.Index) >= len(proposalProcedures) {

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -276,7 +276,7 @@ func (r *ConwayRedeemers) UnmarshalCBOR(cborData []byte) error {
 		// Modern map form — clear any stale legacy state
 		r.legacy = false
 		r.legacyRedeemers = alonzo.AlonzoRedeemers{}
-		if _, err := cbor.Decode(cborData, &(r.Redeemers)); err != nil {
+		if _, err := cbor.Decode(cborData, &r.Redeemers); err != nil {
 			if !cbor.IsDuplicateMapKeyError(err) {
 				return err
 			}
@@ -290,7 +290,7 @@ func (r *ConwayRedeemers) UnmarshalCBOR(cborData []byte) error {
 			// the stored raw CBOR (SetCbor above), so lenient struct decoding
 			// never changes them.
 			r.Redeemers = nil
-			if _, err := cbor.DecodeLenient(cborData, &(r.Redeemers)); err != nil {
+			if _, err := cbor.DecodeLenient(cborData, &r.Redeemers); err != nil {
 				return err
 			}
 		}
@@ -298,7 +298,7 @@ func (r *ConwayRedeemers) UnmarshalCBOR(cborData []byte) error {
 	}
 	// Legacy array form — clear any stale map state
 	r.Redeemers = nil
-	_, err := cbor.Decode(cborData, &(r.legacyRedeemers))
+	_, err := cbor.Decode(cborData, &r.legacyRedeemers)
 	if err != nil {
 		return err
 	}

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -724,7 +724,7 @@ func (v *MaryTransactionOutputValue) UnmarshalCBOR(data []byte) error {
 		return errors.New("empty Mary transaction output value")
 	}
 	if (data[0] & cbor.CborTypeMask) != cbor.CborTypeArray {
-		if _, err := cbor.Decode(data, &(v.Amount)); err != nil {
+		if _, err := cbor.Decode(data, &v.Amount); err != nil {
 			return err
 		}
 		v.Assets = nil


### PR DESCRIPTION
## Problem

`UtxoValidateInlineDatumsWithPlutusV1` is wrong in both directions at once. Conway and Dijkstra delegate rule 18 to this babbage implementation, so all three eras share both defects.

**Too broad.** It rejects whenever a PlutusV1 script is merely *reachable* — present in the witness set, or carried as a reference script on any spent or reference input — rather than when a script purpose actually requires one. An ordinary transaction that spends a UTxO carrying an unrelated PlutusV1 reference script is rejected. This halted a node's sync on a real Preview transaction.

**Too narrow.** The inline-datum scan covered only consumed inputs, missing a datum on a reference input or on one of the transaction's own outputs. It also detected datums through a `*BabbageTransactionOutput` type assertion, which misses outputs wrapped by a later era.

## Change

- New `script.NewTxScriptView`: resolves a transaction's inputs and reference inputs once, then reports both the scripts it makes `Available` and the `Needed` subset some purpose requires. The purpose walk covers spending, minting, certifying, rewarding, voting and proposing in canonical redeemer order; eras without the later purposes simply produce none.
- Rule 18 now keys on `Needed`, scans for inline datums across consumed inputs, reference inputs and produced outputs, and reads datum presence through the `TransactionOutput` interface. Datum-*hash* outputs stay correctly out of scope, since `Datum()` reports nil for them.
- A reference script on a produced output is also rejected — equally unrepresentable in the V1 context.
- Input-resolution failures are skipped rather than returned, matching the existing contract that `UtxoValidateBadInputsUtxo` reports them.

## What is deliberately not asserted

No restriction on the mere presence of a reference input. An earlier revision of this branch did assert one, on the reading that PlutusV1's `TxInfo` cannot represent reference inputs at all. It failed the Conway conformance vector `UTXOS/can use reference scripts` (tx 3), which expects such a transaction to succeed. The vector is authoritative and the restriction was removed; a test now pins the accepting behavior so it is not reintroduced.

## Tests

The rule had **no test coverage anywhere in the repository**, which is how the over-broad behavior survived. Six cases added in `ledger/babbage/rules_plutusv1_internal_test.go`.

Against the previous implementation, three fail — the ones that matter:

| Case | Previous behavior |
| --- | --- |
| unneeded PlutusV1 reference script on a spent input | rejected (the false positive) |
| inline datum on a produced output | accepted |
| reference script on a produced output | accepted |
| needed PlutusV1 spending script with inline datum | rejected — correct, unchanged |
| datum-hash output | accepted — correct, unchanged |
| unresolvable input | skipped — correct, unchanged |

Fixtures store outputs as `*BabbageTransactionOutput`, matching how `BabbageTransactionBody.Outputs()` represents them (`&b.TxOutputs[i]`). Using value types would dodge the previous implementation's type assertion and make the comparison measure the fixture rather than the rule.

The tests are in-package because `ouroboros-mock`'s ledger builder imports `ledger/babbage`, so importing it back is a cycle. The local `utxoOnlyLedgerState` embeds `common.LedgerState` as nil on purpose, so any other method this rule starts calling panics loudly rather than silently returning a zero value.

## Validation

| Check | Result |
| --- | --- |
| `go test ./...` | pass |
| `go test ./internal/test/conformance/` | pass |
| `go vet ./...` | clean |
| `golangci-lint v2.13.0 run ./ledger/...` | 1 pre-existing gofumpt finding in `ledger/common/script/purpose.go`, untouched by this change |

## Downstream

Dingo currently carries a local override of rule 18 for exactly this false positive (blinklabs-io/dingo#3240). Once this lands and dingo bumps, that override and its rule-index machinery can be removed.

`UtxoValidateConwayFeaturesWithPlutusV1V2` (rule 19) has the identical presence-not-neededness flaw and now has `TxScriptView` available to fix it the same way. Left out of this change to keep the conformance surface small; it fires on treasury values, proposal and voting procedures, and Conway certificates, so vote-delegation traffic hits it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the PlutusV1 restriction to scripts the transaction actually needs and scans consumed inputs, reference inputs, and produced outputs via the `TransactionOutput` interface. Previously it rejected on mere script reachability and only scanned consumed inputs; now it rejects only when a V1 script is required and an inline datum is present. Reference scripts and the mere presence of reference inputs are allowed.

- Introduces `script.NewTxScriptView` to resolve inputs once and track Available vs Needed scripts in canonical redeemer order; includes Plutus V4 witness scripts and reference scripts from all resolved inputs.
- `UtxoValidateInlineDatumsWithPlutusV1` now:
  - Fails only if a needed PlutusV1 script exists and an inline datum is on any consumed input, reference input, or produced output. Datum-hash outputs remain allowed.
  - Permits reference scripts on consumed inputs, reference inputs, and produced outputs; skips input-resolution errors (left to `UtxoValidateBadInputsUtxo`).
- Filters voting purposes to voters with script credentials only to avoid key-hash voters being treated as scripts.
- Tests assert the specific error type and cover acceptance of reference scripts, rejection of inline datums on reference inputs, a needed V1 script supplied only via a reference script, and PlutusV2 acceptance with inline datums. Minor `gofumpt` cleanups in `ledger/conway` and `ledger/mary`.

<sup>Written for commit 7f9fce84e569fdc3cfbd267598267b5613c6c937. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Plutus V1 transaction validation by rejecting inline datums and reference scripts only when they are unsupported or required by the transaction.
  - Prevented unrelated reference inputs and unused scripts from causing unnecessary validation failures.
  - Preserved correct handling of datum hashes and unresolved inputs.

- **Tests**
  - Added coverage for accepted and rejected Plutus V1 transaction scenarios, including spending scripts, produced outputs, reference inputs, datum hashes, and unresolved inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->