### PR TITLE
style: satisfy the gofumpt bundled with golangci-lint v2.13.0

### DIFF
--- a/ledger/common/script/purpose.go
+++ b/ledger/common/script/purpose.go
@@ -396,7 +396,7 @@ func scriptPurposeBuilder(
 				return nil, UnmatchedRedeemerError{RedeemerKey: redeemerKey}
 			}
 			return ScriptPurposeVoting{
-				Voter: *(votes[redeemerKey.Index].Key),
+				Voter: *votes[redeemerKey.Index].Key,
 			}, nil
 		case lcommon.RedeemerTagProposing:
 			if int(redeemerKey.Index) >= len(proposalProcedures) {

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -276,7 +276,7 @@ func (r *ConwayRedeemers) UnmarshalCBOR(cborData []byte) error {
 		// Modern map form — clear any stale legacy state
 		r.legacy = false
 		r.legacyRedeemers = alonzo.AlonzoRedeemers{}
-		if _, err := cbor.Decode(cborData, &(r.Redeemers)); err != nil {
+		if _, err := cbor.Decode(cborData, &r.Redeemers); err != nil {
 			if !cbor.IsDuplicateMapKeyError(err) {
 				return err
 			}
@@ -290,7 +290,7 @@ func (r *ConwayRedeemers) UnmarshalCBOR(cborData []byte) error {
 			// the stored raw CBOR (SetCbor above), so lenient struct decoding
 			// never changes them.
 			r.Redeemers = nil
-			if _, err := cbor.DecodeLenient(cborData, &(r.Redeemers)); err != nil {
+			if _, err := cbor.DecodeLenient(cborData, &r.Redeemers); err != nil {
 				return err
 			}
 		}
@@ -298,7 +298,7 @@ func (r *ConwayRedeemers) UnmarshalCBOR(cborData []byte) error {
 	}
 	// Legacy array form — clear any stale map state
 	r.Redeemers = nil
-	_, err := cbor.Decode(cborData, &(r.legacyRedeemers))
+	_, err := cbor.Decode(cborData, &r.legacyRedeemers)
 	if err != nil {
 		return err
 	}

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -724,7 +724,7 @@ func (v *MaryTransactionOutputValue) UnmarshalCBOR(data []byte) error {
 		return errors.New("empty Mary transaction output value")
 	}
 	if (data[0] & cbor.CborTypeMask) != cbor.CborTypeArray {
-		if _, err := cbor.Decode(data, &(v.Amount)); err != nil {
+		if _, err := cbor.Decode(data, &v.Amount); err != nil {
 			return err
 		}
 		v.Assets = nil


### PR DESCRIPTION
## Problem

The `lint` job is red on `main` and therefore on every open pull request:

```
ledger/common/script/purpose.go:399:1: File is not properly formatted (gofumpt)
ledger/conway/conway.go:279:1: File is not properly formatted (gofumpt)
ledger/mary/mary.go:727:1: File is not properly formatted (gofumpt)
```

## Cause

`golangci-lint-action` takes no `version` input, so it installs the latest release — currently v2.13.0, whose bundled gofumpt is stricter than the version that last passed. None of the three files changed; the linter did.

## Change

`gofumpt -w` on the three files. Formatting only.

## Verification

| Revision | `golangci-lint v2.13.0 run ./ledger/...` |
| --- | --- |
| `origin/main` | 3 issues |
| this branch | `0 issues.` |

`go test ./ledger/...` passes.

Unblocks #1980, and any other open PR whose lint job is red for this reason rather than for anything in its diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Formats three files to satisfy the stricter `gofumpt` bundled with `golangci-lint` v2.13.0, fixing the red `lint` job on `main`. No behavior change.

- Only formatting: normalize address-of and dereference spacing (e.g., `&(x)` to `&x`, `*(x)` to `*x`).
- Files: ledger/common/script/purpose.go, ledger/conway/conway.go, ledger/mary/mary.go.
- CI: `golangci-lint` v2.13.0 now passes; `go test ./ledger/...` remains green.

<sup>Written for commit 28edd06804a4359a3299533233cfdaa8f44b40b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

