### PR TITLE
fix(ledger): complete Conway governance proposal and voting checks

### DIFF
--- a/ledger/common/state.go
+++ b/ledger/common/state.go
@@ -157,7 +157,36 @@ type GovActionState struct {
 	ActionId   GovActionId
 	ActionType GovActionType
 	ExpirySlot uint64
+	// Action is the governance action itself, as proposed. It is optional
+	// in the LedgerState contract: a state provider that only records the
+	// action type leaves it nil. Rules that need the proposal's contents
+	// (a hard-fork proposal's proposed protocol version, a parameter
+	// change's modified parameters) skip their content-dependent check
+	// when it is nil rather than guessing.
+	Action GovAction
 	// Add more fields as needed for validation
+}
+
+// GovPurposeRoots holds the current root of each governance-action purpose
+// chain: the most recently enacted action of that purpose, or nil when
+// nothing of that purpose has been enacted yet. It mirrors the GovRelation
+// record reachable through pRootsL/toPrevGovActionIds in cardano-ledger's
+// Cardano.Ledger.Conway.Governance.Proposals.
+type GovPurposeRoots struct {
+	PParamUpdate *GovActionId
+	HardFork     *GovActionId
+	Committee    *GovActionId
+	Constitution *GovActionId
+}
+
+// GovPurposeRootsState is the optional ledger-state capability exposing the
+// current root of each governance-action purpose chain. A ledger state that
+// implements it gets the full Conway ancestry rule enforced (a proposal's
+// predecessor must be the purpose root or a pending proposal of the same
+// purpose); one that does not is limited to ancestor existence and purpose
+// matching.
+type GovPurposeRootsState interface {
+	GovPurposeRoots() (*GovPurposeRoots, error)
 }
 
 // GovState defines the interface for querying governance state

--- a/ledger/conway/pparams.go
+++ b/ledger/conway/pparams.go
@@ -473,6 +473,57 @@ func (u *ConwayProtocolParameterUpdate) BootstrapRestrictedFields() []string {
 	return fields
 }
 
+// SecurityGroupFields returns the names of the parameter fields that this
+// update mutates and that belong to the Conway "security group": the only
+// parameters a stake pool is allowed to vote on
+// (Cardano.Ledger.Conway.Governance.Internal.votingStakePoolThresholdInternal
+// treats a ParameterChange as NoVotingAllowed unless at least one modified
+// parameter is security relevant). Order is stable to make error messages
+// deterministic.
+//
+// The set is the parameters annotated 'SecurityGroup in the ConwayPParams
+// record of cardano-ledger
+// eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs: cppTxFeePerByte,
+// cppTxFeeFixed, cppMaxBBSize, cppMaxTxSize, cppMaxBHSize,
+// cppCoinsPerUTxOByte, cppMaxBlockExUnits, cppMaxValSize,
+// cppGovActionDeposit, and cppMinFeeRefScriptCostPerByte. Every other
+// parameter is 'NoStakePoolGroup, and the protocol version is not
+// changeable by a ParameterChange action at all.
+func (u *ConwayProtocolParameterUpdate) SecurityGroupFields() []string {
+	var fields []string
+	if u.MinFeeA != nil {
+		fields = append(fields, "MinFeeA")
+	}
+	if u.MinFeeB != nil {
+		fields = append(fields, "MinFeeB")
+	}
+	if u.MaxBlockBodySize != nil {
+		fields = append(fields, "MaxBlockBodySize")
+	}
+	if u.MaxTxSize != nil {
+		fields = append(fields, "MaxTxSize")
+	}
+	if u.MaxBlockHeaderSize != nil {
+		fields = append(fields, "MaxBlockHeaderSize")
+	}
+	if u.AdaPerUtxoByte != nil {
+		fields = append(fields, "AdaPerUtxoByte")
+	}
+	if u.MaxBlockExUnits != nil {
+		fields = append(fields, "MaxBlockExUnits")
+	}
+	if u.MaxValueSize != nil {
+		fields = append(fields, "MaxValueSize")
+	}
+	if u.GovActionDeposit != nil {
+		fields = append(fields, "GovActionDeposit")
+	}
+	if u.MinFeeRefScriptCostPerByte != nil {
+		fields = append(fields, "MinFeeRefScriptCostPerByte")
+	}
+	return fields
+}
+
 func (u *ConwayProtocolParameterUpdate) UnmarshalCBOR(cborData []byte) error {
 	type tConwayProtocolParameterUpdate ConwayProtocolParameterUpdate
 	var tmp tConwayProtocolParameterUpdate

--- a/ledger/conway/pparams_test.go
+++ b/ledger/conway/pparams_test.go
@@ -1162,19 +1162,22 @@ func TestConwayProtocolParameterUpdate_BootstrapRestrictedFields(t *testing.T) {
 		}
 	})
 
-	t.Run("DRepDeposit and MinCommitteeSize are restricted", func(t *testing.T) {
-		dep := uint64(500_000_000)
-		size := uint(7)
-		u := &conway.ConwayProtocolParameterUpdate{
-			DRepDeposit:      &dep,
-			MinCommitteeSize: &size,
-		}
-		fields := u.BootstrapRestrictedFields()
-		want := []string{"MinCommitteeSize", "DRepDeposit"}
-		if !reflect.DeepEqual(fields, want) {
-			t.Fatalf("want %v, got %v", want, fields)
-		}
-	})
+	t.Run(
+		"DRepDeposit and MinCommitteeSize are restricted",
+		func(t *testing.T) {
+			dep := uint64(500_000_000)
+			size := uint(7)
+			u := &conway.ConwayProtocolParameterUpdate{
+				DRepDeposit:      &dep,
+				MinCommitteeSize: &size,
+			}
+			fields := u.BootstrapRestrictedFields()
+			want := []string{"MinCommitteeSize", "DRepDeposit"}
+			if !reflect.DeepEqual(fields, want) {
+				t.Fatalf("want %v, got %v", want, fields)
+			}
+		},
+	)
 
 	t.Run("non-restricted fields are ignored", func(t *testing.T) {
 		fee := uint(44)
@@ -1182,6 +1185,89 @@ func TestConwayProtocolParameterUpdate_BootstrapRestrictedFields(t *testing.T) {
 		fields := u.BootstrapRestrictedFields()
 		if len(fields) != 0 {
 			t.Fatalf("want empty for MinFeeA-only update, got %v", fields)
+		}
+	})
+}
+
+// TestConwayProtocolParameterUpdate_SecurityGroupFields pins the Conway
+// security group: the set of protocol parameters annotated 'SecurityGroup in
+// the ConwayPParams record of cardano-ledger
+// eras/conway/impl/src/Cardano/Ledger/Conway/PParams.hs (lines 644-711 at
+// commit 08773e9a8f911f67209560a4e401369cbb21a0cb). Every other parameter is
+// 'NoStakePoolGroup, and cppProtocolVersion is HKDNoUpdate (it is not
+// changeable by a ParameterChange action at all).
+func TestConwayProtocolParameterUpdate_SecurityGroupFields(t *testing.T) {
+	t.Run("empty update touches no security parameter", func(t *testing.T) {
+		u := &conway.ConwayProtocolParameterUpdate{}
+		if fields := u.SecurityGroupFields(); len(fields) != 0 {
+			t.Fatalf("want empty, got %v", fields)
+		}
+	})
+
+	t.Run("every security group parameter is reported", func(t *testing.T) {
+		val := uint(1)
+		val64 := uint64(1)
+		rat := &cbor.Rat{Rat: big.NewRat(1, 2)}
+		u := &conway.ConwayProtocolParameterUpdate{
+			MinFeeA:                    &val,
+			MinFeeB:                    &val,
+			MaxBlockBodySize:           &val,
+			MaxTxSize:                  &val,
+			MaxBlockHeaderSize:         &val,
+			AdaPerUtxoByte:             &val64,
+			MaxBlockExUnits:            &common.ExUnits{Memory: 1, Steps: 1},
+			MaxValueSize:               &val,
+			GovActionDeposit:           &val64,
+			MinFeeRefScriptCostPerByte: rat,
+		}
+		want := []string{
+			"MinFeeA",
+			"MinFeeB",
+			"MaxBlockBodySize",
+			"MaxTxSize",
+			"MaxBlockHeaderSize",
+			"AdaPerUtxoByte",
+			"MaxBlockExUnits",
+			"MaxValueSize",
+			"GovActionDeposit",
+			"MinFeeRefScriptCostPerByte",
+		}
+		if fields := u.SecurityGroupFields(); !reflect.DeepEqual(fields, want) {
+			t.Fatalf("want %v, got %v", want, fields)
+		}
+	})
+
+	t.Run("non-security parameters are ignored", func(t *testing.T) {
+		val := uint(1)
+		val64 := uint64(1)
+		rat := &cbor.Rat{Rat: big.NewRat(1, 2)}
+		u := &conway.ConwayProtocolParameterUpdate{
+			KeyDeposit:  &val,
+			PoolDeposit: &val,
+			MaxEpoch:    &val,
+			NOpt:        &val,
+			A0:          rat,
+			Rho:         rat,
+			Tau:         rat,
+			ProtocolVersion: &common.ProtocolParametersProtocolVersion{
+				Major: 10,
+			},
+			MinPoolCost:             &val64,
+			CostModels:              map[uint][]int64{0: {1}},
+			ExecutionCosts:          &common.ExUnitPrice{},
+			MaxTxExUnits:            &common.ExUnits{Memory: 1, Steps: 1},
+			CollateralPercentage:    &val,
+			MaxCollateralInputs:     &val,
+			PoolVotingThresholds:    &conway.PoolVotingThresholds{},
+			DRepVotingThresholds:    &conway.DRepVotingThresholds{},
+			MinCommitteeSize:        &val,
+			CommitteeTermLimit:      &val64,
+			GovActionValidityPeriod: &val64,
+			DRepDeposit:             &val64,
+			DRepInactivityPeriod:    &val64,
+		}
+		if fields := u.SecurityGroupFields(); len(fields) != 0 {
+			t.Fatalf("want empty, got %v", fields)
 		}
 	})
 }

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -508,6 +508,79 @@ func txProposalActions(
 	return ret
 }
 
