### PR TITLE
feat(blockfetch): pipeline range requests on the client

### DIFF
--- a/protocol/PROTOCOL_LIMITS.md
+++ b/protocol/PROTOCOL_LIMITS.md
@@ -48,14 +48,30 @@ All limits are based on the [Ouroboros Network Specification](https://ouroboros-
 - `BusyTimeout = 5s` - Timeout for server to start batch or respond no blocks
 - `StreamingTimeout = 60s` - Timeout for server to send next block in batch
 
+**Request pipelining constants:**
+- `DefaultMaxInFlightBytes = 9011200` - Bound on the expected size of
+  outstanding pipelined range requests, matching `cardano-node`'s
+  `blockFetchProtocolLimits`: `blockFetchPipeliningMax` (100) times the maximum
+  block body size (88 KiB)
+- `DefaultRequestExpectedBytes = 90112` - Size charged to a request whose
+  caller supplied no estimate (one maximum-size block body), which makes the
+  default bound degrade to 100 outstanding requests
+- `PipelinedIdleMaxPendingMessageBytes` - Idle-state ingress limit for a
+  pipelining client, which must admit a block because the peer's response to
+  the next request can arrive while the state machine is momentarily back in
+  Idle
+
 **Enforcement:**
 - Configuration validation with panic on invalid values
 - Queue size limits enforced by protocol framework
 - Per-state pending message byte limits enforced with connection teardown on violation
 - State transition timeouts enforced with connection teardown on timeout
+- Outstanding pipelined requests bounded in bytes, blocking the caller of
+  `Client.RequestRange` rather than terminating the connection
 
 **Files modified:**
 - `protocol/blockfetch/blockfetch.go` - Added constants, validation, and documentation
+- `protocol/blockfetch/client.go` - Outstanding request queue and in-flight byte bound
 
 ### TxSubmission Protocol
 

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -43,6 +43,17 @@ The Ouroboros protocol uses an agency model where only one party can send messag
 - **Server Agency**: Server sends, client waits
 - **None**: Terminal state (Done)
 
+### Pipelining
+
+A state may set `StateMapEntry.AllowPipelinedSend`, which lets the party
+*without* agency in that state write already-queued messages to the wire. The
+state transition for such a message is deferred until agency returns, so the
+local state machine still applies exactly one transition per message, in send
+order. This is how a protocol that is pipelined on the wire keeps the remote
+peer busy across response boundaries; block-fetch uses it for
+`MsgRequestRange`. States that leave the field false keep the strict "send only
+while holding agency" behavior.
+
 ### Common Patterns
 
 **Acquire/Release Pattern** (LocalStateQuery, LocalTxMonitor):

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -146,6 +146,11 @@ cs.Client.Start()
 cs.Client.RequestNext()
 ```
 
+The embedded common protocol also exposes `SendMessageContext` for operations
+that must stop waiting when a full send queue outlives the caller's context.
+Cancellation applies only until the message enters the queue; a successful
+return means the protocol accepted responsibility for sending it.
+
 ## Common Configuration
 
 All protocols support these common options:

--- a/protocol/blockfetch/README.md
+++ b/protocol/blockfetch/README.md
@@ -131,10 +131,11 @@ if err := client.GetBlockRange(startPoint, endPoint); err != nil {
 
 ## Request Pipelining
 
-`MsgBlock` is the pipelined message of this mini-protocol, and `cardano-node`
-runs up to 100 outstanding requests per peer. A client that waits for a batch
-to finish before sending the next request idles the peer for a round trip at
-every batch boundary.
+`MsgRequestRange` is the pipelined client message of this mini-protocol, while
+`MsgBlock` is the server response that streams blocks back. `cardano-node` runs
+up to 100 outstanding requests per peer. A client that waits for a batch to
+finish before sending the next request idles the peer for a round trip at every
+batch boundary.
 
 A client configured with `RequestPipelining` keeps a FIFO queue of outstanding
 `MsgRequestRange`. Responses are ordered, so queue position identifies the

--- a/protocol/blockfetch/README.md
+++ b/protocol/blockfetch/README.md
@@ -92,7 +92,7 @@ The BlockFetch protocol retrieves blocks by hash from a peer node. It is used in
 | Busy Max Pending Bytes | 2.5 MB | Matches Streaming; a block can arrive before the state machine leaves Busy |
 | Idle Max Pending Bytes | 64 KB | Only control messages are sent in Idle |
 | Idle Max Pending Bytes (pipelining client) | 2.5 MB | A block for the next request can arrive while the state machine is momentarily back in Idle |
-| Default Max In-Flight Bytes | 8.6 MB | Expected size of outstanding pipelined requests: 100 x 88 KiB, as in `cardano-node`'s `blockFetchProtocolLimits` |
+| Default Max In-Flight Bytes | 9.0 MB | Expected size of outstanding pipelined requests: 100 x 88 KiB = 9,011,200 bytes, as in `cardano-node`'s `blockFetchProtocolLimits` |
 | Default Request Expected Bytes | 88 KiB | Size assumed for a request whose caller gave no estimate (one maximum-size block body) |
 
 ## Configuration Options

--- a/protocol/blockfetch/README.md
+++ b/protocol/blockfetch/README.md
@@ -89,7 +89,11 @@ The BlockFetch protocol retrieves blocks by hash from a peer node. It is used in
 | Max Recv Queue Size | 512 | Maximum receive queue messages |
 | Default Recv Queue Size | 384 | Default queue size |
 | Streaming Max Pending Bytes | 2.5 MB | Max pending bytes in Streaming state |
-| Idle/Busy Max Pending Bytes | 64 KB | Max pending bytes in Idle/Busy states |
+| Busy Max Pending Bytes | 2.5 MB | Matches Streaming; a block can arrive before the state machine leaves Busy |
+| Idle Max Pending Bytes | 64 KB | Only control messages are sent in Idle |
+| Idle Max Pending Bytes (pipelining client) | 2.5 MB | A block for the next request can arrive while the state machine is momentarily back in Idle |
+| Default Max In-Flight Bytes | 8.6 MB | Expected size of outstanding pipelined requests: 100 x 88 KiB, as in `cardano-node`'s `blockFetchProtocolLimits` |
+| Default Request Expected Bytes | 88 KiB | Size assumed for a request whose caller gave no estimate (one maximum-size block body) |
 
 ## Configuration Options
 
@@ -102,21 +106,60 @@ blockfetch.NewConfig(
     blockfetch.WithBatchStartTimeout(5 * time.Second),
     blockfetch.WithBlockTimeout(60 * time.Second),
     blockfetch.WithRecvQueueSize(384),
+    // Client request pipelining
+    blockfetch.WithRequestPipelining(true),
+    blockfetch.WithRangeDoneFunc(rangeDoneCallback),
+    blockfetch.WithMaxInFlightBytes(blockfetch.DefaultMaxInFlightBytes),
 )
 ```
 
 ## Usage Example
 
 ```go
-// Request a range of blocks
+// Request a range of blocks. One request is outstanding at a time; a second
+// call blocks until the first batch completes.
 startPoint := Point{Slot: 1000, Hash: startHash}
 endPoint := Point{Slot: 2000, Hash: endHash}
 
-client.RequestRange(startPoint, endPoint)
+if err := client.GetBlockRange(startPoint, endPoint); err != nil {
+    return err
+}
 
-// Blocks arrive via BlockFunc callback
+// Blocks arrive via BlockFunc/BlockRawFunc callback
 // BatchDoneFunc called when range complete
 ```
+
+## Request Pipelining
+
+`MsgBlock` is the pipelined message of this mini-protocol, and `cardano-node`
+runs up to 100 outstanding requests per peer. A client that waits for a batch
+to finish before sending the next request idles the peer for a round trip at
+every batch boundary.
+
+A client configured with `RequestPipelining` keeps a FIFO queue of outstanding
+`MsgRequestRange`. Responses are ordered, so queue position identifies the
+request a `StartBatch`, `Block`, `NoBlocks`, or `BatchDone` belongs to; no wire
+change is involved. `CallbackContext.RequestId` carries that identity to the
+block callbacks, and `RangeDoneFunc` is called exactly once per request with
+the terminal outcome.
+
+```go
+id, err := client.RequestRange(ctx, blockfetch.RangeRequest{
+    Start:         startPoint,
+    End:           endPoint,
+    ExpectedBytes: expectedRangeBytes, // from the chain-sync header sizes
+})
+```
+
+`RequestRange` returns as soon as the request is queued and sent, and blocks
+only while admitting it would exceed `MaxInFlightBytes`. The bound is in bytes
+rather than requests because consumer range sizes vary by orders of magnitude;
+a caller that supplies no estimate is charged one maximum-size block body per
+request, which reproduces `cardano-node`'s limit of 100 outstanding requests.
+
+`RequestPipelining` is protocol request pipelining. It is unrelated to the
+`Pipeline` option, which is a processing pipeline for blocks that have already
+been received.
 
 ## Block Format
 
@@ -132,6 +175,7 @@ type WrappedBlock struct {
 ## Notes
 
 - Used in conjunction with ChainSync (headers) + BlockFetch (bodies)
-- Blocks are streamed in order from start to end point
+- Blocks are streamed in order from start to end point, and batches are
+  answered in request order
 - Large receive queue supports high-throughput block streaming
 - The Streaming state has a higher pending byte limit for efficiency

--- a/protocol/blockfetch/blockfetch.go
+++ b/protocol/blockfetch/blockfetch.go
@@ -108,12 +108,22 @@ type Config struct {
 	BlockFunc           BlockFunc               // Callback for decoded blocks
 	BlockRawFunc        BlockRawFunc            // Callback for raw block data
 	BatchDoneFunc       BatchDoneFunc           // Callback when a batch is done
+	RangeDoneFunc       RangeDoneFunc           // Callback when a pipelined range request completes
 	RequestRangeFunc    RequestRangeFunc        // Callback for range requests
 	BatchStartTimeout   time.Duration           // Timeout for starting a batch
 	BlockTimeout        time.Duration           // Timeout for receiving a block
 	RecvQueueSize       int                     // Size of the receive queue
 	SkipBlockValidation bool                    // Skip block validation during parsing
 	Pipeline            *pipeline.BlockPipeline // Pipeline enables the block processing pipeline for batch operations
+	// RequestPipelining allows the client to keep more than one
+	// MsgRequestRange outstanding through Client.RequestRange. This is
+	// protocol request pipelining and is unrelated to Pipeline above, which
+	// is a processing pipeline for blocks that have already been received.
+	RequestPipelining bool
+	// MaxInFlightBytes bounds the total expected size of the range requests
+	// a pipelining client keeps outstanding. Zero means
+	// DefaultMaxInFlightBytes.
+	MaxInFlightBytes uint64
 }
 
 // MaxRecvQueueSize is the maximum allowed receive queue size (messages).
@@ -130,12 +140,34 @@ const StreamingMaxPendingMessageBytes = 2500000
 // are sent in this state, so the limit can be small.
 const IdleMaxPendingMessageBytes = 65535
 
+// PipelinedIdleMaxPendingMessageBytes is the pending message byte limit used
+// for the Idle state by a client with RequestPipelining enabled. With more
+// than one request outstanding, the peer's MsgBlock for the next request can
+// arrive while the local state machine is momentarily back in Idle, between
+// the previous MsgBatchDone and the deferred transition for the next
+// MsgRequestRange. The Idle limit therefore has to admit a block, for the
+// same reason BusyMaxPendingMessageBytes does.
+const PipelinedIdleMaxPendingMessageBytes = StreamingMaxPendingMessageBytes
+
 // BusyMaxPendingMessageBytes is the maximum allowed pending message bytes
 // in the Busy state. This must match StreamingMaxPendingMessageBytes because
 // MsgBlock can arrive while the protocol state machine is still in Busy
 // (before recvLoop processes MsgStartBatch to transition to Streaming),
 // creating a race between muxerRecvLoop limit checks and state transitions.
 const BusyMaxPendingMessageBytes = StreamingMaxPendingMessageBytes
+
+// DefaultRequestExpectedBytes is the size assumed for a range request whose
+// caller did not estimate one. It is one maximum-size mainnet block body
+// (maxBlockBodySize = 88 KiB), which makes DefaultMaxInFlightBytes degrade to
+// cardano-node's blockFetchPipeliningMax of 100 outstanding requests for
+// callers that cannot estimate.
+const DefaultRequestExpectedBytes uint64 = 88 * 1024
+
+// DefaultMaxInFlightBytes is the default bound on the total expected size of
+// outstanding pipelined range requests. It matches the ingress allowance
+// cardano-node sizes for block-fetch in blockFetchProtocolLimits:
+// blockFetchPipeliningMax (100) times the maximum block body size (88 KiB).
+const DefaultMaxInFlightBytes uint64 = 100 * DefaultRequestExpectedBytes
 
 // BusyTimeout is the timeout for the server to start a batch or respond no blocks.
 const BusyTimeout = 60 * time.Second
@@ -148,6 +180,12 @@ type CallbackContext struct {
 	ConnectionId connection.ConnectionId // Connection ID
 	Client       *Client                 // Client instance (if applicable)
 	Server       *Server                 // Server instance (if applicable)
+	// RequestId identifies the client range request that produced this
+	// callback. Requests are numbered from 1 in the order they were sent,
+	// and block-fetch responses are ordered, so this attributes each block
+	// and completion to the MsgRequestRange that asked for it. It is zero
+	// for server-side callbacks.
+	RequestId uint64
 }
 
 // BlockFunc is a callback for handling decoded blocks.
@@ -156,8 +194,17 @@ type BlockFunc func(CallbackContext, uint, ledger.Block) error
 // BlockRawFunc is a callback for handling raw block data.
 type BlockRawFunc func(CallbackContext, uint, []byte) error
 
-// BatchDoneFunc is a callback invoked when a batch is complete.
+// BatchDoneFunc is a callback invoked when a batch is complete. It is not
+// used for requests made through Client.RequestRange, which report
+// completion through RangeDoneFunc instead.
 type BatchDoneFunc func(CallbackContext) error
+
+// RangeDoneFunc is a callback invoked exactly once for each request made
+// through Client.RequestRange. The error is nil when the peer completed the
+// batch, and otherwise reports why the request will not be completed: the
+// range was unavailable, the peer violated the protocol, or the protocol shut
+// down with the request still outstanding.
+type RangeDoneFunc func(CallbackContext, error) error
 
 // RequestRangeFunc is a callback for handling block range requests.
 type RequestRangeFunc func(CallbackContext, pcommon.Point, pcommon.Point) error
@@ -181,6 +228,7 @@ func NewConfig(options ...BlockFetchOptionFunc) (Config, error) {
 		BatchStartTimeout: 5 * time.Second,
 		BlockTimeout:      60 * time.Second,
 		RecvQueueSize:     DefaultRecvQueueSize,
+		MaxInFlightBytes:  DefaultMaxInFlightBytes,
 	}
 	// Apply provided options functions
 	for _, option := range options {
@@ -224,6 +272,30 @@ func WithBlockFunc(blockFunc BlockFunc) BlockFetchOptionFunc {
 func WithBlockRawFunc(blockRawFunc BlockRawFunc) BlockFetchOptionFunc {
 	return func(c *Config) {
 		c.BlockRawFunc = blockRawFunc
+	}
+}
+
+// WithRangeDoneFunc sets the RangeDoneFunc callback in the Config.
+func WithRangeDoneFunc(rangeDoneFunc RangeDoneFunc) BlockFetchOptionFunc {
+	return func(c *Config) {
+		c.RangeDoneFunc = rangeDoneFunc
+	}
+}
+
+// WithRequestPipelining enables or disables client request pipelining, which
+// allows Client.RequestRange to keep multiple MsgRequestRange outstanding.
+func WithRequestPipelining(enabled bool) BlockFetchOptionFunc {
+	return func(c *Config) {
+		c.RequestPipelining = enabled
+	}
+}
+
+// WithMaxInFlightBytes sets the bound on the total expected size of
+// outstanding pipelined range requests. Zero selects
+// DefaultMaxInFlightBytes.
+func WithMaxInFlightBytes(maxBytes uint64) BlockFetchOptionFunc {
+	return func(c *Config) {
+		c.MaxInFlightBytes = maxBytes
 	}
 }
 

--- a/protocol/blockfetch/client.go
+++ b/protocol/blockfetch/client.go
@@ -582,7 +582,7 @@ func (c *Client) RequestRange(
 			"block-fetch RequestRange requires a RangeDoneFunc callback",
 		)
 	}
-	c.Protocol.Logger().
+	c.ProtocolInstance().Logger().
 		Debug(
 			fmt.Sprintf("calling RequestRange(start: {Slot: %d, Hash: %x}, end: {Slot: %d, Hash: %x})",
 				req.Start.Slot,
@@ -869,9 +869,10 @@ func (c *Client) failOutstanding(err error) {
 	c.queueMutex.Lock()
 	pending := c.drainLocked()
 	c.queueMutex.Unlock()
+	logger := c.ProtocolInstance().Logger()
 	for _, req := range pending {
 		if resolveErr := c.resolve(req, err); resolveErr != nil {
-			c.Protocol.Logger().
+			logger.
 				Warn("range done callback failed during shutdown",
 					"component", "network",
 					"protocol", ProtocolName,

--- a/protocol/blockfetch/client.go
+++ b/protocol/blockfetch/client.go
@@ -68,6 +68,7 @@ const (
 // owns the next MsgStartBatch, MsgNoBlocks, MsgBlock, and MsgBatchDone.
 type rangeRequest struct {
 	id             uint64
+	protocol       *protocol.Protocol
 	delivery       requestDelivery
 	pipelined      bool
 	reservedBytes  uint64
@@ -115,9 +116,7 @@ type Client struct {
 	protoOptions    protocol.ProtocolOptions
 	protoStarted    bool // Whether Protocol.Start() was called
 	// queueMutex protects the outstanding request queue and the in-flight
-	// byte accounting. It is held across the MsgRequestRange send so the
-	// order of the queue always matches the order of the requests on the
-	// wire.
+	// byte accounting.
 	queueMutex    sync.Mutex
 	queue         []*rangeRequest
 	nextRequestId uint64
@@ -125,6 +124,13 @@ type Client struct {
 	// bytesFreed is closed and replaced every time in-flight bytes are
 	// released, to broadcast to callers waiting for admission.
 	bytesFreed chan struct{}
+	// rangeSendToken serializes queue append and MsgRequestRange enqueue so
+	// FIFO queue order always matches wire order. Unlike a mutex, acquiring
+	// the token can be canceled by RequestRange's context.
+	rangeSendToken chan struct{}
+	// beforeRequestReservation is a test synchronization point immediately
+	// before the atomic admission and reservation step.
+	beforeRequestReservation func()
 }
 
 // NewClient creates a new Block Fetch protocol client with the given options and configuration.
@@ -138,7 +144,9 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 		protoOptions:   protoOptions,
 		lifecycleState: clientStateNew,
 		bytesFreed:     make(chan struct{}),
+		rangeSendToken: make(chan struct{}, 1),
 	}
+	c.rangeSendToken <- struct{}{}
 	c.callbackContext = CallbackContext{
 		Client:       c,
 		ConnectionId: protoOptions.ConnectionId,
@@ -325,12 +333,13 @@ func (c *Client) Start() {
 					"protocol", ProtocolName,
 					"connection_id", c.callbackContext.ConnectionId.String(),
 				)
-			c.Protocol.Start()
+			proto := c.ProtocolInstance()
+			proto.Start()
 			c.protoStarted = true
 			c.lifecycleState = clientStateRunning
 			// Resolve any request left outstanding when the protocol shuts
 			// down, so no caller and no callback consumer is left waiting.
-			go c.failOutstandingOnProtocolDone(c.DoneChan())
+			go c.failOutstandingOnProtocolDone(proto)
 			if c.startingDone == ch {
 				close(ch)
 				c.startingDone = nil
@@ -437,6 +446,7 @@ func (c *Client) GetBlockRange(start pcommon.Point, end pcommon.Point) error {
 	token, busyDone := c.acquireBusy()
 	protocolDone := c.DoneChan()
 	req, err := c.sendRequestRange(
+		context.Background(),
 		start,
 		end,
 		deliveryCallback,
@@ -471,6 +481,7 @@ func (c *Client) GetBlock(point pcommon.Point) (ledger.Block, error) {
 	token, _ := c.acquireBusy()
 	protocolDone := c.DoneChan()
 	req, err := c.sendRequestRange(
+		context.Background(),
 		point,
 		point,
 		deliveryChannel,
@@ -577,10 +588,11 @@ func (c *Client) RequestRange(
 	if expectedBytes == 0 {
 		expectedBytes = DefaultRequestExpectedBytes
 	}
-	if err := c.awaitInFlightCapacity(ctx, expectedBytes); err != nil {
-		return 0, err
+	if c.beforeRequestReservation != nil {
+		c.beforeRequestReservation()
 	}
 	sent, err := c.sendRequestRange(
+		ctx,
 		req.Start,
 		req.End,
 		deliveryCallback,
@@ -604,40 +616,25 @@ func (c *Client) maxInFlightBytes() uint64 {
 	return c.config.MaxInFlightBytes
 }
 
-// awaitInFlightCapacity blocks until the given request size fits within the
-// in-flight byte bound. The reservation itself is made by sendRequestRange
-// under the same lock that appends to the queue.
-func (c *Client) awaitInFlightCapacity(
-	ctx context.Context,
-	expectedBytes uint64,
-) error {
-	limit := c.maxInFlightBytes()
-	protocolDone := c.DoneChan()
-	for {
-		c.queueMutex.Lock()
+// hasInFlightCapacityLocked reports whether a pipelined request can reserve
+// expectedBytes. Subtraction avoids wrapping at the top of the uint64 range.
+// The caller must hold queueMutex.
+func (c *Client) hasInFlightCapacityLocked(expectedBytes uint64) bool {
+	if len(c.queue) == 0 {
 		// An empty queue always admits, so a range larger than the whole
 		// bound still makes progress instead of deadlocking.
-		if len(c.queue) == 0 ||
-			c.inFlightBytes+expectedBytes <= limit {
-			c.queueMutex.Unlock()
-			return nil
-		}
-		waitChan := c.bytesFreed
-		c.queueMutex.Unlock()
-		select {
-		case <-waitChan:
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-protocolDone:
-			return protocol.ErrProtocolShuttingDown
-		}
+		return true
 	}
+	limit := c.maxInFlightBytes()
+	return c.inFlightBytes <= limit &&
+		expectedBytes <= limit-c.inFlightBytes
 }
 
 // sendRequestRange appends a request to the outstanding queue and sends its
-// MsgRequestRange. The queue lock is held across the send so queue order
-// always matches wire order.
+// MsgRequestRange. A context-aware send token keeps queue and wire order in
+// sync without holding queueMutex while a full protocol send queue blocks.
 func (c *Client) sendRequestRange(
+	ctx context.Context,
 	start pcommon.Point,
 	end pcommon.Point,
 	delivery requestDelivery,
@@ -645,10 +642,41 @@ func (c *Client) sendRequestRange(
 	expectedBytes uint64,
 	busyToken uint64,
 ) (*rangeRequest, error) {
-	c.queueMutex.Lock()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	proto := c.ProtocolInstance()
+	protocolDone := proto.DoneChan()
+	select {
+	case <-c.rangeSendToken:
+		defer func() {
+			c.rangeSendToken <- struct{}{}
+		}()
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-protocolDone:
+		return nil, protocol.ErrProtocolShuttingDown
+	}
+	for {
+		c.queueMutex.Lock()
+		if pipelined && !c.hasInFlightCapacityLocked(expectedBytes) {
+			waitChan := c.bytesFreed
+			c.queueMutex.Unlock()
+			select {
+			case <-waitChan:
+				continue
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-protocolDone:
+				return nil, protocol.ErrProtocolShuttingDown
+			}
+		}
+		break
+	}
 	c.nextRequestId++
 	req := &rangeRequest{
 		id:            c.nextRequestId,
+		protocol:      proto,
 		delivery:      delivery,
 		pipelined:     pipelined,
 		reservedBytes: expectedBytes,
@@ -660,15 +688,16 @@ func (c *Client) sendRequestRange(
 	}
 	c.queue = append(c.queue, req)
 	c.inFlightBytes += expectedBytes
-	err := c.SendMessage(NewMsgRequestRange(start, end))
+	c.queueMutex.Unlock()
+	err := proto.SendMessageContext(ctx, NewMsgRequestRange(start, end))
 	if err != nil {
 		// The request never reached the wire, so it can be removed without
 		// disturbing the position of any other entry.
+		c.queueMutex.Lock()
 		c.removeLocked(req)
 		c.queueMutex.Unlock()
 		return nil, err
 	}
-	c.queueMutex.Unlock()
 	return req, nil
 }
 
@@ -803,11 +832,45 @@ func (c *Client) failOutstanding(err error) {
 	}
 }
 
+// failOutstandingForProtocol resolves only requests owned by proto. A delayed
+// shutdown watcher from an earlier client start must not resolve requests
+// queued after the client has restarted with a new protocol instance.
+func (c *Client) failOutstandingForProtocol(
+	proto *protocol.Protocol,
+	err error,
+) {
+	c.queueMutex.Lock()
+	pending := make([]*rangeRequest, 0)
+	remaining := make([]*rangeRequest, 0, len(c.queue))
+	for _, req := range c.queue {
+		if req.protocol == proto {
+			pending = append(pending, req)
+			c.releaseBytesLocked(req.reservedBytes)
+			continue
+		}
+		remaining = append(remaining, req)
+	}
+	c.queue = remaining
+	c.queueMutex.Unlock()
+	for _, req := range pending {
+		if resolveErr := c.resolve(req, err); resolveErr != nil {
+			proto.Logger().
+				Warn("range done callback failed during shutdown",
+					"component", "network",
+					"protocol", ProtocolName,
+					"role", "client",
+					"connection_id", c.callbackContext.ConnectionId.String(),
+					"error", resolveErr.Error(),
+				)
+		}
+	}
+}
+
 // failOutstandingOnProtocolDone resolves outstanding requests once the
 // protocol shuts down.
-func (c *Client) failOutstandingOnProtocolDone(done <-chan struct{}) {
-	<-done
-	c.failOutstanding(protocol.ErrProtocolShuttingDown)
+func (c *Client) failOutstandingOnProtocolDone(proto *protocol.Protocol) {
+	<-proto.DoneChan()
+	c.failOutstandingForProtocol(proto, protocol.ErrProtocolShuttingDown)
 }
 
 // callbackContextFor returns the callback context for a request, carrying its

--- a/protocol/blockfetch/client.go
+++ b/protocol/blockfetch/client.go
@@ -130,9 +130,13 @@ type Client struct {
 	// FIFO queue order always matches wire order. Unlike a mutex, acquiring
 	// the token can be canceled by RequestRange's context.
 	rangeSendToken chan struct{}
-	// beforeRequestReservation is a test synchronization point immediately
-	// before the atomic admission and reservation step.
-	beforeRequestReservation func()
+	// beforeRequestAdmission is a test synchronization point at the start of
+	// the admission path, before the in-flight wait and before the send token.
+	// It exists to release two callers into that path together, which is what
+	// makes the recheck under the token observable: the capacity check and the
+	// reservation are already atomic by construction, sharing one queueMutex
+	// hold, so no hook placed between them could observe anything.
+	beforeRequestAdmission func()
 	// beforeInFlightWait is a test synchronization point immediately before a
 	// pipelined caller parks on the in-flight byte bound. The park is
 	// otherwise unobservable, and the ordering it establishes is what proves
@@ -595,8 +599,8 @@ func (c *Client) RequestRange(
 	if expectedBytes == 0 {
 		expectedBytes = DefaultRequestExpectedBytes
 	}
-	if c.beforeRequestReservation != nil {
-		c.beforeRequestReservation()
+	if c.beforeRequestAdmission != nil {
+		c.beforeRequestAdmission()
 	}
 	sent, err := c.sendRequestRange(
 		ctx,

--- a/protocol/blockfetch/client.go
+++ b/protocol/blockfetch/client.go
@@ -38,10 +38,12 @@ const (
 	clientStateStopped
 )
 
-// errNoBlocks is the error reported for a range the peer answered with
-// MsgNoBlocks. The message is part of the client's observable behavior;
-// consumers match on it.
-var errNoBlocks = errors.New("block(s) not found")
+// ErrNoBlocks is the error reported for a range the peer answered with
+// MsgNoBlocks: through RangeDoneFunc for a request made with RequestRange,
+// and as the return value of GetBlock. Consumers match on it with errors.Is.
+// The message is unchanged because it was previously the only thing to match
+// on.
+var ErrNoBlocks = errors.New("block(s) not found")
 
 // ErrRequestPipeliningDisabled is returned by RequestRange when the client
 // was not configured with RequestPipelining.
@@ -531,7 +533,7 @@ func (c *Client) GetBlock(point pcommon.Point) (ledger.Block, error) {
 		}
 		if block == nil {
 			// The peer completed the batch without sending a block
-			return nil, errNoBlocks
+			return nil, ErrNoBlocks
 		}
 		return block, nil
 	}
@@ -989,7 +991,7 @@ func (c *Client) handleNoBlocks() error {
 	}
 	c.removeLocked(req)
 	c.queueMutex.Unlock()
-	return c.resolve(req, errNoBlocks)
+	return c.resolve(req, ErrNoBlocks)
 }
 
 // handleBlock handles the Block message from the server.

--- a/protocol/blockfetch/client.go
+++ b/protocol/blockfetch/client.go
@@ -131,6 +131,11 @@ type Client struct {
 	// beforeRequestReservation is a test synchronization point immediately
 	// before the atomic admission and reservation step.
 	beforeRequestReservation func()
+	// beforeInFlightWait is a test synchronization point immediately before a
+	// pipelined caller parks on the in-flight byte bound. The park is
+	// otherwise unobservable, and the ordering it establishes is what proves
+	// a parked caller holds nothing another caller needs.
+	beforeInFlightWait func()
 }
 
 // NewClient creates a new Block Fetch protocol client with the given options and configuration.
@@ -630,9 +635,41 @@ func (c *Client) hasInFlightCapacityLocked(expectedBytes uint64) bool {
 		expectedBytes <= limit-c.inFlightBytes
 }
 
+// waitForInFlightCapacity blocks until the in-flight byte budget can admit
+// expectedBytes. It is called without rangeSendToken held, so a caller parked
+// on the byte bound never delays another caller's queue append and send.
+func (c *Client) waitForInFlightCapacity(
+	ctx context.Context,
+	protocolDone <-chan struct{},
+	expectedBytes uint64,
+) error {
+	for {
+		c.queueMutex.Lock()
+		if c.hasInFlightCapacityLocked(expectedBytes) {
+			c.queueMutex.Unlock()
+			return nil
+		}
+		waitChan := c.bytesFreed
+		c.queueMutex.Unlock()
+		if c.beforeInFlightWait != nil {
+			c.beforeInFlightWait()
+		}
+		select {
+		case <-waitChan:
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-protocolDone:
+			return protocol.ErrProtocolShuttingDown
+		}
+	}
+}
+
 // sendRequestRange appends a request to the outstanding queue and sends its
-// MsgRequestRange. A context-aware send token keeps queue and wire order in
-// sync without holding queueMutex while a full protocol send queue blocks.
+// MsgRequestRange. A context-aware send token covers only the queue append and
+// the MsgRequestRange enqueue, so FIFO queue order always matches wire order
+// without holding queueMutex while a full protocol send queue blocks. Waiting
+// for in-flight capacity happens outside the token; the reservation is
+// rechecked under it, and the token is handed back before parking again.
 func (c *Client) sendRequestRange(
 	ctx context.Context,
 	start pcommon.Point,
@@ -647,48 +684,56 @@ func (c *Client) sendRequestRange(
 	}
 	proto := c.ProtocolInstance()
 	protocolDone := proto.DoneChan()
-	select {
-	case <-c.rangeSendToken:
-		defer func() {
-			c.rangeSendToken <- struct{}{}
-		}()
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case <-protocolDone:
-		return nil, protocol.ErrProtocolShuttingDown
-	}
+	var req *rangeRequest
 	for {
-		c.queueMutex.Lock()
-		if pipelined && !c.hasInFlightCapacityLocked(expectedBytes) {
-			waitChan := c.bytesFreed
-			c.queueMutex.Unlock()
-			select {
-			case <-waitChan:
-				continue
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-protocolDone:
-				return nil, protocol.ErrProtocolShuttingDown
+		if pipelined {
+			if err := c.waitForInFlightCapacity(
+				ctx,
+				protocolDone,
+				expectedBytes,
+			); err != nil {
+				return nil, err
 			}
 		}
+		select {
+		case <-c.rangeSendToken:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-protocolDone:
+			return nil, protocol.ErrProtocolShuttingDown
+		}
+		c.queueMutex.Lock()
+		if pipelined && !c.hasInFlightCapacityLocked(expectedBytes) {
+			// Another caller took the capacity between the wait and the
+			// token. Hand the token back before parking again so no other
+			// caller is held behind this one.
+			c.queueMutex.Unlock()
+			c.rangeSendToken <- struct{}{}
+			continue
+		}
+		c.nextRequestId++
+		req = &rangeRequest{
+			id:            c.nextRequestId,
+			protocol:      proto,
+			delivery:      delivery,
+			pipelined:     pipelined,
+			reservedBytes: expectedBytes,
+			busyToken:     busyToken,
+			hasBusyToken:  busyToken != 0,
+			startChan:     make(chan error, 1),
+			blockChan:     make(chan ledger.Block, 1),
+			doneChan:      make(chan error, 1),
+		}
+		c.queue = append(c.queue, req)
+		c.inFlightBytes += expectedBytes
+		c.queueMutex.Unlock()
 		break
 	}
-	c.nextRequestId++
-	req := &rangeRequest{
-		id:            c.nextRequestId,
-		protocol:      proto,
-		delivery:      delivery,
-		pipelined:     pipelined,
-		reservedBytes: expectedBytes,
-		busyToken:     busyToken,
-		hasBusyToken:  busyToken != 0,
-		startChan:     make(chan error, 1),
-		blockChan:     make(chan ledger.Block, 1),
-		doneChan:      make(chan error, 1),
-	}
-	c.queue = append(c.queue, req)
-	c.inFlightBytes += expectedBytes
-	c.queueMutex.Unlock()
+	// The token is held from the queue append through the MsgRequestRange
+	// enqueue, which is what keeps queue order equal to wire order.
+	defer func() {
+		c.rangeSendToken <- struct{}{}
+	}()
 	err := proto.SendMessageContext(ctx, NewMsgRequestRange(start, end))
 	if err != nil {
 		// The request never reached the wire, so it can be removed without

--- a/protocol/blockfetch/client.go
+++ b/protocol/blockfetch/client.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -37,26 +38,93 @@ const (
 	clientStateStopped
 )
 
+// errNoBlocks is the error reported for a range the peer answered with
+// MsgNoBlocks. The message is part of the client's observable behavior;
+// consumers match on it.
+var errNoBlocks = errors.New("block(s) not found")
+
+// ErrRequestPipeliningDisabled is returned by RequestRange when the client
+// was not configured with RequestPipelining.
+var ErrRequestPipeliningDisabled = errors.New(
+	"block-fetch request pipelining is not enabled on this client",
+)
+
+// requestDelivery selects how a queued range request delivers its blocks.
+type requestDelivery uint8
+
+const (
+	// deliveryCallback delivers blocks through the configured block
+	// callbacks or the block processing pipeline (GetBlockRange,
+	// RequestRange).
+	deliveryCallback requestDelivery = iota
+	// deliveryChannel delivers a single decoded block through the request's
+	// own channel (GetBlock).
+	deliveryChannel
+)
+
+// rangeRequest tracks one MsgRequestRange that has been sent and not yet
+// resolved. Block-fetch responses are ordered, so an entry's position in the
+// client's FIFO queue identifies the response it will receive; the head entry
+// owns the next MsgStartBatch, MsgNoBlocks, MsgBlock, and MsgBatchDone.
+type rangeRequest struct {
+	id             uint64
+	delivery       requestDelivery
+	pipelined      bool
+	reservedBytes  uint64
+	busyToken      uint64
+	hasBusyToken   bool
+	started        bool
+	blockDelivered bool
+	// startChan carries the MsgStartBatch outcome to a synchronous caller.
+	startChan chan error
+	// blockChan carries the single block of a deliveryChannel request.
+	blockChan chan ledger.Block
+	// doneChan carries the terminal outcome of the request.
+	doneChan chan error
+	// resolveOnce ensures a request is resolved exactly once, whichever of
+	// the response path and the shutdown path reaches it first.
+	resolveOnce sync.Once
+}
+
+// RangeRequest describes a single block range request queued through
+// Client.RequestRange.
+type RangeRequest struct {
+	Start pcommon.Point // Start point of the range (inclusive)
+	End   pcommon.Point // End point of the range (inclusive)
+	// ExpectedBytes is the caller's estimate of the total serialized size of
+	// the blocks in this range, used for the client's in-flight byte bound.
+	// A caller driving block-fetch from chain-sync headers has this from the
+	// header block body sizes. Zero means DefaultRequestExpectedBytes.
+	ExpectedBytes uint64
+}
+
 // Client implements the Block Fetch protocol client, which requests blocks from a server.
 type Client struct {
 	*protocol.Protocol
-	protocolMu           sync.RWMutex
-	config               *Config           // Protocol configuration
-	callbackContext      CallbackContext   // Callback context for client
-	blockChan            chan ledger.Block // Channel for received blocks
-	startBatchResultChan chan error        // Channel for batch start results
-	batchDoneChan        chan struct{}     // Channel to signal batch completion in GetBlock mode
-	busyMutex            sync.Mutex        // Mutex for busy state
-	busyStateMutex       sync.Mutex        // Protects busy lock ownership
-	busyLocked           bool
-	busyToken            uint64
-	busyDoneChan         chan struct{}
-	lifecycleMutex       sync.Mutex // Mutex for lifecycle state
-	lifecycleState       clientLifecycleState
-	startingDone         chan struct{}
-	protoOptions         protocol.ProtocolOptions
-	blockUseCallback     bool // Whether to use callback for blocks
-	protoStarted         bool // Whether Protocol.Start() was called
+	protocolMu      sync.RWMutex
+	config          *Config         // Protocol configuration
+	callbackContext CallbackContext // Callback context for client
+	busyMutex       sync.Mutex      // Mutex for busy state
+	busyStateMutex  sync.Mutex      // Protects busy lock ownership
+	busyLocked      bool
+	busyToken       uint64
+	busyDoneChan    chan struct{}
+	lifecycleMutex  sync.Mutex // Mutex for lifecycle state
+	lifecycleState  clientLifecycleState
+	startingDone    chan struct{}
+	protoOptions    protocol.ProtocolOptions
+	protoStarted    bool // Whether Protocol.Start() was called
+	// queueMutex protects the outstanding request queue and the in-flight
+	// byte accounting. It is held across the MsgRequestRange send so the
+	// order of the queue always matches the order of the requests on the
+	// wire.
+	queueMutex    sync.Mutex
+	queue         []*rangeRequest
+	nextRequestId uint64
+	inFlightBytes uint64
+	// bytesFreed is closed and replaced every time in-flight bytes are
+	// released, to broadcast to callers waiting for admission.
+	bytesFreed chan struct{}
 }
 
 // NewClient creates a new Block Fetch protocol client with the given options and configuration.
@@ -69,6 +137,7 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 		config:         cfg,
 		protoOptions:   protoOptions,
 		lifecycleState: clientStateNew,
+		bytesFreed:     make(chan struct{}),
 	}
 	c.callbackContext = CallbackContext{
 		Client:       c,
@@ -79,21 +148,31 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 }
 
 func (c *Client) initProtocol() {
-	// Recreate channels
-	c.blockChan = make(chan ledger.Block)
-	c.startBatchResultChan = make(chan error)
-	c.batchDoneChan = make(chan struct{})
 	c.protoStarted = false
 
 	// Update state map with timeouts
 	stateMap := StateMap.Copy()
 	if entry, ok := stateMap[StateBusy]; ok {
 		entry.Timeout = c.config.BatchStartTimeout
+		if c.config.RequestPipelining {
+			// The client may send the next MsgRequestRange while the peer is
+			// still answering the previous one.
+			entry.AllowPipelinedSend = true
+		}
 		stateMap[StateBusy] = entry
 	}
 	if entry, ok := stateMap[StateStreaming]; ok {
 		entry.Timeout = c.config.BlockTimeout
+		if c.config.RequestPipelining {
+			entry.AllowPipelinedSend = true
+		}
 		stateMap[StateStreaming] = entry
+	}
+	if c.config.RequestPipelining {
+		if entry, ok := stateMap[StateIdle]; ok {
+			entry.PendingMessageByteLimit = PipelinedIdleMaxPendingMessageBytes
+			stateMap[StateIdle] = entry
+		}
 	}
 	// Configure underlying Protocol
 	protoConfig := protocol.ProtocolConfig{
@@ -249,6 +328,9 @@ func (c *Client) Start() {
 			c.Protocol.Start()
 			c.protoStarted = true
 			c.lifecycleState = clientStateRunning
+			// Resolve any request left outstanding when the protocol shuts
+			// down, so no caller and no callback consumer is left waiting.
+			go c.failOutstandingOnProtocolDone(c.DoneChan())
 			if c.startingDone == ch {
 				close(ch)
 				c.startingDone = nil
@@ -272,6 +354,7 @@ func (c *Client) Stop() error {
 
 	switch c.lifecycleState {
 	case clientStateNew, clientStateStopped:
+		c.failOutstanding(protocol.ErrProtocolShuttingDown)
 		c.releaseCurrentBusy()
 		return nil
 	case clientStateStarting:
@@ -282,6 +365,7 @@ func (c *Client) Stop() error {
 			close(c.startingDone)
 			c.startingDone = nil
 		}
+		c.failOutstanding(protocol.ErrProtocolShuttingDown)
 		c.releaseCurrentBusy()
 		return nil
 	case clientStateRunning:
@@ -307,40 +391,21 @@ func (c *Client) Stop() error {
 	}
 
 	// Stop/unregister the underlying protocol instance first, then wait for
-	// message handlers to finish before closing channels to avoid send-on-closed panics.
+	// message handlers to finish before resolving outstanding requests.
 	doneChan := c.DoneChan()
 	c.Protocol.Stop()
 	c.lifecycleState = clientStateStopped
 
-	// Capture channel references before releasing lock to avoid closing
-	// channels recreated by a concurrent Start().
-	blockChanToClose := c.blockChan
-	startBatchResultChanToClose := c.startBatchResultChan
-	batchDoneChanToClose := c.batchDoneChan
-
 	// Release lock while waiting for protocol shutdown to avoid deadlock.
-	// Do NOT set channels to nil yet - message handlers may still be running
-	// and sending to nil channels would block forever.
 	c.lifecycleMutex.Unlock()
 	<-doneChan
+	// Every queued request is resolved with a terminal error. Each request
+	// owns its own buffered channels, so a handler that is still running
+	// cannot send on a closed channel and no waiter is stranded.
+	c.failOutstanding(protocol.ErrProtocolShuttingDown)
 	c.releaseCurrentBusy()
 
-	// Now safe to close captured channels - message handlers have stopped
-	if blockChanToClose != nil {
-		close(blockChanToClose)
-	}
-	if startBatchResultChanToClose != nil {
-		close(startBatchResultChanToClose)
-	}
-	if batchDoneChanToClose != nil {
-		close(batchDoneChanToClose)
-	}
-
-	// Now safe to nil out channels and clean up
 	c.lifecycleMutex.Lock()
-	c.blockChan = nil
-	c.startBatchResultChan = nil
-	c.batchDoneChan = nil
 	// Unblock any goroutine waiting for an in-progress start.
 	if c.startingDone != nil {
 		close(c.startingDone)
@@ -351,6 +416,10 @@ func (c *Client) Stop() error {
 
 // GetBlockRange starts an async process to fetch all blocks in the specified range (inclusive).
 // The provided callbacks are used for each block and when the batch is done.
+//
+// Only one GetBlockRange or GetBlock call is in progress at a time; a second
+// call blocks until the first batch completes. Use RequestRange to keep
+// multiple requests outstanding.
 func (c *Client) GetBlockRange(start pcommon.Point, end pcommon.Point) error {
 	c.Protocol.Logger().
 		Debug(
@@ -366,27 +435,23 @@ func (c *Client) GetBlockRange(start pcommon.Point, end pcommon.Point) error {
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
 	token, busyDone := c.acquireBusy()
-	c.blockUseCallback = true
 	protocolDone := c.DoneChan()
-	msg := NewMsgRequestRange(start, end)
-	if err := c.SendMessage(msg); err != nil {
+	req, err := c.sendRequestRange(
+		start,
+		end,
+		deliveryCallback,
+		false,
+		0,
+		token,
+	)
+	if err != nil {
 		c.releaseBusy(token)
 		return err
 	}
 	// Wait for batch start
-	select {
-	case err, ok := <-c.startBatchResultChan:
-		if !ok {
-			c.releaseBusy(token)
-			return protocol.ErrProtocolShuttingDown
-		}
-		if err != nil {
-			c.releaseBusy(token)
-			return err
-		}
-	case <-protocolDone:
+	if err := c.waitForBatchStart(req, protocolDone); err != nil {
 		c.releaseBusy(token)
-		return protocol.ErrProtocolShuttingDown
+		return err
 	}
 	go c.releaseBusyOnProtocolDone(token, busyDone, protocolDone)
 	return nil
@@ -404,54 +469,353 @@ func (c *Client) GetBlock(point pcommon.Point) (ledger.Block, error) {
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
 	token, _ := c.acquireBusy()
-	c.blockUseCallback = false
 	protocolDone := c.DoneChan()
-	msg := NewMsgRequestRange(point, point)
-	if err := c.SendMessage(msg); err != nil {
+	req, err := c.sendRequestRange(
+		point,
+		point,
+		deliveryChannel,
+		false,
+		0,
+		token,
+	)
+	if err != nil {
 		c.releaseBusy(token)
 		return nil, err
 	}
 	// Wait for batch start
+	if err := c.waitForBatchStart(req, protocolDone); err != nil {
+		c.releaseBusy(token)
+		return nil, err
+	}
+	// Wait for the block. Both the block and the completion can already be
+	// buffered by the time we get here, and a select over two ready cases
+	// picks at random, so a completed batch is only believed after checking
+	// for a delivered block.
+	var block ledger.Block
+	var batchDone error
+	var batchIsDone bool
 	select {
-	case err, ok := <-c.startBatchResultChan:
-		if !ok {
-			c.releaseBusy(token)
-			return nil, protocol.ErrProtocolShuttingDown
-		}
-		if err != nil {
-			c.releaseBusy(token)
-			return nil, err
+	case b := <-req.blockChan:
+		block = b
+	case err := <-req.doneChan:
+		batchDone, batchIsDone = err, true
+		select {
+		case b := <-req.blockChan:
+			block = b
+		default:
 		}
 	case <-protocolDone:
 		c.releaseBusy(token)
 		return nil, protocol.ErrProtocolShuttingDown
 	}
-	// Wait for block
-	var block ledger.Block
-	select {
-	case b, ok := <-c.blockChan:
-		if !ok {
-			c.releaseBusy(token)
-			return nil, protocol.ErrProtocolShuttingDown
-		}
-		block = b
-	case <-protocolDone:
+	if batchIsDone {
 		c.releaseBusy(token)
-		return nil, protocol.ErrProtocolShuttingDown
+		if batchDone != nil {
+			return nil, batchDone
+		}
+		if block == nil {
+			// The peer completed the batch without sending a block
+			return nil, errNoBlocks
+		}
+		return block, nil
 	}
 	// Wait for BatchDone before returning to ensure the protocol state machine
 	// completes the batch properly (transitions back to Idle state).
-	// handleBatchDone signals batchDoneChan in GetBlock mode instead of unlocking.
 	select {
-	case <-c.batchDoneChan:
-		// BatchDone was processed successfully
+	case err := <-req.doneChan:
 		c.releaseBusy(token)
+		if err != nil {
+			return nil, err
+		}
 		return block, nil
 	case <-protocolDone:
 		// Shutdown while waiting for BatchDone
 		c.releaseBusy(token)
 		return nil, protocol.ErrProtocolShuttingDown
 	}
+}
+
+// RequestRange queues a request for the given block range without waiting for
+// previously queued requests to complete, so the peer always has work in hand
+// at a batch boundary. It returns the request ID, which the client reports in
+// CallbackContext.RequestId for every block of the range and in the
+// RangeDoneFunc call that completes it. Blocks are delivered through the same
+// callbacks GetBlockRange uses.
+//
+// It blocks while the expected size of the outstanding requests would exceed
+// the configured MaxInFlightBytes, and returns the context's error if the
+// caller gives up first. A request larger than the whole bound is admitted
+// once the queue is empty, so an oversized range cannot stall forever.
+//
+// The client must be configured with RequestPipelining and a RangeDoneFunc.
+func (c *Client) RequestRange(
+	ctx context.Context,
+	req RangeRequest,
+) (uint64, error) {
+	if !c.config.RequestPipelining {
+		return 0, ErrRequestPipeliningDisabled
+	}
+	if c.config.RangeDoneFunc == nil {
+		return 0, errors.New(
+			"block-fetch RequestRange requires a RangeDoneFunc callback",
+		)
+	}
+	c.Protocol.Logger().
+		Debug(
+			fmt.Sprintf("calling RequestRange(start: {Slot: %d, Hash: %x}, end: {Slot: %d, Hash: %x})",
+				req.Start.Slot,
+				req.Start.Hash,
+				req.End.Slot,
+				req.End.Hash,
+			),
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "client",
+			"connection_id", c.callbackContext.ConnectionId.String(),
+		)
+	expectedBytes := req.ExpectedBytes
+	if expectedBytes == 0 {
+		expectedBytes = DefaultRequestExpectedBytes
+	}
+	if err := c.awaitInFlightCapacity(ctx, expectedBytes); err != nil {
+		return 0, err
+	}
+	sent, err := c.sendRequestRange(
+		req.Start,
+		req.End,
+		deliveryCallback,
+		true,
+		expectedBytes,
+		0,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return sent.id, nil
+}
+
+// maxInFlightBytes returns the configured in-flight byte bound, treating an
+// unset value as the default. Config is built directly by some consumers, so
+// the default cannot only be applied in NewConfig.
+func (c *Client) maxInFlightBytes() uint64 {
+	if c.config.MaxInFlightBytes == 0 {
+		return DefaultMaxInFlightBytes
+	}
+	return c.config.MaxInFlightBytes
+}
+
+// awaitInFlightCapacity blocks until the given request size fits within the
+// in-flight byte bound. The reservation itself is made by sendRequestRange
+// under the same lock that appends to the queue.
+func (c *Client) awaitInFlightCapacity(
+	ctx context.Context,
+	expectedBytes uint64,
+) error {
+	limit := c.maxInFlightBytes()
+	protocolDone := c.DoneChan()
+	for {
+		c.queueMutex.Lock()
+		// An empty queue always admits, so a range larger than the whole
+		// bound still makes progress instead of deadlocking.
+		if len(c.queue) == 0 ||
+			c.inFlightBytes+expectedBytes <= limit {
+			c.queueMutex.Unlock()
+			return nil
+		}
+		waitChan := c.bytesFreed
+		c.queueMutex.Unlock()
+		select {
+		case <-waitChan:
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-protocolDone:
+			return protocol.ErrProtocolShuttingDown
+		}
+	}
+}
+
+// sendRequestRange appends a request to the outstanding queue and sends its
+// MsgRequestRange. The queue lock is held across the send so queue order
+// always matches wire order.
+func (c *Client) sendRequestRange(
+	start pcommon.Point,
+	end pcommon.Point,
+	delivery requestDelivery,
+	pipelined bool,
+	expectedBytes uint64,
+	busyToken uint64,
+) (*rangeRequest, error) {
+	c.queueMutex.Lock()
+	c.nextRequestId++
+	req := &rangeRequest{
+		id:            c.nextRequestId,
+		delivery:      delivery,
+		pipelined:     pipelined,
+		reservedBytes: expectedBytes,
+		busyToken:     busyToken,
+		hasBusyToken:  busyToken != 0,
+		startChan:     make(chan error, 1),
+		blockChan:     make(chan ledger.Block, 1),
+		doneChan:      make(chan error, 1),
+	}
+	c.queue = append(c.queue, req)
+	c.inFlightBytes += expectedBytes
+	err := c.SendMessage(NewMsgRequestRange(start, end))
+	if err != nil {
+		// The request never reached the wire, so it can be removed without
+		// disturbing the position of any other entry.
+		c.removeLocked(req)
+		c.queueMutex.Unlock()
+		return nil, err
+	}
+	c.queueMutex.Unlock()
+	return req, nil
+}
+
+// waitForBatchStart waits for the peer to accept a request, for the
+// synchronous GetBlockRange and GetBlock paths.
+func (c *Client) waitForBatchStart(
+	req *rangeRequest,
+	protocolDone <-chan struct{},
+) error {
+	select {
+	case err := <-req.startChan:
+		return err
+	case <-protocolDone:
+		return protocol.ErrProtocolShuttingDown
+	}
+}
+
+// removeLocked removes a request from the queue and releases its reserved
+// bytes. The caller must hold queueMutex.
+func (c *Client) removeLocked(req *rangeRequest) {
+	for i, queued := range c.queue {
+		if queued == req {
+			c.queue = slices.Delete(c.queue, i, i+1)
+			c.releaseBytesLocked(req.reservedBytes)
+			return
+		}
+	}
+}
+
+// releaseBytesLocked returns reserved bytes to the in-flight budget and wakes
+// every caller waiting for admission. The caller must hold queueMutex.
+func (c *Client) releaseBytesLocked(reserved uint64) {
+	if reserved > c.inFlightBytes {
+		c.inFlightBytes = 0
+	} else {
+		c.inFlightBytes -= reserved
+	}
+	if c.bytesFreed != nil {
+		close(c.bytesFreed)
+	}
+	c.bytesFreed = make(chan struct{})
+}
+
+// headForResponse returns the queue entry a response belongs to. Block-fetch
+// responses are ordered, so that is always the head entry, and it must be in
+// the state the response implies: streaming for MsgBlock and MsgBatchDone,
+// not yet started for MsgStartBatch and MsgNoBlocks. Anything else is a peer
+// that is talking out of turn, and is reported rather than applied to the
+// following entry. The caller must hold queueMutex.
+func (c *Client) headForResponse(
+	msgName string,
+	wantStarted bool,
+) (*rangeRequest, error) {
+	if len(c.queue) == 0 {
+		return nil, fmt.Errorf(
+			"%s: received %s with no outstanding range request",
+			ProtocolName,
+			msgName,
+		)
+	}
+	req := c.queue[0]
+	if req.started != wantStarted {
+		return nil, fmt.Errorf(
+			"%s: received %s for range request %d in the wrong order",
+			ProtocolName,
+			msgName,
+			req.id,
+		)
+	}
+	return req, nil
+}
+
+// drainLocked empties the queue and clears the in-flight byte accounting,
+// returning the entries the caller must resolve. The caller must hold
+// queueMutex.
+func (c *Client) drainLocked() []*rangeRequest {
+	pending := c.queue
+	c.queue = nil
+	if len(pending) > 0 {
+		c.inFlightBytes = 0
+		close(c.bytesFreed)
+		c.bytesFreed = make(chan struct{})
+	}
+	return pending
+}
+
+// resolve delivers a request's terminal outcome. It must be called without
+// queueMutex held, because it can invoke a user callback.
+func (c *Client) resolve(req *rangeRequest, err error) error {
+	var callbackErr error
+	req.resolveOnce.Do(func() {
+		if err != nil {
+			// Release a caller that is still waiting for the batch to start.
+			select {
+			case req.startChan <- err:
+			default:
+			}
+		}
+		select {
+		case req.doneChan <- err:
+		default:
+		}
+		if req.hasBusyToken {
+			c.releaseBusy(req.busyToken)
+		}
+		if req.pipelined && c.config.RangeDoneFunc != nil {
+			callbackErr = c.config.RangeDoneFunc(
+				c.callbackContextFor(req),
+				err,
+			)
+		}
+	})
+	return callbackErr
+}
+
+// failOutstanding resolves every queued request with the given error.
+func (c *Client) failOutstanding(err error) {
+	c.queueMutex.Lock()
+	pending := c.drainLocked()
+	c.queueMutex.Unlock()
+	for _, req := range pending {
+		if resolveErr := c.resolve(req, err); resolveErr != nil {
+			c.Protocol.Logger().
+				Warn("range done callback failed during shutdown",
+					"component", "network",
+					"protocol", ProtocolName,
+					"role", "client",
+					"connection_id", c.callbackContext.ConnectionId.String(),
+					"error", resolveErr.Error(),
+				)
+		}
+	}
+}
+
+// failOutstandingOnProtocolDone resolves outstanding requests once the
+// protocol shuts down.
+func (c *Client) failOutstandingOnProtocolDone(done <-chan struct{}) {
+	<-done
+	c.failOutstanding(protocol.ErrProtocolShuttingDown)
+}
+
+// callbackContextFor returns the callback context for a request, carrying its
+// FIFO identity.
+func (c *Client) callbackContextFor(req *rangeRequest) CallbackContext {
+	ctx := c.callbackContext
+	ctx.RequestId = req.id
+	return ctx
 }
 
 // messageHandler handles incoming protocol messages for the client.
@@ -485,13 +849,18 @@ func (c *Client) handleStartBatch() error {
 			"role", "client",
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
-	// Check for shutdown
+	c.queueMutex.Lock()
+	req, err := c.headForResponse("StartBatch", false)
+	if err != nil {
+		c.queueMutex.Unlock()
+		return err
+	}
+	req.started = true
+	c.queueMutex.Unlock()
 	select {
-	case <-c.DoneChan():
-		return protocol.ErrProtocolShuttingDown
+	case req.startChan <- nil:
 	default:
 	}
-	c.startBatchResultChan <- nil
 	return nil
 }
 
@@ -504,15 +873,15 @@ func (c *Client) handleNoBlocks() error {
 			"role", "client",
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
-	// Check for shutdown
-	select {
-	case <-c.DoneChan():
-		return protocol.ErrProtocolShuttingDown
-	default:
+	c.queueMutex.Lock()
+	req, err := c.headForResponse("NoBlocks", false)
+	if err != nil {
+		c.queueMutex.Unlock()
+		return err
 	}
-	err := errors.New("block(s) not found")
-	c.startBatchResultChan <- err
-	return nil
+	c.removeLocked(req)
+	c.queueMutex.Unlock()
+	return c.resolve(req, errNoBlocks)
 }
 
 // handleBlock handles the Block message from the server.
@@ -524,23 +893,44 @@ func (c *Client) handleBlock(msgGeneric protocol.Message) error {
 			"role", "client",
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
-	msg := msgGeneric.(*MsgBlock)
+	msg, ok := msgGeneric.(*MsgBlock)
+	if !ok {
+		return fmt.Errorf("%s: unexpected message type", ProtocolName)
+	}
+	c.queueMutex.Lock()
+	req, err := c.headForResponse("Block", true)
+	if err != nil {
+		c.queueMutex.Unlock()
+		return err
+	}
+	if req.delivery == deliveryChannel {
+		if req.blockDelivered {
+			c.queueMutex.Unlock()
+			return fmt.Errorf(
+				"%s: received more than one block for single-block request %d",
+				ProtocolName,
+				req.id,
+			)
+		}
+		req.blockDelivered = true
+	}
+	c.queueMutex.Unlock()
 	// Decode only enough to get the block type value
 	var wrappedBlock WrappedBlock
 	if _, err := cbor.Decode(msg.WrappedBlock, &wrappedBlock); err != nil {
-		if c.blockUseCallback {
-			c.releaseCurrentBusy()
-		}
-		return fmt.Errorf("%s: decode error: %w", ProtocolName, err)
+		return c.failRequest(
+			req,
+			fmt.Errorf("%s: decode error: %w", ProtocolName, err),
+		)
 	}
 	// If pipeline is configured, submit to pipeline
-	// Only use pipeline if we are in callback mode (GetBlockRange), preserving GetBlock functionality.
-	if c.config.Pipeline != nil && c.blockUseCallback {
+	// Only use pipeline if we are in callback mode (GetBlockRange, RequestRange),
+	// preserving GetBlock functionality.
+	if c.config.Pipeline != nil && req.delivery == deliveryCallback {
 		// Check for shutdown
 		select {
 		case <-c.DoneChan():
-			c.releaseCurrentBusy()
-			return protocol.ErrProtocolShuttingDown
+			return c.failRequest(req, protocol.ErrProtocolShuttingDown)
 		default:
 		}
 
@@ -564,13 +954,12 @@ func (c *Client) handleBlock(msgGeneric protocol.Message) error {
 		)
 		cancel() // Ensure goroutine exits promptly
 		if err != nil {
-			c.releaseCurrentBusy()
-			return err
+			return c.failRequest(req, err)
 		}
 		return nil
 	}
 	var block ledger.Block
-	if !c.blockUseCallback || c.config.BlockFunc != nil {
+	if req.delivery == deliveryChannel || c.config.BlockFunc != nil {
 		var err error
 		block, err = ledger.NewBlockFromCbor(
 			wrappedBlock.Type,
@@ -580,41 +969,61 @@ func (c *Client) handleBlock(msgGeneric protocol.Message) error {
 			},
 		)
 		if err != nil {
-			if c.blockUseCallback {
-				c.releaseCurrentBusy()
-			}
-			return err
+			return c.failRequest(req, err)
 		}
 	}
 	// Check for shutdown
 	select {
 	case <-c.DoneChan():
-		if c.blockUseCallback {
-			c.releaseCurrentBusy()
-		}
-		return protocol.ErrProtocolShuttingDown
+		return c.failRequest(req, protocol.ErrProtocolShuttingDown)
 	default:
 	}
-	// We use the callback when requesting ranges and the internal channel for a single block
-	if c.blockUseCallback {
-		if c.config.BlockRawFunc != nil {
-			if err := c.config.BlockRawFunc(c.callbackContext, wrappedBlock.Type, wrappedBlock.RawBlock); err != nil {
-				c.releaseCurrentBusy()
-				return err
+	// We use the callbacks when requesting ranges and the request's own
+	// channel for a single block
+	if req.delivery == deliveryCallback {
+		cbCtx := c.callbackContextFor(req)
+		switch {
+		case c.config.BlockRawFunc != nil:
+			if err := c.config.BlockRawFunc(cbCtx, wrappedBlock.Type, wrappedBlock.RawBlock); err != nil {
+				return c.failRequest(req, err)
 			}
-		} else if c.config.BlockFunc != nil {
-			if err := c.config.BlockFunc(c.callbackContext, wrappedBlock.Type, block); err != nil {
-				c.releaseCurrentBusy()
-				return err
+		case c.config.BlockFunc != nil:
+			if err := c.config.BlockFunc(cbCtx, wrappedBlock.Type, block); err != nil {
+				return c.failRequest(req, err)
 			}
-		} else {
-			c.releaseCurrentBusy()
-			return errors.New("received block-fetch Block message but no callback function is defined")
+		default:
+			return c.failRequest(
+				req,
+				errors.New(
+					"received block-fetch Block message but no callback function is defined",
+				),
+			)
 		}
-	} else {
-		c.blockChan <- block
+		return nil
+	}
+	select {
+	case req.blockChan <- block:
+	default:
 	}
 	return nil
+}
+
+// failRequest retires a request that cannot be completed and returns the
+// error so the protocol is torn down, matching the previous behavior of
+// releasing the busy lock before returning a handler error.
+func (c *Client) failRequest(req *rangeRequest, err error) error {
+	c.queueMutex.Lock()
+	retired := len(c.queue) > 0 && c.queue[0] == req
+	if retired {
+		c.removeLocked(req)
+	}
+	c.queueMutex.Unlock()
+	if retired {
+		if resolveErr := c.resolve(req, err); resolveErr != nil {
+			return errors.Join(err, resolveErr)
+		}
+	}
+	return err
 }
 
 // handleBatchDone handles the BatchDone message from the server.
@@ -626,23 +1035,27 @@ func (c *Client) handleBatchDone() error {
 			"role", "client",
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
-	// Notify the user if requested
-	if c.blockUseCallback && c.config.BatchDoneFunc != nil {
-		if err := c.config.BatchDoneFunc(c.callbackContext); err != nil {
+	c.queueMutex.Lock()
+	req, err := c.headForResponse("BatchDone", true)
+	if err != nil {
+		c.queueMutex.Unlock()
+		return err
+	}
+	c.removeLocked(req)
+	c.queueMutex.Unlock()
+	// Notify the user if requested. A pipelined request reports completion
+	// through RangeDoneFunc in resolve() instead, so it gets exactly one
+	// completion callback.
+	if !req.pipelined && req.delivery == deliveryCallback &&
+		c.config.BatchDoneFunc != nil {
+		if err := c.config.BatchDoneFunc(c.callbackContextFor(req)); err != nil {
+			// The request is already retired; still resolve it so no caller
+			// is left waiting for a batch that will not be reported.
+			if resolveErr := c.resolve(req, err); resolveErr != nil {
+				return errors.Join(err, resolveErr)
+			}
 			return err
 		}
 	}
-	if c.blockUseCallback {
-		c.releaseCurrentBusy()
-	} else {
-		// In GetBlock mode, signal completion so GetBlock can unlock and return.
-		// This avoids a double-unlock race during shutdown where GetBlock might
-		// unlock via DoneChan before handleBatchDone runs.
-		select {
-		case c.batchDoneChan <- struct{}{}:
-		case <-c.DoneChan():
-			// Protocol is shutting down, GetBlock will handle cleanup
-		}
-	}
-	return nil
+	return c.resolve(req, nil)
 }

--- a/protocol/blockfetch/client_pipelined_test.go
+++ b/protocol/blockfetch/client_pipelined_test.go
@@ -699,7 +699,7 @@ func TestRequestRangeNoBlocksResolvesOnlyItsOwnRequest(t *testing.T) {
 
 	first := h.nextDone(t)
 	require.Equal(t, id1, first.requestId)
-	require.ErrorContains(t, first.err, "block(s) not found")
+	require.ErrorIs(t, first.err, blockfetch.ErrNoBlocks)
 
 	require.Equal(t, deliveredBlock{requestId: id2, slot: 200}, h.nextBlock(t))
 	second := h.nextDone(t)
@@ -736,7 +736,7 @@ func TestGetBlockEmptyBatch(t *testing.T) {
 	select {
 	case res := <-results:
 		require.Nil(t, res.block)
-		require.ErrorContains(t, res.err, "block(s) not found")
+		require.ErrorIs(t, res.err, blockfetch.ErrNoBlocks)
 	case err := <-h.connErrs:
 		t.Fatalf("unexpected connection error: %s", err)
 	case <-time.After(testTimeout):

--- a/protocol/blockfetch/client_pipelined_test.go
+++ b/protocol/blockfetch/client_pipelined_test.go
@@ -16,6 +16,7 @@ package blockfetch_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -391,7 +392,7 @@ func TestGetBlockRangeUnaffectedByPipelining(t *testing.T) {
 	select {
 	case res := <-h.done:
 		t.Fatalf("unexpected RangeDoneFunc call for request %d", res.requestId)
-	default:
+	case <-time.After(testTimeout):
 	}
 }
 
@@ -573,6 +574,10 @@ func TestRequestRangeInFlightByteBound(t *testing.T) {
 	}
 	firstBlockEntered := make(chan struct{})
 	releaseFirstBlock := make(chan struct{})
+	var releaseFirstBlockOnce sync.Once
+	release := func() {
+		releaseFirstBlockOnce.Do(func() { close(releaseFirstBlock) })
+	}
 	blocks := make(chan deliveredBlock, 16)
 	h := newPipelineHarness(
 		t,
@@ -592,7 +597,10 @@ func TestRequestRangeInFlightByteBound(t *testing.T) {
 			},
 		),
 	)
-	defer h.close(t)
+	defer func() {
+		release()
+		h.close(t)
+	}()
 	nextBlock := func() deliveredBlock {
 		t.Helper()
 		select {
@@ -640,7 +648,7 @@ func TestRequestRangeInFlightByteBound(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		// Still blocked, as required
 	}
-	close(releaseFirstBlock)
+	release()
 	require.Equal(t, deliveredBlock{requestId: 1, slot: 100}, nextBlock())
 	first := h.nextDone(t)
 	require.Equal(t, uint64(1), first.requestId)

--- a/protocol/blockfetch/client_pipelined_test.go
+++ b/protocol/blockfetch/client_pipelined_test.go
@@ -193,11 +193,17 @@ func (h *pipelineHarness) nextDone(t *testing.T) rangeResult {
 	return rangeResult{}
 }
 
-// TestRequestRangePipelinedOutstandingRequests is the acceptance test: three
-// MsgRequestRange are outstanding at once, and the responses are attributed
-// to them in request order. The mock peer answers nothing until it has
-// received all three requests, so a client that serializes requests cannot
-// get past the second conversation entry.
+// TestRequestRangePipelinedOutstandingRequests covers request accounting with
+// three MsgRequestRange outstanding at once: the responses are attributed to
+// them in request order. The mock peer answers nothing until it has received
+// all three requests, so a client that waits for each response before sending
+// the next cannot get past the second conversation entry.
+//
+// It does not prove the pipelined send path ran. sendLoop batches messages
+// that are already queued into a single segment and defers their state
+// transitions, so which path carries the second and third request depends on
+// scheduling. TestRequestRangeInFlightByteBound covers the pipelined send
+// path deterministically.
 func TestRequestRangePipelinedOutstandingRequests(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	wrapped1, point1 := testBlock(t, 100)
@@ -533,6 +539,11 @@ func TestRequestRangeShutdownResolvesOutstanding(t *testing.T) {
 // open by blocking inside its block callback, which runs on the protocol
 // receive goroutine, so nothing can retire it and release capacity until the
 // test says so. While it is pinned, a third request cannot be admitted.
+//
+// This also covers the pipelined send path deterministically: the third
+// request is admitted only once the first retires, with the state machine
+// mid-batch for the second, so its MsgRequestRange can only reach the wire
+// while the peer holds agency.
 func TestRequestRangeInFlightByteBound(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	wrapped1, point1 := testBlock(t, 100)

--- a/protocol/blockfetch/client_pipelined_test.go
+++ b/protocol/blockfetch/client_pipelined_test.go
@@ -1,0 +1,734 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blockfetch_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/blinklabs-io/gouroboros/protocol/blockfetch"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+// testTimeout bounds every channel wait in this file. Nothing here uses
+// time.Sleep for synchronization.
+const testTimeout = 5 * time.Second
+
+type deliveredBlock struct {
+	requestId uint64
+	slot      uint64
+}
+
+type rangeResult struct {
+	requestId uint64
+	err       error
+}
+
+// testBlock builds a Babbage block for the given slot, along with the
+// block-fetch wrapped CBOR the mock peer sends and the point identifying it.
+func testBlock(t *testing.T, slot uint64) ([]byte, pcommon.Point) {
+	t.Helper()
+	blk := ledger.BabbageBlock{BlockHeader: &ledger.BabbageBlockHeader{}}
+	blk.BlockHeader.Body.BlockNumber = slot
+	blk.BlockHeader.Body.Slot = slot
+	blockCbor, err := cbor.Encode(blk)
+	require.NoError(t, err)
+	_, err = cbor.Decode(blockCbor, &blk)
+	require.NoError(t, err)
+	wrapped, err := cbor.Encode(blockfetch.WrappedBlock{
+		Type:     ledger.BlockTypeBabbage,
+		RawBlock: cbor.RawMessage(blockCbor),
+	})
+	require.NoError(t, err)
+	return wrapped, pcommon.NewPoint(slot, blk.Hash().Bytes())
+}
+
+func requestRangeInput() ouroboros_mock.ConversationEntry {
+	return ouroboros_mock.ConversationEntryInput{
+		ProtocolId:  blockfetch.ProtocolId,
+		MessageType: blockfetch.MessageTypeRequestRange,
+	}
+}
+
+func batchOutput(msgs ...protocol.Message) ouroboros_mock.ConversationEntry {
+	return ouroboros_mock.ConversationEntryOutput{
+		ProtocolId: blockfetch.ProtocolId,
+		IsResponse: true,
+		Messages:   msgs,
+	}
+}
+
+type pipelineHarness struct {
+	oConn  *ouroboros.Connection
+	client *blockfetch.Client
+	blocks chan deliveredBlock
+	done   chan rangeResult
+	// connErrs receives errors reported by the Ouroboros connection, which is
+	// where a protocol violation by the mock peer surfaces.
+	connErrs chan error
+}
+
+func newPipelineHarness(
+	t *testing.T,
+	conversation []ouroboros_mock.ConversationEntry,
+	options ...blockfetch.BlockFetchOptionFunc,
+) *pipelineHarness {
+	t.Helper()
+	h := &pipelineHarness{
+		blocks:   make(chan deliveredBlock, 16),
+		done:     make(chan rangeResult, 16),
+		connErrs: make(chan error, 4),
+	}
+	mockConn := ouroboros_mock.NewConnection(
+		ouroboros_mock.ProtocolRoleClient,
+		conversation,
+	)
+	opts := append(
+		[]blockfetch.BlockFetchOptionFunc{
+			blockfetch.WithRequestPipelining(true),
+			blockfetch.WithBlockFunc(
+				func(ctx blockfetch.CallbackContext, _ uint, block ledger.Block) error {
+					h.blocks <- deliveredBlock{
+						requestId: ctx.RequestId,
+						slot:      block.SlotNumber(),
+					}
+					return nil
+				},
+			),
+			blockfetch.WithRangeDoneFunc(
+				func(ctx blockfetch.CallbackContext, err error) error {
+					h.done <- rangeResult{requestId: ctx.RequestId, err: err}
+					return nil
+				},
+			),
+		},
+		options...,
+	)
+	cfg, err := blockfetch.NewConfig(opts...)
+	require.NoError(t, err)
+	cfg.SkipBlockValidation = true
+	oConn, err := ouroboros.New(
+		ouroboros.WithConnection(mockConn),
+		ouroboros.WithNetworkMagic(ouroboros_mock.MockNetworkMagic),
+		ouroboros.WithNodeToNode(true),
+		ouroboros.WithBlockFetchConfig(cfg),
+	)
+	require.NoError(t, err)
+	h.oConn = oConn
+	h.client = oConn.BlockFetch().Client
+	go func() {
+		for err := range oConn.ErrorChan() {
+			if err != nil {
+				h.connErrs <- err
+			}
+		}
+		close(h.connErrs)
+	}()
+	return h
+}
+
+func (h *pipelineHarness) close(t *testing.T) {
+	t.Helper()
+	_ = h.oConn.Close()
+	// Drain remaining connection errors so the reader goroutine exits
+	deadline := time.After(testTimeout)
+	for {
+		select {
+		case _, ok := <-h.connErrs:
+			if !ok {
+				return
+			}
+		case <-deadline:
+			t.Fatal("connection did not shut down within timeout")
+		}
+	}
+}
+
+func (h *pipelineHarness) nextBlock(t *testing.T) deliveredBlock {
+	t.Helper()
+	select {
+	case blk := <-h.blocks:
+		return blk
+	case err := <-h.connErrs:
+		t.Fatalf("unexpected connection error while awaiting block: %s", err)
+	case <-time.After(testTimeout):
+		t.Fatal("timed out waiting for a block")
+	}
+	return deliveredBlock{}
+}
+
+func (h *pipelineHarness) nextDone(t *testing.T) rangeResult {
+	t.Helper()
+	select {
+	case res := <-h.done:
+		return res
+	case err := <-h.connErrs:
+		t.Fatalf(
+			"unexpected connection error while awaiting range done: %s",
+			err,
+		)
+	case <-time.After(testTimeout):
+		t.Fatal("timed out waiting for a range request to complete")
+	}
+	return rangeResult{}
+}
+
+// TestRequestRangePipelinedOutstandingRequests is the acceptance test: three
+// MsgRequestRange are outstanding at once, and the responses are attributed
+// to them in request order. The mock peer answers nothing until it has
+// received all three requests, so a client that serializes requests cannot
+// get past the second conversation entry.
+func TestRequestRangePipelinedOutstandingRequests(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	wrapped1, point1 := testBlock(t, 100)
+	wrapped2, point2 := testBlock(t, 200)
+	wrapped3, point3 := testBlock(t, 300)
+	conversation := []ouroboros_mock.ConversationEntry{
+		ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+		ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+		requestRangeInput(),
+		requestRangeInput(),
+		requestRangeInput(),
+		batchOutput(
+			blockfetch.NewMsgStartBatch(),
+			blockfetch.NewMsgBlock(wrapped1),
+			blockfetch.NewMsgBatchDone(),
+		),
+		batchOutput(
+			blockfetch.NewMsgStartBatch(),
+			blockfetch.NewMsgBlock(wrapped2),
+			blockfetch.NewMsgBatchDone(),
+		),
+		batchOutput(
+			blockfetch.NewMsgStartBatch(),
+			blockfetch.NewMsgBlock(wrapped3),
+			blockfetch.NewMsgBatchDone(),
+		),
+	}
+	h := newPipelineHarness(t, conversation)
+	defer h.close(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+	ids := make([]uint64, 0, 3)
+	for _, point := range []pcommon.Point{point1, point2, point3} {
+		id, err := h.client.RequestRange(ctx, blockfetch.RangeRequest{
+			Start:         point,
+			End:           point,
+			ExpectedBytes: 1024,
+		})
+		require.NoError(t, err)
+		ids = append(ids, id)
+	}
+	require.Equal(t, []uint64{1, 2, 3}, ids)
+
+	for i, slot := range []uint64{100, 200, 300} {
+		blk := h.nextBlock(t)
+		require.Equal(
+			t,
+			deliveredBlock{requestId: ids[i], slot: slot},
+			blk,
+			"block for request %d attributed incorrectly",
+			ids[i],
+		)
+		res := h.nextDone(t)
+		require.Equal(t, ids[i], res.requestId)
+		require.NoError(t, res.err)
+	}
+}
+
+// TestRequestRangeRequiresOptIn verifies a client that has not opted into
+// request pipelining rejects RequestRange instead of silently changing its
+// wire behavior.
+func TestRequestRangeRequiresOptIn(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	conversation := []ouroboros_mock.ConversationEntry{
+		ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+		ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+	}
+	mockConn := ouroboros_mock.NewConnection(
+		ouroboros_mock.ProtocolRoleClient,
+		conversation,
+	)
+	oConn, err := ouroboros.New(
+		ouroboros.WithConnection(mockConn),
+		ouroboros.WithNetworkMagic(ouroboros_mock.MockNetworkMagic),
+		ouroboros.WithNodeToNode(true),
+		ouroboros.WithBlockFetchConfig(
+			blockfetch.Config{SkipBlockValidation: true},
+		),
+	)
+	require.NoError(t, err)
+	errDrained := make(chan struct{})
+	go func() {
+		for range oConn.ErrorChan() {
+		}
+		close(errDrained)
+	}()
+	_, err = oConn.BlockFetch().Client.RequestRange(
+		context.Background(),
+		blockfetch.RangeRequest{},
+	)
+	require.ErrorIs(t, err, blockfetch.ErrRequestPipeliningDisabled)
+	require.NoError(t, oConn.Close())
+	select {
+	case <-errDrained:
+	case <-time.After(testTimeout):
+		t.Fatal("connection did not shut down within timeout")
+	}
+}
+
+// TestRequestRangeRequiresRangeDoneFunc verifies a pipelining client refuses
+// to queue a request it cannot report the completion of.
+func TestRequestRangeRequiresRangeDoneFunc(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	conversation := []ouroboros_mock.ConversationEntry{
+		ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+		ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+	}
+	mockConn := ouroboros_mock.NewConnection(
+		ouroboros_mock.ProtocolRoleClient,
+		conversation,
+	)
+	oConn, err := ouroboros.New(
+		ouroboros.WithConnection(mockConn),
+		ouroboros.WithNetworkMagic(ouroboros_mock.MockNetworkMagic),
+		ouroboros.WithNodeToNode(true),
+		ouroboros.WithBlockFetchConfig(blockfetch.Config{
+			SkipBlockValidation: true,
+			RequestPipelining:   true,
+		}),
+	)
+	require.NoError(t, err)
+	errDrained := make(chan struct{})
+	go func() {
+		for range oConn.ErrorChan() {
+		}
+		close(errDrained)
+	}()
+	_, err = oConn.BlockFetch().Client.RequestRange(
+		context.Background(),
+		blockfetch.RangeRequest{},
+	)
+	require.ErrorContains(t, err, "requires a RangeDoneFunc")
+	require.NoError(t, oConn.Close())
+	select {
+	case <-errDrained:
+	case <-time.After(testTimeout):
+		t.Fatal("connection did not shut down within timeout")
+	}
+}
+
+// TestGetBlockRangeUnaffectedByPipelining verifies that the existing
+// single-request path keeps its semantics on a client that has pipelining
+// enabled: GetBlockRange waits for MsgStartBatch, blocks arrive through
+// BlockFunc, and BatchDoneFunc reports completion.
+func TestGetBlockRangeUnaffectedByPipelining(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	wrapped1, point1 := testBlock(t, 100)
+	conversation := []ouroboros_mock.ConversationEntry{
+		ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+		ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+		requestRangeInput(),
+		batchOutput(
+			blockfetch.NewMsgStartBatch(),
+			blockfetch.NewMsgBlock(wrapped1),
+			blockfetch.NewMsgBatchDone(),
+		),
+	}
+	batchDone := make(chan uint64, 4)
+	h := newPipelineHarness(
+		t,
+		conversation,
+		blockfetch.WithBatchDoneFunc(
+			func(ctx blockfetch.CallbackContext) error {
+				batchDone <- ctx.RequestId
+				return nil
+			},
+		),
+	)
+	defer h.close(t)
+
+	require.NoError(t, h.client.GetBlockRange(point1, point1))
+	blk := h.nextBlock(t)
+	require.Equal(t, deliveredBlock{requestId: 1, slot: 100}, blk)
+	select {
+	case id := <-batchDone:
+		require.Equal(t, uint64(1), id)
+	case err := <-h.connErrs:
+		t.Fatalf("unexpected connection error: %s", err)
+	case <-time.After(testTimeout):
+		t.Fatal("timed out waiting for BatchDoneFunc")
+	}
+	// A GetBlockRange request is not a pipelined request, so it must not also
+	// be reported through RangeDoneFunc.
+	select {
+	case res := <-h.done:
+		t.Fatalf("unexpected RangeDoneFunc call for request %d", res.requestId)
+	default:
+	}
+}
+
+// TestRequestRangeExcessBatchDoneNotAppliedToNextRequest is the negative
+// case: a peer that sends a second MsgBatchDone after completing the first
+// batch must not have it applied to the next queued request. The connection
+// fails and the still-outstanding request is resolved with an error rather
+// than reported complete.
+func TestRequestRangeExcessBatchDoneNotAppliedToNextRequest(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	wrapped1, point1 := testBlock(t, 100)
+	_, point2 := testBlock(t, 200)
+	conversation := []ouroboros_mock.ConversationEntry{
+		ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+		ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+		requestRangeInput(),
+		requestRangeInput(),
+		batchOutput(
+			blockfetch.NewMsgStartBatch(),
+			blockfetch.NewMsgBlock(wrapped1),
+			blockfetch.NewMsgBatchDone(),
+			// Excess BatchDone for a request that has already been retired
+			blockfetch.NewMsgBatchDone(),
+		),
+	}
+	h := newPipelineHarness(t, conversation)
+	defer h.close(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+	id1, err := h.client.RequestRange(ctx, blockfetch.RangeRequest{
+		Start: point1, End: point1, ExpectedBytes: 1024,
+	})
+	require.NoError(t, err)
+	id2, err := h.client.RequestRange(ctx, blockfetch.RangeRequest{
+		Start: point2, End: point2, ExpectedBytes: 1024,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, deliveredBlock{requestId: id1, slot: 100}, h.nextBlock(t))
+	first := h.nextDone(t)
+	require.Equal(t, id1, first.requestId)
+	require.NoError(t, first.err)
+
+	// The second request must be resolved with a failure, never with the
+	// excess BatchDone that belonged to the retired request.
+	second := waitForDone(t, h, id2)
+	require.Error(t, second.err)
+	// No block was ever delivered for the second request
+	select {
+	case blk := <-h.blocks:
+		t.Fatalf("unexpected block delivered: %+v", blk)
+	default:
+	}
+}
+
+// waitForDone waits for the completion of a specific request, tolerating a
+// connection error arriving first since a protocol violation reports on both
+// paths.
+func waitForDone(
+	t *testing.T,
+	h *pipelineHarness,
+	requestId uint64,
+) rangeResult {
+	t.Helper()
+	deadline := time.After(testTimeout)
+	for {
+		select {
+		case res := <-h.done:
+			if res.requestId == requestId {
+				return res
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for request %d to resolve", requestId)
+		}
+	}
+}
+
+// TestRequestRangeShutdownResolvesOutstanding verifies that a connection
+// teardown mid-pipeline resolves every outstanding request exactly once, with
+// no goroutine left waiting.
+func TestRequestRangeShutdownResolvesOutstanding(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	_, point1 := testBlock(t, 100)
+	_, point2 := testBlock(t, 200)
+	_, point3 := testBlock(t, 300)
+	conversation := []ouroboros_mock.ConversationEntry{
+		ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+		ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+		requestRangeInput(),
+		requestRangeInput(),
+		requestRangeInput(),
+		// The peer starts the first batch and then disappears
+		batchOutput(blockfetch.NewMsgStartBatch()),
+		ouroboros_mock.ConversationEntryClose{},
+	}
+	h := newPipelineHarness(t, conversation)
+	defer h.close(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+	ids := make([]uint64, 0, 3)
+	for _, point := range []pcommon.Point{point1, point2, point3} {
+		id, err := h.client.RequestRange(ctx, blockfetch.RangeRequest{
+			Start: point, End: point, ExpectedBytes: 1024,
+		})
+		require.NoError(t, err)
+		ids = append(ids, id)
+	}
+
+	resolved := make(map[uint64]error, len(ids))
+	deadline := time.After(testTimeout)
+	for len(resolved) < len(ids) {
+		select {
+		case res := <-h.done:
+			_, dup := resolved[res.requestId]
+			require.False(
+				t,
+				dup,
+				"request %d resolved more than once",
+				res.requestId,
+			)
+			resolved[res.requestId] = res.err
+		case <-deadline:
+			t.Fatalf(
+				"only %d of %d outstanding requests resolved on shutdown",
+				len(resolved),
+				len(ids),
+			)
+		}
+	}
+	for _, id := range ids {
+		require.ErrorIs(
+			t,
+			resolved[id],
+			protocol.ErrProtocolShuttingDown,
+			"request %d",
+			id,
+		)
+	}
+}
+
+// TestRequestRangeInFlightByteBound verifies the in-flight bound is expressed
+// in bytes and actually holds a request back. The first request is pinned
+// open by blocking inside its block callback, which runs on the protocol
+// receive goroutine, so nothing can retire it and release capacity until the
+// test says so. While it is pinned, a third request cannot be admitted.
+func TestRequestRangeInFlightByteBound(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	wrapped1, point1 := testBlock(t, 100)
+	wrapped2, point2 := testBlock(t, 200)
+	wrapped3, point3 := testBlock(t, 300)
+	conversation := []ouroboros_mock.ConversationEntry{
+		ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+		ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+		requestRangeInput(),
+		requestRangeInput(),
+		batchOutput(
+			blockfetch.NewMsgStartBatch(),
+			blockfetch.NewMsgBlock(wrapped1),
+			blockfetch.NewMsgBatchDone(),
+		),
+		requestRangeInput(),
+		batchOutput(
+			blockfetch.NewMsgStartBatch(),
+			blockfetch.NewMsgBlock(wrapped2),
+			blockfetch.NewMsgBatchDone(),
+		),
+		batchOutput(
+			blockfetch.NewMsgStartBatch(),
+			blockfetch.NewMsgBlock(wrapped3),
+			blockfetch.NewMsgBatchDone(),
+		),
+	}
+	firstBlockEntered := make(chan struct{})
+	releaseFirstBlock := make(chan struct{})
+	blocks := make(chan deliveredBlock, 16)
+	h := newPipelineHarness(
+		t,
+		conversation,
+		blockfetch.WithMaxInFlightBytes(2048),
+		blockfetch.WithBlockFunc(
+			func(ctx blockfetch.CallbackContext, _ uint, block ledger.Block) error {
+				if block.SlotNumber() == 100 {
+					close(firstBlockEntered)
+					<-releaseFirstBlock
+				}
+				blocks <- deliveredBlock{
+					requestId: ctx.RequestId,
+					slot:      block.SlotNumber(),
+				}
+				return nil
+			},
+		),
+	)
+	defer h.close(t)
+	nextBlock := func() deliveredBlock {
+		t.Helper()
+		select {
+		case blk := <-blocks:
+			return blk
+		case err := <-h.connErrs:
+			t.Fatalf("unexpected connection error: %s", err)
+		case <-time.After(testTimeout):
+			t.Fatal("timed out waiting for a block")
+		}
+		return deliveredBlock{}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+	for _, point := range []pcommon.Point{point1, point2} {
+		_, err := h.client.RequestRange(ctx, blockfetch.RangeRequest{
+			Start: point, End: point, ExpectedBytes: 1024,
+		})
+		require.NoError(t, err)
+	}
+	// Wait until the first request is pinned open inside its block callback.
+	select {
+	case <-firstBlockEntered:
+	case err := <-h.connErrs:
+		t.Fatalf("unexpected connection error: %s", err)
+	case <-time.After(testTimeout):
+		t.Fatal("timed out waiting for the first block callback")
+	}
+	// The bound is reached and nothing can release it, so a third request
+	// must not be admitted.
+	thirdAccepted := make(chan error, 1)
+	go func() {
+		_, err := h.client.RequestRange(ctx, blockfetch.RangeRequest{
+			Start: point3, End: point3, ExpectedBytes: 1024,
+		})
+		thirdAccepted <- err
+	}()
+	select {
+	case err := <-thirdAccepted:
+		t.Fatalf(
+			"third request was admitted past the in-flight byte bound: %v",
+			err,
+		)
+	case <-time.After(100 * time.Millisecond):
+		// Still blocked, as required
+	}
+	close(releaseFirstBlock)
+	require.Equal(t, deliveredBlock{requestId: 1, slot: 100}, nextBlock())
+	first := h.nextDone(t)
+	require.Equal(t, uint64(1), first.requestId)
+	require.NoError(t, first.err)
+	select {
+	case err := <-thirdAccepted:
+		require.NoError(t, err)
+	case <-time.After(testTimeout):
+		t.Fatal("third request was not admitted after capacity was released")
+	}
+	for i, slot := range []uint64{200, 300} {
+		id := uint64(i + 2)
+		require.Equal(
+			t,
+			deliveredBlock{requestId: id, slot: slot},
+			nextBlock(),
+		)
+		res := h.nextDone(t)
+		require.Equal(t, id, res.requestId)
+		require.NoError(t, res.err)
+	}
+}
+
+// TestRequestRangeNoBlocksResolvesOnlyItsOwnRequest verifies a MsgNoBlocks
+// answer fails the request it belongs to and leaves the following request
+// outstanding.
+func TestRequestRangeNoBlocksResolvesOnlyItsOwnRequest(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	_, point1 := testBlock(t, 100)
+	wrapped2, point2 := testBlock(t, 200)
+	conversation := []ouroboros_mock.ConversationEntry{
+		ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+		ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+		requestRangeInput(),
+		requestRangeInput(),
+		batchOutput(blockfetch.NewMsgNoBlocks()),
+		batchOutput(
+			blockfetch.NewMsgStartBatch(),
+			blockfetch.NewMsgBlock(wrapped2),
+			blockfetch.NewMsgBatchDone(),
+		),
+	}
+	h := newPipelineHarness(t, conversation)
+	defer h.close(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+	id1, err := h.client.RequestRange(ctx, blockfetch.RangeRequest{
+		Start: point1, End: point1, ExpectedBytes: 1024,
+	})
+	require.NoError(t, err)
+	id2, err := h.client.RequestRange(ctx, blockfetch.RangeRequest{
+		Start: point2, End: point2, ExpectedBytes: 1024,
+	})
+	require.NoError(t, err)
+
+	first := h.nextDone(t)
+	require.Equal(t, id1, first.requestId)
+	require.ErrorContains(t, first.err, "block(s) not found")
+
+	require.Equal(t, deliveredBlock{requestId: id2, slot: 200}, h.nextBlock(t))
+	second := h.nextDone(t)
+	require.Equal(t, id2, second.requestId)
+	require.NoError(t, second.err)
+}
+
+// TestGetBlockEmptyBatch verifies GetBlock reports a missing block rather than
+// hanging when a peer completes a batch without sending one.
+func TestGetBlockEmptyBatch(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	_, point1 := testBlock(t, 100)
+	conversation := []ouroboros_mock.ConversationEntry{
+		ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+		ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+		requestRangeInput(),
+		batchOutput(
+			blockfetch.NewMsgStartBatch(),
+			blockfetch.NewMsgBatchDone(),
+		),
+	}
+	h := newPipelineHarness(t, conversation)
+	defer h.close(t)
+
+	type result struct {
+		block ledger.Block
+		err   error
+	}
+	results := make(chan result, 1)
+	go func() {
+		blk, err := h.client.GetBlock(point1)
+		results <- result{block: blk, err: err}
+	}()
+	select {
+	case res := <-results:
+		require.Nil(t, res.block)
+		require.ErrorContains(t, res.err, "block(s) not found")
+	case err := <-h.connErrs:
+		t.Fatalf("unexpected connection error: %s", err)
+	case <-time.After(testTimeout):
+		t.Fatal("GetBlock did not return for a batch with no blocks")
+	}
+}

--- a/protocol/blockfetch/client_queue_internal_test.go
+++ b/protocol/blockfetch/client_queue_internal_test.go
@@ -46,13 +46,22 @@ func newQueueTestClient(cfg *Config) *Client {
 	}, cfg)
 }
 
-// newStartedQueueTestClient provides a live protocol send queue while draining
-// the other side of an in-memory connection. It deliberately sends no peer
-// responses, leaving accepted requests outstanding for queue assertions.
-func newStartedQueueTestClient(t *testing.T, cfg *Config) *Client {
+// newInMemoryPeer is the shared transport fixture for queue tests that need a
+// live muxer. ouroboros-mock emits one muxer segment per message, so it cannot
+// inject the multi-segment oversized messages exercised by the Idle ingress
+// tests below.
+func newInMemoryPeer(
+	t *testing.T,
+	cfg *Config,
+	startMuxer bool,
+	errorChan chan error,
+) *idlePeer {
 	t.Helper()
 	localConn, peerConn := net.Pipe()
 	m := muxer.New(localConn)
+	if startMuxer {
+		m.Start()
+	}
 	peerDone := make(chan struct{})
 	go func() {
 		_, _ = io.Copy(io.Discard, peerConn)
@@ -63,8 +72,9 @@ func newStartedQueueTestClient(t *testing.T, cfg *Config) *Client {
 			LocalAddr:  localConn.LocalAddr(),
 			RemoteAddr: localConn.RemoteAddr(),
 		},
-		Muxer: m,
-		Mode:  protocol.ProtocolModeNodeToNode,
+		Muxer:     m,
+		ErrorChan: errorChan,
+		Mode:      protocol.ProtocolModeNodeToNode,
 	}, cfg)
 	c.Start()
 	t.Cleanup(func() {
@@ -84,7 +94,15 @@ func newStartedQueueTestClient(t *testing.T, cfg *Config) *Client {
 			t.Error("peer drain did not stop")
 		}
 	})
-	return c
+	return &idlePeer{client: c, conn: peerConn, errorChan: errorChan}
+}
+
+// newStartedQueueTestClient provides a live protocol send queue while draining
+// the other side of an in-memory connection. It deliberately sends no peer
+// responses, leaving accepted requests outstanding for queue assertions.
+func newStartedQueueTestClient(t *testing.T, cfg *Config) *Client {
+	t.Helper()
+	return newInMemoryPeer(t, cfg, false, nil).client
 }
 
 func (c *Client) appendTestRequest(reservedBytes uint64) *rangeRequest {
@@ -364,8 +382,9 @@ func TestInFlightWaitDoesNotBlockOtherCallers(t *testing.T) {
 	// A concurrent GetBlockRange must still reach the wire. It blocks
 	// afterwards waiting for MsgStartBatch, which the test peer never sends,
 	// so the observable is its queue entry rather than its return.
+	legacyDone := make(chan error, 1)
 	go func() {
-		_ = c.GetBlockRange(pcommon.Point{}, pcommon.Point{})
+		legacyDone <- c.GetBlockRange(pcommon.Point{}, pcommon.Point{})
 	}()
 	require.Eventually(t, func() bool {
 		c.queueMutex.Lock()
@@ -392,6 +411,13 @@ func TestInFlightWaitDoesNotBlockOtherCallers(t *testing.T) {
 		require.ErrorIs(t, err, context.Canceled)
 	case <-time.After(time.Second):
 		t.Fatal("parked RequestRange did not return after cancellation")
+	}
+	c.failOutstanding(protocol.ErrProtocolShuttingDown)
+	select {
+	case err := <-legacyDone:
+		require.ErrorIs(t, err, protocol.ErrProtocolShuttingDown)
+	case <-time.After(time.Second):
+		t.Fatal("GetBlockRange was not released by shutdown")
 	}
 }
 
@@ -466,6 +492,10 @@ func TestOldProtocolShutdownDoesNotFailRestartedRequests(t *testing.T) {
 		protocol.ErrProtocolShuttingDown,
 	)
 	require.Equal(t, []uint64{req.id}, completions)
+	c.queueMutex.Lock()
+	defer c.queueMutex.Unlock()
+	require.Empty(t, c.queue)
+	require.Zero(t, c.inFlightBytes)
 }
 
 // idleLimitObservationWindow bounds both halves of the Idle-state ingress
@@ -486,43 +516,8 @@ type idlePeer struct {
 
 func newIdlePeer(t *testing.T, cfg *Config) *idlePeer {
 	t.Helper()
-	localConn, peerConn := net.Pipe()
-	m := muxer.New(localConn)
-	m.Start()
-	peerDone := make(chan struct{})
-	go func() {
-		_, _ = io.Copy(io.Discard, peerConn)
-		close(peerDone)
-	}()
 	errorChan := make(chan error, 10)
-	c := NewClient(protocol.ProtocolOptions{
-		ConnectionId: connection.ConnectionId{
-			LocalAddr:  localConn.LocalAddr(),
-			RemoteAddr: localConn.RemoteAddr(),
-		},
-		Muxer:     m,
-		ErrorChan: errorChan,
-		Mode:      protocol.ProtocolModeNodeToNode,
-	}, cfg)
-	c.Start()
-	t.Cleanup(func() {
-		proto := c.ProtocolInstance()
-		proto.Stop()
-		select {
-		case <-proto.DoneChan():
-		case <-time.After(time.Second):
-			t.Error("protocol did not stop")
-		}
-		c.failOutstanding(protocol.ErrProtocolShuttingDown)
-		m.Stop()
-		_ = peerConn.Close()
-		select {
-		case <-peerDone:
-		case <-time.After(time.Second):
-			t.Error("peer drain did not stop")
-		}
-	})
-	return &idlePeer{client: c, conn: peerConn, errorChan: errorChan}
+	return newInMemoryPeer(t, cfg, true, errorChan)
 }
 
 // send writes a message to the client as raw muxer segments, splitting it

--- a/protocol/blockfetch/client_queue_internal_test.go
+++ b/protocol/blockfetch/client_queue_internal_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blockfetch
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+// newQueueTestClient builds a client whose protocol was never started. The
+// outstanding-request queue and the in-flight byte accounting do not touch the
+// network, so they can be exercised directly.
+func newQueueTestClient(cfg *Config) *Client {
+	return NewClient(protocol.ProtocolOptions{
+		ConnectionId: connection.ConnectionId{
+			LocalAddr:  &net.TCPAddr{},
+			RemoteAddr: &net.TCPAddr{},
+		},
+	}, cfg)
+}
+
+func (c *Client) appendTestRequest(reservedBytes uint64) *rangeRequest {
+	c.queueMutex.Lock()
+	defer c.queueMutex.Unlock()
+	c.nextRequestId++
+	req := &rangeRequest{
+		id:            c.nextRequestId,
+		delivery:      deliveryCallback,
+		pipelined:     true,
+		reservedBytes: reservedBytes,
+		startChan:     make(chan error, 1),
+		blockChan:     make(chan ledger.Block, 1),
+		doneChan:      make(chan error, 1),
+	}
+	c.queue = append(c.queue, req)
+	c.inFlightBytes += reservedBytes
+	return req
+}
+
+// TestQueueRejectsResponseWithNoOutstandingRequest covers a peer answering
+// when nothing was asked for.
+func TestQueueRejectsResponseWithNoOutstandingRequest(t *testing.T) {
+	c := newQueueTestClient(&Config{
+		RequestPipelining: true,
+		RangeDoneFunc: func(CallbackContext, error) error {
+			return nil
+		},
+	})
+	require.ErrorContains(
+		t,
+		c.handleStartBatch(),
+		"no outstanding range request",
+	)
+	require.ErrorContains(
+		t,
+		c.handleBatchDone(),
+		"no outstanding range request",
+	)
+	require.ErrorContains(t, c.handleNoBlocks(), "no outstanding range request")
+}
+
+// TestQueueExcessBatchDoneIsNotAppliedToNextRequest is the negative case for
+// FIFO attribution: once a request is retired, a further MsgBatchDone must be
+// rejected instead of completing the request behind it.
+func TestQueueExcessBatchDoneIsNotAppliedToNextRequest(t *testing.T) {
+	completions := make(chan uint64, 4)
+	c := newQueueTestClient(&Config{
+		RequestPipelining: true,
+		RangeDoneFunc: func(ctx CallbackContext, err error) error {
+			require.NoError(t, err)
+			completions <- ctx.RequestId
+			return nil
+		},
+	})
+	first := c.appendTestRequest(1024)
+	second := c.appendTestRequest(1024)
+
+	require.NoError(t, c.handleStartBatch())
+	require.True(t, first.started)
+	require.False(t, second.started)
+	require.NoError(t, c.handleBatchDone())
+	require.Equal(t, uint64(1), <-completions)
+
+	// The second request is now at the head but has never been started, so a
+	// further BatchDone belongs to nothing.
+	require.ErrorContains(t, c.handleBatchDone(), "in the wrong order")
+	c.queueMutex.Lock()
+	queueLen := len(c.queue)
+	c.queueMutex.Unlock()
+	require.Equal(t, 1, queueLen, "the queue must still hold request 2")
+	require.Len(t, completions, 0, "request 2 must not be reported complete")
+	select {
+	case err := <-second.doneChan:
+		t.Fatalf("request 2 was resolved by an excess BatchDone: %v", err)
+	default:
+	}
+}
+
+// TestQueueRejectsBlockBeforeStartBatch covers a peer streaming a block for a
+// request the head entry has not started.
+func TestQueueRejectsBlockBeforeStartBatch(t *testing.T) {
+	c := newQueueTestClient(&Config{
+		RequestPipelining: true,
+		RangeDoneFunc: func(CallbackContext, error) error {
+			return nil
+		},
+	})
+	c.appendTestRequest(1024)
+	require.ErrorContains(
+		t,
+		c.handleBlock(NewMsgBlock([]byte{0x80})),
+		"in the wrong order",
+	)
+}
+
+// TestQueueRetiredBytesAreReleased covers the in-flight accounting: retiring a
+// request returns its reserved bytes to the budget.
+func TestQueueRetiredBytesAreReleased(t *testing.T) {
+	c := newQueueTestClient(&Config{
+		RequestPipelining: true,
+		RangeDoneFunc: func(CallbackContext, error) error {
+			return nil
+		},
+	})
+	c.appendTestRequest(4096)
+	c.queueMutex.Lock()
+	inFlight := c.inFlightBytes
+	c.queueMutex.Unlock()
+	require.Equal(t, uint64(4096), inFlight)
+
+	require.NoError(t, c.handleStartBatch())
+	require.NoError(t, c.handleBatchDone())
+	c.queueMutex.Lock()
+	inFlight = c.inFlightBytes
+	queueLen := len(c.queue)
+	c.queueMutex.Unlock()
+	require.Equal(t, uint64(0), inFlight)
+	require.Equal(t, 0, queueLen)
+}
+
+// TestAwaitInFlightCapacityAdmitsOversizedRequestOnEmptyQueue verifies a range
+// whose expected size exceeds the whole bound is still admitted when nothing
+// else is outstanding, so an oversized range cannot stall forever.
+func TestAwaitInFlightCapacityAdmitsOversizedRequestOnEmptyQueue(t *testing.T) {
+	c := newQueueTestClient(&Config{
+		RequestPipelining: true,
+		MaxInFlightBytes:  1024,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, c.awaitInFlightCapacity(ctx, 1024*1024))
+}
+
+// TestAwaitInFlightCapacityBlocksAtBound verifies that a request which does
+// not fit is held, and that the wait is released by the caller's context
+// rather than being admitted anyway.
+func TestAwaitInFlightCapacityBlocksAtBound(t *testing.T) {
+	c := newQueueTestClient(&Config{
+		RequestPipelining: true,
+		MaxInFlightBytes:  1024,
+	})
+	req := c.appendTestRequest(1024)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, c.awaitInFlightCapacity(ctx, 1024), context.Canceled)
+
+	// Releasing the outstanding request makes room again
+	c.queueMutex.Lock()
+	c.removeLocked(req)
+	c.queueMutex.Unlock()
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	require.NoError(t, c.awaitInFlightCapacity(ctx2, 1024))
+}
+
+// TestAwaitInFlightCapacityDefaultsBound verifies an unset MaxInFlightBytes
+// resolves to the documented default rather than to zero, which would admit
+// nothing.
+func TestAwaitInFlightCapacityDefaultsBound(t *testing.T) {
+	c := newQueueTestClient(&Config{RequestPipelining: true})
+	require.Equal(t, DefaultMaxInFlightBytes, c.maxInFlightBytes())
+}

--- a/protocol/blockfetch/client_queue_internal_test.go
+++ b/protocol/blockfetch/client_queue_internal_test.go
@@ -16,6 +16,8 @@ package blockfetch
 
 import (
 	"context"
+	"encoding/binary"
+	"fmt"
 	"io"
 	"math"
 	"net"
@@ -23,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/muxer"
@@ -459,4 +462,173 @@ func TestOldProtocolShutdownDoesNotFailRestartedRequests(t *testing.T) {
 		protocol.ErrProtocolShuttingDown,
 	)
 	require.Equal(t, []uint64{req.id}, completions)
+}
+
+// idleLimitObservationWindow bounds both halves of the Idle-state ingress
+// limit pair below: the non-pipelining client must report the oversized
+// message within it, and the pipelining client must not.
+const idleLimitObservationWindow = time.Second
+
+// idlePeer drives a client attached to a real muxer over an in-memory
+// connection. The ouroboros-mock conversation harness cannot express these
+// cases: it puts each message in a single muxer segment, and a segment
+// payload is capped at muxer.SegmentMaxPayloadLength, so it cannot deliver a
+// mainnet-sized block at all.
+type idlePeer struct {
+	client    *Client
+	conn      net.Conn
+	errorChan chan error
+}
+
+func newIdlePeer(t *testing.T, cfg *Config) *idlePeer {
+	t.Helper()
+	localConn, peerConn := net.Pipe()
+	m := muxer.New(localConn)
+	m.Start()
+	peerDone := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, peerConn)
+		close(peerDone)
+	}()
+	errorChan := make(chan error, 10)
+	c := NewClient(protocol.ProtocolOptions{
+		ConnectionId: connection.ConnectionId{
+			LocalAddr:  localConn.LocalAddr(),
+			RemoteAddr: localConn.RemoteAddr(),
+		},
+		Muxer:     m,
+		ErrorChan: errorChan,
+		Mode:      protocol.ProtocolModeNodeToNode,
+	}, cfg)
+	c.Start()
+	t.Cleanup(func() {
+		proto := c.ProtocolInstance()
+		proto.Stop()
+		select {
+		case <-proto.DoneChan():
+		case <-time.After(time.Second):
+			t.Error("protocol did not stop")
+		}
+		c.failOutstanding(protocol.ErrProtocolShuttingDown)
+		m.Stop()
+		_ = peerConn.Close()
+		select {
+		case <-peerDone:
+		case <-time.After(time.Second):
+			t.Error("peer drain did not stop")
+		}
+	})
+	return &idlePeer{client: c, conn: peerConn, errorChan: errorChan}
+}
+
+// send writes a message to the client as raw muxer segments, splitting it
+// across segments the way Protocol.sendLoop does for an oversized payload.
+// net.Pipe is unbuffered, so this returns only once the client's muxer has
+// read every byte.
+func (p *idlePeer) send(t *testing.T, msg protocol.Message) {
+	t.Helper()
+	data, err := cbor.Encode(msg)
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+	for len(data) > 0 {
+		chunkLen := min(len(data), muxer.SegmentMaxPayloadLength)
+		segment := muxer.NewSegment(ProtocolId, data[:chunkLen], true)
+		require.NotNil(t, segment)
+		require.NoError(
+			t,
+			binary.Write(p.conn, binary.BigEndian, segment.SegmentHeader),
+		)
+		_, err := p.conn.Write(segment.Payload)
+		require.NoError(t, err)
+		data = data[chunkLen:]
+	}
+}
+
+// completeOneEmptyBatch drives a single pipelined request to completion so the
+// client's state machine returns to Idle through MsgBatchDone, which is the
+// state a peer's next MsgBlock can arrive in.
+func (p *idlePeer) completeOneEmptyBatch(t *testing.T, done chan error) {
+	t.Helper()
+	_, err := p.client.RequestRange(
+		context.Background(),
+		RangeRequest{ExpectedBytes: 1},
+	)
+	require.NoError(t, err)
+	p.send(t, NewMsgStartBatch())
+	p.send(t, NewMsgBatchDone())
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case err := <-p.errorChan:
+		t.Fatalf("unexpected protocol error before the batch completed: %s", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("the first range request never completed")
+	}
+}
+
+// bigBlockMsg returns a MsgBlock whose encoded size exceeds
+// IdleMaxPendingMessageBytes. Its body is one maximum-size mainnet block body,
+// which is what a real peer streams during catch-up sync.
+func bigBlockMsg(t *testing.T) protocol.Message {
+	t.Helper()
+	msg := NewMsgBlock(make([]byte, DefaultRequestExpectedBytes))
+	encoded, err := cbor.Encode(msg)
+	require.NoError(t, err)
+	require.Greater(t, len(encoded), IdleMaxPendingMessageBytes)
+	require.LessOrEqual(t, len(encoded), PipelinedIdleMaxPendingMessageBytes)
+	return msg
+}
+
+// TestPipelinedIdleLimitAdmitsMainnetSizedBlock covers the Idle-state ingress
+// limit for a pipelining client. With more than one request outstanding, the
+// peer's MsgBlock for the next request can arrive while the state machine is
+// momentarily back in Idle after a MsgBatchDone, so the Idle limit has to
+// admit a block. A limit of IdleMaxPendingMessageBytes tears the connection
+// down instead, which only shows up against a real peer because the blocks in
+// the mock conversations are tiny.
+func TestPipelinedIdleLimitAdmitsMainnetSizedBlock(t *testing.T) {
+	done := make(chan error, 4)
+	p := newIdlePeer(t, &Config{
+		RequestPipelining: true,
+		RangeDoneFunc: func(_ CallbackContext, err error) error {
+			done <- err
+			return nil
+		},
+	})
+	p.completeOneEmptyBatch(t, done)
+
+	// The state machine is back in Idle and the block is larger than the
+	// unpipelined Idle limit. It must be admitted rather than rejected as
+	// oversized; nothing consumes it, because the client has agency in Idle.
+	p.send(t, bigBlockMsg(t))
+	select {
+	case err := <-p.errorChan:
+		t.Fatalf(
+			"a mainnet-sized block was rejected while the state machine was in Idle: %s",
+			err,
+		)
+	case <-p.client.ProtocolInstance().DoneChan():
+		t.Fatal("the protocol was torn down by a mainnet-sized block in Idle")
+	case <-time.After(idleLimitObservationWindow):
+	}
+}
+
+// TestUnpipelinedIdleLimitRejectsMainnetSizedBlock is the paired positive
+// case. It keeps the unpipelined Idle limit honest, and it proves the
+// observation window above is long enough to see the rejection when the limit
+// does produce one.
+func TestUnpipelinedIdleLimitRejectsMainnetSizedBlock(t *testing.T) {
+	p := newIdlePeer(t, &Config{})
+	p.send(t, bigBlockMsg(t))
+	select {
+	case err := <-p.errorChan:
+		require.ErrorContains(t, err, "received oversized message")
+		require.ErrorContains(
+			t,
+			err,
+			fmt.Sprintf("exceeding limit (%d bytes)", IdleMaxPendingMessageBytes),
+		)
+	case <-time.After(idleLimitObservationWindow):
+		t.Fatal("an oversized block in Idle was not rejected")
+	}
 }

--- a/protocol/blockfetch/client_queue_internal_test.go
+++ b/protocol/blockfetch/client_queue_internal_test.go
@@ -16,11 +16,16 @@ package blockfetch
 
 import (
 	"context"
+	"io"
+	"math"
 	"net"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/muxer"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	"github.com/stretchr/testify/require"
 )
@@ -37,12 +42,54 @@ func newQueueTestClient(cfg *Config) *Client {
 	}, cfg)
 }
 
+// newStartedQueueTestClient provides a live protocol send queue while draining
+// the other side of an in-memory connection. It deliberately sends no peer
+// responses, leaving accepted requests outstanding for queue assertions.
+func newStartedQueueTestClient(t *testing.T, cfg *Config) *Client {
+	t.Helper()
+	localConn, peerConn := net.Pipe()
+	m := muxer.New(localConn)
+	peerDone := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, peerConn)
+		close(peerDone)
+	}()
+	c := NewClient(protocol.ProtocolOptions{
+		ConnectionId: connection.ConnectionId{
+			LocalAddr:  localConn.LocalAddr(),
+			RemoteAddr: localConn.RemoteAddr(),
+		},
+		Muxer: m,
+		Mode:  protocol.ProtocolModeNodeToNode,
+	}, cfg)
+	c.Start()
+	t.Cleanup(func() {
+		proto := c.ProtocolInstance()
+		proto.Stop()
+		select {
+		case <-proto.DoneChan():
+		case <-time.After(time.Second):
+			t.Error("protocol did not stop")
+		}
+		c.failOutstanding(protocol.ErrProtocolShuttingDown)
+		m.Stop()
+		_ = peerConn.Close()
+		select {
+		case <-peerDone:
+		case <-time.After(time.Second):
+			t.Error("peer drain did not stop")
+		}
+	})
+	return c
+}
+
 func (c *Client) appendTestRequest(reservedBytes uint64) *rangeRequest {
 	c.queueMutex.Lock()
 	defer c.queueMutex.Unlock()
 	c.nextRequestId++
 	req := &rangeRequest{
 		id:            c.nextRequestId,
+		protocol:      c.ProtocolInstance(),
 		delivery:      deliveryCallback,
 		pipelined:     true,
 		reservedBytes: reservedBytes,
@@ -156,45 +203,185 @@ func TestQueueRetiredBytesAreReleased(t *testing.T) {
 	require.Equal(t, 0, queueLen)
 }
 
-// TestAwaitInFlightCapacityAdmitsOversizedRequestOnEmptyQueue verifies a range
+// TestInFlightCapacityAdmitsOversizedRequestOnEmptyQueue verifies a range
 // whose expected size exceeds the whole bound is still admitted when nothing
 // else is outstanding, so an oversized range cannot stall forever.
-func TestAwaitInFlightCapacityAdmitsOversizedRequestOnEmptyQueue(t *testing.T) {
+func TestInFlightCapacityAdmitsOversizedRequestOnEmptyQueue(t *testing.T) {
 	c := newQueueTestClient(&Config{
 		RequestPipelining: true,
 		MaxInFlightBytes:  1024,
 	})
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	require.NoError(t, c.awaitInFlightCapacity(ctx, 1024*1024))
+	c.queueMutex.Lock()
+	defer c.queueMutex.Unlock()
+	require.True(t, c.hasInFlightCapacityLocked(1024*1024))
 }
 
-// TestAwaitInFlightCapacityBlocksAtBound verifies that a request which does
-// not fit is held, and that the wait is released by the caller's context
-// rather than being admitted anyway.
-func TestAwaitInFlightCapacityBlocksAtBound(t *testing.T) {
+// TestInFlightCapacityBlocksAtBound verifies that a request which does not fit
+// is held until the existing request retires.
+func TestInFlightCapacityBlocksAtBound(t *testing.T) {
 	c := newQueueTestClient(&Config{
 		RequestPipelining: true,
 		MaxInFlightBytes:  1024,
 	})
 	req := c.appendTestRequest(1024)
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	require.ErrorIs(t, c.awaitInFlightCapacity(ctx, 1024), context.Canceled)
+	c.queueMutex.Lock()
+	require.False(t, c.hasInFlightCapacityLocked(1024))
+	c.queueMutex.Unlock()
 
 	// Releasing the outstanding request makes room again
 	c.queueMutex.Lock()
 	c.removeLocked(req)
+	require.True(t, c.hasInFlightCapacityLocked(1024))
 	c.queueMutex.Unlock()
-	ctx2, cancel2 := context.WithCancel(context.Background())
-	defer cancel2()
-	require.NoError(t, c.awaitInFlightCapacity(ctx2, 1024))
 }
 
-// TestAwaitInFlightCapacityDefaultsBound verifies an unset MaxInFlightBytes
+// TestInFlightCapacityDefaultsBound verifies an unset MaxInFlightBytes
 // resolves to the documented default rather than to zero, which would admit
 // nothing.
-func TestAwaitInFlightCapacityDefaultsBound(t *testing.T) {
+func TestInFlightCapacityDefaultsBound(t *testing.T) {
 	c := newQueueTestClient(&Config{RequestPipelining: true})
 	require.Equal(t, DefaultMaxInFlightBytes, c.maxInFlightBytes())
+}
+
+func TestInFlightCapacityDoesNotOverflow(t *testing.T) {
+	c := newQueueTestClient(&Config{
+		RequestPipelining: true,
+		MaxInFlightBytes:  math.MaxUint64,
+	})
+	c.appendTestRequest(math.MaxUint64)
+	c.queueMutex.Lock()
+	defer c.queueMutex.Unlock()
+	require.False(t, c.hasInFlightCapacityLocked(1))
+}
+
+func TestRequestRangeAdmissionAndReservationAreAtomic(t *testing.T) {
+	c := newStartedQueueTestClient(t, &Config{
+		RequestPipelining: true,
+		MaxInFlightBytes:  1,
+		RangeDoneFunc: func(CallbackContext, error) error {
+			return nil
+		},
+	})
+
+	var arrived sync.WaitGroup
+	arrived.Add(2)
+	release := make(chan struct{})
+	c.beforeRequestReservation = func() {
+		arrived.Done()
+		<-release
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	results := make(chan error, 2)
+	for range 2 {
+		go func() {
+			_, err := c.RequestRange(ctx, RangeRequest{ExpectedBytes: 1})
+			results <- err
+		}()
+	}
+	arrived.Wait()
+	close(release)
+
+	// Both callers reached the admission boundary while the queue was empty.
+	// Exactly one may reserve the entire bound; the other must be held back by
+	// the recheck under the same lock as reservation.
+	select {
+	case err := <-results:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("no request was admitted")
+	}
+	select {
+	case err := <-results:
+		t.Fatalf("second request was admitted past the bound: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	c.queueMutex.Lock()
+	require.Len(t, c.queue, 1)
+	require.Equal(t, uint64(1), c.inFlightBytes)
+	c.queueMutex.Unlock()
+	cancel()
+	select {
+	case err := <-results:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("waiting RequestRange did not return after cancellation")
+	}
+	c.queueMutex.Lock()
+	defer c.queueMutex.Unlock()
+	require.Len(t, c.queue, 1)
+	require.Equal(t, uint64(1), c.inFlightBytes)
+}
+
+func TestRequestRangeContextCancelsBlockedSend(t *testing.T) {
+	c := newQueueTestClient(&Config{
+		RequestPipelining: true,
+		MaxInFlightBytes:  1,
+		RangeDoneFunc: func(CallbackContext, error) error {
+			return nil
+		},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	results := make(chan error, 1)
+	go func() {
+		_, err := c.RequestRange(ctx, RangeRequest{ExpectedBytes: 1})
+		results <- err
+	}()
+
+	// A protocol that has not started has no send queue, so the request is
+	// guaranteed to be blocked after reservation rather than already sent.
+	require.Eventually(t, func() bool {
+		c.queueMutex.Lock()
+		defer c.queueMutex.Unlock()
+		return len(c.queue) == 1 && c.inFlightBytes == 1
+	}, time.Second, time.Millisecond)
+	cancel()
+	select {
+	case err := <-results:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("RequestRange remained blocked after cancellation")
+	}
+	c.queueMutex.Lock()
+	defer c.queueMutex.Unlock()
+	require.Empty(t, c.queue)
+	require.Zero(t, c.inFlightBytes)
+}
+
+func TestOldProtocolShutdownDoesNotFailRestartedRequests(t *testing.T) {
+	var completions []uint64
+	c := newQueueTestClient(&Config{
+		RequestPipelining: true,
+		RangeDoneFunc: func(ctx CallbackContext, _ error) error {
+			completions = append(completions, ctx.RequestId)
+			return nil
+		},
+	})
+	oldProto := c.ProtocolInstance()
+	c.initProtocol()
+	newProto := c.ProtocolInstance()
+	req := c.appendTestRequest(1)
+
+	c.failOutstandingForProtocol(
+		oldProto,
+		protocol.ErrProtocolShuttingDown,
+	)
+	c.queueMutex.Lock()
+	require.Len(t, c.queue, 1)
+	require.Same(t, req, c.queue[0])
+	require.Equal(t, uint64(1), c.inFlightBytes)
+	c.queueMutex.Unlock()
+	require.Empty(t, completions)
+	select {
+	case err := <-req.doneChan:
+		t.Fatalf("old protocol shutdown resolved restarted request: %v", err)
+	default:
+	}
+
+	c.failOutstandingForProtocol(
+		newProto,
+		protocol.ErrProtocolShuttingDown,
+	)
+	require.Equal(t, []uint64{req.id}, completions)
 }

--- a/protocol/blockfetch/client_queue_internal_test.go
+++ b/protocol/blockfetch/client_queue_internal_test.go
@@ -258,7 +258,11 @@ func TestInFlightCapacityDoesNotOverflow(t *testing.T) {
 	require.False(t, c.hasInFlightCapacityLocked(1))
 }
 
-func TestRequestRangeAdmissionAndReservationAreAtomic(t *testing.T) {
+// TestConcurrentAdmissionRespectsInFlightBound pins the recheck under the send
+// token: two callers released into the admission path together both pass the
+// capacity check made before the token, so without the recheck the second is
+// admitted past MaxInFlightBytes.
+func TestConcurrentAdmissionRespectsInFlightBound(t *testing.T) {
 	c := newStartedQueueTestClient(t, &Config{
 		RequestPipelining: true,
 		MaxInFlightBytes:  1,
@@ -270,7 +274,7 @@ func TestRequestRangeAdmissionAndReservationAreAtomic(t *testing.T) {
 	var arrived sync.WaitGroup
 	arrived.Add(2)
 	release := make(chan struct{})
-	c.beforeRequestReservation = func() {
+	c.beforeRequestAdmission = func() {
 		arrived.Done()
 		<-release
 	}

--- a/protocol/blockfetch/client_queue_internal_test.go
+++ b/protocol/blockfetch/client_queue_internal_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/muxer"
 	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/require"
 )
 
@@ -311,6 +312,80 @@ func TestRequestRangeAdmissionAndReservationAreAtomic(t *testing.T) {
 	defer c.queueMutex.Unlock()
 	require.Len(t, c.queue, 1)
 	require.Equal(t, uint64(1), c.inFlightBytes)
+}
+
+// TestInFlightWaitDoesNotBlockOtherCallers covers the wedge: a pipelined
+// caller parked on the in-flight byte bound must not hold the send token,
+// because every other request path shares it. GetBlockRange and GetBlock pass
+// context.Background(), so a caller wedged behind the parked request would
+// only be released by protocol shutdown.
+func TestInFlightWaitDoesNotBlockOtherCallers(t *testing.T) {
+	c := newStartedQueueTestClient(t, &Config{
+		RequestPipelining: true,
+		MaxInFlightBytes:  1,
+		RangeDoneFunc: func(CallbackContext, error) error {
+			return nil
+		},
+	})
+	waiting := make(chan struct{})
+	var waitingOnce sync.Once
+	c.beforeInFlightWait = func() {
+		waitingOnce.Do(func() { close(waiting) })
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// The first request takes the whole bound. The test peer never answers,
+	// so nothing retires it and nothing releases capacity.
+	_, err := c.RequestRange(ctx, RangeRequest{ExpectedBytes: 1})
+	require.NoError(t, err)
+
+	// The second request cannot be admitted and parks on the byte bound.
+	blocked := make(chan error, 1)
+	go func() {
+		_, err := c.RequestRange(ctx, RangeRequest{ExpectedBytes: 1})
+		blocked <- err
+	}()
+	select {
+	case <-waiting:
+	case err := <-blocked:
+		t.Fatalf("second request was not held by the byte bound: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("second request never reached the in-flight wait")
+	}
+
+	// A concurrent GetBlockRange must still reach the wire. It blocks
+	// afterwards waiting for MsgStartBatch, which the test peer never sends,
+	// so the observable is its queue entry rather than its return.
+	go func() {
+		_ = c.GetBlockRange(pcommon.Point{}, pcommon.Point{})
+	}()
+	require.Eventually(t, func() bool {
+		c.queueMutex.Lock()
+		defer c.queueMutex.Unlock()
+		for _, queued := range c.queue {
+			if !queued.pipelined {
+				return true
+			}
+		}
+		return false
+	}, time.Second, time.Millisecond,
+		"GetBlockRange never queued its request: it is wedged behind a RequestRange parked on the in-flight byte bound",
+	)
+
+	// The parked request is still parked, holding nothing.
+	select {
+	case err := <-blocked:
+		t.Fatalf("second request was admitted past the bound: %v", err)
+	default:
+	}
+	cancel()
+	select {
+	case err := <-blocked:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("parked RequestRange did not return after cancellation")
+	}
 }
 
 func TestRequestRangeContextCancelsBlockedSend(t *testing.T) {

--- a/protocol/leiosfetch/client.go
+++ b/protocol/leiosfetch/client.go
@@ -257,7 +257,7 @@ func (c *Client) BlockRequest(
 		return nil, err
 	}
 	msg := NewMsgBlockRequest(point)
-	if err := c.SendMessage(msg); err != nil {
+	if err := c.SendMessageContext(ctx, msg); err != nil {
 		c.blockSlot.release(w)
 		return nil, err
 	}
@@ -292,7 +292,7 @@ func (c *Client) BlockTxsRequest(
 		return nil, err
 	}
 	msg := NewMsgBlockTxsRequest(point, bitmaps)
-	if err := c.SendMessage(msg); err != nil {
+	if err := c.SendMessageContext(ctx, msg); err != nil {
 		c.blockTxsSlot.release(w)
 		return nil, err
 	}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -17,6 +17,7 @@ package protocol
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -338,7 +339,13 @@ func (p *Protocol) pipelinedSendAllowed() bool {
 
 // SendMessage appends a message to the send queue
 func (p *Protocol) SendMessage(msg Message) error {
-	return p.enqueueMessage(msg, nil)
+	return p.enqueueMessage(context.Background(), msg, nil)
+}
+
+// SendMessageContext appends a message to the send queue, or returns the
+// context's error if the message cannot be queued before the context ends.
+func (p *Protocol) SendMessageContext(ctx context.Context, msg Message) error {
+	return p.enqueueMessage(ctx, msg, nil)
 }
 
 // SendMessageAndWait queues a message and waits until its final muxer segment
@@ -346,7 +353,11 @@ func (p *Protocol) SendMessage(msg Message) error {
 // fails or the protocol shuts down before delivery completes.
 func (p *Protocol) SendMessageAndWait(msg Message) error {
 	deliveryChan := make(chan error, 1)
-	if err := p.enqueueMessage(msg, deliveryChan); err != nil {
+	if err := p.enqueueMessage(
+		context.Background(),
+		msg,
+		deliveryChan,
+	); err != nil {
 		return err
 	}
 	return p.waitForMessageDelivery(deliveryChan)
@@ -376,7 +387,14 @@ func deliveryResultOrShutdown(deliveryChan <-chan error) error {
 	}
 }
 
-func (p *Protocol) enqueueMessage(msg Message, deliveryChan chan error) error {
+func (p *Protocol) enqueueMessage(
+	ctx context.Context,
+	msg Message,
+	deliveryChan chan error,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	// Immediately return if we're already shutting down
 	select {
 	case <-p.stopChan:
@@ -424,9 +442,12 @@ func (p *Protocol) enqueueMessage(msg Message, deliveryChan chan error) error {
 		message:      msg,
 		deliveryChan: deliveryChan,
 	}
+	var enqueueErr error
 	select {
 	case p.sendQueueChan <- outbound:
 		return nil
+	case <-ctx.Done():
+		enqueueErr = ctx.Err()
 	case <-p.stopChan:
 	case <-p.doneChan:
 	case <-p.muxerDoneChan:
@@ -438,6 +459,9 @@ func (p *Protocol) enqueueMessage(msg Message, deliveryChan chan error) error {
 	p.pendingBytesMu.Lock()
 	p.pendingSendBytes -= msgLen
 	p.pendingBytesMu.Unlock()
+	if enqueueErr != nil {
+		return enqueueErr
+	}
 	return ErrProtocolShuttingDown
 }
 

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -316,6 +316,26 @@ func (p *Protocol) getCurrentState() State {
 	return p.currentState
 }
 
+// pipelinedSendAllowed reports whether the current state permits our role to
+// write queued messages while the peer holds agency. Only the role without
+// agency in the state pipelines; the role with agency uses the normal path.
+func (p *Protocol) pipelinedSendAllowed() bool {
+	entry, ok := p.config.StateMap[p.getCurrentState()]
+	if !ok || !entry.AllowPipelinedSend {
+		return false
+	}
+	switch entry.Agency {
+	case AgencyClient:
+		return p.config.Role == ProtocolRoleServer
+	case AgencyServer:
+		return p.config.Role == ProtocolRoleClient
+	case AgencyNone:
+		return false
+	default:
+		return false
+	}
+}
+
 // SendMessage appends a message to the send queue
 func (p *Protocol) SendMessage(msg Message) error {
 	return p.enqueueMessage(msg, nil)
@@ -459,18 +479,49 @@ func (p *Protocol) sendLoop() {
 	var queuedStateTransitions []Message
 waitSendReadyChan:
 	for {
-		select {
-		case <-p.stopChan:
-			return
-		case <-p.recvDoneChan:
-			// Break out of send loop if we're shutting down
-			return
-		case <-p.sendReadyChan:
-			// We are ready to send based on state map
+		// haveAgency records that we were woken because the state map granted
+		// our role agency, as opposed to being woken by a pipelined message
+		// that may be written while the peer holds agency.
+		haveAgency := false
+		// pipelinedOutbound holds a message dequeued through the pipelined
+		// send path. Its state transition, and those of any messages batched
+		// behind it, are deferred until agency returns.
+		var pipelinedOutbound *outboundMessage
+		if p.pipelinedSendAllowed() {
+			select {
+			case <-p.stopChan:
+				return
+			case <-p.recvDoneChan:
+				// Break out of send loop if we're shutting down
+				return
+			case <-p.sendReadyChan:
+				// We are ready to send based on state map
+				haveAgency = true
+			case outbound, ok := <-p.sendQueueChan:
+				if !ok {
+					// We're shutting down
+					return
+				}
+				tmpOutbound := outbound
+				pipelinedOutbound = &tmpOutbound
+			}
+		} else {
+			select {
+			case <-p.stopChan:
+				return
+			case <-p.recvDoneChan:
+				// Break out of send loop if we're shutting down
+				return
+			case <-p.sendReadyChan:
+				// We are ready to send based on state map
+				haveAgency = true
+			}
 		}
 
-		// Check for queued state transitions
-		if len(queuedStateTransitions) > 0 {
+		// Check for queued state transitions. A pipelined message is written
+		// while the peer holds agency, so it can never satisfy a deferred
+		// transition and must not delay the bytes we already have in hand.
+		if haveAgency && len(queuedStateTransitions) > 0 {
 			if err := p.transitionState(queuedStateTransitions[0]); err != nil {
 				if errors.Is(err, ErrProtocolShuttingDown) {
 					// Graceful shutdown in progress
@@ -494,87 +545,97 @@ waitSendReadyChan:
 		// Read queued messages and write into buffer
 		payloadBuf := bytes.NewBuffer(nil)
 		msgCount := 0
-		queueTransition := false
+		// A message taken from the pipelined send path goes out while the peer
+		// holds agency, so its transition is deferred along with those of any
+		// messages batched behind it.
+		queueTransition := !haveAgency
 		var deliveryChan chan error
 	readSendQueueLoop:
 		for {
 			// Get next message from send queue
-			select {
-			case <-p.stopChan:
-				return
-			case <-p.recvDoneChan:
-				// Break out of send loop if we're shutting down
-				return
-			case outbound, ok := <-p.sendQueueChan:
-				if !ok {
-					// We're shutting down
+			var outbound outboundMessage
+			if pipelinedOutbound != nil {
+				outbound = *pipelinedOutbound
+				pipelinedOutbound = nil
+			} else {
+				select {
+				case <-p.stopChan:
+					return
+				case <-p.recvDoneChan:
+					// Break out of send loop if we're shutting down
+					return
+				case queued, ok := <-p.sendQueueChan:
+					if !ok {
+						// We're shutting down
+						return
+					}
+					outbound = queued
+				}
+			}
+			msg := outbound.message
+			msgCount = msgCount + 1
+
+			// Get raw CBOR from message
+			data := msg.Cbor()
+			// If message has no raw CBOR, encode the message
+			if data == nil {
+				var err error
+				data, err = cbor.Encode(msg)
+				if err != nil {
+					p.SendError(err)
 					return
 				}
-				msg := outbound.message
-				msgCount = msgCount + 1
+			}
+			payloadBuf.Write(data)
+			// After sending, decrement pendingSendBytes
+			p.pendingBytesMu.Lock()
+			p.pendingSendBytes -= len(data)
+			if p.pendingSendBytes < 0 {
+				p.Logger().Warn(
+					"negative pendingSendBytes reset",
+					"protocol", p.config.Name,
+					"value", p.pendingSendBytes,
+				)
+				p.pendingSendBytes = 0
+			}
+			p.pendingBytesMu.Unlock()
 
-				// Get raw CBOR from message
-				data := msg.Cbor()
-				// If message has no raw CBOR, encode the message
-				if data == nil {
-					var err error
-					data, err = cbor.Encode(msg)
-					if err != nil {
-						p.SendError(err)
+			if queueTransition {
+				queuedStateTransitions = append(queuedStateTransitions, msg)
+			} else {
+				if err := p.transitionState(msg); err != nil {
+					if errors.Is(err, ErrProtocolShuttingDown) {
+						// Graceful shutdown in progress
 						return
 					}
-				}
-				payloadBuf.Write(data)
-				// After sending, decrement pendingSendBytes
-				p.pendingBytesMu.Lock()
-				p.pendingSendBytes -= len(data)
-				if p.pendingSendBytes < 0 {
-					p.Logger().Warn(
-						"negative pendingSendBytes reset",
-						"protocol", p.config.Name,
-						"value", p.pendingSendBytes,
+					p.SendError(
+						fmt.Errorf(
+							"%s: error sending message: %w",
+							p.config.Name,
+							err,
+						),
 					)
-					p.pendingSendBytes = 0
+					return
 				}
-				p.pendingBytesMu.Unlock()
+				// Queue any state transitions after the initial one for this message batch
+				queueTransition = true
+			}
+			if outbound.deliveryChan != nil {
+				deliveryChan = outbound.deliveryChan
+				break readSendQueueLoop
+			}
 
-				if queueTransition {
-					queuedStateTransitions = append(queuedStateTransitions, msg)
-				} else {
-					if err := p.transitionState(msg); err != nil {
-						if errors.Is(err, ErrProtocolShuttingDown) {
-							// Graceful shutdown in progress
-							return
-						}
-						p.SendError(
-							fmt.Errorf(
-								"%s: error sending message: %w",
-								p.config.Name,
-								err,
-							),
-						)
-						return
-					}
-					// Queue any state transitions after the initial one for this message batch
-					queueTransition = true
-				}
-				if outbound.deliveryChan != nil {
-					deliveryChan = outbound.deliveryChan
-					break readSendQueueLoop
-				}
-
-				// We don't want more than maxMessagesPerSegment messages in a segment
-				if msgCount >= maxMessagesPerSegment {
-					break readSendQueueLoop
-				}
-				// We don't want to add more messages once we spill over into a second segment
-				if payloadBuf.Len() > muxer.SegmentMaxPayloadLength {
-					break readSendQueueLoop
-				}
-				// Check if there are any more queued messages
-				if len(p.sendQueueChan) == 0 {
-					break readSendQueueLoop
-				}
+			// We don't want more than maxMessagesPerSegment messages in a segment
+			if msgCount >= maxMessagesPerSegment {
+				break readSendQueueLoop
+			}
+			// We don't want to add more messages once we spill over into a second segment
+			if payloadBuf.Len() > muxer.SegmentMaxPayloadLength {
+				break readSendQueueLoop
+			}
+			// Check if there are any more queued messages
+			if len(p.sendQueueChan) == 0 {
+				break readSendQueueLoop
 			}
 		}
 

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -15,6 +15,7 @@
 package protocol
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -75,7 +76,11 @@ func TestEnqueueMessageReturnsWhenFullQueueShutsDown(t *testing.T) {
 			msg.SetCbor([]byte{0x80})
 			resultChan := make(chan error, 1)
 			go func() {
-				resultChan <- p.enqueueMessage(msg, nil)
+				resultChan <- p.enqueueMessage(
+					context.Background(),
+					msg,
+					nil,
+				)
 			}()
 
 			require.Eventually(t, func() bool {
@@ -97,6 +102,43 @@ func TestEnqueueMessageReturnsWhenFullQueueShutsDown(t *testing.T) {
 			require.Zero(t, p.pendingSendBytes)
 		})
 	}
+}
+
+func TestSendMessageContextReturnsWhenFullQueueContextEnds(t *testing.T) {
+	p := &Protocol{
+		stopChan:      make(chan struct{}),
+		doneChan:      make(chan struct{}),
+		muxerDoneChan: make(chan bool),
+		recvDoneChan:  make(chan struct{}),
+		sendDoneChan:  make(chan struct{}),
+		sendQueueChan: make(chan outboundMessage, 1),
+	}
+	p.sendQueueChan <- outboundMessage{}
+
+	msg := &MessageBase{}
+	msg.SetCbor([]byte{0x80})
+	ctx, cancel := context.WithCancel(context.Background())
+	resultChan := make(chan error, 1)
+	go func() {
+		resultChan <- p.SendMessageContext(ctx, msg)
+	}()
+
+	require.Eventually(t, func() bool {
+		p.pendingBytesMu.Lock()
+		defer p.pendingBytesMu.Unlock()
+		return p.pendingSendBytes == 1
+	}, time.Second, time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-resultChan:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("SendMessageContext remained blocked after cancellation")
+	}
+	p.pendingBytesMu.Lock()
+	defer p.pendingBytesMu.Unlock()
+	require.Zero(t, p.pendingSendBytes)
 }
 
 func TestWaitForMessageDeliveryPrefersReportedResult(t *testing.T) {

--- a/protocol/state.go
+++ b/protocol/state.go
@@ -65,6 +65,15 @@ type StateMapEntry struct {
 	Timeout                 time.Duration        // Fixed timeout for this state (0 = no timeout)
 	TimeoutFunc             func() time.Duration // Dynamic timeout; if set, overrides Timeout
 	PendingMessageByteLimit int                  // Maximum pending message bytes allowed in this state (0 = no limit)
+	// AllowPipelinedSend permits the role that does NOT hold agency in this
+	// state to write queued messages to the wire while the state is active.
+	// The state transition for such a message is deferred until agency
+	// returns, so the local state machine still applies exactly one
+	// transition per message, in send order. This is how mini-protocols that
+	// are pipelined on the wire (block-fetch MsgRequestRange, for example)
+	// keep the remote peer busy across response boundaries. Leaving this
+	// false preserves the strict "send only while holding agency" behavior.
+	AllowPipelinedSend bool
 }
 
 // StateMap represents the state machine definition for a mini-protocol


### PR DESCRIPTION
Closes #1985.

## Summary

- Add opt-in mini-protocol sends while the peer holds agency, with deferred state transitions in wire order.
- Add opt-in block-fetch range pipelining with FIFO response attribution, per-request completion, and an expected-byte in-flight bound.
- Make admission and reservation atomic and overflow-safe; keep full-queue sends context-cancellable.
- Bind shutdown cleanup to the owning protocol instance so a delayed watcher cannot fail requests after restart.
- Document the common context-aware send API and corrected block-fetch limits.

## Compatibility

- The block-fetch wire format is unchanged, and request pipelining remains disabled by default.
- Existing SendMessage behavior is unchanged; SendMessageContext is additive.
- Existing GetBlock and GetBlockRange signatures remain unchanged.