### PR TITLE
refactor(ledger): collapse per-era Plutus-script availability maps

### DIFF
--- a/ledger/common/script/needed.go
+++ b/ledger/common/script/needed.go
@@ -51,10 +51,12 @@ func (v TxScriptView) AllResolvedInputs() []lcommon.Utxo {
 	if v.allResolvedInputs != nil {
 		return v.allResolvedInputs
 	}
-	return concatResolvedInputs(v.ResolvedInputs, v.ResolvedReferenceInputs)
+	return ConcatResolvedInputs(v.ResolvedInputs, v.ResolvedReferenceInputs)
 }
 
-func concatResolvedInputs(inputs, refInputs []lcommon.Utxo) []lcommon.Utxo {
+// ConcatResolvedInputs returns the consumed and reference inputs
+// concatenated, consumed first, matching AllResolvedInputs order.
+func ConcatResolvedInputs(inputs, refInputs []lcommon.Utxo) []lcommon.Utxo {
 	out := make(
 		[]lcommon.Utxo,
 		0,
@@ -91,39 +93,55 @@ func NewTxScriptView(
 	if tx == nil || ls == nil {
 		return view, nil
 	}
-	view.ResolvedInputs = make([]lcommon.Utxo, 0, len(tx.Inputs()))
+	inputs, refInputs, err := ResolveTxInputs(tx, ls)
+	if err != nil {
+		return view, err
+	}
+	view.ResolvedInputs = inputs
+	view.ResolvedReferenceInputs = refInputs
+	view.allResolvedInputs = ConcatResolvedInputs(inputs, refInputs)
+	view.Available = availableScripts(tx, view.allResolvedInputs)
+	view.Needed = neededScripts(tx, view)
+	return view, nil
+}
+
+// ResolveTxInputs resolves a transaction's consumed inputs and reference
+// inputs against ls, one UtxoById call per input, in tx.Inputs() then
+// tx.ReferenceInputs() order. It performs no nil check on tx or ls; a caller
+// that must tolerate either being nil checks before calling, as
+// NewTxScriptView does.
+//
+// Input-resolution failures are reported as InputResolutionError or
+// ReferenceInputResolutionError, the same errors NewTxScriptView reports, so
+// a caller skipping them in favor of UtxoValidateBadInputsUtxo's own report
+// can match on either type regardless of which resolver it called.
+func ResolveTxInputs(
+	tx lcommon.Transaction,
+	ls lcommon.LedgerState,
+) (inputs, refInputs []lcommon.Utxo, err error) {
+	inputs = make([]lcommon.Utxo, 0, len(tx.Inputs()))
 	for _, input := range tx.Inputs() {
 		utxo, err := ls.UtxoById(input)
 		if err != nil {
-			return view, lcommon.InputResolutionError{Input: input, Err: err}
-		}
-		view.ResolvedInputs = append(view.ResolvedInputs, utxo)
-	}
-	view.ResolvedReferenceInputs = make(
-		[]lcommon.Utxo,
-		0,
-		len(tx.ReferenceInputs()),
-	)
-	for _, input := range tx.ReferenceInputs() {
-		utxo, err := ls.UtxoById(input)
-		if err != nil {
-			return view, lcommon.ReferenceInputResolutionError{
+			return nil, nil, lcommon.InputResolutionError{
 				Input: input,
 				Err:   err,
 			}
 		}
-		view.ResolvedReferenceInputs = append(
-			view.ResolvedReferenceInputs,
-			utxo,
-		)
+		inputs = append(inputs, utxo)
 	}
-	view.allResolvedInputs = concatResolvedInputs(
-		view.ResolvedInputs,
-		view.ResolvedReferenceInputs,
-	)
-	view.Available = availableScripts(tx, view.allResolvedInputs)
-	view.Needed = neededScripts(tx, view)
-	return view, nil
+	refInputs = make([]lcommon.Utxo, 0, len(tx.ReferenceInputs()))
+	for _, input := range tx.ReferenceInputs() {
+		utxo, err := ls.UtxoById(input)
+		if err != nil {
+			return nil, nil, lcommon.ReferenceInputResolutionError{
+				Input: input,
+				Err:   err,
+			}
+		}
+		refInputs = append(refInputs, utxo)
+	}
+	return inputs, refInputs, nil
 }
 
 // availableScripts collects witness-set scripts and reference scripts from the
@@ -157,6 +175,67 @@ func availableScripts(
 		if s := utxo.Output.ScriptRef(); s != nil {
 			out[s.Hash()] = s
 		}
+	}
+	return out
+}
+
+// PlutusWitnessScripts collects a transaction's witness-set Plutus V1-V4
+// scripts, keyed by hash. A nil witness set yields an empty, non-nil map.
+//
+// This is the single source for the "witness Plutus scripts" half of a
+// script-execution availability map. Conway's UtxoValidatePlutusScripts and
+// Dijkstra's guarding-redeemer execution both need it, plus per-sub-transaction
+// in Dijkstra's case; a fourth hand-rolled copy is exactly the drift #1980 had
+// to fix in a third one.
+func PlutusWitnessScripts(
+	wits lcommon.TransactionWitnessSet,
+) map[lcommon.ScriptHash]lcommon.Script {
+	out := make(map[lcommon.ScriptHash]lcommon.Script)
+	if wits == nil {
+		return out
+	}
+	for _, s := range wits.PlutusV1Scripts() {
+		out[s.Hash()] = s
+	}
+	for _, s := range wits.PlutusV2Scripts() {
+		out[s.Hash()] = s
+	}
+	for _, s := range wits.PlutusV3Scripts() {
+		out[s.Hash()] = s
+	}
+	for _, s := range lcommon.PlutusV4ScriptsFromWitnessSet(wits) {
+		out[s.Hash()] = s
+	}
+	return out
+}
+
+// AvailablePlutusScripts collects PlutusWitnessScripts plus any Plutus
+// reference script carried by a resolved input, keyed by hash.
+//
+// Native scripts and non-Plutus reference scripts are deliberately excluded,
+// unlike TxScriptView.Available. A caller executing redeemers keys on this
+// map by script hash and falls through any non-Plutus type it finds there
+// anyway, but a caller distinguishing "no script available" from "script
+// available" for an unmatched redeemer -- Dijkstra's native-script guard
+// fallback, for instance -- needs a native script absent from this map, not
+// present and merely unexecutable by its Plutus type switch.
+func AvailablePlutusScripts(
+	tx lcommon.Transaction,
+	resolved []lcommon.Utxo,
+) map[lcommon.ScriptHash]lcommon.Script {
+	out := PlutusWitnessScripts(tx.Witnesses())
+	for _, utxo := range resolved {
+		if utxo.Output == nil {
+			continue
+		}
+		scriptRef := utxo.Output.ScriptRef()
+		if scriptRef == nil {
+			continue
+		}
+		if _, ok := lcommon.PlutusScriptVersion(scriptRef); !ok {
+			continue
+		}
+		out[scriptRef.Hash()] = scriptRef
 	}
 	return out
 }

--- a/ledger/common/script/needed_test.go
+++ b/ledger/common/script/needed_test.go
@@ -157,10 +157,13 @@ func refOutput(s common.Script) common.TransactionOutput {
 // AvailablePlutusScripts backs conway.UtxoValidatePlutusScripts' and
 // dijkstra's guarding-redeemer execution's script-availability maps. Both
 // key an unmatched redeemer's "no script" branch on a hash's absence here,
-// and Dijkstra's native-script guard fallback (see rules_test.go's
-// TestUtxoValidateGuardingRedeemerRejectsNativeScriptGuard) depends on a
-// native script -- witness or reference -- staying absent rather than
-// present-but-unexecutable.
+// and Dijkstra's native-script guard fallback depends on a native script --
+// witness or reference -- staying absent rather than
+// present-but-unexecutable. dijkstra/rules_test.go's
+// TestUtxoValidateGuardingRedeemerRejectsNativeScriptGuard pins the witness
+// case at the rule level;
+// TestUtxoValidateGuardingRedeemerRejectsNativeReferenceScriptGuard pins the
+// reference case there.
 func TestAvailablePlutusScriptsExcludesNativeScripts(t *testing.T) {
 	v1 := common.PlutusV1Script([]byte{0x01})
 	v2 := common.PlutusV2Script([]byte{0x02})

--- a/ledger/common/script/needed_test.go
+++ b/ledger/common/script/needed_test.go
@@ -15,12 +15,16 @@
 package script_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/common/script"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
 	"github.com/stretchr/testify/require"
 )
 
@@ -120,4 +124,192 @@ func TestTxScriptViewAllResolvedInputsWithoutCache(t *testing.T) {
 	}
 	require.Len(t, view.AllResolvedInputs(), 2)
 	require.Empty(t, script.TxScriptView{}.AllResolvedInputs())
+}
+
+func testNativeScript(t *testing.T, slot uint64) common.NativeScript {
+	t.Helper()
+	scriptCbor, err := cbor.Encode(
+		common.NativeScriptInvalidBefore{Type: 4, Slot: slot},
+	)
+	require.NoError(t, err)
+	var ns common.NativeScript
+	require.NoError(t, ns.UnmarshalCBOR(scriptCbor))
+	return ns
+}
+
+func refOutput(s common.Script) common.TransactionOutput {
+	refType := uint(common.ScriptRefTypeNativeScript)
+	switch s.(type) {
+	case common.PlutusV1Script:
+		refType = common.ScriptRefTypePlutusV1
+	case common.PlutusV2Script:
+		refType = common.ScriptRefTypePlutusV2
+	case common.PlutusV3Script:
+		refType = common.ScriptRefTypePlutusV3
+	case common.PlutusV4Script:
+		refType = common.ScriptRefTypePlutusV4
+	}
+	return &babbage.BabbageTransactionOutput{
+		TxOutScriptRef: &common.ScriptRef{Type: refType, Script: s},
+	}
+}
+
+// AvailablePlutusScripts backs conway.UtxoValidatePlutusScripts' and
+// dijkstra's guarding-redeemer execution's script-availability maps. Both
+// key an unmatched redeemer's "no script" branch on a hash's absence here,
+// and Dijkstra's native-script guard fallback (see rules_test.go's
+// TestUtxoValidateGuardingRedeemerRejectsNativeScriptGuard) depends on a
+// native script -- witness or reference -- staying absent rather than
+// present-but-unexecutable.
+func TestAvailablePlutusScriptsExcludesNativeScripts(t *testing.T) {
+	v1 := common.PlutusV1Script([]byte{0x01})
+	v2 := common.PlutusV2Script([]byte{0x02})
+	nativeWitness := testNativeScript(t, 0)
+	nativeRef := testNativeScript(t, 1000)
+
+	tx := &conway.ConwayTransaction{
+		WitnessSet: conway.ConwayTransactionWitnessSet{
+			WsPlutusV1Scripts: cbor.NewSetType(
+				[]common.PlutusV1Script{v1},
+				false,
+			),
+			WsNativeScripts: cbor.NewSetType(
+				[]common.NativeScript{nativeWitness},
+				false,
+			),
+		},
+	}
+	resolved := []common.Utxo{
+		{Output: refOutput(v2)},
+		{Output: refOutput(nativeRef)},
+	}
+
+	available := script.AvailablePlutusScripts(tx, resolved)
+
+	require.Contains(
+		t,
+		available,
+		v1.Hash(),
+		"witness PlutusV1 script must be available",
+	)
+	require.Contains(
+		t,
+		available,
+		v2.Hash(),
+		"Plutus reference script must be available",
+	)
+	require.NotContains(
+		t,
+		available,
+		nativeWitness.Hash(),
+		"witness native script must not be an available Plutus script",
+	)
+	require.NotContains(
+		t,
+		available,
+		nativeRef.Hash(),
+		"native reference script must not be an available Plutus script",
+	)
+}
+
+func TestPlutusWitnessScriptsNilWitnessSet(t *testing.T) {
+	out := script.PlutusWitnessScripts(nil)
+	require.NotNil(t, out)
+	require.Empty(t, out)
+}
+
+// ResolveTxInputs is the single UtxoById caller NewTxScriptView,
+// conway.UtxoValidatePlutusScripts, and Dijkstra's guarding-redeemer
+// execution now all share. These pin its order and error-type contract.
+func TestResolveTxInputsOrderAndErrors(t *testing.T) {
+	in1 := shelley.NewShelleyTransactionInput(
+		"1111111111111111111111111111111111111111111111111111111111111111",
+		0,
+	)
+	in2 := shelley.NewShelleyTransactionInput(
+		"2222222222222222222222222222222222222222222222222222222222222222",
+		1,
+	)
+	ref1 := shelley.NewShelleyTransactionInput(
+		"3333333333333333333333333333333333333333333333333333333333333333",
+		0,
+	)
+	tx := &conway.ConwayTransaction{
+		Body: conway.ConwayTransactionBody{
+			TxInputs: conway.NewConwayTransactionInputSet(
+				[]shelley.ShelleyTransactionInput{in1, in2},
+			),
+			TxReferenceInputs: cbor.NewSetType(
+				[]shelley.ShelleyTransactionInput{ref1},
+				false,
+			),
+		},
+	}
+
+	ls := mockledger.NewLedgerStateBuilder().
+		WithUtxoById(func(input common.TransactionInput) (common.Utxo, error) {
+			switch input.String() {
+			case in1.String(), in2.String(), ref1.String():
+				return common.Utxo{Id: input}, nil
+			default:
+				return common.Utxo{}, errors.New("utxo not found")
+			}
+		}).
+		Build()
+
+	inputs, refInputs, err := script.ResolveTxInputs(tx, ls)
+	require.NoError(t, err)
+	require.Len(t, inputs, 2)
+	require.Equal(
+		t,
+		in1.String(),
+		inputs[0].Id.String(),
+		"consumed inputs stay in tx.Inputs() order",
+	)
+	require.Equal(t, in2.String(), inputs[1].Id.String())
+	require.Len(t, refInputs, 1)
+	require.Equal(t, ref1.String(), refInputs[0].Id.String())
+
+	concat := script.ConcatResolvedInputs(inputs, refInputs)
+	require.Len(t, concat, 3)
+	require.Equal(
+		t,
+		in1.String(),
+		concat[0].Id.String(),
+		"consumed inputs come first",
+	)
+	require.Equal(t, in2.String(), concat[1].Id.String())
+	require.Equal(
+		t,
+		ref1.String(),
+		concat[2].Id.String(),
+		"reference inputs come last",
+	)
+
+	failLs := mockledger.NewLedgerStateBuilder().
+		WithUtxoById(func(common.TransactionInput) (common.Utxo, error) {
+			return common.Utxo{}, errors.New("boom")
+		}).
+		Build()
+
+	consumedOnlyTx := &conway.ConwayTransaction{
+		Body: conway.ConwayTransactionBody{
+			TxInputs: conway.NewConwayTransactionInputSet(
+				[]shelley.ShelleyTransactionInput{in1},
+			),
+		},
+	}
+	_, _, err = script.ResolveTxInputs(consumedOnlyTx, failLs)
+	require.ErrorAs(t, err, &common.InputResolutionError{})
+
+	refOnlyTx := &conway.ConwayTransaction{
+		Body: conway.ConwayTransactionBody{
+			TxReferenceInputs: cbor.NewSetType(
+				[]shelley.ShelleyTransactionInput{ref1},
+				false,
+			),
+		},
+	}
+	_, _, err = script.ResolveTxInputs(refOnlyTx, failLs)
+	require.ErrorAs(t, err, &common.ReferenceInputResolutionError{})
 }

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -2354,30 +2354,23 @@ func UtxoValidatePlutusScripts(
 	}
 
 	// Resolve all inputs (regular + reference) for building script context
-	inputCount := len(tx.Inputs()) + len(tx.ReferenceInputs())
-	resolvedInputs := make([]common.Utxo, 0, inputCount)
-	resolvedInputsMap := make(map[string]common.Utxo)
-	for _, input := range tx.Inputs() {
-		utxo, err := ls.UtxoById(input)
-		if err != nil {
-			return common.InputResolutionError{
-				Input: input,
-				Err:   err,
-			}
-		}
-		resolvedInputs = append(resolvedInputs, utxo)
-		resolvedInputsMap[input.String()] = utxo
+	inputsResolved, refInputsResolved, err := script.ResolveTxInputs(tx, ls)
+	if err != nil {
+		return err
 	}
-	for _, refInput := range tx.ReferenceInputs() {
-		utxo, err := ls.UtxoById(refInput)
-		if err != nil {
-			return common.ReferenceInputResolutionError{
-				Input: refInput,
-				Err:   err,
-			}
-		}
-		resolvedInputs = append(resolvedInputs, utxo)
-		resolvedInputsMap[refInput.String()] = utxo
+	resolvedInputs := script.ConcatResolvedInputs(
+		inputsResolved,
+		refInputsResolved,
+	)
+	resolvedInputsMap := make(
+		map[string]common.Utxo,
+		len(inputsResolved)+len(refInputsResolved),
+	)
+	for i, input := range tx.Inputs() {
+		resolvedInputsMap[input.String()] = inputsResolved[i]
+	}
+	for i, refInput := range tx.ReferenceInputs() {
+		resolvedInputsMap[refInput.String()] = refInputsResolved[i]
 	}
 
 	// Build TxInfo lazily based on script version
@@ -2387,33 +2380,7 @@ func UtxoValidatePlutusScripts(
 	var txInfoV1Built, txInfoV2Built, txInfoV3Built bool
 
 	// Collect all available scripts (witness scripts + reference scripts)
-	availableScripts := make(map[common.ScriptHash]common.Script)
-
-	// Add witness scripts
-	for _, s := range witnesses.PlutusV1Scripts() {
-		availableScripts[s.Hash()] = s
-	}
-	for _, s := range witnesses.PlutusV2Scripts() {
-		availableScripts[s.Hash()] = s
-	}
-	for _, s := range witnesses.PlutusV3Scripts() {
-		availableScripts[s.Hash()] = s
-	}
-	for _, s := range common.PlutusV4ScriptsFromWitnessSet(witnesses) {
-		availableScripts[s.Hash()] = s
-	}
-
-	// Add reference scripts from resolved inputs
-	for _, utxo := range resolvedInputs {
-		if utxo.Output == nil {
-			continue
-		}
-		scriptRef := utxo.Output.ScriptRef()
-		if scriptRef == nil {
-			continue
-		}
-		availableScripts[scriptRef.Hash()] = scriptRef
-	}
+	availableScripts := script.AvailablePlutusScripts(tx, resolvedInputs)
 
 	// Get sorted inputs for redeemer index mapping.
 	// The Cardano ledger spec requires spend redeemer indices to

--- a/ledger/dijkstra/rules.go
+++ b/ledger/dijkstra/rules.go
@@ -413,28 +413,16 @@ func validateGuardingPlutusScripts(
 		return nil
 	}
 
-	availableScripts := make(map[common.ScriptHash]common.Script)
-	addPlutusScriptsFromWitnessSet(availableScripts, wits)
-	if dijkstraTx, ok := tx.(*DijkstraTransaction); ok {
-		for _, subTx := range dijkstraTx.Body.TxSubTransactions.Items() {
-			addPlutusScriptsFromWitnessSet(availableScripts, subTx.WitnessSet)
-		}
-	}
-
 	resolvedInputs, err := resolvedInputsForGuardingPlutus(tx, ls)
 	if err != nil {
 		return err
 	}
-	for _, utxo := range resolvedInputs {
-		if utxo.Output == nil {
-			continue
-		}
-		scriptRef := utxo.Output.ScriptRef()
-		if scriptRef == nil {
-			continue
-		}
-		if _, ok := common.PlutusScriptVersion(scriptRef); ok {
-			availableScripts[scriptRef.Hash()] = scriptRef
+	availableScripts := script.AvailablePlutusScripts(tx, resolvedInputs)
+	if dijkstraTx, ok := tx.(*DijkstraTransaction); ok {
+		for _, subTx := range dijkstraTx.Body.TxSubTransactions.Items() {
+			for hash, s := range script.PlutusWitnessScripts(subTx.WitnessSet) {
+				availableScripts[hash] = s
+			}
 		}
 	}
 
@@ -616,33 +604,11 @@ func validateGuardingPlutusScripts(
 	return nil
 }
 
-func addPlutusScriptsFromWitnessSet(
-	availableScripts map[common.ScriptHash]common.Script,
-	wits common.TransactionWitnessSet,
-) {
-	if wits == nil {
-		return
-	}
-	for _, s := range wits.PlutusV1Scripts() {
-		availableScripts[s.Hash()] = s
-	}
-	for _, s := range wits.PlutusV2Scripts() {
-		availableScripts[s.Hash()] = s
-	}
-	for _, s := range wits.PlutusV3Scripts() {
-		availableScripts[s.Hash()] = s
-	}
-	for _, s := range common.PlutusV4ScriptsFromWitnessSet(wits) {
-		availableScripts[s.Hash()] = s
-	}
-}
-
 func resolvedInputsForGuardingPlutus(
 	tx common.Transaction,
 	ls common.LedgerState,
 ) ([]common.Utxo, error) {
-	inputCount := len(tx.Inputs()) + len(tx.ReferenceInputs())
-	if inputCount == 0 {
+	if len(tx.Inputs())+len(tx.ReferenceInputs()) == 0 {
 		return nil, nil
 	}
 	if ls == nil {
@@ -650,28 +616,11 @@ func resolvedInputsForGuardingPlutus(
 			"ledger state is required for Dijkstra guarding Plutus validation",
 		)
 	}
-	resolvedInputs := make([]common.Utxo, 0, inputCount)
-	for _, input := range tx.Inputs() {
-		utxo, err := ls.UtxoById(input)
-		if err != nil {
-			return nil, common.InputResolutionError{
-				Input: input,
-				Err:   err,
-			}
-		}
-		resolvedInputs = append(resolvedInputs, utxo)
+	inputs, refInputs, err := script.ResolveTxInputs(tx, ls)
+	if err != nil {
+		return nil, err
 	}
-	for _, refInput := range tx.ReferenceInputs() {
-		utxo, err := ls.UtxoById(refInput)
-		if err != nil {
-			return nil, common.ReferenceInputResolutionError{
-				Input: refInput,
-				Err:   err,
-			}
-		}
-		resolvedInputs = append(resolvedInputs, utxo)
-	}
-	return resolvedInputs, nil
+	return script.ConcatResolvedInputs(inputs, refInputs), nil
 }
 
 func dijkstraGuardingPurpose(

--- a/ledger/dijkstra/rules.go
+++ b/ledger/dijkstra/rules.go
@@ -442,14 +442,11 @@ func validateGuardingPlutusScripts(
 		scriptHash := purpose.ScriptHash()
 		plutusScript, ok := availableScripts[scriptHash]
 		if !ok {
-			nativeGuard, err := dijkstraGuardResolvesToNativeScript(
+			nativeGuard := dijkstraGuardResolvesToNativeScriptFromResolved(
 				tx,
-				ls,
+				resolvedInputs,
 				redeemerKey.Index,
 			)
-			if err != nil {
-				return err
-			}
 			if nativeGuard {
 				return conway.ExtraRedeemerError{RedeemerKey: redeemerKey}
 			}
@@ -1428,20 +1425,12 @@ func dijkstraGuardResolvesToNativeScript(
 	ls common.LedgerState,
 	index uint32,
 ) (bool, error) {
-	guard, ok := dijkstraGuardCredentialAt(tx, index)
-	if !ok || guard.CredType != common.CredentialTypeScriptHash {
+	scriptHash, ok := dijkstraGuardScriptHash(tx, index)
+	if !ok {
 		return false, nil
 	}
-	scriptHash := common.ScriptHash(guard.Credential)
-	if witnessSetHasNativeScript(tx.Witnesses(), scriptHash) {
+	if dijkstraGuardWitnessesHaveNativeScript(tx, scriptHash) {
 		return true, nil
-	}
-	if dijkstraTx, ok := tx.(*DijkstraTransaction); ok {
-		for _, subTx := range dijkstraTx.Body.TxSubTransactions.Items() {
-			if witnessSetHasNativeScript(subTx.WitnessSet, scriptHash) {
-				return true, nil
-			}
-		}
 	}
 	if ls == nil {
 		return false, nil
@@ -1469,6 +1458,65 @@ func dijkstraGuardResolvesToNativeScript(
 		}
 	}
 	return false, nil
+}
+
+// dijkstraGuardResolvesToNativeScriptFromResolved is
+// dijkstraGuardResolvesToNativeScript's check for a caller that already
+// resolved the transaction's inputs -- validateGuardingPlutusScripts, via
+// resolvedInputsForGuardingPlutus -- so it does not repeat those UtxoById
+// calls.
+func dijkstraGuardResolvesToNativeScriptFromResolved(
+	tx common.Transaction,
+	resolvedInputs []common.Utxo,
+	index uint32,
+) bool {
+	scriptHash, ok := dijkstraGuardScriptHash(tx, index)
+	if !ok {
+		return false
+	}
+	if dijkstraGuardWitnessesHaveNativeScript(tx, scriptHash) {
+		return true
+	}
+	for _, utxo := range resolvedInputs {
+		if utxo.Output != nil &&
+			scriptRefIsNativeHash(utxo.Output.ScriptRef(), scriptHash) {
+			return true
+		}
+	}
+	return false
+}
+
+// dijkstraGuardScriptHash resolves the guard credential at index to a script
+// hash, reporting false if it is absent or not a script credential.
+func dijkstraGuardScriptHash(
+	tx common.Transaction,
+	index uint32,
+) (common.ScriptHash, bool) {
+	guard, ok := dijkstraGuardCredentialAt(tx, index)
+	if !ok || guard.CredType != common.CredentialTypeScriptHash {
+		return common.ScriptHash{}, false
+	}
+	return common.ScriptHash(guard.Credential), true
+}
+
+// dijkstraGuardWitnessesHaveNativeScript checks the transaction's own witness
+// set and every sub-transaction's witness set for a native script matching
+// scriptHash.
+func dijkstraGuardWitnessesHaveNativeScript(
+	tx common.Transaction,
+	scriptHash common.ScriptHash,
+) bool {
+	if witnessSetHasNativeScript(tx.Witnesses(), scriptHash) {
+		return true
+	}
+	if dijkstraTx, ok := tx.(*DijkstraTransaction); ok {
+		for _, subTx := range dijkstraTx.Body.TxSubTransactions.Items() {
+			if witnessSetHasNativeScript(subTx.WitnessSet, scriptHash) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func witnessSetHasNativeScript(

--- a/ledger/dijkstra/rules_test.go
+++ b/ledger/dijkstra/rules_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/common/script"
 	commontestdata "github.com/blinklabs-io/gouroboros/ledger/common/testdata"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
 	"github.com/stretchr/testify/require"
 )
@@ -136,6 +137,70 @@ func TestUtxoValidateGuardingRedeemerRejectsNativeScriptGuard(t *testing.T) {
 		tx,
 		0,
 		mockledger.NewLedgerStateBuilder().Build(),
+		&DijkstraProtocolParameters{},
+	)
+	require.ErrorAs(t, err, &conway.ExtraRedeemerError{})
+}
+
+// The witness case above pins the guard's native script arriving through the
+// witness set. A native script arriving as a *reference* script on a
+// resolved input exercises a different path -- script.AvailablePlutusScripts
+// filters it out by PlutusScriptVersion, not by TransactionWitnessSet.
+// NativeScripts -- so it needs its own rule-level case rather than assuming
+// the witness test covers it too.
+func TestUtxoValidateGuardingRedeemerRejectsNativeReferenceScriptGuard(
+	t *testing.T,
+) {
+	guardCred := testGuardCredential()
+	nativeScript := testRequireGuardNativeScript(t, guardCred)
+	nativeScriptCred := common.Credential{
+		CredType:   common.CredentialTypeScriptHash,
+		Credential: nativeScript.Hash(),
+	}
+	refInput := shelley.NewShelleyTransactionInput(
+		"4444444444444444444444444444444444444444444444444444444444444444",
+		0,
+	)
+	tx := &DijkstraTransaction{
+		Body: DijkstraTransactionBody{
+			TxGuards: &DijkstraGuards{
+				Credentials: []common.Credential{
+					nativeScriptCred,
+					guardCred,
+				},
+			},
+			TxReferenceInputs: cbor.NewSetType(
+				[]shelley.ShelleyTransactionInput{refInput},
+				false,
+			),
+		},
+		WitnessSet: DijkstraTransactionWitnessSet{
+			WsRedeemers: DijkstraRedeemers{
+				Redeemers: map[common.RedeemerKey]common.RedeemerValue{
+					{Tag: common.RedeemerTagGuarding, Index: 0}: {
+						ExUnits: common.ExUnits{Steps: 1, Memory: 1},
+					},
+				},
+			},
+		},
+		TxIsValid: true,
+	}
+	refOutput := babbage.BabbageTransactionOutput{
+		TxOutScriptRef: &common.ScriptRef{
+			Type:   common.ScriptRefTypeNativeScript,
+			Script: nativeScript,
+		},
+	}
+	ls := mockledger.NewLedgerStateBuilder().
+		WithUtxoById(func(input common.TransactionInput) (common.Utxo, error) {
+			return common.Utxo{Id: input, Output: &refOutput}, nil
+		}).
+		Build()
+
+	err := UtxoValidatePlutusScripts(
+		tx,
+		0,
+		ls,
 		&DijkstraProtocolParameters{},
 	)
 	require.ErrorAs(t, err, &conway.ExtraRedeemerError{})


### PR DESCRIPTION
## Problem

`ledger/common/script/needed.go`'s `TxScriptView` (added in #1980) is the
third copy of "which scripts does this transaction make available." The
other two:

- `ledger/conway/rules.go` (`UtxoValidatePlutusScripts`)
- `ledger/dijkstra/rules.go` (`validateGuardingPlutusScripts` +
  `resolvedInputsForGuardingPlutus`)

Each builds the witness PlutusV1/V2/V3/V4 scripts plus reference scripts from
resolved inputs, keyed by script hash, alongside its own input resolution.
Three independent copies drift, and a divergence is a validation gap rather
than a visible failure — the V4 omission #1980 had to fix was exactly that
failure mode.

## Change

- Export `script.ResolveTxInputs` and `script.ConcatResolvedInputs` from
  `needed.go`: the shared consumed/reference input resolution `NewTxScriptView`
  already did, now reused by Conway and Dijkstra instead of re-implemented.
  Each call site still makes exactly one `UtxoById` call per input.
- Export `script.PlutusWitnessScripts` and `script.AvailablePlutusScripts`:
  the shared "witness Plutus scripts + Plutus reference scripts" map, reused
  by `conway.UtxoValidatePlutusScripts` and Dijkstra's guarding-redeemer
  execution (including its per-sub-transaction witness merge).

## Native-script exclusion

`AvailablePlutusScripts` excludes native scripts, matching Dijkstra's
existing filtered behavior rather than Conway's previously-unfiltered one.
This is deliberate: Dijkstra's native-script guard fallback
(`TestUtxoValidateGuardingRedeemerRejectsNativeScriptGuard`) depends on a
native script being *absent* from the availability map so it falls into the
"missing script" branch and returns `ExtraRedeemerError`; a native script
present-but-unexecutable-by-the-Plutus-switch would silently pass instead.
Conway has no such branch, so applying the same exclusion there is a no-op
(a native script hits `default: continue` either way).

Verified by temporarily reverting the exclusion locally: both the new test
and the pre-existing Dijkstra test fail exactly as expected.

## Tests

New in `ledger/common/script/needed_test.go`:
- `TestAvailablePlutusScriptsExcludesNativeScripts` — pins the exclusion.
- `TestPlutusWitnessScriptsNilWitnessSet`
- `TestResolveTxInputsOrderAndErrors` — order and
  `InputResolutionError`/`ReferenceInputResolutionError` contract.

## Validation

- `make test` (root + all example modules)
- `make lint`
- `go run go.uber.org/nilaway/cmd/nilaway@latest -include-pkgs=github.com/blinklabs-io/gouroboros ./...`
- `go test -v ./internal/test/conformance/...` — 315/315 vectors pass, unchanged
- `go test -race ./...` — full suite green

Fixes #1982

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapses per-era Plutus-script availability and input resolution into shared helpers to remove drift and prevent validation gaps. Old: Conway and Dijkstra each built their own maps/resolvers; new: both use `script.PlutusWitnessScripts`, `script.AvailablePlutusScripts`, `script.ResolveTxInputs`, and `script.ConcatResolvedInputs`. Also removes duplicate `UtxoById` calls in Dijkstra’s native-script guard fallback by reusing already-resolved inputs.

- Replaces per-era loops with exports from `ledger/common/script`; still exactly one `UtxoById` call per input.
- `AvailablePlutusScripts` excludes native scripts (matches Dijkstra); in Conway this is behavior-neutral.
- Dijkstra merges sub-transaction witness scripts via `script.PlutusWitnessScripts` and checks native-guard fallback using resolved inputs; the non-resolved code path remains for other callers.
- Adds tests pinning native-script exclusion, the resolver’s order/error-type contract, and Dijkstra’s native reference-script guard rejection; conformance results stay unchanged.

<sup>Written for commit d8953249fb214b974f708ca5605750182f89ea38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/1991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Plutus script validation for transactions using both consumed and reference inputs.
  * Ensured reference scripts are correctly discovered while native scripts are excluded.
  * Preserved clear, typed errors when transaction inputs cannot be resolved.
  * Improved validation consistency across supported ledger eras, including Dijkstra subtransactions.
* **Tests**
  * Added coverage for input resolution order, reference inputs, missing inputs, native-script exclusion, and transactions without witness sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->