+// govActionResolver answers questions about the governance action a voting
+// procedure names, consulting the proposals of the transaction under
+// validation before the ledger state.
+//
+// cardano-ledger's conwayGovTransition folds the transaction's proposals into
+// the proposal set before checking its votes
+// (eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs at commit
+// 08773e9a8f911f67209560a4e401369cbb21a0cb), so a vote may name an action its
+// own transaction proposes. A rule that only consults the ledger state either
+// rejects such a vote as unknown or leaves its restriction unenforced.
+//
+// The proposal index is built lazily, so a transaction with no voting
+// procedures or no proposals pays nothing.
+type govActionResolver struct {
+	tx        common.Transaction
+	ls        common.LedgerState
+	proposals map[common.GovActionId]txGovProposal
+	loaded    bool
+}
+
+// txProposal returns the proposal of the transaction under validation that
+// receives actionId once the transaction is accepted.
+func (r *govActionResolver) txProposal(
+	actionId common.GovActionId,
+) (txGovProposal, bool) {
+	if !r.loaded {
+		r.proposals = txProposalActions(r.tx)
+		r.loaded = true
+	}
+	proposal, ok := r.proposals[actionId]
+	return proposal, ok
+}
+
+// exists reports whether actionId names a governance action the ledger state
+// records or the transaction under validation proposes. A proposal whose
+// action contents are absent still counts as existing: a proposal procedure
+// always carries an action on the wire, and cardano-ledger adds the proposal
+// to the folded proposal set regardless of what it proposes.
+func (r *govActionResolver) exists(actionId common.GovActionId) bool {
+	if r.ls != nil && r.ls.GovActionExists(actionId) {
+		return true
+	}
+	_, ok := r.txProposal(actionId)
+	return ok
+}
+
+// resolve returns the type and, where available, the contents of the
+// governance action named by actionId. ok is false when neither the
+// transaction nor the ledger state can classify the action, which leaves a
+// type-dependent restriction unenforced rather than guessed at.
+func (r *govActionResolver) resolve(
+	actionId common.GovActionId,
+) (actionType common.GovActionType, action common.GovAction, ok bool) {
+	if proposal, found := r.txProposal(actionId); found {
+		if proposal.action == nil {
+			return 0, nil, false
+		}
+		resolvedType, err := conwayGovActionType(proposal.action)
+		if err != nil {
+			return 0, nil, false
+		}
+		return common.GovActionType(resolvedType), proposal.action, true
+	}
+	if r.ls == nil {
+		return 0, nil, false
+	}
+	actionState, err := r.ls.GovActionById(actionId)
+	if err != nil || actionState == nil {
+		return 0, nil, false
+	}
+	return actionState.ActionType, actionState.Action, true
+}
+
 // hardForkProposedVersion returns the protocol version proposed by a
 // HardForkInitiation action. ok is false for any other action type, matching
 // the pattern match on HardForkInitiation in cardano-ledger's
@@ -3254,16 +3327,26 @@ func PoolValidateVrfKeyUniqueness(
 }
 
 // UtxoValidateUnknownGovActionIds rejects voting procedures that reference a
-// governance action id that does not exist in the ledger state
+// governance action id that neither the ledger state records nor the
+// transaction under validation proposes
 // (ConwayGovPredFailure.GovActionsDoNotExist). This is the rule referenced
 // by the "unknown action ID is handled by other validation rules" comment
 // in UtxoValidateCCVotingRestrictions.
+//
+// An action proposed by the transaction under validation counts as existing:
+// cardano-ledger folds the transaction's proposals into the proposal set
+// before checking its votes, so a transaction that proposes an action and
+// votes on it is not voting on an unknown action. Rejecting it here would
+// also make the same-transaction resolution in
+// UtxoValidateStakePoolVotingRestrictions unreachable, since this rule runs
+// first in UtxoValidationRules.
 func UtxoValidateUnknownGovActionIds(
 	tx common.Transaction,
 	slot uint64,
 	ls common.LedgerState,
 	pp common.ProtocolParameters,
 ) error {
+	resolver := govActionResolver{tx: tx, ls: ls}
 	var unknown []common.GovActionId
 	for _, actionVotes := range tx.VotingProcedures() {
 		for actionId := range actionVotes {
@@ -3276,7 +3359,7 @@ func UtxoValidateUnknownGovActionIds(
 				unknown = append(unknown, common.GovActionId{})
 				continue
 			}
-			if !ls.GovActionExists(*actionId) {
+			if !resolver.exists(*actionId) {
 				unknown = append(unknown, *actionId)
 			}
 		}
@@ -3444,6 +3527,10 @@ func UtxoValidateVotingOnExpiredGovAction(
 // InfoAction). A nil action id is rejected directly here (matching
 // UtxoValidateCCVotingRestrictions's convention) rather than silently
 // skipped.
+//
+// The action type is resolved from the transaction's own proposals when the
+// vote names an action that transaction proposes, so a same-transaction
+// propose-and-vote does not escape the restriction.
 func UtxoValidateBootstrapVotingRestrictions(
 	tx common.Transaction,
 	slot uint64,
@@ -3468,6 +3555,7 @@ func UtxoValidateBootstrapVotingRestrictions(
 			return false
 		}
 	}
+	resolver := govActionResolver{tx: tx, ls: ls}
 	for voter, actionVotes := range tx.VotingProcedures() {
 		if voter == nil {
 			continue
@@ -3480,16 +3568,16 @@ func UtxoValidateBootstrapVotingRestrictions(
 					Restriction: "nil action ID in voting procedures",
 				}
 			}
-			actionState, err := ls.GovActionById(*actionId)
-			if err != nil || actionState == nil {
+			actionType, _, ok := resolver.resolve(*actionId)
+			if !ok {
 				continue
 			}
 			var allowed bool
 			switch voter.Type {
 			case common.VoterTypeDRepKeyHash, common.VoterTypeDRepScriptHash:
-				allowed = actionState.ActionType == common.GovActionTypeInfo
+				allowed = actionType == common.GovActionTypeInfo
 			default:
-				allowed = isBootstrapAction(actionState.ActionType)
+				allowed = isBootstrapAction(actionType)
 			}
 			if !allowed {
 				return BootstrapVotingRestrictionError{
@@ -3498,7 +3586,7 @@ func UtxoValidateBootstrapVotingRestrictions(
 					Restriction: fmt.Sprintf(
 						"voter type %d cannot vote on action type %d during bootstrap phase",
 						voter.Type,
-						actionState.ActionType,
+						actionType,
 					),
 				}
 			}
@@ -3534,8 +3622,7 @@ func UtxoValidateStakePoolVotingRestrictions(
 	if len(votes) == 0 {
 		return nil
 	}
-	var txProposals map[common.GovActionId]txGovProposal
-	txProposalsLoaded := false
+	resolver := govActionResolver{tx: tx, ls: ls}
 	for voter, actionVotes := range votes {
 		if voter == nil || voter.Type != common.VoterTypeStakingPoolKeyHash {
 			continue
@@ -3548,32 +3635,9 @@ func UtxoValidateStakePoolVotingRestrictions(
 					Restriction: "nil action ID in voting procedures",
 				}
 			}
-			if !txProposalsLoaded {
-				txProposals = txProposalActions(tx)
-				txProposalsLoaded = true
-			}
-			var actionType common.GovActionType
-			var action common.GovAction
-			if txProposal, ok := txProposals[*actionId]; ok {
-				if txProposal.action == nil {
-					continue
-				}
-				action = txProposal.action
-				resolvedType, err := conwayGovActionType(action)
-				if err != nil {
-					continue
-				}
-				actionType = common.GovActionType(resolvedType)
-			} else {
-				if ls == nil {
-					continue
-				}
-				actionState, err := ls.GovActionById(*actionId)
-				if err != nil || actionState == nil {
-					continue
-				}
-				actionType = actionState.ActionType
-				action = actionState.Action
+			actionType, action, ok := resolver.resolve(*actionId)
+			if !ok {
+				continue
 			}
 			var restriction string
 			switch actionType {
@@ -3614,6 +3678,10 @@ func UtxoValidateStakePoolVotingRestrictions(
 // UtxoValidateCCVotingRestrictions validates CC voting restrictions per cardano-ledger spec.
 // Constitutional Committee members cannot vote on NoConfidence or UpdateCommittee actions.
 // Enforced at ledger level for PV11+ (ProtocolVersionVanRossem).
+//
+// The action type is resolved from the transaction's own proposals when the
+// vote names an action that transaction proposes, so a same-transaction
+// propose-and-vote does not escape the restriction.
 func UtxoValidateCCVotingRestrictions(
 	tx common.Transaction,
 	slot uint64,
@@ -3635,6 +3703,7 @@ func UtxoValidateCCVotingRestrictions(
 		return nil
 	}
 
+	resolver := govActionResolver{tx: tx, ls: ls}
 	for voter, actionVotes := range votes {
 		// Only check CC voters
 		if voter.Type != common.VoterTypeConstitutionalCommitteeHotKeyHash &&
@@ -3652,22 +3721,19 @@ func UtxoValidateCCVotingRestrictions(
 				}
 			}
 
-			// Look up the action type from governance state
-			actionState, err := ls.GovActionById(*actionId)
-			if err != nil {
-				// If we can't look up the action, skip this check
-				// (unknown action ID is handled by other validation rules)
-				continue
-			}
-			if actionState == nil {
+			// Resolve the action type from the transaction's own proposals
+			// or, failing that, from governance state. An action neither
+			// names is reported by UtxoValidateUnknownGovActionIds.
+			actionType, _, ok := resolver.resolve(*actionId)
+			if !ok {
 				continue
 			}
 
 			// CC members cannot vote on NoConfidence or UpdateCommittee
-			if actionState.ActionType == common.GovActionTypeNoConfidence ||
-				actionState.ActionType == common.GovActionTypeUpdateCommittee {
+			if actionType == common.GovActionTypeNoConfidence ||
+				actionType == common.GovActionTypeUpdateCommittee {
 				restriction := "CC cannot vote on NoConfidence"
-				if actionState.ActionType == common.GovActionTypeUpdateCommittee {
+				if actionType == common.GovActionTypeUpdateCommittee {
 					restriction = "CC cannot vote on UpdateCommittee"
 				}
 				return CCVotingRestrictionError{

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"slices"
 
@@ -467,6 +468,96 @@ func protocolVersionCanFollow(
 	return newMajor == curMajor && newMinor == curMinor+1
 }
 
+// txGovProposal is a governance action proposed by the transaction under
+// validation, together with its position in the transaction's proposal
+// procedures.
+type txGovProposal struct {
+	idx    int
+	action common.GovAction
+}
+
+// txProposalActions indexes the governance actions proposed by tx itself by
+// the governance action id each one receives once the transaction is
+// accepted, (transaction id, proposal index).
+//
+// cardano-ledger's conwayGovTransition folds processProposal over the
+// proposal procedures in order and threads the accumulated Proposals through
+// every subsequent check, so a proposal may name an earlier proposal of the
+// same transaction as its predecessor, and a vote may refer to an action
+// proposed by its own transaction. Rules that only consult the ledger state
+// would reject those as unknown.
+func txProposalActions(
+	tx common.Transaction,
+) map[common.GovActionId]txGovProposal {
+	proposals := tx.ProposalProcedures()
+	if len(proposals) == 0 {
+		return nil
+	}
+	txId := tx.Hash()
+	ret := make(map[common.GovActionId]txGovProposal, len(proposals))
+	for idx, proposal := range proposals {
+		if idx > math.MaxUint32 {
+			break
+		}
+		actionId := common.GovActionId{
+			TransactionId: txId,
+			GovActionIdx:  uint32(idx), // #nosec G115 -- bounded above
+		}
+		ret[actionId] = txGovProposal{idx: idx, action: proposal.GovAction()}
+	}
+	return ret
+}
+
+// hardForkProposedVersion returns the protocol version proposed by a
+// HardForkInitiation action. ok is false for any other action type, matching
+// the pattern match on HardForkInitiation in cardano-ledger's
+// preceedingHardFork.
+func hardForkProposedVersion(
+	action common.GovAction,
+) (major, minor uint, ok bool) {
+	hf, isHardFork := action.(*common.HardForkInitiationGovAction)
+	if !isHardFork {
+		return 0, 0, false
+	}
+	return hf.ProtocolVersion.Major, hf.ProtocolVersion.Minor, true
+}
+
+// govPurposeRoots returns the current root of each governance-action purpose
+// chain when the ledger state implements the optional
+// common.GovPurposeRootsState capability, and nil when it does not.
+func govPurposeRoots(
+	ls common.LedgerState,
+) (*common.GovPurposeRoots, error) {
+	rootsState, ok := ls.(common.GovPurposeRootsState)
+	if !ok {
+		return nil, nil
+	}
+	return rootsState.GovPurposeRoots()
+}
+
+// govPurposeRootId returns the root governance action id recorded for a
+// purpose, or nil when nothing of that purpose has been enacted yet.
+func govPurposeRootId(
+	roots *common.GovPurposeRoots,
+	purpose govActionPurpose,
+) *common.GovActionId {
+	if roots == nil {
+		return nil
+	}
+	switch purpose {
+	case govPurposePParamUpdate:
+		return roots.PParamUpdate
+	case govPurposeHardFork:
+		return roots.HardFork
+	case govPurposeCommittee:
+		return roots.Committee
+	case govPurposeConstitution:
+		return roots.Constitution
+	default:
+		return nil
+	}
+}
+
 // UtxoValidateGovActionWellFormedness performs structural well-formedness
 // checks on governance actions beyond the ParameterChange-specific checks in
 // UtxoValidateProposalProcedures (ConwayGovPredFailure.MalformedProposal),
@@ -560,19 +651,33 @@ func UtxoValidateGovActionWellFormedness(
 }
 
 // UtxoValidateHardForkCanFollow checks that a HardForkInitiation governance
-// action's proposed protocol version can legally follow the current
-// protocol version (ConwayGovPredFailure.ProposalCantFollow).
+// action's proposed protocol version can legally follow the protocol version
+// it succeeds (ConwayGovPredFailure.ProposalCantFollow).
 //
-// NOTE: the ledger spec compares against the *referenced ancestor's*
-// proposed protocol version when the proposal has a PrevGovActionId,
-// falling back to the currently enacted protocol version only when there is
-// no ancestor (or the proposed major version already exceeds the current
-// major's direct successor). GovActionState in this codebase only records
-// ActionType and ExpirySlot, not the ancestor's proposed ProtVer, so when an
-// ancestor is referenced this rule intentionally defers the numeric version
-// check (ancestor existence/purpose is validated separately by
-// UtxoValidateProposalAncestry) rather than comparing against the wrong
-// reference version.
+// This mirrors preceedingHardFork plus the pvCanFollow guard in
+// cardano-ledger's conwayGovTransition
+// (eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs lines 488-499 and
+// 673-695 at commit 08773e9a8f911f67209560a4e401369cbb21a0cb):
+//
+//   - a proposed major version more than one above the currently enacted
+//     major version is compared against the enacted version, so a chain of
+//     pending proposals cannot be used to jump ahead;
+//   - otherwise a proposal with a predecessor is compared against that
+//     predecessor's proposed protocol version, taken from the transaction
+//     itself for a predecessor proposed by the same transaction, or from the
+//     ledger state's record of the referenced action;
+//   - a proposal with no predecessor is compared against the enacted
+//     version. The enacted protocol version is always the version proposed
+//     by the hard-fork action that is the current root of the hard-fork
+//     purpose chain, since a ParameterChange action cannot alter the
+//     protocol version, so comparing against the recorded proposed version
+//     of a predecessor that is the root gives the same verdict as the
+//     reference implementation's comparison against the enacted version.
+//
+// A predecessor whose contents the ledger state does not record (see
+// common.GovActionState.Action) leaves the numeric check deferred rather
+// than run against the wrong reference version; the predecessor's existence
+// and purpose are validated by UtxoValidateProposalAncestry.
 func UtxoValidateHardForkCanFollow(
 	tx common.Transaction,
 	slot uint64,
@@ -583,21 +688,58 @@ func UtxoValidateHardForkCanFollow(
 	if !ok {
 		return errors.New("pparams are not expected type")
 	}
-	for _, proposal := range tx.ProposalProcedures() {
+	curPV := conwayPp.ProtocolVersion
+	var txProposals map[common.GovActionId]txGovProposal
+	txProposalsLoaded := false
+	for idx, proposal := range tx.ProposalProcedures() {
 		hf, ok := proposal.GovAction().(*common.HardForkInitiationGovAction)
 		if !ok {
 			continue
 		}
-		if hf.ActionId != nil {
-			// See NOTE above: cannot verify the exact version chain without
-			// the ancestor's proposed protocol version.
-			continue
-		}
-		curPV := conwayPp.ProtocolVersion
 		newPV := hf.ProtocolVersion
+		// Equivalent to `Just (pvMajor newProtVer) > succVersion (pvMajor
+		// current)` without risking an overflow on curPV.Major+1.
+		majorTooHigh := newPV.Major > curPV.Major &&
+			newPV.Major-curPV.Major > 1
+		refMajor, refMinor := curPV.Major, curPV.Minor
+		if hf.ActionId != nil && !majorTooHigh {
+			if !txProposalsLoaded {
+				txProposals = txProposalActions(tx)
+				txProposalsLoaded = true
+			}
+			var ancestorAction common.GovAction
+			if txProposal, ok := txProposals[*hf.ActionId]; ok {
+				if txProposal.idx >= idx {
+					// Only an earlier proposal of the same transaction has
+					// been folded into the proposal set at this point; a
+					// forward or self reference is reported by
+					// UtxoValidateProposalAncestry.
+					continue
+				}
+				ancestorAction = txProposal.action
+			} else if ls != nil {
+				ancestorState, err := ls.GovActionById(*hf.ActionId)
+				if err != nil || ancestorState == nil {
+					// A missing predecessor is reported by
+					// UtxoValidateProposalAncestry.
+					continue
+				}
+				ancestorAction = ancestorState.Action
+			}
+			if ancestorAction == nil {
+				continue
+			}
+			major, minor, isHardFork := hardForkProposedVersion(ancestorAction)
+			if !isHardFork {
+				// A predecessor of another purpose is reported by
+				// UtxoValidateProposalAncestry.
+				continue
+			}
+			refMajor, refMinor = major, minor
+		}
 		if !protocolVersionCanFollow(
-			curPV.Major,
-			curPV.Minor,
+			refMajor,
+			refMinor,
 			newPV.Major,
 			newPV.Minor,
 		) {
@@ -606,7 +748,10 @@ func UtxoValidateHardForkCanFollow(
 					Major: newPV.Major,
 					Minor: newPV.Minor,
 				},
-				Expected: curPV,
+				Expected: common.ProtocolParametersProtocolVersion{
+					Major: refMajor,
+					Minor: refMinor,
+				},
 			}
 		}
 	}
@@ -614,36 +759,90 @@ func UtxoValidateHardForkCanFollow(
 }
 
 // UtxoValidateProposalAncestry checks that a governance action's optional
-// PrevGovActionId, if present, references an existing governance action
-// belonging to the same purpose chain (ConwayGovPredFailure.InvalidPrevGovActionId).
+// PrevGovActionId names a valid predecessor in its purpose chain
+// (ConwayGovPredFailure.InvalidPrevGovActionId).
 //
-// NOTE: the ledger spec additionally verifies that the referenced ancestor
-// is the *current* root of its purpose chain (i.e., no other pending action
-// of that purpose exists that isn't this proposal's ancestor). GovState in
-// this codebase does not expose per-purpose root tracking, so this rule is
-// limited to existence and purpose-type matching.
+// cardano-ledger accepts a proposal only when runProposalsAddAction can
+// attach it to the purpose's tree
+// (eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Proposals.hs lines
+// 305-334 at commit 08773e9a8f911f67209560a4e401369cbb21a0cb, reached from
+// the proposalsAddAction call in conwayGovTransition,
+// eras/conway/impl/src/Cardano/Ledger/Conway/Rules/Gov.hs lines 550-556):
+// the proposal's predecessor must either equal the current root of that
+// purpose chain, including the case where both are absent, or be a proposal
+// of that purpose that is still pending.
 //
-// This also means the rule's safety (rejecting when an ancestor isn't
-// found) implicitly depends on the LedgerState implementation keeping
-// enacted governance actions queryable via GovActionById rather than
-// pruning them once enacted, since the current root of a purpose chain is
-// normally an already-enacted action; the LedgerState interface does not
-// explicitly promise this, so a backend that prunes enacted proposals would
-// start incorrectly rejecting valid proposals.
+// The current root is only available when the ledger state implements the
+// optional common.GovPurposeRootsState capability. Without it this rule
+// stays limited to ancestor existence and purpose matching, so a ledger
+// state that cannot report roots is not made to reject proposals it has no
+// way to judge.
 func UtxoValidateProposalAncestry(
 	tx common.Transaction,
 	slot uint64,
 	ls common.LedgerState,
 	pp common.ProtocolParameters,
 ) error {
-	for _, proposal := range tx.ProposalProcedures() {
+	proposals := tx.ProposalProcedures()
+	if len(proposals) == 0 {
+		return nil
+	}
+	roots, err := govPurposeRoots(ls)
+	if err != nil {
+		return fmt.Errorf("governance purpose roots lookup failed: %w", err)
+	}
+	txProposals := txProposalActions(tx)
+	for idx, proposal := range proposals {
 		govAction := proposal.GovAction()
 		if govAction == nil {
 			continue
 		}
 		ancestorId, purpose, hasPurpose := govActionAncestor(govAction)
-		if !hasPurpose || ancestorId == nil {
+		if !hasPurpose {
 			continue
+		}
+		rootId := govPurposeRootId(roots, purpose)
+		if ancestorId == nil {
+			// A proposal without a predecessor is only valid while the
+			// purpose chain has no root. Skip the check entirely when the
+			// roots are unknown.
+			if roots == nil || rootId == nil {
+				continue
+			}
+			return InvalidGovActionAncestorError{
+				ActionId: *rootId,
+				Reason: "proposal has no predecessor but the purpose chain " +
+					"root is set",
+			}
+		}
+		// The predecessor is the current root of its purpose chain.
+		if rootId != nil && rootId.Equal(*ancestorId) {
+			continue
+		}
+		// The predecessor is an earlier proposal of the same purpose in this
+		// same transaction.
+		if txProposal, ok := txProposals[*ancestorId]; ok {
+			if txProposal.idx < idx && txProposal.action != nil {
+				_, txPurpose, txHasPurpose := govActionAncestor(
+					txProposal.action,
+				)
+				if txHasPurpose && txPurpose == purpose {
+					continue
+				}
+			}
+			return InvalidGovActionAncestorError{
+				ActionId: *ancestorId,
+				Reason: "referenced ancestor governance action is not an " +
+					"earlier proposal of the same purpose in this transaction",
+			}
+		}
+		// Otherwise the predecessor must be a pending proposal of the same
+		// purpose recorded in the ledger state.
+		if ls == nil {
+			return InvalidGovActionAncestorError{
+				ActionId: *ancestorId,
+				Reason:   "no ledger state available to resolve the ancestor",
+			}
 		}
 		ancestorState, err := ls.GovActionById(*ancestorId)
 		if err != nil {
@@ -663,6 +862,20 @@ func UtxoValidateProposalAncestry(
 			return InvalidGovActionAncestorError{
 				ActionId: *ancestorId,
 				Reason:   "referenced ancestor governance action has a mismatched purpose",
+			}
+		}
+		// An expired proposal is no longer in the purpose tree, so it cannot
+		// be a predecessor. ExpirySlot is optional in the LedgerState
+		// contract (see UtxoValidateVotingOnExpiredGovAction): a state
+		// provider that does not model expiry leaves it zero, which is
+		// treated as "expiry not modeled" rather than "expired at slot 0".
+		if ancestorState.ExpirySlot != 0 && slot > ancestorState.ExpirySlot {
+			return InvalidGovActionAncestorError{
+				ActionId: *ancestorId,
+				Reason: fmt.Sprintf(
+					"referenced ancestor governance action expired at slot %d",
+					ancestorState.ExpirySlot,
+				),
 			}
 		}
 	}
@@ -3295,17 +3508,22 @@ func UtxoValidateBootstrapVotingRestrictions(
 }
 
 // UtxoValidateStakePoolVotingRestrictions validates stake pool (SPO) voting
-// restrictions per the Conway ledger's isStakePoolVotingAllowed: SPOs may
-// never vote on NewConstitution or TreasuryWithdrawal actions. A nil action
-// id is rejected directly here (matching UtxoValidateCCVotingRestrictions's
+// restrictions per isStakePoolVotingAllowed and
+// votingStakePoolThresholdInternal in cardano-ledger
+// (eras/conway/impl/src/Cardano/Ledger/Conway/Governance/Internal.hs lines
+// 353-405 at commit 08773e9a8f911f67209560a4e401369cbb21a0cb): SPOs may
+// never vote on NewConstitution or TreasuryWithdrawal actions, and may vote
+// on a ParameterChange only when at least one of the parameters it modifies
+// belongs to the security group (see
+// ConwayProtocolParameterUpdate.SecurityGroupFields). A nil action id is
+// rejected directly here (matching UtxoValidateCCVotingRestrictions's
 // convention) rather than silently skipped.
 //
-// NOTE: the ledger spec also disallows SPO votes on ParameterChange
-// proposals that don't touch "security group" parameters. This codebase
-// does not currently classify ParameterChange fields into security-relevant
-// groups (distinct from the bootstrap-restricted-fields classification), so
-// that narrower restriction is intentionally left unenforced here rather
-// than guessed at.
+// Classifying a ParameterChange requires the proposed parameter update. It
+// is read from the transaction itself when the action is proposed by the
+// same transaction, otherwise from common.GovActionState.Action. A ledger
+// state that does not record the action contents leaves the parameter-group
+// restriction unenforced rather than guessed at.
 func UtxoValidateStakePoolVotingRestrictions(
 	tx common.Transaction,
 	slot uint64,
@@ -3316,6 +3534,8 @@ func UtxoValidateStakePoolVotingRestrictions(
 	if len(votes) == 0 {
 		return nil
 	}
+	var txProposals map[common.GovActionId]txGovProposal
+	txProposalsLoaded := false
 	for voter, actionVotes := range votes {
 		if voter == nil || voter.Type != common.VoterTypeStakingPoolKeyHash {
 			continue
@@ -3328,18 +3548,52 @@ func UtxoValidateStakePoolVotingRestrictions(
 					Restriction: "nil action ID in voting procedures",
 				}
 			}
-			actionState, err := ls.GovActionById(*actionId)
-			if err != nil || actionState == nil {
-				continue
+			if !txProposalsLoaded {
+				txProposals = txProposalActions(tx)
+				txProposalsLoaded = true
+			}
+			var actionType common.GovActionType
+			var action common.GovAction
+			if txProposal, ok := txProposals[*actionId]; ok {
+				if txProposal.action == nil {
+					continue
+				}
+				action = txProposal.action
+				resolvedType, err := conwayGovActionType(action)
+				if err != nil {
+					continue
+				}
+				actionType = common.GovActionType(resolvedType)
+			} else {
+				if ls == nil {
+					continue
+				}
+				actionState, err := ls.GovActionById(*actionId)
+				if err != nil || actionState == nil {
+					continue
+				}
+				actionType = actionState.ActionType
+				action = actionState.Action
 			}
 			var restriction string
-			switch actionState.ActionType {
+			switch actionType {
 			case common.GovActionTypeNewConstitution:
 				restriction = "stake pools cannot vote on NewConstitution"
 			case common.GovActionTypeTreasuryWithdrawal:
 				restriction = "stake pools cannot vote on TreasuryWithdrawal"
-			case common.GovActionTypeParameterChange,
-				common.GovActionTypeHardForkInitiation,
+			case common.GovActionTypeParameterChange:
+				paramChange, ok := action.(*ConwayParameterChangeGovAction)
+				if !ok {
+					// The action contents are not available, so the
+					// parameter groups it modifies are unknown.
+					continue
+				}
+				if len(paramChange.ParamUpdate.SecurityGroupFields()) > 0 {
+					continue
+				}
+				restriction = "stake pools cannot vote on a parameter change " +
+					"that does not modify security group parameters"
+			case common.GovActionTypeHardForkInitiation,
 				common.GovActionTypeNoConfidence,
 				common.GovActionTypeUpdateCommittee,
 				common.GovActionTypeInfo:

--- a/ledger/conway/rules_gov_transition_test.go
+++ b/ledger/conway/rules_gov_transition_test.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
 	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
@@ -833,6 +834,7 @@ func TestUtxoValidateBootstrapVotingRestrictions(t *testing.T) {
 		require.ErrorAs(t, err, &bootErr)
 		assert.Equal(t, common.GovActionId{}, bootErr.ActionId)
 	})
+
 }
 
 func TestUtxoValidateStakePoolVotingRestrictions(t *testing.T) {
@@ -928,9 +930,14 @@ func mkHfAction(
 }
 
 // mkProposalsTx builds a transaction carrying several proposal procedures in
-// order, so a later proposal can reference an earlier one in the same
-// transaction by its (txid, index) governance action id.
-func mkProposalsTx(actions ...common.GovAction) *conway.ConwayTransaction {
+// order and fixes its transaction id, so a later proposal or a vote can
+// reference an earlier proposal of the same transaction by the
+// (txid, index) governance action id selfActionId reports.
+func mkProposalsTx(
+	t *testing.T,
+	actions ...common.GovAction,
+) *conway.ConwayTransaction {
+	t.Helper()
 	tx := &conway.ConwayTransaction{}
 	for _, action := range actions {
 		tx.Body.TxProposalProcedures = append(
@@ -940,7 +947,72 @@ func mkProposalsTx(actions ...common.GovAction) *conway.ConwayTransaction {
 			},
 		)
 	}
+	fixTxId(t, tx)
 	return tx
+}
+
+// fixTxId gives tx a transaction id derived from the body as built.
+//
+// ConwayTransactionBody.Id() hashes the body's stored CBOR, and a body built
+// in Go stores none, so without this every hand-built transaction shares the
+// hash of an empty byte string: a governance action id derived from tx.Hash()
+// would resolve against any transaction, and a test could not tell an id that
+// belongs to the transaction under validation from one that belongs to
+// another.
+//
+// A proposal or vote that names an action proposed by its own transaction
+// cannot be built by hashing the finished body, because the referenced
+// governance action id contains the hash of the body that carries the
+// reference. The id is therefore fixed here from the body as first built, and
+// the reference is patched into the action afterwards; the stored CBOR keeps
+// the id stable across that mutation, which the rules under test rely on
+// because they read the body fields rather than its CBOR.
+func fixTxId(t *testing.T, tx *conway.ConwayTransaction) {
+	t.Helper()
+	tx.Body.SetCbor(nil)
+	encoded, err := cbor.Encode(&tx.Body)
+	require.NoError(t, err)
+	tx.Body.SetCbor(encoded)
+}
+
+// selfActionId returns the governance action id that proposal idx of tx
+// receives once tx is accepted.
+func selfActionId(
+	tx *conway.ConwayTransaction,
+	idx uint32,
+) common.GovActionId {
+	return common.GovActionId{TransactionId: tx.Hash(), GovActionIdx: idx}
+}
+
+// requireDistinctTxIds asserts that two hand-built transactions carry
+// different transaction ids, so a governance action id built from one cannot
+// resolve against the other.
+//
+// GovActionId.TransactionId is a bare [32]byte while Transaction.Hash()
+// returns common.Blake2b256, so comparing the two through testify's untyped
+// assertions reports them as different whatever the bytes are. The
+// conversion is what makes the assertion mean anything.
+func requireDistinctTxIds(t *testing.T, a, b *conway.ConwayTransaction) {
+	t.Helper()
+	require.NotEqual(t, [32]byte(a.Hash()), [32]byte(b.Hash()))
+}
+
+// addVote attaches a voting procedure to tx without disturbing the
+// transaction id fixed by mkProposalsTx.
+func addVote(
+	tx *conway.ConwayTransaction,
+	voter common.Voter,
+	actionId common.GovActionId,
+	vote uint8,
+) {
+	v := voter
+	aid := actionId
+	if tx.Body.TxVotingProcedures == nil {
+		tx.Body.TxVotingProcedures = common.VotingProcedures{}
+	}
+	tx.Body.TxVotingProcedures[&v] = map[*common.GovActionId]common.VotingProcedure{
+		&aid: {Vote: vote},
+	}
 }
 
 // rootedLedgerState decorates a ledger state with the optional
@@ -980,7 +1052,7 @@ func TestUtxoValidateHardForkCanFollowWithAncestor(t *testing.T) {
 	t.Run(
 		"minor bump on the ancestor's version is allowed",
 		func(t *testing.T) {
-			tx := mkProposalsTx(mkHfAction(&pendingId, 10, 1))
+			tx := mkProposalsTx(t, mkHfAction(&pendingId, 10, 1))
 			require.NoError(
 				t,
 				conway.UtxoValidateHardForkCanFollow(tx, 0, ls, pp),
@@ -989,7 +1061,7 @@ func TestUtxoValidateHardForkCanFollowWithAncestor(t *testing.T) {
 	)
 
 	t.Run("gap from the ancestor's version is rejected", func(t *testing.T) {
-		tx := mkProposalsTx(mkHfAction(&pendingId, 10, 5))
+		tx := mkProposalsTx(t, mkHfAction(&pendingId, 10, 5))
 		err := conway.UtxoValidateHardForkCanFollow(tx, 0, ls, pp)
 		var hfErr conway.BadHardForkProtocolVersionError
 		require.ErrorAs(t, err, &hfErr)
@@ -1006,7 +1078,7 @@ func TestUtxoValidateHardForkCanFollowWithAncestor(t *testing.T) {
 	t.Run(
 		"major version too high is rejected via an ancestor",
 		func(t *testing.T) {
-			tx := mkProposalsTx(mkHfAction(&pendingId, 11, 0))
+			tx := mkProposalsTx(t, mkHfAction(&pendingId, 11, 0))
 			err := conway.UtxoValidateHardForkCanFollow(tx, 0, ls, pp)
 			var hfErr conway.BadHardForkProtocolVersionError
 			require.ErrorAs(t, err, &hfErr)
@@ -1016,32 +1088,50 @@ func TestUtxoValidateHardForkCanFollowWithAncestor(t *testing.T) {
 	)
 
 	t.Run("ancestor in the same transaction", func(t *testing.T) {
-		first := mkHfAction(nil, 10, 0)
-		tx := mkProposalsTx(first, nil)
-		firstId := common.GovActionId{
-			TransactionId: tx.Hash(),
-			GovActionIdx:  0,
-		}
-		// Rebuild with the second proposal pointing at the first.
-		tx = mkProposalsTx(first, mkHfAction(&firstId, 10, 1))
+		// The second proposal names the first proposal of its own
+		// transaction, so the reference is patched in after the
+		// transaction id is fixed.
+		second := mkHfAction(nil, 10, 1)
+		tx := mkProposalsTx(t, mkHfAction(nil, 10, 0), second)
+		firstId := selfActionId(tx, 0)
+		second.ActionId = &firstId
 		require.NoError(
 			t,
 			conway.UtxoValidateHardForkCanFollow(tx, 0, ls, pp),
 		)
 
-		bad := mkProposalsTx(first, mkHfAction(&firstId, 10, 4))
+		badSecond := mkHfAction(nil, 10, 4)
+		bad := mkProposalsTx(t, mkHfAction(nil, 10, 0), badSecond)
+		badFirstId := selfActionId(bad, 0)
+		badSecond.ActionId = &badFirstId
 		err := conway.UtxoValidateHardForkCanFollow(bad, 0, ls, pp)
 		var hfErr conway.BadHardForkProtocolVersionError
 		require.ErrorAs(t, err, &hfErr)
 		assert.Equal(t, uint(10), hfErr.Expected.Major)
 		assert.Equal(t, uint(0), hfErr.Expected.Minor)
+		assert.Equal(t, uint(4), hfErr.Supplied.Minor)
+	})
+
+	// An ancestor id that carries another transaction's id is not a
+	// same-transaction ancestor, whatever its index: the numeric check is
+	// deferred to the ledger state, which does not record it.
+	t.Run("ancestor id of another transaction", func(t *testing.T) {
+		other := mkProposalsTx(t, mkHfAction(nil, 10, 0))
+		otherId := selfActionId(other, 0)
+		second := mkHfAction(&otherId, 10, 4)
+		tx := mkProposalsTx(t, mkHfAction(nil, 10, 0), second)
+		requireDistinctTxIds(t, other, tx)
+		require.NoError(
+			t,
+			conway.UtxoValidateHardForkCanFollow(tx, 0, ls, pp),
+		)
 	})
 
 	// A state provider that does not expose the ancestor's proposed
 	// protocol version cannot support the comparison; the check is skipped
 	// rather than run against the wrong reference version.
 	t.Run("ancestor without contents defers the check", func(t *testing.T) {
-		tx := mkProposalsTx(mkHfAction(&opaqueId, 10, 7))
+		tx := mkProposalsTx(t, mkHfAction(&opaqueId, 10, 7))
 		require.NoError(
 			t,
 			conway.UtxoValidateHardForkCanFollow(tx, 0, ls, pp),
@@ -1083,7 +1173,7 @@ func TestUtxoValidateProposalAncestryPurposeRoot(t *testing.T) {
 	}
 
 	t.Run("predecessor is the purpose root", func(t *testing.T) {
-		tx := mkProposalsTx(mkHfAction(&rootId, 10, 0))
+		tx := mkProposalsTx(t, mkHfAction(&rootId, 10, 0))
 		require.NoError(
 			t,
 			conway.UtxoValidateProposalAncestry(tx, 50, withRoot, pp),
@@ -1091,7 +1181,7 @@ func TestUtxoValidateProposalAncestryPurposeRoot(t *testing.T) {
 	})
 
 	t.Run("predecessor is a pending proposal", func(t *testing.T) {
-		tx := mkProposalsTx(mkHfAction(&pendingId, 10, 0))
+		tx := mkProposalsTx(t, mkHfAction(&pendingId, 10, 0))
 		require.NoError(
 			t,
 			conway.UtxoValidateProposalAncestry(tx, 50, withRoot, pp),
@@ -1099,7 +1189,7 @@ func TestUtxoValidateProposalAncestryPurposeRoot(t *testing.T) {
 	})
 
 	t.Run("no predecessor while a root exists is rejected", func(t *testing.T) {
-		tx := mkProposalsTx(mkHfAction(nil, 10, 0))
+		tx := mkProposalsTx(t, mkHfAction(nil, 10, 0))
 		err := conway.UtxoValidateProposalAncestry(tx, 50, withRoot, pp)
 		var ancErr conway.InvalidGovActionAncestorError
 		require.ErrorAs(t, err, &ancErr)
@@ -1107,7 +1197,7 @@ func TestUtxoValidateProposalAncestryPurposeRoot(t *testing.T) {
 	})
 
 	t.Run("no predecessor with an empty root is allowed", func(t *testing.T) {
-		tx := mkProposalsTx(mkHfAction(nil, 10, 0))
+		tx := mkProposalsTx(t, mkHfAction(nil, 10, 0))
 		require.NoError(
 			t,
 			conway.UtxoValidateProposalAncestry(tx, 50, emptyRoots, pp),
@@ -1115,7 +1205,7 @@ func TestUtxoValidateProposalAncestryPurposeRoot(t *testing.T) {
 	})
 
 	t.Run("expired predecessor is rejected", func(t *testing.T) {
-		tx := mkProposalsTx(mkHfAction(&expiredId, 10, 0))
+		tx := mkProposalsTx(t, mkHfAction(&expiredId, 10, 0))
 		err := conway.UtxoValidateProposalAncestry(tx, 50, withRoot, pp)
 		var ancErr conway.InvalidGovActionAncestorError
 		require.ErrorAs(t, err, &ancErr)
@@ -1123,17 +1213,32 @@ func TestUtxoValidateProposalAncestryPurposeRoot(t *testing.T) {
 	})
 
 	t.Run("predecessor in the same transaction", func(t *testing.T) {
-		first := mkHfAction(&rootId, 10, 0)
-		tx := mkProposalsTx(first, nil)
-		firstId := common.GovActionId{
-			TransactionId: tx.Hash(),
-			GovActionIdx:  0,
-		}
-		tx = mkProposalsTx(first, mkHfAction(&firstId, 10, 1))
+		second := mkHfAction(nil, 10, 1)
+		tx := mkProposalsTx(t, mkHfAction(&rootId, 10, 0), second)
+		firstId := selfActionId(tx, 0)
+		second.ActionId = &firstId
 		require.NoError(
 			t,
 			conway.UtxoValidateProposalAncestry(tx, 50, withRoot, pp),
 		)
+	})
+
+	// The same reference against another transaction's id is not a
+	// same-transaction predecessor and is not recorded by the ledger
+	// state either, so it is rejected as nonexistent.
+	t.Run("predecessor id of another transaction", func(t *testing.T) {
+		other := mkProposalsTx(t, mkHfAction(&rootId, 10, 0))
+		otherId := selfActionId(other, 0)
+		tx := mkProposalsTx(
+			t,
+			mkHfAction(&rootId, 10, 0),
+			mkHfAction(&otherId, 10, 1),
+		)
+		requireDistinctTxIds(t, other, tx)
+		err := conway.UtxoValidateProposalAncestry(tx, 50, withRoot, pp)
+		var ancErr conway.InvalidGovActionAncestorError
+		require.ErrorAs(t, err, &ancErr)
+		assert.Equal(t, otherId, ancErr.ActionId)
 	})
 
 	// Only an earlier proposal of the same transaction is a candidate
@@ -1142,12 +1247,10 @@ func TestUtxoValidateProposalAncestryPurposeRoot(t *testing.T) {
 	t.Run(
 		"self reference in the same transaction is rejected",
 		func(t *testing.T) {
-			tx := mkProposalsTx(mkHfAction(&rootId, 10, 0))
-			selfId := common.GovActionId{
-				TransactionId: tx.Hash(),
-				GovActionIdx:  0,
-			}
-			tx = mkProposalsTx(mkHfAction(&selfId, 10, 0))
+			only := mkHfAction(&rootId, 10, 0)
+			tx := mkProposalsTx(t, only)
+			selfId := selfActionId(tx, 0)
+			only.ActionId = &selfId
 			err := conway.UtxoValidateProposalAncestry(tx, 50, withRoot, pp)
 			var ancErr conway.InvalidGovActionAncestorError
 			require.ErrorAs(t, err, &ancErr)
@@ -1159,13 +1262,13 @@ func TestUtxoValidateProposalAncestryPurposeRoot(t *testing.T) {
 	// existence-and-purpose behavior, so a syncing node backed by such a
 	// state is not wedged by the stricter rule.
 	t.Run("no roots capability keeps existence checks", func(t *testing.T) {
-		tx := mkProposalsTx(mkHfAction(nil, 10, 0))
+		tx := mkProposalsTx(t, mkHfAction(nil, 10, 0))
 		require.NoError(
 			t,
 			conway.UtxoValidateProposalAncestry(tx, 50, base, pp),
 		)
 		missing := common.GovActionId{TransactionId: common.Blake2b256{0xFE}}
-		bad := mkProposalsTx(mkHfAction(&missing, 10, 0))
+		bad := mkProposalsTx(t, mkHfAction(&missing, 10, 0))
 		err := conway.UtxoValidateProposalAncestry(bad, 50, base, pp)
 		var ancErr conway.InvalidGovActionAncestorError
 		require.ErrorAs(t, err, &ancErr)
@@ -1257,33 +1360,58 @@ func TestUtxoValidateStakePoolVotingRestrictionsParameterChange(t *testing.T) {
 		mkTx := func(
 			update conway.ConwayProtocolParameterUpdate,
 		) *conway.ConwayTransaction {
-			tx := mkProposalsTx(&conway.ConwayParameterChangeGovAction{
+			tx := mkProposalsTx(t, &conway.ConwayParameterChangeGovAction{
 				ParamUpdate: update,
 			})
-			actionId := common.GovActionId{
-				TransactionId: tx.Hash(),
-				GovActionIdx:  0,
-			}
-			v := spoVoter
-			tx.Body.TxVotingProcedures = common.VotingProcedures{
-				&v: {
-					&actionId: common.VotingProcedure{
-						Vote: common.GovVoteYes,
-					},
-				},
-			}
+			addVote(tx, spoVoter, selfActionId(tx, 0), common.GovVoteYes)
 			return tx
 		}
+		securityTx := mkTx(securityUpdate)
+		nonSecurityTx := mkTx(nonSecurityUpdate)
+		// The ledger state records neither transaction's proposal, so a
+		// verdict here can only come from the transaction's own proposals.
+		require.False(t, ls.GovActionExists(selfActionId(securityTx, 0)))
+		require.False(t, ls.GovActionExists(selfActionId(nonSecurityTx, 0)))
 		require.NoError(
 			t,
 			conway.UtxoValidateStakePoolVotingRestrictions(
-				mkTx(securityUpdate), 0, ls, pp,
+				securityTx, 0, ls, pp,
 			),
 		)
 		err := conway.UtxoValidateStakePoolVotingRestrictions(
-			mkTx(nonSecurityUpdate), 0, ls, pp,
+			nonSecurityTx, 0, ls, pp,
 		)
 		var spoErr conway.StakePoolVotingRestrictionError
 		require.ErrorAs(t, err, &spoErr)
+		assert.Equal(t, selfActionId(nonSecurityTx, 0), spoErr.ActionId)
+	})
+
+	// A vote naming an action that another transaction proposes is not
+	// resolved from this transaction's proposals; the SPO restriction is
+	// left to the ledger state, which does not record it.
+	t.Run("action proposed by another transaction", func(t *testing.T) {
+		// Both transactions propose the same non-security parameter
+		// change at index 0, so only the transaction id in the action id
+		// distinguishes them. other carries a second proposal purely to
+		// give it a different body, and therefore a different id.
+		other := mkProposalsTx(
+			t,
+			&conway.ConwayParameterChangeGovAction{
+				ParamUpdate: nonSecurityUpdate,
+			},
+			&conway.ConwayParameterChangeGovAction{
+				ParamUpdate: nonSecurityUpdate,
+			},
+		)
+		tx := mkProposalsTx(t, &conway.ConwayParameterChangeGovAction{
+			ParamUpdate: nonSecurityUpdate,
+		})
+		requireDistinctTxIds(t, other, tx)
+		otherId := selfActionId(other, 0)
+		addVote(tx, spoVoter, otherId, common.GovVoteYes)
+		require.NoError(
+			t,
+			conway.UtxoValidateStakePoolVotingRestrictions(tx, 0, ls, pp),
+		)
 	})
 }

--- a/ledger/conway/rules_gov_transition_test.go
+++ b/ledger/conway/rules_gov_transition_test.go
@@ -534,6 +534,40 @@ func TestUtxoValidateUnknownGovActionIds(t *testing.T) {
 		assert.Equal(t, common.GovActionId{}, unkErr.ActionIds[0])
 	})
 
+	// cardano-ledger folds the transaction's proposals into the proposal set
+	// before checking its votes, so an action the voting transaction
+	// proposes is not an unknown action.
+	t.Run("action proposed by the voting transaction", func(t *testing.T) {
+		tx := mkProposalsTx(t, &common.InfoGovAction{})
+		actionId := selfActionId(tx, 0)
+		require.False(t, ls.GovActionExists(actionId))
+		addVote(tx, voter, actionId, common.GovVoteYes)
+		require.NoError(
+			t,
+			conway.UtxoValidateUnknownGovActionIds(tx, 0, ls, pp),
+		)
+	})
+
+	// An action id that names another transaction is still unknown, so the
+	// same-transaction allowance is keyed on the transaction id and not on
+	// the proposal index alone.
+	t.Run("action proposed by another transaction", func(t *testing.T) {
+		other := mkProposalsTx(t, &common.InfoGovAction{})
+		tx := mkProposalsTx(
+			t,
+			&common.InfoGovAction{},
+			&common.InfoGovAction{},
+		)
+		requireDistinctTxIds(t, other, tx)
+		otherId := selfActionId(other, 0)
+		addVote(tx, voter, otherId, common.GovVoteYes)
+		err := conway.UtxoValidateUnknownGovActionIds(tx, 0, ls, pp)
+		var unkErr conway.UnknownGovActionIdError
+		require.ErrorAs(t, err, &unkErr)
+		require.Len(t, unkErr.ActionIds, 1)
+		assert.Equal(t, otherId, unkErr.ActionIds[0])
+	})
+
 	t.Run(
 		"multiple unknown action ids sort deterministically",
 		func(t *testing.T) {
@@ -835,6 +869,89 @@ func TestUtxoValidateBootstrapVotingRestrictions(t *testing.T) {
 		assert.Equal(t, common.GovActionId{}, bootErr.ActionId)
 	})
 
+	// A vote on an action the same transaction proposes is classified from
+	// that proposal, so a propose-and-vote does not escape the restriction
+	// by being absent from the ledger state.
+	t.Run(
+		"PV9 DRep cannot vote on a self-proposed hard fork",
+		func(t *testing.T) {
+			tx := mkProposalsTx(t, mkHfAction(nil, 10, 0))
+			actionId := selfActionId(tx, 0)
+			require.False(t, ls.GovActionExists(actionId))
+			addVote(tx, drepVoter, actionId, common.GovVoteYes)
+			err := conway.UtxoValidateBootstrapVotingRestrictions(
+				tx, 0, ls, pv9,
+			)
+			var bootErr conway.BootstrapVotingRestrictionError
+			require.ErrorAs(t, err, &bootErr)
+			assert.Equal(t, actionId, bootErr.ActionId)
+		},
+	)
+
+	t.Run(
+		"PV9 DRep can vote on a self-proposed InfoAction",
+		func(t *testing.T) {
+			tx := mkProposalsTx(t, &common.InfoGovAction{})
+			addVote(tx, drepVoter, selfActionId(tx, 0), common.GovVoteYes)
+			require.NoError(
+				t,
+				conway.UtxoValidateBootstrapVotingRestrictions(
+					tx, 0, ls, pv9,
+				),
+			)
+		},
+	)
+}
+
+// A CC vote on an action its own transaction proposes is classified from that
+// proposal. The ledger state records none of these actions, so a verdict can
+// only come from the transaction's proposal procedures.
+func TestUtxoValidateCCVotingRestrictionsSameTransactionProposal(
+	t *testing.T,
+) {
+	pp := mkConwayPp(common.ProtocolVersionVanRossem, 0)
+	ls := mockledger.NewLedgerStateBuilder().Build()
+	ccVoter := common.Voter{
+		Type: common.VoterTypeConstitutionalCommitteeHotKeyHash,
+		Hash: common.Blake2b224{0x01},
+	}
+
+	t.Run("CC cannot vote on a self-proposed NoConfidence", func(t *testing.T) {
+		tx := mkProposalsTx(t, &common.NoConfidenceGovAction{})
+		actionId := selfActionId(tx, 0)
+		require.False(t, ls.GovActionExists(actionId))
+		addVote(tx, ccVoter, actionId, common.GovVoteYes)
+		err := conway.UtxoValidateCCVotingRestrictions(tx, 0, ls, pp)
+		var ccErr conway.CCVotingRestrictionError
+		require.ErrorAs(t, err, &ccErr)
+		assert.Equal(t, actionId, ccErr.ActionId)
+	})
+
+	t.Run("CC can vote on a self-proposed InfoAction", func(t *testing.T) {
+		tx := mkProposalsTx(t, &common.InfoGovAction{})
+		addVote(tx, ccVoter, selfActionId(tx, 0), common.GovVoteYes)
+		require.NoError(
+			t,
+			conway.UtxoValidateCCVotingRestrictions(tx, 0, ls, pp),
+		)
+	})
+
+	// The same vote against another transaction's action id is not resolved
+	// from this transaction's proposals.
+	t.Run("CC vote on another transaction's NoConfidence", func(t *testing.T) {
+		other := mkProposalsTx(t, &common.NoConfidenceGovAction{})
+		tx := mkProposalsTx(
+			t,
+			&common.NoConfidenceGovAction{},
+			&common.NoConfidenceGovAction{},
+		)
+		requireDistinctTxIds(t, other, tx)
+		addVote(tx, ccVoter, selfActionId(other, 0), common.GovVoteYes)
+		require.NoError(
+			t,
+			conway.UtxoValidateCCVotingRestrictions(tx, 0, ls, pp),
+		)
+	})
 }
 
 func TestUtxoValidateStakePoolVotingRestrictions(t *testing.T) {

--- a/ledger/conway/rules_gov_transition_test.go
+++ b/ledger/conway/rules_gov_transition_test.go
@@ -387,21 +387,21 @@ func TestUtxoValidateHardForkCanFollow(t *testing.T) {
 	})
 
 	t.Run(
-		"proposal with an ancestor defers the numeric check",
+		"a version jump is rejected even with an ancestor",
 		func(t *testing.T) {
 			pp := mkConwayPp(9, 0)
 			ancestor := common.GovActionId{
 				TransactionId: common.Blake2b256{0x01},
 			}
-			// This version jump would be invalid if compared against the
-			// current protocol version, but since an ancestor is referenced we
-			// document that we cannot verify the chain without the ancestor's
-			// proposed version, so no error is raised here.
+			// preceedingHardFork compares against the enacted protocol
+			// version once the proposed major version is more than one
+			// above it, whatever the proposal's predecessor is.
 			tx := mkHfTx(&ancestor, 99, 0)
-			require.NoError(
-				t,
-				conway.UtxoValidateHardForkCanFollow(tx, 0, nil, pp),
-			)
+			err := conway.UtxoValidateHardForkCanFollow(tx, 0, nil, pp)
+			var hfErr conway.BadHardForkProtocolVersionError
+			require.ErrorAs(t, err, &hfErr)
+			assert.Equal(t, uint(99), hfErr.Supplied.Major)
+			assert.Equal(t, uint(9), hfErr.Expected.Major)
 		},
 	)
 }
@@ -887,14 +887,13 @@ func TestUtxoValidateStakePoolVotingRestrictions(t *testing.T) {
 		)
 	})
 
-	// See the NOTE on UtxoValidateStakePoolVotingRestrictions: the ledger
-	// spec also restricts SPO votes on ParameterChange proposals that
-	// don't touch "security group" parameters, but this codebase does not
-	// classify ParameterChange fields into security-relevant groups, so
-	// that narrower restriction is intentionally unenforced. This pins
-	// that documented behavior rather than leaving it untested.
+	// The security-group restriction on SPO votes over ParameterChange
+	// needs the proposed parameter update. This ledger state records only
+	// the action type, so the restriction stays unenforced for it; see
+	// TestUtxoValidateStakePoolVotingRestrictionsParameterChange for the
+	// enforced cases.
 	t.Run(
-		"SPO vote on ParameterChange is unenforced (documented gap)",
+		"SPO vote on an opaque ParameterChange is not classified",
 		func(t *testing.T) {
 			tx := mkVoteTx(spoVoter, paramChangeId, common.GovVoteYes)
 			require.NoError(
@@ -910,5 +909,381 @@ func TestUtxoValidateStakePoolVotingRestrictions(t *testing.T) {
 		var spoErr conway.StakePoolVotingRestrictionError
 		require.ErrorAs(t, err, &spoErr)
 		assert.Equal(t, common.GovActionId{}, spoErr.ActionId)
+	})
+}
+
+// The tests below close https://github.com/blinklabs-io/gouroboros/issues/1986:
+// hard-fork protocol version succession against a referenced ancestor,
+// purpose-root ancestry, and the Conway security-group restriction on stake
+// pool votes over parameter changes.
+
+func mkHfAction(
+	actionId *common.GovActionId,
+	major, minor uint,
+) *common.HardForkInitiationGovAction {
+	action := &common.HardForkInitiationGovAction{ActionId: actionId}
+	action.ProtocolVersion.Major = major
+	action.ProtocolVersion.Minor = minor
+	return action
+}
+
+// mkProposalsTx builds a transaction carrying several proposal procedures in
+// order, so a later proposal can reference an earlier one in the same
+// transaction by its (txid, index) governance action id.
+func mkProposalsTx(actions ...common.GovAction) *conway.ConwayTransaction {
+	tx := &conway.ConwayTransaction{}
+	for _, action := range actions {
+		tx.Body.TxProposalProcedures = append(
+			tx.Body.TxProposalProcedures,
+			conway.ConwayProposalProcedure{
+				PPGovAction: conway.ConwayGovAction{Action: action},
+			},
+		)
+	}
+	return tx
+}
+
+// rootedLedgerState decorates a ledger state with the optional
+// GovPurposeRootsState capability.
+type rootedLedgerState struct {
+	common.LedgerState
+	roots *common.GovPurposeRoots
+	err   error
+}
+
+func (l rootedLedgerState) GovPurposeRoots() (*common.GovPurposeRoots, error) {
+	return l.roots, l.err
+}
+
+func TestUtxoValidateHardForkCanFollowWithAncestor(t *testing.T) {
+	// Current protocol version is 9.0 throughout.
+	pp := mkConwayPp(9, 0)
+	pendingId := common.GovActionId{TransactionId: common.Blake2b256{0x11}}
+	opaqueId := common.GovActionId{TransactionId: common.Blake2b256{0x12}}
+	govActions := map[string]*common.GovActionState{
+		// A pending hard-fork proposal for 10.0 whose contents the ledger
+		// state exposes.
+		govActionKey(pendingId): {
+			ActionId:   pendingId,
+			ActionType: common.GovActionTypeHardForkInitiation,
+			Action:     mkHfAction(nil, 10, 0),
+		},
+		// The same proposal from a state provider that only records the
+		// action type.
+		govActionKey(opaqueId): {
+			ActionId:   opaqueId,
+			ActionType: common.GovActionTypeHardForkInitiation,
+		},
+	}
+	ls := mockledger.NewLedgerStateBuilder().WithGovActions(govActions).Build()
+
+	t.Run(
+		"minor bump on the ancestor's version is allowed",
+		func(t *testing.T) {
+			tx := mkProposalsTx(mkHfAction(&pendingId, 10, 1))
+			require.NoError(
+				t,
+				conway.UtxoValidateHardForkCanFollow(tx, 0, ls, pp),
+			)
+		},
+	)
+
+	t.Run("gap from the ancestor's version is rejected", func(t *testing.T) {
+		tx := mkProposalsTx(mkHfAction(&pendingId, 10, 5))
+		err := conway.UtxoValidateHardForkCanFollow(tx, 0, ls, pp)
+		var hfErr conway.BadHardForkProtocolVersionError
+		require.ErrorAs(t, err, &hfErr)
+		assert.Equal(t, uint(10), hfErr.Supplied.Major)
+		assert.Equal(t, uint(5), hfErr.Supplied.Minor)
+		assert.Equal(t, uint(10), hfErr.Expected.Major)
+		assert.Equal(t, uint(0), hfErr.Expected.Minor)
+	})
+
+	// preceedingHardFork compares against the *current* protocol version,
+	// not the ancestor's, once the proposed major version is more than one
+	// above the current one. A chain of pending proposals therefore cannot
+	// be used to jump ahead.
+	t.Run(
+		"major version too high is rejected via an ancestor",
+		func(t *testing.T) {
+			tx := mkProposalsTx(mkHfAction(&pendingId, 11, 0))
+			err := conway.UtxoValidateHardForkCanFollow(tx, 0, ls, pp)
+			var hfErr conway.BadHardForkProtocolVersionError
+			require.ErrorAs(t, err, &hfErr)
+			assert.Equal(t, uint(11), hfErr.Supplied.Major)
+			assert.Equal(t, uint(9), hfErr.Expected.Major)
+		},
+	)
+
+	t.Run("ancestor in the same transaction", func(t *testing.T) {
+		first := mkHfAction(nil, 10, 0)
+		tx := mkProposalsTx(first, nil)
+		firstId := common.GovActionId{
+			TransactionId: tx.Hash(),
+			GovActionIdx:  0,
+		}
+		// Rebuild with the second proposal pointing at the first.
+		tx = mkProposalsTx(first, mkHfAction(&firstId, 10, 1))
+		require.NoError(
+			t,
+			conway.UtxoValidateHardForkCanFollow(tx, 0, ls, pp),
+		)
+
+		bad := mkProposalsTx(first, mkHfAction(&firstId, 10, 4))
+		err := conway.UtxoValidateHardForkCanFollow(bad, 0, ls, pp)
+		var hfErr conway.BadHardForkProtocolVersionError
+		require.ErrorAs(t, err, &hfErr)
+		assert.Equal(t, uint(10), hfErr.Expected.Major)
+		assert.Equal(t, uint(0), hfErr.Expected.Minor)
+	})
+
+	// A state provider that does not expose the ancestor's proposed
+	// protocol version cannot support the comparison; the check is skipped
+	// rather than run against the wrong reference version.
+	t.Run("ancestor without contents defers the check", func(t *testing.T) {
+		tx := mkProposalsTx(mkHfAction(&opaqueId, 10, 7))
+		require.NoError(
+			t,
+			conway.UtxoValidateHardForkCanFollow(tx, 0, ls, pp),
+		)
+	})
+}
+
+func TestUtxoValidateProposalAncestryPurposeRoot(t *testing.T) {
+	pp := mkConwayPp(common.ProtocolVersionConway, 0)
+	rootId := common.GovActionId{TransactionId: common.Blake2b256{0x21}}
+	pendingId := common.GovActionId{TransactionId: common.Blake2b256{0x22}}
+	expiredId := common.GovActionId{TransactionId: common.Blake2b256{0x23}}
+	govActions := map[string]*common.GovActionState{
+		govActionKey(rootId): {
+			ActionId:   rootId,
+			ActionType: common.GovActionTypeHardForkInitiation,
+		},
+		govActionKey(pendingId): {
+			ActionId:   pendingId,
+			ActionType: common.GovActionTypeHardForkInitiation,
+			ExpirySlot: 100,
+		},
+		govActionKey(expiredId): {
+			ActionId:   expiredId,
+			ActionType: common.GovActionTypeHardForkInitiation,
+			ExpirySlot: 10,
+		},
+	}
+	base := mockledger.NewLedgerStateBuilder().
+		WithGovActions(govActions).
+		Build()
+	withRoot := rootedLedgerState{
+		LedgerState: base,
+		roots:       &common.GovPurposeRoots{HardFork: &rootId},
+	}
+	emptyRoots := rootedLedgerState{
+		LedgerState: base,
+		roots:       &common.GovPurposeRoots{},
+	}
+
+	t.Run("predecessor is the purpose root", func(t *testing.T) {
+		tx := mkProposalsTx(mkHfAction(&rootId, 10, 0))
+		require.NoError(
+			t,
+			conway.UtxoValidateProposalAncestry(tx, 50, withRoot, pp),
+		)
+	})
+
+	t.Run("predecessor is a pending proposal", func(t *testing.T) {
+		tx := mkProposalsTx(mkHfAction(&pendingId, 10, 0))
+		require.NoError(
+			t,
+			conway.UtxoValidateProposalAncestry(tx, 50, withRoot, pp),
+		)
+	})
+
+	t.Run("no predecessor while a root exists is rejected", func(t *testing.T) {
+		tx := mkProposalsTx(mkHfAction(nil, 10, 0))
+		err := conway.UtxoValidateProposalAncestry(tx, 50, withRoot, pp)
+		var ancErr conway.InvalidGovActionAncestorError
+		require.ErrorAs(t, err, &ancErr)
+		assert.Equal(t, rootId, ancErr.ActionId)
+	})
+
+	t.Run("no predecessor with an empty root is allowed", func(t *testing.T) {
+		tx := mkProposalsTx(mkHfAction(nil, 10, 0))
+		require.NoError(
+			t,
+			conway.UtxoValidateProposalAncestry(tx, 50, emptyRoots, pp),
+		)
+	})
+
+	t.Run("expired predecessor is rejected", func(t *testing.T) {
+		tx := mkProposalsTx(mkHfAction(&expiredId, 10, 0))
+		err := conway.UtxoValidateProposalAncestry(tx, 50, withRoot, pp)
+		var ancErr conway.InvalidGovActionAncestorError
+		require.ErrorAs(t, err, &ancErr)
+		assert.Equal(t, expiredId, ancErr.ActionId)
+	})
+
+	t.Run("predecessor in the same transaction", func(t *testing.T) {
+		first := mkHfAction(&rootId, 10, 0)
+		tx := mkProposalsTx(first, nil)
+		firstId := common.GovActionId{
+			TransactionId: tx.Hash(),
+			GovActionIdx:  0,
+		}
+		tx = mkProposalsTx(first, mkHfAction(&firstId, 10, 1))
+		require.NoError(
+			t,
+			conway.UtxoValidateProposalAncestry(tx, 50, withRoot, pp),
+		)
+	})
+
+	// Only an earlier proposal of the same transaction is a candidate
+	// predecessor: cardano-ledger folds the proposals in order, so a
+	// proposal cannot name itself or a later proposal.
+	t.Run(
+		"self reference in the same transaction is rejected",
+		func(t *testing.T) {
+			tx := mkProposalsTx(mkHfAction(&rootId, 10, 0))
+			selfId := common.GovActionId{
+				TransactionId: tx.Hash(),
+				GovActionIdx:  0,
+			}
+			tx = mkProposalsTx(mkHfAction(&selfId, 10, 0))
+			err := conway.UtxoValidateProposalAncestry(tx, 50, withRoot, pp)
+			var ancErr conway.InvalidGovActionAncestorError
+			require.ErrorAs(t, err, &ancErr)
+			assert.Equal(t, selfId, ancErr.ActionId)
+		},
+	)
+
+	// A ledger state that cannot report purpose roots keeps the looser
+	// existence-and-purpose behavior, so a syncing node backed by such a
+	// state is not wedged by the stricter rule.
+	t.Run("no roots capability keeps existence checks", func(t *testing.T) {
+		tx := mkProposalsTx(mkHfAction(nil, 10, 0))
+		require.NoError(
+			t,
+			conway.UtxoValidateProposalAncestry(tx, 50, base, pp),
+		)
+		missing := common.GovActionId{TransactionId: common.Blake2b256{0xFE}}
+		bad := mkProposalsTx(mkHfAction(&missing, 10, 0))
+		err := conway.UtxoValidateProposalAncestry(bad, 50, base, pp)
+		var ancErr conway.InvalidGovActionAncestorError
+		require.ErrorAs(t, err, &ancErr)
+	})
+}
+
+func TestUtxoValidateStakePoolVotingRestrictionsParameterChange(t *testing.T) {
+	pp := mkConwayPp(common.ProtocolVersionPlomin, 0)
+	securityId := common.GovActionId{TransactionId: common.Blake2b256{0x31}}
+	nonSecurityId := common.GovActionId{TransactionId: common.Blake2b256{0x32}}
+	emptyId := common.GovActionId{TransactionId: common.Blake2b256{0x33}}
+	maxBlockBodySize := uint(90112)
+	keyDeposit := uint(2_000_000)
+
+	securityUpdate := conway.ConwayProtocolParameterUpdate{
+		MaxBlockBodySize: &maxBlockBodySize,
+	}
+	nonSecurityUpdate := conway.ConwayProtocolParameterUpdate{
+		KeyDeposit: &keyDeposit,
+	}
+	govActions := map[string]*common.GovActionState{
+		govActionKey(securityId): {
+			ActionId:   securityId,
+			ActionType: common.GovActionTypeParameterChange,
+			Action: &conway.ConwayParameterChangeGovAction{
+				ParamUpdate: securityUpdate,
+			},
+		},
+		govActionKey(nonSecurityId): {
+			ActionId:   nonSecurityId,
+			ActionType: common.GovActionTypeParameterChange,
+			Action: &conway.ConwayParameterChangeGovAction{
+				ParamUpdate: nonSecurityUpdate,
+			},
+		},
+		govActionKey(emptyId): {
+			ActionId:   emptyId,
+			ActionType: common.GovActionTypeParameterChange,
+			Action:     &conway.ConwayParameterChangeGovAction{},
+		},
+	}
+	ls := mockledger.NewLedgerStateBuilder().WithGovActions(govActions).Build()
+	spoVoter := common.Voter{
+		Type: common.VoterTypeStakingPoolKeyHash,
+		Hash: common.Blake2b224{0x01},
+	}
+	drepVoter := common.Voter{
+		Type: common.VoterTypeDRepKeyHash,
+		Hash: common.Blake2b224{0x02},
+	}
+
+	t.Run("SPO may vote on a security group change", func(t *testing.T) {
+		tx := mkVoteTx(spoVoter, securityId, common.GovVoteYes)
+		require.NoError(
+			t,
+			conway.UtxoValidateStakePoolVotingRestrictions(tx, 0, ls, pp),
+		)
+	})
+
+	t.Run("SPO may not vote on a non-security change", func(t *testing.T) {
+		tx := mkVoteTx(spoVoter, nonSecurityId, common.GovVoteYes)
+		err := conway.UtxoValidateStakePoolVotingRestrictions(tx, 0, ls, pp)
+		var spoErr conway.StakePoolVotingRestrictionError
+		require.ErrorAs(t, err, &spoErr)
+		assert.Equal(t, nonSecurityId, spoErr.ActionId)
+	})
+
+	t.Run("SPO may not vote on an empty parameter change", func(t *testing.T) {
+		tx := mkVoteTx(spoVoter, emptyId, common.GovVoteYes)
+		err := conway.UtxoValidateStakePoolVotingRestrictions(tx, 0, ls, pp)
+		var spoErr conway.StakePoolVotingRestrictionError
+		require.ErrorAs(t, err, &spoErr)
+	})
+
+	t.Run(
+		"DRep vote on a non-security change is unaffected",
+		func(t *testing.T) {
+			tx := mkVoteTx(drepVoter, nonSecurityId, common.GovVoteYes)
+			require.NoError(
+				t,
+				conway.UtxoValidateStakePoolVotingRestrictions(tx, 0, ls, pp),
+			)
+		},
+	)
+
+	// A vote may refer to an action proposed by its own transaction, whose
+	// contents are then available whatever the ledger state records.
+	t.Run("action proposed by the voting transaction", func(t *testing.T) {
+		mkTx := func(
+			update conway.ConwayProtocolParameterUpdate,
+		) *conway.ConwayTransaction {
+			tx := mkProposalsTx(&conway.ConwayParameterChangeGovAction{
+				ParamUpdate: update,
+			})
+			actionId := common.GovActionId{
+				TransactionId: tx.Hash(),
+				GovActionIdx:  0,
+			}
+			v := spoVoter
+			tx.Body.TxVotingProcedures = common.VotingProcedures{
+				&v: {
+					&actionId: common.VotingProcedure{
+						Vote: common.GovVoteYes,
+					},
+				},
+			}
+			return tx
+		}
+		require.NoError(
+			t,
+			conway.UtxoValidateStakePoolVotingRestrictions(
+				mkTx(securityUpdate), 0, ls, pp,
+			),
+		)
+		err := conway.UtxoValidateStakePoolVotingRestrictions(
+			mkTx(nonSecurityUpdate), 0, ls, pp,
+		)
+		var spoErr conway.StakePoolVotingRestrictionError
+		require.ErrorAs(t, err, &spoErr)
 	})
 }


### PR DESCRIPTION
Closes #1986.

## Summary

- Enforce Conway hard-fork proposal succession against the enacted version or the referenced pending proposal.
- Accept proposal ancestry only from the purpose root or that purpose's pending graph, while rejecting self and forward references.
- Reject SPO votes on constitutions and treasury withdrawals, and allow parameter-change votes only for security-group fields.
- Define and test the ten Conway security-group protocol-parameter fields.

## Compatibility

`GovActionState.Action` and the `GovPurposeRootsState` capability are optional, so existing state providers continue to compile. Dingo's current state adapter does not populate them; the ancestry rule is therefore looser there until the capability is implemented, while self/forward-reference and hard-fork succession checks apply immediately.

`ExpirySlot` implementations must represent the last slot for which an action remains alive. Tests cover positive and negative cases for all four rule groups and fail when the validation changes are removed.
