### PR TITLE
feat(consensus): add Byron PBFT validation

### DIFF
--- a/consensus/byron/byron.go
+++ b/consensus/byron/byron.go
@@ -170,6 +170,8 @@ func NewByronConfigFromGenesis(genesis *ledgerbyron.ByronGenesis) (ByronConfig, 
 	if genesis.ProtocolConsts.ProtocolMagic < 0 || int64(genesis.ProtocolConsts.ProtocolMagic) > math.MaxUint32 {
 		return ByronConfig{}, fmt.Errorf("invalid protocol magic: %d (must be 0 to %d)", genesis.ProtocolConsts.ProtocolMagic, uint32(math.MaxUint32))
 	}
+	// #nosec G115 -- ProtocolMagic is validated to fit in uint32 above
+	protocolMagic := uint32(genesis.ProtocolConsts.ProtocolMagic)
 
 	// Extract genesis delegate key hashes
 	keyHashes, err := genesis.GenesisDelegateKeyHashes()
@@ -186,6 +188,9 @@ func NewByronConfigFromGenesis(genesis *ledgerbyron.ByronGenesis) (ByronConfig, 
 		map[common.Blake2b224]common.Blake2b224,
 		len(genesis.HeavyDelegation),
 	)
+	genesisValidator := NewHeaderValidator(ByronConfig{
+		ProtocolMagic: protocolMagic,
+	})
 	for genesisHashHex, delegation := range genesis.HeavyDelegation {
 		genesisHashBytes, err := hex.DecodeString(genesisHashHex)
 		if err != nil {
@@ -234,17 +239,37 @@ func NewByronConfigFromGenesis(genesis *ledgerbyron.ByronGenesis) (ByronConfig, 
 				err,
 			)
 		}
-		if len(delegateKey) != 64 {
-			return ByronConfig{}, fmt.Errorf(
-				"invalid delegate verification key length for genesis key %s: got %d, expected 64",
-				genesisHashHex,
-				len(delegateKey),
-			)
-		}
 		delegateHash, err := PBFTVerificationKeyHash(delegateKey)
 		if err != nil {
 			return ByronConfig{}, fmt.Errorf(
 				"derive delegate verification key hash for genesis key %s: %w",
+				genesisHashHex,
+				err,
+			)
+		}
+		if delegation.Omega < 0 {
+			return ByronConfig{}, fmt.Errorf(
+				"invalid delegation omega for genesis key %s: %d",
+				genesisHashHex,
+				delegation.Omega,
+			)
+		}
+		certificateSignature, err := hex.DecodeString(delegation.Cert)
+		if err != nil {
+			return ByronConfig{}, fmt.Errorf(
+				"decode delegation certificate signature for genesis key %s: %w",
+				genesisHashHex,
+				err,
+			)
+		}
+		if err := genesisValidator.validateDelegationCertSignature(
+			issuerKey,
+			delegateKey,
+			certificateSignature,
+			uint64(delegation.Omega),
+		); err != nil {
+			return ByronConfig{}, fmt.Errorf(
+				"validate delegation certificate for genesis key %s: %w",
 				genesisHashHex,
 				err,
 			)
@@ -269,8 +294,7 @@ func NewByronConfigFromGenesis(genesis *ledgerbyron.ByronGenesis) (ByronConfig, 
 	}
 
 	return ByronConfig{
-		// #nosec G115 -- ProtocolMagic is validated to fit in uint32 above
-		ProtocolMagic:      uint32(genesis.ProtocolConsts.ProtocolMagic),
+		ProtocolMagic:      protocolMagic,
 		SlotsPerEpoch:      slotsPerEpoch,
 		SlotDuration:       slotDuration,
 		SecurityParam:      k,

--- a/consensus/byron/byron.go
+++ b/consensus/byron/byron.go
@@ -23,11 +23,15 @@
 package byron
 
 import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"math"
 	"time"
 
 	ledgerbyron "github.com/blinklabs-io/gouroboros/ledger/byron"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
 // ByronConfig contains Byron-specific consensus configuration.
@@ -39,7 +43,13 @@ type ByronConfig struct {
 	SecurityParam    uint64
 	NumGenesisKeys   int
 	GenesisKeyHashes [][]byte // Hashes of genesis delegate keys
-	TxFeePolicy      ByronTxFeePolicy
+	// GenesisDelegations maps each genesis verification-key hash to the
+	// verification-key hash of its currently active block-signing delegate.
+	// NewByronConfigFromGenesis initializes this from the genesis heavy
+	// delegation certificates. Callers that track later Byron delegation
+	// updates must replace entries with their active ledger view.
+	GenesisDelegations map[common.Blake2b224]common.Blake2b224
+	TxFeePolicy        ByronTxFeePolicy
 }
 
 // ByronTxFeePolicy contains the transaction fee policy parameters.
@@ -172,6 +182,76 @@ func NewByronConfigFromGenesis(genesis *ledgerbyron.ByronGenesis) (ByronConfig, 
 	for i, h := range keyHashes {
 		keyHashBytes[i] = h.Bytes()
 	}
+	genesisDelegations := make(
+		map[common.Blake2b224]common.Blake2b224,
+		len(genesis.HeavyDelegation),
+	)
+	for genesisHashHex, delegation := range genesis.HeavyDelegation {
+		genesisHashBytes, err := hex.DecodeString(genesisHashHex)
+		if err != nil {
+			return ByronConfig{}, fmt.Errorf(
+				"decode genesis delegation key hash %q: %w",
+				genesisHashHex,
+				err,
+			)
+		}
+		if len(genesisHashBytes) != common.Blake2b224Size {
+			return ByronConfig{}, fmt.Errorf(
+				"invalid genesis delegation key hash length for %q: got %d, expected %d",
+				genesisHashHex,
+				len(genesisHashBytes),
+				common.Blake2b224Size,
+			)
+		}
+		issuerKey, err := base64.StdEncoding.DecodeString(delegation.IssuerPk)
+		if err != nil {
+			return ByronConfig{}, fmt.Errorf(
+				"decode issuer verification key for genesis key %s: %w",
+				genesisHashHex,
+				err,
+			)
+		}
+		issuerHash, err := PBFTVerificationKeyHash(issuerKey)
+		if err != nil {
+			return ByronConfig{}, fmt.Errorf(
+				"derive issuer verification key hash for genesis key %s: %w",
+				genesisHashHex,
+				err,
+			)
+		}
+		if !bytes.Equal(issuerHash.Bytes(), genesisHashBytes) {
+			return ByronConfig{}, fmt.Errorf(
+				"issuer verification key hash mismatch for genesis key %s: got %s",
+				genesisHashHex,
+				issuerHash.String(),
+			)
+		}
+		delegateKey, err := base64.StdEncoding.DecodeString(delegation.DelegatePk)
+		if err != nil {
+			return ByronConfig{}, fmt.Errorf(
+				"decode delegate verification key for genesis key %s: %w",
+				genesisHashHex,
+				err,
+			)
+		}
+		if len(delegateKey) != 64 {
+			return ByronConfig{}, fmt.Errorf(
+				"invalid delegate verification key length for genesis key %s: got %d, expected 64",
+				genesisHashHex,
+				len(delegateKey),
+			)
+		}
+		delegateHash, err := PBFTVerificationKeyHash(delegateKey)
+		if err != nil {
+			return ByronConfig{}, fmt.Errorf(
+				"derive delegate verification key hash for genesis key %s: %w",
+				genesisHashHex,
+				err,
+			)
+		}
+		genesisHash := common.NewBlake2b224(genesisHashBytes)
+		genesisDelegations[genesisHash] = delegateHash
+	}
 
 	// Byron slots per epoch = 10 * K (security parameter)
 	// This is the standard Byron formula
@@ -190,12 +270,13 @@ func NewByronConfigFromGenesis(genesis *ledgerbyron.ByronGenesis) (ByronConfig, 
 
 	return ByronConfig{
 		// #nosec G115 -- ProtocolMagic is validated to fit in uint32 above
-		ProtocolMagic:    uint32(genesis.ProtocolConsts.ProtocolMagic),
-		SlotsPerEpoch:    slotsPerEpoch,
-		SlotDuration:     slotDuration,
-		SecurityParam:    k,
-		NumGenesisKeys:   len(keyHashes),
-		GenesisKeyHashes: keyHashBytes,
-		TxFeePolicy:      feePolicy,
+		ProtocolMagic:      uint32(genesis.ProtocolConsts.ProtocolMagic),
+		SlotsPerEpoch:      slotsPerEpoch,
+		SlotDuration:       slotDuration,
+		SecurityParam:      k,
+		NumGenesisKeys:     len(keyHashes),
+		GenesisKeyHashes:   keyHashBytes,
+		GenesisDelegations: genesisDelegations,
+		TxFeePolicy:        feePolicy,
 	}, nil
 }

--- a/consensus/byron/pbft.go
+++ b/consensus/byron/pbft.go
@@ -52,6 +52,42 @@ func ValidatePBFTHeader(
 	header *ledgerbyron.ByronMainBlockHeader,
 	config ByronConfig,
 ) (PBFTIssuer, error) {
+	if len(config.GenesisDelegations) == 0 {
+		return PBFTIssuer{}, errors.New(
+			"byron PBFT active delegation state is empty",
+		)
+	}
+	issuer, err := ValidatePBFTHeaderCrypto(header, config)
+	if err != nil {
+		return PBFTIssuer{}, err
+	}
+	activeDelegate, ok := config.GenesisDelegations[issuer.GenesisKeyHash]
+	if !ok {
+		return PBFTIssuer{}, fmt.Errorf(
+			"byron PBFT genesis issuer %s has no active delegate",
+			issuer.GenesisKeyHash.String(),
+		)
+	}
+	if activeDelegate != issuer.DelegateKeyHash {
+		return PBFTIssuer{}, fmt.Errorf(
+			"byron PBFT active delegate mismatch for genesis issuer %s: got %s, expected %s",
+			issuer.GenesisKeyHash.String(),
+			issuer.DelegateKeyHash.String(),
+			activeDelegate.String(),
+		)
+	}
+	return issuer, nil
+}
+
+// ValidatePBFTHeaderCrypto validates the cryptographic and configured-genesis
+// parts of a Byron PBFT main-block header without consulting the active
+// delegation map. Callers may use it for parallel stateless pre-validation,
+// but must still call ValidatePBFTHeader against the ordered delegation-ledger
+// view before committing the block.
+func ValidatePBFTHeaderCrypto(
+	header *ledgerbyron.ByronMainBlockHeader,
+	config ByronConfig,
+) (PBFTIssuer, error) {
 	if header == nil {
 		return PBFTIssuer{}, errors.New("nil byron PBFT header")
 	}
@@ -60,14 +96,15 @@ func ValidatePBFTHeader(
 			"byron PBFT genesis issuer set is empty",
 		)
 	}
-	if len(config.GenesisDelegations) == 0 {
-		return PBFTIssuer{}, errors.New(
-			"byron PBFT active delegation state is empty",
-		)
-	}
 
-	issuer, err := pbftIssuerFromHeader(header)
+	issuer, activationEpoch, err := parsePBFTIssuerFromHeader(header)
 	if err != nil {
+		return PBFTIssuer{}, err
+	}
+	if err := validatePBFTCertificateEpoch(
+		activationEpoch,
+		header.ConsensusData.SlotId.Epoch,
+	); err != nil {
 		return PBFTIssuer{}, err
 	}
 	input := &ValidateHeaderInput{
@@ -101,32 +138,33 @@ func ValidatePBFTHeader(
 			issuer.GenesisKeyHash.String(),
 		)
 	}
-	activeDelegate, ok := config.GenesisDelegations[issuer.GenesisKeyHash]
-	if !ok {
-		return PBFTIssuer{}, fmt.Errorf(
-			"byron PBFT genesis issuer %s has no active delegate",
-			issuer.GenesisKeyHash.String(),
-		)
-	}
-	if !bytes.Equal(
-		activeDelegate.Bytes(),
-		issuer.DelegateKeyHash.Bytes(),
-	) {
-		return PBFTIssuer{}, fmt.Errorf(
-			"byron PBFT active delegate mismatch for genesis issuer %s: got %s, expected %s",
-			issuer.GenesisKeyHash.String(),
-			issuer.DelegateKeyHash.String(),
-			activeDelegate.String(),
-		)
-	}
 	return issuer, nil
 }
 
-func pbftIssuerFromHeader(
+// PBFTIssuerFromHeader parses the PBFT identities carried by a Byron main
+// block header without verifying either signature or consulting the active
+// delegation ledger view. ConsensusData.PubKey is the genesis issuer's
+// extended verification key; element 2 of the heavyweight proxy certificate
+// is the delegate extended verification key that signed the block.
+//
+// This is intended for replay of already-trusted canonical headers. New or
+// otherwise untrusted headers must use ValidatePBFTHeaderCrypto and then
+// ValidatePBFTHeader against the ordered active-delegation view.
+func PBFTIssuerFromHeader(
 	header *ledgerbyron.ByronMainBlockHeader,
 ) (PBFTIssuer, error) {
+	issuer, _, err := parsePBFTIssuerFromHeader(header)
+	return issuer, err
+}
+
+func parsePBFTIssuerFromHeader(
+	header *ledgerbyron.ByronMainBlockHeader,
+) (PBFTIssuer, uint64, error) {
+	if header == nil {
+		return PBFTIssuer{}, 0, errors.New("nil byron PBFT header")
+	}
 	if len(header.ConsensusData.PubKey) != 64 {
-		return PBFTIssuer{}, fmt.Errorf(
+		return PBFTIssuer{}, 0, fmt.Errorf(
 			"invalid Byron PBFT genesis issuer key length: got %d, expected 64",
 			len(header.ConsensusData.PubKey),
 		)
@@ -135,20 +173,20 @@ func pbftIssuerFromHeader(
 		header.ConsensusData.PubKey,
 	)
 	if err != nil {
-		return PBFTIssuer{}, err
+		return PBFTIssuer{}, 0, err
 	}
 	issuer := PBFTIssuer{
 		GenesisKeyHash: genesisKeyHash,
 	}
 	if len(header.ConsensusData.BlockSig) != 2 {
-		return PBFTIssuer{}, fmt.Errorf(
+		return PBFTIssuer{}, 0, fmt.Errorf(
 			"invalid Byron PBFT signature shape: got %d elements, expected 2",
 			len(header.ConsensusData.BlockSig),
 		)
 	}
 	signatureType, err := extractUint64(header.ConsensusData.BlockSig[0])
 	if err != nil {
-		return PBFTIssuer{}, fmt.Errorf(
+		return PBFTIssuer{}, 0, fmt.Errorf(
 			"decode Byron PBFT signature type: %w",
 			err,
 		)
@@ -157,7 +195,7 @@ func pbftIssuerFromHeader(
 	case byronSigTypeHeavy:
 		inner, ok := header.ConsensusData.BlockSig[1].([]any)
 		if !ok || len(inner) != 2 {
-			return PBFTIssuer{}, fmt.Errorf(
+			return PBFTIssuer{}, 0, fmt.Errorf(
 				"invalid Byron PBFT proxy signature payload: got %T with %d elements",
 				header.ConsensusData.BlockSig[1],
 				len(inner),
@@ -165,7 +203,7 @@ func pbftIssuerFromHeader(
 		}
 		certificate, ok := inner[0].([]any)
 		if !ok || len(certificate) != 4 {
-			return PBFTIssuer{}, fmt.Errorf(
+			return PBFTIssuer{}, 0, fmt.Errorf(
 				"invalid Byron PBFT proxy certificate: got %T with %d elements",
 				inner[0],
 				len(certificate),
@@ -173,20 +211,14 @@ func pbftIssuerFromHeader(
 		}
 		activationEpoch, err := extractUint64(certificate[0])
 		if err != nil {
-			return PBFTIssuer{}, fmt.Errorf(
+			return PBFTIssuer{}, 0, fmt.Errorf(
 				"decode Byron PBFT delegation activation epoch: %w",
 				err,
 			)
 		}
-		if err := validatePBFTCertificateEpoch(
-			activationEpoch,
-			header.ConsensusData.SlotId.Epoch,
-		); err != nil {
-			return PBFTIssuer{}, err
-		}
 		delegateKey, ok := certificate[2].([]byte)
 		if !ok || len(delegateKey) != 64 {
-			return PBFTIssuer{}, fmt.Errorf(
+			return PBFTIssuer{}, 0, fmt.Errorf(
 				"invalid Byron PBFT delegate key: got %T with length %d",
 				certificate[2],
 				len(delegateKey),
@@ -197,22 +229,22 @@ func pbftIssuerFromHeader(
 			certificateIssuerKey,
 			header.ConsensusData.PubKey,
 		) {
-			return PBFTIssuer{}, errors.New(
+			return PBFTIssuer{}, 0, errors.New(
 				"byron PBFT proxy certificate genesis issuer does not match header issuer",
 			)
 		}
 		issuer.DelegateKeyHash, err = PBFTVerificationKeyHash(delegateKey)
 		if err != nil {
-			return PBFTIssuer{}, err
+			return PBFTIssuer{}, 0, err
 		}
-		return issuer, nil
+		return issuer, activationEpoch, nil
 	case byronSigTypeSimple, byronSigTypeLight:
-		return PBFTIssuer{}, fmt.Errorf(
+		return PBFTIssuer{}, 0, fmt.Errorf(
 			"unsupported Byron PBFT signature type: %d; heavyweight delegation is required",
 			signatureType,
 		)
 	default:
-		return PBFTIssuer{}, fmt.Errorf(
+		return PBFTIssuer{}, 0, fmt.Errorf(
 			"unknown Byron PBFT signature type: %d",
 			signatureType,
 		)
@@ -259,6 +291,7 @@ func PBFTVerificationKeyHash(
 // main-block headers. Values are immutable: every update returns a new state.
 type PBFTState struct {
 	signatureHistory []common.Blake2b224
+	securityParam    uint64
 }
 
 // NewPBFTState constructs state from an already ordered oldest-to-newest
@@ -284,6 +317,7 @@ func NewPBFTState(
 			[]common.Blake2b224(nil),
 			signatureHistory...,
 		),
+		securityParam: securityParam,
 	}, nil
 }
 
@@ -298,32 +332,34 @@ func (s PBFTState) SignatureHistory() []common.Blake2b224 {
 // explicitly chosen to trust, such as its persisted historical chain.
 func (s PBFTState) Observe(
 	issuer common.Blake2b224,
-	securityParam uint64,
 ) (PBFTState, error) {
-	if securityParam == 0 {
+	if s.securityParam == 0 {
 		return PBFTState{}, errors.New(
-			"byron PBFT security parameter must be greater than zero",
+			"invalid Byron PBFT issuer state: security parameter must be greater than zero",
 		)
 	}
-	if uint64(len(s.signatureHistory)) > securityParam {
+	if uint64(len(s.signatureHistory)) > s.securityParam {
 		return PBFTState{}, fmt.Errorf(
 			"invalid Byron PBFT issuer state: history has %d entries, security parameter is %d",
 			len(s.signatureHistory),
-			securityParam,
+			s.securityParam,
 		)
 	}
 	history := make(
 		[]common.Blake2b224,
 		0,
-		min(uint64(len(s.signatureHistory))+1, securityParam),
+		min(uint64(len(s.signatureHistory))+1, s.securityParam),
 	)
-	if uint64(len(s.signatureHistory)) >= securityParam {
+	if uint64(len(s.signatureHistory)) >= s.securityParam {
 		history = append(history, s.signatureHistory[1:]...)
 	} else {
 		history = append(history, s.signatureHistory...)
 	}
 	history = append(history, issuer)
-	return PBFTState{signatureHistory: history}, nil
+	return PBFTState{
+		signatureHistory: history,
+		securityParam:    s.securityParam,
+	}, nil
 }
 
 // Transition applies the pinned Byron SIGCNT rule: append the genesis issuer,
@@ -331,9 +367,8 @@ func (s PBFTState) Observe(
 // than floor(0.22*k) times in the resulting window.
 func (s PBFTState) Transition(
 	issuer common.Blake2b224,
-	securityParam uint64,
 ) (PBFTState, error) {
-	next, err := s.Observe(issuer, securityParam)
+	next, err := s.Observe(issuer)
 	if err != nil {
 		return PBFTState{}, err
 	}
@@ -343,13 +378,13 @@ func (s PBFTState) Transition(
 			issuerCount++
 		}
 	}
-	maxSignatures := pbftMaxSignatures(securityParam)
+	maxSignatures := pbftMaxSignatures(s.securityParam)
 	if issuerCount > maxSignatures {
 		return PBFTState{}, fmt.Errorf(
 			"byron PBFT signature threshold exceeded for genesis issuer %s: got %d signatures in the last %d, maximum is %d",
 			issuer.String(),
 			issuerCount,
-			securityParam,
+			s.securityParam,
 			maxSignatures,
 		)
 	}

--- a/consensus/byron/pbft.go
+++ b/consensus/byron/pbft.go
@@ -1,0 +1,365 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package byron
+
+import (
+	"bytes"
+	"crypto/sha3"
+	"errors"
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	ledgerbyron "github.com/blinklabs-io/gouroboros/ledger/byron"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+const (
+	// DefaultPBFTSignatureThresholdNumerator and
+	// DefaultPBFTSignatureThresholdDenominator encode the pinned Byron PBFT
+	// issuer threshold, 0.22, without floating-point rounding.
+	DefaultPBFTSignatureThresholdNumerator   uint64 = 22
+	DefaultPBFTSignatureThresholdDenominator uint64 = 100
+)
+
+// PBFTIssuer identifies the genesis key whose signing quota is charged and
+// the active delegate key that actually signed a Byron main-block header.
+type PBFTIssuer struct {
+	GenesisKeyHash  common.Blake2b224
+	DelegateKeyHash common.Blake2b224
+}
+
+// ValidatePBFTHeader validates the stateless and delegation-ledger-view parts
+// of a Byron PBFT main-block header. It verifies the protocol magic, the exact
+// Byron block and proxy-certificate signatures, genesis issuer membership,
+// and that the signing delegate matches the caller's active delegation view.
+//
+// This deliberately does not apply OBFT round-robin leader selection. The
+// inbound PBFT rule charges the genesis issuer against a rolling signature
+// window; use PBFTState.Transition for that stateful rule.
+func ValidatePBFTHeader(
+	header *ledgerbyron.ByronMainBlockHeader,
+	config ByronConfig,
+) (PBFTIssuer, error) {
+	if header == nil {
+		return PBFTIssuer{}, errors.New("nil byron PBFT header")
+	}
+	if len(config.GenesisKeyHashes) == 0 {
+		return PBFTIssuer{}, errors.New(
+			"byron PBFT genesis issuer set is empty",
+		)
+	}
+	if len(config.GenesisDelegations) == 0 {
+		return PBFTIssuer{}, errors.New(
+			"byron PBFT active delegation state is empty",
+		)
+	}
+
+	issuer, err := pbftIssuerFromHeader(header)
+	if err != nil {
+		return PBFTIssuer{}, err
+	}
+	input := &ValidateHeaderInput{
+		Slot:           header.SlotNumber(),
+		BlockNumber:    header.BlockNumber(),
+		PrevHash:       header.PrevHash().Bytes(),
+		ProtocolMagic:  header.ProtocolMagic,
+		IssuerPubKey:   header.ConsensusData.PubKey[:32],
+		BlockSig:       header.ConsensusData.BlockSig,
+		HeaderCbor:     header.Cbor(),
+		EnvelopeOnly:   false,
+		IsEBB:          false,
+		BlockSignature: nil,
+	}
+	validator := NewHeaderValidator(config)
+	if err := validator.validateProtocolMagic(input); err != nil {
+		return PBFTIssuer{}, fmt.Errorf(
+			"validate Byron PBFT protocol magic: %w",
+			err,
+		)
+	}
+	if err := validator.validateBlockSignature(input); err != nil {
+		return PBFTIssuer{}, fmt.Errorf(
+			"validate Byron PBFT block signature: %w",
+			err,
+		)
+	}
+	if !validator.genesisKeyHashes[string(issuer.GenesisKeyHash.Bytes())] {
+		return PBFTIssuer{}, fmt.Errorf(
+			"validate Byron PBFT genesis issuer: issuer %s is not configured",
+			issuer.GenesisKeyHash.String(),
+		)
+	}
+	activeDelegate, ok := config.GenesisDelegations[issuer.GenesisKeyHash]
+	if !ok {
+		return PBFTIssuer{}, fmt.Errorf(
+			"byron PBFT genesis issuer %s has no active delegate",
+			issuer.GenesisKeyHash.String(),
+		)
+	}
+	if !bytes.Equal(
+		activeDelegate.Bytes(),
+		issuer.DelegateKeyHash.Bytes(),
+	) {
+		return PBFTIssuer{}, fmt.Errorf(
+			"byron PBFT active delegate mismatch for genesis issuer %s: got %s, expected %s",
+			issuer.GenesisKeyHash.String(),
+			issuer.DelegateKeyHash.String(),
+			activeDelegate.String(),
+		)
+	}
+	return issuer, nil
+}
+
+func pbftIssuerFromHeader(
+	header *ledgerbyron.ByronMainBlockHeader,
+) (PBFTIssuer, error) {
+	if len(header.ConsensusData.PubKey) != 64 {
+		return PBFTIssuer{}, fmt.Errorf(
+			"invalid Byron PBFT genesis issuer key length: got %d, expected 64",
+			len(header.ConsensusData.PubKey),
+		)
+	}
+	genesisKeyHash, err := PBFTVerificationKeyHash(
+		header.ConsensusData.PubKey,
+	)
+	if err != nil {
+		return PBFTIssuer{}, err
+	}
+	issuer := PBFTIssuer{
+		GenesisKeyHash: genesisKeyHash,
+	}
+	if len(header.ConsensusData.BlockSig) != 2 {
+		return PBFTIssuer{}, fmt.Errorf(
+			"invalid Byron PBFT signature shape: got %d elements, expected 2",
+			len(header.ConsensusData.BlockSig),
+		)
+	}
+	signatureType, err := extractUint64(header.ConsensusData.BlockSig[0])
+	if err != nil {
+		return PBFTIssuer{}, fmt.Errorf(
+			"decode Byron PBFT signature type: %w",
+			err,
+		)
+	}
+	switch signatureType {
+	case byronSigTypeHeavy:
+		inner, ok := header.ConsensusData.BlockSig[1].([]any)
+		if !ok || len(inner) != 2 {
+			return PBFTIssuer{}, fmt.Errorf(
+				"invalid Byron PBFT proxy signature payload: got %T with %d elements",
+				header.ConsensusData.BlockSig[1],
+				len(inner),
+			)
+		}
+		certificate, ok := inner[0].([]any)
+		if !ok || len(certificate) != 4 {
+			return PBFTIssuer{}, fmt.Errorf(
+				"invalid Byron PBFT proxy certificate: got %T with %d elements",
+				inner[0],
+				len(certificate),
+			)
+		}
+		activationEpoch, err := extractUint64(certificate[0])
+		if err != nil {
+			return PBFTIssuer{}, fmt.Errorf(
+				"decode Byron PBFT delegation activation epoch: %w",
+				err,
+			)
+		}
+		if err := validatePBFTCertificateEpoch(
+			activationEpoch,
+			header.ConsensusData.SlotId.Epoch,
+		); err != nil {
+			return PBFTIssuer{}, err
+		}
+		delegateKey, ok := certificate[2].([]byte)
+		if !ok || len(delegateKey) != 64 {
+			return PBFTIssuer{}, fmt.Errorf(
+				"invalid Byron PBFT delegate key: got %T with length %d",
+				certificate[2],
+				len(delegateKey),
+			)
+		}
+		certificateIssuerKey, ok := certificate[1].([]byte)
+		if !ok || !bytes.Equal(
+			certificateIssuerKey,
+			header.ConsensusData.PubKey,
+		) {
+			return PBFTIssuer{}, errors.New(
+				"byron PBFT proxy certificate genesis issuer does not match header issuer",
+			)
+		}
+		issuer.DelegateKeyHash, err = PBFTVerificationKeyHash(delegateKey)
+		if err != nil {
+			return PBFTIssuer{}, err
+		}
+		return issuer, nil
+	case byronSigTypeSimple, byronSigTypeLight:
+		return PBFTIssuer{}, fmt.Errorf(
+			"unsupported Byron PBFT signature type: %d; heavyweight delegation is required",
+			signatureType,
+		)
+	default:
+		return PBFTIssuer{}, fmt.Errorf(
+			"unknown Byron PBFT signature type: %d",
+			signatureType,
+		)
+	}
+}
+
+func validatePBFTCertificateEpoch(
+	activationEpoch uint64,
+	headerEpoch uint64,
+) error {
+	if activationEpoch > headerEpoch {
+		return fmt.Errorf(
+			"byron PBFT delegation certificate is not active: activation epoch %d is after header epoch %d",
+			activationEpoch,
+			headerEpoch,
+		)
+	}
+	return nil
+}
+
+// PBFTVerificationKeyHash derives the Byron key identity used by genesis and
+// delegation state: blake2b-224(sha3-256(CBOR(extended verification key))).
+func PBFTVerificationKeyHash(
+	verificationKey []byte,
+) (common.Blake2b224, error) {
+	if len(verificationKey) != 64 {
+		return common.Blake2b224{}, fmt.Errorf(
+			"invalid Byron extended verification key length: got %d, expected 64",
+			len(verificationKey),
+		)
+	}
+	verificationKeyCbor, err := cbor.Encode(verificationKey)
+	if err != nil {
+		return common.Blake2b224{}, fmt.Errorf(
+			"encode Byron extended verification key: %w",
+			err,
+		)
+	}
+	sha3Hash := sha3.Sum256(verificationKeyCbor)
+	return common.Blake2b224Hash(sha3Hash[:]), nil
+}
+
+// PBFTState contains the genesis issuers charged in the last k signed Byron
+// main-block headers. Values are immutable: every update returns a new state.
+type PBFTState struct {
+	signatureHistory []common.Blake2b224
+}
+
+// NewPBFTState constructs state from an already ordered oldest-to-newest
+// issuer history. It rejects histories that cannot fit in the security window.
+func NewPBFTState(
+	signatureHistory []common.Blake2b224,
+	securityParam uint64,
+) (PBFTState, error) {
+	if securityParam == 0 {
+		return PBFTState{}, errors.New(
+			"byron PBFT security parameter must be greater than zero",
+		)
+	}
+	if uint64(len(signatureHistory)) > securityParam {
+		return PBFTState{}, fmt.Errorf(
+			"byron PBFT issuer history has %d entries, exceeding security parameter %d",
+			len(signatureHistory),
+			securityParam,
+		)
+	}
+	return PBFTState{
+		signatureHistory: append(
+			[]common.Blake2b224(nil),
+			signatureHistory...,
+		),
+	}, nil
+}
+
+// SignatureHistory returns an independent oldest-to-newest copy of the
+// state's charged genesis issuers.
+func (s PBFTState) SignatureHistory() []common.Blake2b224 {
+	return append([]common.Blake2b224(nil), s.signatureHistory...)
+}
+
+// Observe advances the rolling issuer window without applying its threshold.
+// It is intended only for reconstructing state from blocks a caller has
+// explicitly chosen to trust, such as its persisted historical chain.
+func (s PBFTState) Observe(
+	issuer common.Blake2b224,
+	securityParam uint64,
+) (PBFTState, error) {
+	if securityParam == 0 {
+		return PBFTState{}, errors.New(
+			"byron PBFT security parameter must be greater than zero",
+		)
+	}
+	if uint64(len(s.signatureHistory)) > securityParam {
+		return PBFTState{}, fmt.Errorf(
+			"invalid Byron PBFT issuer state: history has %d entries, security parameter is %d",
+			len(s.signatureHistory),
+			securityParam,
+		)
+	}
+	history := make(
+		[]common.Blake2b224,
+		0,
+		min(uint64(len(s.signatureHistory))+1, securityParam),
+	)
+	if uint64(len(s.signatureHistory)) >= securityParam {
+		history = append(history, s.signatureHistory[1:]...)
+	} else {
+		history = append(history, s.signatureHistory...)
+	}
+	history = append(history, issuer)
+	return PBFTState{signatureHistory: history}, nil
+}
+
+// Transition applies the pinned Byron SIGCNT rule: append the genesis issuer,
+// retain only the last k issuers, then reject when that issuer appears more
+// than floor(0.22*k) times in the resulting window.
+func (s PBFTState) Transition(
+	issuer common.Blake2b224,
+	securityParam uint64,
+) (PBFTState, error) {
+	next, err := s.Observe(issuer, securityParam)
+	if err != nil {
+		return PBFTState{}, err
+	}
+	var issuerCount uint64
+	for _, historicalIssuer := range next.signatureHistory {
+		if historicalIssuer == issuer {
+			issuerCount++
+		}
+	}
+	maxSignatures := pbftMaxSignatures(securityParam)
+	if issuerCount > maxSignatures {
+		return PBFTState{}, fmt.Errorf(
+			"byron PBFT signature threshold exceeded for genesis issuer %s: got %d signatures in the last %d, maximum is %d",
+			issuer.String(),
+			issuerCount,
+			securityParam,
+			maxSignatures,
+		)
+	}
+	return next, nil
+}
+
+func pbftMaxSignatures(securityParam uint64) uint64 {
+	quotient := securityParam / DefaultPBFTSignatureThresholdDenominator
+	remainder := securityParam % DefaultPBFTSignatureThresholdDenominator
+	return quotient*DefaultPBFTSignatureThresholdNumerator +
+		(remainder*DefaultPBFTSignatureThresholdNumerator)/
+			DefaultPBFTSignatureThresholdDenominator
+}

--- a/consensus/byron/pbft_delegation.go
+++ b/consensus/byron/pbft_delegation.go
@@ -1,0 +1,369 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package byron
+
+import (
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+type pbftScheduledDelegation struct {
+	activationSlot uint64
+	delegator      common.Blake2b224
+	delegate       common.Blake2b224
+}
+
+type pbftDelegationKeyEpoch struct {
+	epoch     uint64
+	delegator common.Blake2b224
+}
+
+// PBFTDelegationState is the Byron heavyweight-delegation ledger view used by
+// PBFT header validation. Values are immutable: every update returns a new
+// state so callers can publish it only after their surrounding transaction
+// commits.
+type PBFTDelegationState struct {
+	activeDelegations    map[common.Blake2b224]common.Blake2b224
+	delegationSlots      map[common.Blake2b224]uint64
+	scheduledDelegations []pbftScheduledDelegation
+	keyEpochDelegations  map[pbftDelegationKeyEpoch]struct{}
+	allowedDelegators    map[common.Blake2b224]struct{}
+	protocolMagic        uint32
+	securityParam        uint64
+}
+
+// NewPBFTDelegationState constructs the initial Byron delegation state. Every
+// configured genesis key initially delegates to itself, then the genesis
+// heavyweight-delegation view overrides those entries at slot zero.
+func NewPBFTDelegationState(
+	config ByronConfig,
+) (PBFTDelegationState, error) {
+	if config.SecurityParam == 0 {
+		return PBFTDelegationState{}, errors.New(
+			"byron PBFT delegation security parameter must be greater than zero",
+		)
+	}
+	if len(config.GenesisKeyHashes) == 0 {
+		return PBFTDelegationState{}, errors.New(
+			"byron PBFT delegation genesis issuer set is empty",
+		)
+	}
+	state := PBFTDelegationState{
+		activeDelegations: make(
+			map[common.Blake2b224]common.Blake2b224,
+			len(config.GenesisKeyHashes),
+		),
+		delegationSlots: make(
+			map[common.Blake2b224]uint64,
+			len(config.GenesisKeyHashes),
+		),
+		keyEpochDelegations: make(
+			map[pbftDelegationKeyEpoch]struct{},
+			len(config.GenesisKeyHashes),
+		),
+		allowedDelegators: make(
+			map[common.Blake2b224]struct{},
+			len(config.GenesisKeyHashes),
+		),
+		protocolMagic: config.ProtocolMagic,
+		securityParam: config.SecurityParam,
+	}
+	for _, hashBytes := range config.GenesisKeyHashes {
+		if len(hashBytes) != common.Blake2b224Size {
+			return PBFTDelegationState{}, fmt.Errorf(
+				"invalid Byron PBFT genesis issuer hash length: got %d, expected %d",
+				len(hashBytes),
+				common.Blake2b224Size,
+			)
+		}
+		hash := common.NewBlake2b224(hashBytes)
+		if _, exists := state.allowedDelegators[hash]; exists {
+			return PBFTDelegationState{}, fmt.Errorf(
+				"duplicate Byron PBFT genesis issuer %s",
+				hash.String(),
+			)
+		}
+		state.allowedDelegators[hash] = struct{}{}
+		state.activeDelegations[hash] = hash
+		state.delegationSlots[hash] = 0
+	}
+	for delegator, delegate := range config.GenesisDelegations {
+		if _, ok := state.allowedDelegators[delegator]; !ok {
+			return PBFTDelegationState{}, fmt.Errorf(
+				"byron PBFT genesis delegation has unknown delegator %s",
+				delegator.String(),
+			)
+		}
+		if state.delegateIsActiveForOther(delegator, delegate) {
+			return PBFTDelegationState{}, fmt.Errorf(
+				"byron PBFT genesis delegate %s is already active",
+				delegate.String(),
+			)
+		}
+		state.activeDelegations[delegator] = delegate
+		state.keyEpochDelegations[pbftDelegationKeyEpoch{
+			epoch:     0,
+			delegator: delegator,
+		}] = struct{}{}
+	}
+	return state, nil
+}
+
+// ActiveDelegations returns an independent copy of the current mapping from
+// genesis verification-key hashes to active block-signing delegate hashes.
+func (s PBFTDelegationState) ActiveDelegations() map[common.Blake2b224]common.Blake2b224 {
+	ret := make(
+		map[common.Blake2b224]common.Blake2b224,
+		len(s.activeDelegations),
+	)
+	for delegator, delegate := range s.activeDelegations {
+		ret[delegator] = delegate
+	}
+	return ret
+}
+
+// Tick activates all scheduled delegations due at currentSlot and prunes
+// schedules and epoch duplicate records that can no longer affect the ledger.
+func (s PBFTDelegationState) Tick(
+	currentEpoch uint64,
+	currentSlot uint64,
+) PBFTDelegationState {
+	next := s.clone()
+	for _, delegation := range next.scheduledDelegations {
+		if delegation.activationSlot <= currentSlot {
+			next.activate(delegation)
+		}
+	}
+	kept := next.scheduledDelegations[:0]
+	for _, delegation := range next.scheduledDelegations {
+		if delegation.activationSlot > currentSlot {
+			kept = append(kept, delegation)
+		}
+	}
+	next.scheduledDelegations = kept
+	for keyEpoch := range next.keyEpochDelegations {
+		if keyEpoch.epoch < currentEpoch {
+			delete(next.keyEpochDelegations, keyEpoch)
+		}
+	}
+	return next
+}
+
+// ApplyPayload schedules the certificates in a Byron main-block delegation
+// payload and performs the delegation tick for that block. The update is
+// atomic: malformed or invalid certificates leave the input state unchanged.
+func (s PBFTDelegationState) ApplyPayload(
+	currentEpoch uint64,
+	currentSlot uint64,
+	payload []any,
+) (PBFTDelegationState, error) {
+	next := s.clone()
+	for i, rawCertificate := range payload {
+		if err := next.scheduleCertificate(
+			currentEpoch,
+			currentSlot,
+			rawCertificate,
+		); err != nil {
+			return PBFTDelegationState{}, fmt.Errorf(
+				"schedule Byron PBFT delegation certificate %d: %w",
+				i,
+				err,
+			)
+		}
+	}
+	return next.Tick(currentEpoch, currentSlot), nil
+}
+
+func (s PBFTDelegationState) clone() PBFTDelegationState {
+	next := PBFTDelegationState{
+		activeDelegations: make(
+			map[common.Blake2b224]common.Blake2b224,
+			len(s.activeDelegations),
+		),
+		delegationSlots: make(
+			map[common.Blake2b224]uint64,
+			len(s.delegationSlots),
+		),
+		scheduledDelegations: append(
+			[]pbftScheduledDelegation(nil),
+			s.scheduledDelegations...,
+		),
+		keyEpochDelegations: make(
+			map[pbftDelegationKeyEpoch]struct{},
+			len(s.keyEpochDelegations),
+		),
+		allowedDelegators: make(
+			map[common.Blake2b224]struct{},
+			len(s.allowedDelegators),
+		),
+		protocolMagic: s.protocolMagic,
+		securityParam: s.securityParam,
+	}
+	for delegator, delegate := range s.activeDelegations {
+		next.activeDelegations[delegator] = delegate
+	}
+	for delegator, slot := range s.delegationSlots {
+		next.delegationSlots[delegator] = slot
+	}
+	for keyEpoch := range s.keyEpochDelegations {
+		next.keyEpochDelegations[keyEpoch] = struct{}{}
+	}
+	for delegator := range s.allowedDelegators {
+		next.allowedDelegators[delegator] = struct{}{}
+	}
+	return next
+}
+
+func (s *PBFTDelegationState) scheduleCertificate(
+	currentEpoch uint64,
+	currentSlot uint64,
+	rawCertificate any,
+) error {
+	certificate, ok := rawCertificate.([]any)
+	if !ok || len(certificate) != 4 {
+		return fmt.Errorf(
+			"invalid certificate shape: got %T with %d elements",
+			rawCertificate,
+			len(certificate),
+		)
+	}
+	delegationEpoch, err := extractUint64(certificate[0])
+	if err != nil {
+		return fmt.Errorf("decode delegation epoch: %w", err)
+	}
+	if delegationEpoch < currentEpoch ||
+		delegationEpoch-currentEpoch > 1 {
+		return fmt.Errorf(
+			"delegation epoch %d is not current epoch %d or its successor",
+			delegationEpoch,
+			currentEpoch,
+		)
+	}
+	issuerKey, ok := certificate[1].([]byte)
+	if !ok || len(issuerKey) != 64 {
+		return fmt.Errorf(
+			"invalid issuer verification key: got %T with length %d",
+			certificate[1],
+			len(issuerKey),
+		)
+	}
+	delegateKey, ok := certificate[2].([]byte)
+	if !ok || len(delegateKey) != 64 {
+		return fmt.Errorf(
+			"invalid delegate verification key: got %T with length %d",
+			certificate[2],
+			len(delegateKey),
+		)
+	}
+	certificateSignature, ok := certificate[3].([]byte)
+	if !ok || len(certificateSignature) != 64 {
+		return fmt.Errorf(
+			"invalid certificate signature: got %T with length %d",
+			certificate[3],
+			len(certificateSignature),
+		)
+	}
+	delegator, err := PBFTVerificationKeyHash(issuerKey)
+	if err != nil {
+		return fmt.Errorf("derive delegation issuer: %w", err)
+	}
+	if _, ok := s.allowedDelegators[delegator]; !ok {
+		return fmt.Errorf(
+			"delegation issuer %s is not a configured genesis key",
+			delegator.String(),
+		)
+	}
+	keyEpoch := pbftDelegationKeyEpoch{
+		epoch:     delegationEpoch,
+		delegator: delegator,
+	}
+	if _, exists := s.keyEpochDelegations[keyEpoch]; exists {
+		return fmt.Errorf(
+			"genesis issuer %s already delegated for epoch %d",
+			delegator.String(),
+			delegationEpoch,
+		)
+	}
+	if s.securityParam > math.MaxUint64/2 ||
+		currentSlot > math.MaxUint64-2*s.securityParam {
+		return errors.New("byron PBFT delegation activation slot overflows")
+	}
+	activationSlot := currentSlot + 2*s.securityParam
+	for _, scheduled := range s.scheduledDelegations {
+		if scheduled.delegator == delegator &&
+			scheduled.activationSlot == activationSlot {
+			return fmt.Errorf(
+				"genesis issuer %s already delegated in slot %d",
+				delegator.String(),
+				currentSlot,
+			)
+		}
+	}
+	validator := NewHeaderValidator(ByronConfig{
+		ProtocolMagic: s.protocolMagic,
+	})
+	if err := validator.validateDelegationCertSignature(
+		issuerKey,
+		delegateKey,
+		certificateSignature,
+		delegationEpoch,
+	); err != nil {
+		return fmt.Errorf("validate delegation certificate: %w", err)
+	}
+	delegate, err := PBFTVerificationKeyHash(delegateKey)
+	if err != nil {
+		return fmt.Errorf("derive delegation delegate: %w", err)
+	}
+	s.scheduledDelegations = append(
+		s.scheduledDelegations,
+		pbftScheduledDelegation{
+			activationSlot: activationSlot,
+			delegator:      delegator,
+			delegate:       delegate,
+		},
+	)
+	s.keyEpochDelegations[keyEpoch] = struct{}{}
+	return nil
+}
+
+func (s *PBFTDelegationState) activate(
+	delegation pbftScheduledDelegation,
+) {
+	previousSlot := s.delegationSlots[delegation.delegator]
+	if s.delegateIsActiveForOther(
+		delegation.delegator,
+		delegation.delegate,
+	) || (delegation.activationSlot != 0 &&
+		previousSlot >= delegation.activationSlot) {
+		return
+	}
+	s.activeDelegations[delegation.delegator] = delegation.delegate
+	s.delegationSlots[delegation.delegator] = delegation.activationSlot
+}
+
+func (s PBFTDelegationState) delegateIsActiveForOther(
+	delegator common.Blake2b224,
+	delegate common.Blake2b224,
+) bool {
+	for activeDelegator, activeDelegate := range s.activeDelegations {
+		if activeDelegator != delegator && activeDelegate == delegate {
+			return true
+		}
+	}
+	return false
+}

--- a/consensus/byron/pbft_delegation.go
+++ b/consensus/byron/pbft_delegation.go
@@ -109,17 +109,26 @@ func NewPBFTDelegationState(
 				delegator.String(),
 			)
 		}
-		if state.delegateIsActiveForOther(delegator, delegate) {
-			return PBFTDelegationState{}, fmt.Errorf(
-				"byron PBFT genesis delegate %s is already active",
-				delegate.String(),
-			)
-		}
 		state.activeDelegations[delegator] = delegate
 		state.keyEpochDelegations[pbftDelegationKeyEpoch{
 			epoch:     0,
 			delegator: delegator,
 		}] = struct{}{}
+	}
+	activeDelegators := make(
+		map[common.Blake2b224]common.Blake2b224,
+		len(state.activeDelegations),
+	)
+	for delegator, delegate := range state.activeDelegations {
+		if otherDelegator, exists := activeDelegators[delegate]; exists {
+			return PBFTDelegationState{}, fmt.Errorf(
+				"byron PBFT genesis delegate %s is active for both %s and %s",
+				delegate.String(),
+				otherDelegator.String(),
+				delegator.String(),
+			)
+		}
+		activeDelegators[delegate] = delegator
 	}
 	return state, nil
 }

--- a/consensus/byron/pbft_delegation_test.go
+++ b/consensus/byron/pbft_delegation_test.go
@@ -144,6 +144,56 @@ func TestPBFTDelegationStateActivationAndRevocation(t *testing.T) {
 	)
 }
 
+func TestNewPBFTDelegationStateUsesFinalGenesisView(t *testing.T) {
+	issuerAKey, _ := deterministicPBFTVerificationKey(0x31)
+	issuerBKey, _ := deterministicPBFTVerificationKey(0x32)
+	delegateKey, _ := deterministicPBFTVerificationKey(0x33)
+	issuerA, err := PBFTVerificationKeyHash(issuerAKey)
+	require.NoError(t, err)
+	issuerB, err := PBFTVerificationKeyHash(issuerBKey)
+	require.NoError(t, err)
+	delegate, err := PBFTVerificationKeyHash(delegateKey)
+	require.NoError(t, err)
+	config := ByronConfig{
+		ProtocolMagic:    42,
+		SecurityParam:    10,
+		GenesisKeyHashes: [][]byte{issuerA.Bytes(), issuerB.Bytes()},
+		GenesisDelegations: map[common.Blake2b224]common.Blake2b224{
+			issuerA: issuerB,
+			issuerB: delegate,
+		},
+	}
+
+	for range 100 {
+		state, err := NewPBFTDelegationState(config)
+		require.NoError(t, err)
+		require.Equal(t, config.GenesisDelegations, state.ActiveDelegations())
+	}
+}
+
+func TestNewPBFTDelegationStateRejectsFinalDelegateCollision(t *testing.T) {
+	issuerAKey, _ := deterministicPBFTVerificationKey(0x34)
+	issuerBKey, _ := deterministicPBFTVerificationKey(0x35)
+	delegateKey, _ := deterministicPBFTVerificationKey(0x36)
+	issuerA, err := PBFTVerificationKeyHash(issuerAKey)
+	require.NoError(t, err)
+	issuerB, err := PBFTVerificationKeyHash(issuerBKey)
+	require.NoError(t, err)
+	delegate, err := PBFTVerificationKeyHash(delegateKey)
+	require.NoError(t, err)
+
+	_, err = NewPBFTDelegationState(ByronConfig{
+		ProtocolMagic:    42,
+		SecurityParam:    10,
+		GenesisKeyHashes: [][]byte{issuerA.Bytes(), issuerB.Bytes()},
+		GenesisDelegations: map[common.Blake2b224]common.Blake2b224{
+			issuerA: delegate,
+			issuerB: delegate,
+		},
+	})
+	require.ErrorContains(t, err, "is active for both")
+}
+
 func TestPBFTDelegationStateRejectsInvalidPayloadAtomically(t *testing.T) {
 	const protocolMagic = uint32(42)
 	issuerKey, issuerPrivateKey := deterministicPBFTVerificationKey(0x41)

--- a/consensus/byron/pbft_delegation_test.go
+++ b/consensus/byron/pbft_delegation_test.go
@@ -1,0 +1,214 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package byron
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/require"
+)
+
+func deterministicPBFTVerificationKey(
+	seedByte byte,
+) ([]byte, ed25519.PrivateKey) {
+	privateKey := ed25519.NewKeyFromSeed(bytes.Repeat(
+		[]byte{seedByte},
+		ed25519.SeedSize,
+	))
+	verificationKey := make([]byte, 64)
+	copy(verificationKey, privateKey.Public().(ed25519.PublicKey))
+	copy(verificationKey[32:], bytes.Repeat([]byte{seedByte ^ 0xff}, 32))
+	return verificationKey, privateKey
+}
+
+func signedPBFTDelegationCertificate(
+	t *testing.T,
+	protocolMagic uint32,
+	epoch uint64,
+	issuerKey []byte,
+	issuerPrivateKey ed25519.PrivateKey,
+	delegateKey []byte,
+) []any {
+	t.Helper()
+	epochCbor, err := cbor.Encode(epoch)
+	require.NoError(t, err)
+	inner := make([]byte, 0, 2+len(delegateKey)+len(epochCbor))
+	inner = append(inner, '0', '0')
+	inner = append(inner, delegateKey...)
+	inner = append(inner, epochCbor...)
+	innerCbor, err := cbor.Encode(inner)
+	require.NoError(t, err)
+	protocolMagicCbor, err := cbor.Encode(protocolMagic)
+	require.NoError(t, err)
+	signed := []byte{byronSignTagCertificate}
+	signed = append(signed, protocolMagicCbor...)
+	signed = append(signed, innerCbor...)
+	return []any{
+		epoch,
+		append([]byte(nil), issuerKey...),
+		append([]byte(nil), delegateKey...),
+		ed25519.Sign(issuerPrivateKey, signed),
+	}
+}
+
+func TestPBFTDelegationStateActivationAndRevocation(t *testing.T) {
+	const (
+		protocolMagic = uint32(42)
+		securityParam = uint64(10)
+	)
+	issuerKey, issuerPrivateKey := deterministicPBFTVerificationKey(0x11)
+	initialDelegateKey, _ := deterministicPBFTVerificationKey(0x22)
+	replacementDelegateKey, _ := deterministicPBFTVerificationKey(0x33)
+	issuerHash, err := PBFTVerificationKeyHash(issuerKey)
+	require.NoError(t, err)
+	initialDelegateHash, err := PBFTVerificationKeyHash(initialDelegateKey)
+	require.NoError(t, err)
+	replacementDelegateHash, err := PBFTVerificationKeyHash(
+		replacementDelegateKey,
+	)
+	require.NoError(t, err)
+	state, err := NewPBFTDelegationState(ByronConfig{
+		ProtocolMagic:    protocolMagic,
+		SecurityParam:    securityParam,
+		GenesisKeyHashes: [][]byte{issuerHash.Bytes()},
+		GenesisDelegations: map[common.Blake2b224]common.Blake2b224{
+			issuerHash: initialDelegateHash,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, initialDelegateHash, state.ActiveDelegations()[issuerHash])
+
+	activationCertificate := signedPBFTDelegationCertificate(
+		t,
+		protocolMagic,
+		1,
+		issuerKey,
+		issuerPrivateKey,
+		replacementDelegateKey,
+	)
+	state, err = state.ApplyPayload(1, 101, []any{activationCertificate})
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		initialDelegateHash,
+		state.ActiveDelegations()[issuerHash],
+		"a certificate must not activate before slot current+2k",
+	)
+	state = state.Tick(1, 120)
+	require.Equal(t, initialDelegateHash, state.ActiveDelegations()[issuerHash])
+	state = state.Tick(1, 121)
+	require.Equal(
+		t,
+		replacementDelegateHash,
+		state.ActiveDelegations()[issuerHash],
+	)
+
+	revocationCertificate := signedPBFTDelegationCertificate(
+		t,
+		protocolMagic,
+		2,
+		issuerKey,
+		issuerPrivateKey,
+		issuerKey,
+	)
+	state, err = state.ApplyPayload(2, 201, []any{revocationCertificate})
+	require.NoError(t, err)
+	state = state.Tick(2, 220)
+	require.Equal(
+		t,
+		replacementDelegateHash,
+		state.ActiveDelegations()[issuerHash],
+	)
+	state = state.Tick(2, 221)
+	require.Equal(
+		t,
+		issuerHash,
+		state.ActiveDelegations()[issuerHash],
+		"self-delegation must revoke the prior delegate",
+	)
+}
+
+func TestPBFTDelegationStateRejectsInvalidPayloadAtomically(t *testing.T) {
+	const protocolMagic = uint32(42)
+	issuerKey, issuerPrivateKey := deterministicPBFTVerificationKey(0x41)
+	initialDelegateKey, _ := deterministicPBFTVerificationKey(0x42)
+	replacementDelegateKey, _ := deterministicPBFTVerificationKey(0x43)
+	issuerHash, err := PBFTVerificationKeyHash(issuerKey)
+	require.NoError(t, err)
+	initialDelegateHash, err := PBFTVerificationKeyHash(initialDelegateKey)
+	require.NoError(t, err)
+	state, err := NewPBFTDelegationState(ByronConfig{
+		ProtocolMagic:    protocolMagic,
+		SecurityParam:    10,
+		GenesisKeyHashes: [][]byte{issuerHash.Bytes()},
+		GenesisDelegations: map[common.Blake2b224]common.Blake2b224{
+			issuerHash: initialDelegateHash,
+		},
+	})
+	require.NoError(t, err)
+	certificate := signedPBFTDelegationCertificate(
+		t,
+		protocolMagic,
+		1,
+		issuerKey,
+		issuerPrivateKey,
+		replacementDelegateKey,
+	)
+	_, err = state.ApplyPayload(1, 101, []any{certificate, []any{}})
+	require.ErrorContains(t, err, "invalid certificate shape")
+	require.Equal(
+		t,
+		initialDelegateHash,
+		state.ActiveDelegations()[issuerHash],
+		"a rejected payload must not mutate the input state",
+	)
+	require.Empty(t, state.scheduledDelegations)
+}
+
+func TestPBFTDelegationStateRejectsDuplicateEpoch(t *testing.T) {
+	const protocolMagic = uint32(42)
+	issuerKey, issuerPrivateKey := deterministicPBFTVerificationKey(0x51)
+	initialDelegateKey, _ := deterministicPBFTVerificationKey(0x52)
+	replacementDelegateKey, _ := deterministicPBFTVerificationKey(0x53)
+	issuerHash, err := PBFTVerificationKeyHash(issuerKey)
+	require.NoError(t, err)
+	initialDelegateHash, err := PBFTVerificationKeyHash(initialDelegateKey)
+	require.NoError(t, err)
+	state, err := NewPBFTDelegationState(ByronConfig{
+		ProtocolMagic:    protocolMagic,
+		SecurityParam:    10,
+		GenesisKeyHashes: [][]byte{issuerHash.Bytes()},
+		GenesisDelegations: map[common.Blake2b224]common.Blake2b224{
+			issuerHash: initialDelegateHash,
+		},
+	})
+	require.NoError(t, err)
+	certificate := signedPBFTDelegationCertificate(
+		t,
+		protocolMagic,
+		1,
+		issuerKey,
+		issuerPrivateKey,
+		replacementDelegateKey,
+	)
+	state, err = state.ApplyPayload(1, 101, []any{certificate})
+	require.NoError(t, err)
+	_, err = state.ApplyPayload(1, 102, []any{certificate})
+	require.ErrorContains(t, err, "already delegated for epoch 1")
+}

--- a/consensus/byron/pbft_test.go
+++ b/consensus/byron/pbft_test.go
@@ -70,31 +70,83 @@ func TestValidatePBFTHeaderRealMainnet(t *testing.T) {
 	require.Equal(t, expectedIssuer, issuer)
 }
 
+func TestPBFTIssuerFromHeaderRealMainnet(t *testing.T) {
+	header, _, expectedIssuer := realPBFTHeaderFixture(t)
+
+	issuer, err := PBFTIssuerFromHeader(header)
+	require.NoError(t, err)
+	require.Equal(t, expectedIssuer.GenesisKeyHash, issuer.GenesisKeyHash)
+	require.Equal(t, expectedIssuer.DelegateKeyHash, issuer.DelegateKeyHash)
+	require.NotEqual(t, issuer.GenesisKeyHash, issuer.DelegateKeyHash)
+}
+
+func TestPBFTIssuerFromHeaderRejectsMalformedIdentity(t *testing.T) {
+	header, _, _ := realPBFTHeaderFixture(t)
+	_, err := PBFTIssuerFromHeader(nil)
+	require.ErrorContains(t, err, "nil")
+
+	header.ConsensusData.PubKey = header.ConsensusData.PubKey[:32]
+	_, err = PBFTIssuerFromHeader(header)
+	require.ErrorContains(t, err, "genesis issuer key length")
+}
+
+func TestPBFTIssuerFromHeaderIsParseOnly(t *testing.T) {
+	header, _, expectedIssuer := realPBFTHeaderFixture(t)
+	inner := header.ConsensusData.BlockSig[1].([]any)
+	certificate := inner[0].([]any)
+	certificate[0] = header.ConsensusData.SlotId.Epoch + 1
+	signature := inner[1].([]byte)
+	signature[0] ^= 0xff
+
+	issuer, err := PBFTIssuerFromHeader(header)
+	require.NoError(t, err)
+	require.Equal(t, expectedIssuer, issuer)
+}
+
+func TestValidateProxySignatureUsesWireTypeTag(t *testing.T) {
+	header, config, _ := realPBFTHeaderFixture(t)
+	blockSig := append([]any(nil), header.ConsensusData.BlockSig...)
+	blockSig[0] = uint64(byronSigTypeLight)
+	input := &ValidateHeaderInput{
+		Slot:          header.SlotNumber(),
+		BlockNumber:   header.BlockNumber(),
+		ProtocolMagic: header.ProtocolMagic,
+		IssuerPubKey:  header.ConsensusData.PubKey[:32],
+		BlockSig:      blockSig,
+		HeaderCbor:    header.Cbor(),
+	}
+
+	err := NewHeaderValidator(config).validateBlockSignature(input)
+	require.ErrorContains(t, err, "block signature verification failed")
+}
+
 func TestValidatePBFTHeaderRejectsInvalidVectors(t *testing.T) {
 	tests := []struct {
 		name      string
-		mutate    func(*ledgerbyron.ByronMainBlockHeader, *ByronConfig)
+		mutate    func(*testing.T, *ledgerbyron.ByronMainBlockHeader, *ByronConfig)
 		wantError string
 	}{
 		{
 			name: "protocol magic",
-			mutate: func(header *ledgerbyron.ByronMainBlockHeader, _ *ByronConfig) {
+			mutate: func(_ *testing.T, header *ledgerbyron.ByronMainBlockHeader, _ *ByronConfig) {
 				header.ProtocolMagic++
 			},
 			wantError: "protocol magic",
 		},
 		{
 			name: "block signature",
-			mutate: func(header *ledgerbyron.ByronMainBlockHeader, _ *ByronConfig) {
-				inner := header.ConsensusData.BlockSig[1].([]any)
-				signature := inner[1].([]byte)
+			mutate: func(t *testing.T, header *ledgerbyron.ByronMainBlockHeader, _ *ByronConfig) {
+				inner, ok := header.ConsensusData.BlockSig[1].([]any)
+				require.True(t, ok)
+				signature, ok := inner[1].([]byte)
+				require.True(t, ok)
 				signature[0] ^= 0xff
 			},
 			wantError: "block signature",
 		},
 		{
 			name: "unknown genesis issuer",
-			mutate: func(_ *ledgerbyron.ByronMainBlockHeader, config *ByronConfig) {
+			mutate: func(_ *testing.T, _ *ledgerbyron.ByronMainBlockHeader, config *ByronConfig) {
 				unknown := common.Blake2b224Hash([]byte("unknown genesis issuer"))
 				config.GenesisKeyHashes = [][]byte{unknown.Bytes()}
 			},
@@ -102,7 +154,7 @@ func TestValidatePBFTHeaderRejectsInvalidVectors(t *testing.T) {
 		},
 		{
 			name: "replaced or revoked delegate",
-			mutate: func(header *ledgerbyron.ByronMainBlockHeader, config *ByronConfig) {
+			mutate: func(t *testing.T, header *ledgerbyron.ByronMainBlockHeader, config *ByronConfig) {
 				genesisHash, err := PBFTVerificationKeyHash(
 					header.ConsensusData.PubKey,
 				)
@@ -115,16 +167,18 @@ func TestValidatePBFTHeaderRejectsInvalidVectors(t *testing.T) {
 		},
 		{
 			name: "unsupported lightweight delegation",
-			mutate: func(header *ledgerbyron.ByronMainBlockHeader, _ *ByronConfig) {
+			mutate: func(_ *testing.T, header *ledgerbyron.ByronMainBlockHeader, _ *ByronConfig) {
 				header.ConsensusData.BlockSig[0] = uint64(byronSigTypeLight)
 			},
 			wantError: "unsupported Byron PBFT signature type",
 		},
 		{
 			name: "delegation certificate activates after header epoch",
-			mutate: func(header *ledgerbyron.ByronMainBlockHeader, _ *ByronConfig) {
-				inner := header.ConsensusData.BlockSig[1].([]any)
-				certificate := inner[0].([]any)
+			mutate: func(t *testing.T, header *ledgerbyron.ByronMainBlockHeader, _ *ByronConfig) {
+				inner, ok := header.ConsensusData.BlockSig[1].([]any)
+				require.True(t, ok)
+				certificate, ok := inner[0].([]any)
+				require.True(t, ok)
 				certificate[0] = header.ConsensusData.SlotId.Epoch + 1
 			},
 			wantError: "not active",
@@ -134,7 +188,7 @@ func TestValidatePBFTHeaderRejectsInvalidVectors(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			header, config, _ := realPBFTHeaderFixture(t)
-			test.mutate(header, &config)
+			test.mutate(t, header, &config)
 			_, err := ValidatePBFTHeader(header, config)
 			require.ErrorContains(t, err, test.wantError)
 		})
@@ -189,7 +243,7 @@ func TestPBFTStateTransitionVectors(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, issuer := range []common.Blake2b224{issuerA, issuerB, issuerA} {
-		state, err = state.Transition(issuer, 10)
+		state, err = state.Transition(issuer)
 		require.NoError(t, err)
 	}
 	require.Equal(
@@ -198,7 +252,7 @@ func TestPBFTStateTransitionVectors(t *testing.T) {
 		state.SignatureHistory(),
 	)
 
-	_, err = state.Transition(issuerA, 10)
+	_, err = state.Transition(issuerA)
 	require.ErrorContains(t, err, "signature threshold")
 	require.Equal(
 		t,
@@ -208,7 +262,7 @@ func TestPBFTStateTransitionVectors(t *testing.T) {
 	)
 
 	for range 8 {
-		state, err = state.Observe(issuerC, 10)
+		state, err = state.Observe(issuerC)
 		require.NoError(t, err)
 	}
 	require.Len(t, state.SignatureHistory(), 10)
@@ -224,6 +278,28 @@ func TestPBFTStateRejectsInvalidState(t *testing.T) {
 		2,
 	)
 	require.ErrorContains(t, err, "issuer history")
+	_, err = (PBFTState{}).Observe(issuer)
+	require.ErrorContains(t, err, "security parameter")
+}
+
+func TestPBFTMaxSignatures(t *testing.T) {
+	tests := []struct {
+		securityParam uint64
+		want          uint64
+	}{
+		{securityParam: 1, want: 0},
+		{securityParam: 4, want: 0},
+		{securityParam: 5, want: 1},
+		{securityParam: 100, want: 22},
+		{securityParam: 2160, want: 475},
+	}
+	for _, test := range tests {
+		require.Equal(
+			t,
+			test.want,
+			pbftMaxSignatures(test.securityParam),
+		)
+	}
 }
 
 func TestNewByronConfigFromGenesisBuildsPBFTDelegationView(t *testing.T) {
@@ -247,4 +323,43 @@ func TestNewByronConfigFromGenesisBuildsPBFTDelegationView(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, delegateHash, config.GenesisDelegations[genesisHash])
 	}
+}
+
+func TestGenesisDerivedConfigValidatesRealPBFTHeader(t *testing.T) {
+	genesis, err := ledgerbyron.NewByronGenesisFromReader(
+		strings.NewReader(testByronGenesisJSON),
+	)
+	require.NoError(t, err)
+	config, err := NewByronConfigFromGenesis(&genesis)
+	require.NoError(t, err)
+
+	blockBytes, err := hex.DecodeString(testByronMainBlockHex)
+	require.NoError(t, err)
+	block, err := ledgerbyron.NewByronMainBlockFromCbor(
+		blockBytes,
+		common.VerifyConfig{SkipBodyHashValidation: true},
+	)
+	require.NoError(t, err)
+	issuer, err := ValidatePBFTHeader(block.BlockHeader, config)
+	require.NoError(t, err)
+	require.Contains(t, config.GenesisKeyHashes, issuer.GenesisKeyHash.Bytes())
+	require.Equal(
+		t,
+		issuer.DelegateKeyHash,
+		config.GenesisDelegations[issuer.GenesisKeyHash],
+	)
+}
+
+func TestNewByronConfigFromGenesisRejectsInvalidDelegationCertificate(t *testing.T) {
+	genesis, err := ledgerbyron.NewByronGenesisFromReader(
+		strings.NewReader(testByronGenesisJSON),
+	)
+	require.NoError(t, err)
+	const genesisHash = "af2800c124e599d6dec188a75f8bfde397ebb778163a18240371f2d1"
+	delegation := genesis.HeavyDelegation[genesisHash]
+	delegation.Cert = "00" + delegation.Cert[2:]
+	genesis.HeavyDelegation[genesisHash] = delegation
+
+	_, err = NewByronConfigFromGenesis(&genesis)
+	require.ErrorContains(t, err, "validate delegation certificate")
 }

--- a/consensus/byron/pbft_test.go
+++ b/consensus/byron/pbft_test.go
@@ -1,0 +1,250 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package byron
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	ledgerbyron "github.com/blinklabs-io/gouroboros/ledger/byron"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/require"
+)
+
+func realPBFTHeaderFixture(
+	t *testing.T,
+) (*ledgerbyron.ByronMainBlockHeader, ByronConfig, PBFTIssuer) {
+	t.Helper()
+	blockBytes, err := hex.DecodeString(testByronMainBlockHex)
+	require.NoError(t, err)
+	block, err := ledgerbyron.NewByronMainBlockFromCbor(
+		blockBytes,
+		common.VerifyConfig{SkipBodyHashValidation: true},
+	)
+	require.NoError(t, err)
+	header := block.BlockHeader
+	inner, ok := header.ConsensusData.BlockSig[1].([]any)
+	require.True(t, ok)
+	certificate, ok := inner[0].([]any)
+	require.True(t, ok)
+	delegateKey, ok := certificate[2].([]byte)
+	require.True(t, ok)
+	require.Len(t, delegateKey, 64)
+	genesisHash, err := PBFTVerificationKeyHash(header.ConsensusData.PubKey)
+	require.NoError(t, err)
+	delegateHash, err := PBFTVerificationKeyHash(delegateKey)
+	require.NoError(t, err)
+	issuer := PBFTIssuer{
+		GenesisKeyHash:  genesisHash,
+		DelegateKeyHash: delegateHash,
+	}
+	config := ByronConfig{
+		ProtocolMagic:    header.ProtocolMagic,
+		SecurityParam:    testByronSecurityParam,
+		GenesisKeyHashes: [][]byte{issuer.GenesisKeyHash.Bytes()},
+		GenesisDelegations: map[common.Blake2b224]common.Blake2b224{
+			issuer.GenesisKeyHash: issuer.DelegateKeyHash,
+		},
+	}
+	return header, config, issuer
+}
+
+func TestValidatePBFTHeaderRealMainnet(t *testing.T) {
+	header, config, expectedIssuer := realPBFTHeaderFixture(t)
+	issuer, err := ValidatePBFTHeader(header, config)
+	require.NoError(t, err)
+	require.Equal(t, expectedIssuer, issuer)
+}
+
+func TestValidatePBFTHeaderRejectsInvalidVectors(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*ledgerbyron.ByronMainBlockHeader, *ByronConfig)
+		wantError string
+	}{
+		{
+			name: "protocol magic",
+			mutate: func(header *ledgerbyron.ByronMainBlockHeader, _ *ByronConfig) {
+				header.ProtocolMagic++
+			},
+			wantError: "protocol magic",
+		},
+		{
+			name: "block signature",
+			mutate: func(header *ledgerbyron.ByronMainBlockHeader, _ *ByronConfig) {
+				inner := header.ConsensusData.BlockSig[1].([]any)
+				signature := inner[1].([]byte)
+				signature[0] ^= 0xff
+			},
+			wantError: "block signature",
+		},
+		{
+			name: "unknown genesis issuer",
+			mutate: func(_ *ledgerbyron.ByronMainBlockHeader, config *ByronConfig) {
+				unknown := common.Blake2b224Hash([]byte("unknown genesis issuer"))
+				config.GenesisKeyHashes = [][]byte{unknown.Bytes()}
+			},
+			wantError: "genesis issuer",
+		},
+		{
+			name: "replaced or revoked delegate",
+			mutate: func(header *ledgerbyron.ByronMainBlockHeader, config *ByronConfig) {
+				genesisHash, err := PBFTVerificationKeyHash(
+					header.ConsensusData.PubKey,
+				)
+				require.NoError(t, err)
+				config.GenesisDelegations[genesisHash] = common.Blake2b224Hash(
+					[]byte("different delegate"),
+				)
+			},
+			wantError: "active delegate",
+		},
+		{
+			name: "unsupported lightweight delegation",
+			mutate: func(header *ledgerbyron.ByronMainBlockHeader, _ *ByronConfig) {
+				header.ConsensusData.BlockSig[0] = uint64(byronSigTypeLight)
+			},
+			wantError: "unsupported Byron PBFT signature type",
+		},
+		{
+			name: "delegation certificate activates after header epoch",
+			mutate: func(header *ledgerbyron.ByronMainBlockHeader, _ *ByronConfig) {
+				inner := header.ConsensusData.BlockSig[1].([]any)
+				certificate := inner[0].([]any)
+				certificate[0] = header.ConsensusData.SlotId.Epoch + 1
+			},
+			wantError: "not active",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			header, config, _ := realPBFTHeaderFixture(t)
+			test.mutate(header, &config)
+			_, err := ValidatePBFTHeader(header, config)
+			require.ErrorContains(t, err, test.wantError)
+		})
+	}
+}
+
+func TestValidatePBFTCertificateEpoch(t *testing.T) {
+	tests := []struct {
+		name            string
+		activationEpoch uint64
+		headerEpoch     uint64
+		wantError       string
+	}{
+		{
+			name:            "activated in earlier epoch",
+			activationEpoch: 0,
+			headerEpoch:     10,
+		},
+		{
+			name:            "activated in header epoch",
+			activationEpoch: 10,
+			headerEpoch:     10,
+		},
+		{
+			name:            "activation is in future",
+			activationEpoch: 11,
+			headerEpoch:     10,
+			wantError:       "not active",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validatePBFTCertificateEpoch(
+				test.activationEpoch,
+				test.headerEpoch,
+			)
+			if test.wantError == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, test.wantError)
+		})
+	}
+}
+
+func TestPBFTStateTransitionVectors(t *testing.T) {
+	issuerA := common.Blake2b224Hash([]byte("issuer-a"))
+	issuerB := common.Blake2b224Hash([]byte("issuer-b"))
+	issuerC := common.Blake2b224Hash([]byte("issuer-c"))
+	state, err := NewPBFTState(nil, 10)
+	require.NoError(t, err)
+
+	for _, issuer := range []common.Blake2b224{issuerA, issuerB, issuerA} {
+		state, err = state.Transition(issuer, 10)
+		require.NoError(t, err)
+	}
+	require.Equal(
+		t,
+		[]common.Blake2b224{issuerA, issuerB, issuerA},
+		state.SignatureHistory(),
+	)
+
+	_, err = state.Transition(issuerA, 10)
+	require.ErrorContains(t, err, "signature threshold")
+	require.Equal(
+		t,
+		[]common.Blake2b224{issuerA, issuerB, issuerA},
+		state.SignatureHistory(),
+		"a rejected transition must not mutate prior state",
+	)
+
+	for range 8 {
+		state, err = state.Observe(issuerC, 10)
+		require.NoError(t, err)
+	}
+	require.Len(t, state.SignatureHistory(), 10)
+	require.Equal(t, issuerB, state.SignatureHistory()[0])
+}
+
+func TestPBFTStateRejectsInvalidState(t *testing.T) {
+	issuer := common.Blake2b224Hash([]byte("issuer"))
+	_, err := NewPBFTState([]common.Blake2b224{issuer}, 0)
+	require.ErrorContains(t, err, "security parameter")
+	_, err = NewPBFTState(
+		[]common.Blake2b224{issuer, issuer, issuer},
+		2,
+	)
+	require.ErrorContains(t, err, "issuer history")
+}
+
+func TestNewByronConfigFromGenesisBuildsPBFTDelegationView(t *testing.T) {
+	genesis, err := ledgerbyron.NewByronGenesisFromReader(
+		strings.NewReader(testByronGenesisJSON),
+	)
+	require.NoError(t, err)
+	config, err := NewByronConfigFromGenesis(&genesis)
+	require.NoError(t, err)
+	require.Len(t, config.GenesisDelegations, len(genesis.HeavyDelegation))
+
+	for genesisHashHex, delegation := range genesis.HeavyDelegation {
+		genesisHashBytes, err := hex.DecodeString(genesisHashHex)
+		require.NoError(t, err)
+		genesisHash := common.NewBlake2b224(genesisHashBytes)
+		delegateKey, err := base64.StdEncoding.DecodeString(
+			delegation.DelegatePk,
+		)
+		require.NoError(t, err)
+		delegateHash, err := PBFTVerificationKeyHash(delegateKey)
+		require.NoError(t, err)
+		require.Equal(t, delegateHash, config.GenesisDelegations[genesisHash])
+	}
+}

--- a/consensus/byron/validate.go
+++ b/consensus/byron/validate.go
@@ -259,14 +259,16 @@ func (v *HeaderValidator) validateProtocolMagic(
 	return nil
 }
 
-// Byron signature types from CDDL:
+// Byron signature types from the legacy wire format. The pinned
+// cardano-ledger Byron implementation only decodes type 2 for current blocks;
+// types 0 and 1 are retained here for the older OBFT compatibility validator.
 // - Type 0: BlockPSignatureSimple - simple signature [0, signature]
-// - Type 1: BlockPSignatureHeavy - heavy delegation [1, [[epoch, issuerVK, delegateVK, cert], signature]]
-// - Type 2: BlockPSignatureLight - lightweight delegation [2, [[omega, issuerVK, delegateVK, cert], signature]]
+// - Type 1: BlockPSignatureLight - lightweight delegation
+// - Type 2: BlockPSignatureHeavy - heavyweight delegation
 const (
 	byronSigTypeSimple = 0
-	byronSigTypeHeavy  = 1
-	byronSigTypeLight  = 2
+	byronSigTypeLight  = 1
+	byronSigTypeHeavy  = 2
 )
 
 // validateBlockSignature verifies the block signature based on its type.

--- a/consensus/byron/validate.go
+++ b/consensus/byron/validate.go
@@ -399,9 +399,8 @@ func (v *HeaderValidator) validateBlockSignatureWithProxy(
 // 1. Validating the delegation certificate structure (issuer -> delegate)
 // 2. Verifying the block signature (delegate signed the ToSign data)
 //
-// Note: Full certificate signature verification requires the exact Cardano cryptographic
-// signing format which is complex and involves extended Ed25519 keys. For now, we validate
-// the structure and verify the delegate signed the block correctly.
+// Both the delegation certificate and the delegated block signature are
+// verified using Byron's domain-separated signing format.
 func (v *HeaderValidator) validateProxySignature(
 	input *ValidateHeaderInput,
 	sigType uint64,
@@ -543,10 +542,19 @@ func (v *HeaderValidator) validateProxySignature(
 		return fmt.Errorf("failed to build ToSign data: %w", err)
 	}
 
-	// Get the signing tag
-	// Both light and heavy delegation use MainBlockHeavy tag for block signing
-	// (the light/heavy distinction is about the delegation certificate, not the block signature)
-	signingTag := byte(byronSignTagMainBlockHeavy) // 0x09
+	// Select the proxy-signature tag encoded by the wire-level signature type.
+	var signingTag byte
+	switch sigType {
+	case byronSigTypeLight:
+		signingTag = byronSignTagMainBlockLight
+	case byronSigTypeHeavy:
+		signingTag = byronSignTagMainBlockHeavy
+	default:
+		return fmt.Errorf(
+			"unsupported Byron proxy signature type: %d",
+			sigType,
+		)
+	}
 
 	// Encode protocol magic
 	pmBytes, err := cbor.Encode(v.config.ProtocolMagic)

--- a/consensus/byron/validate_test.go
+++ b/consensus/byron/validate_test.go
@@ -1735,7 +1735,8 @@ const testByronGenesisJSON = `{
     "heavyDelegation": {
         "1deb82908402c7ee3efeb16f369d97fba316ee621d09b32b8969e54b":{"cert":"c8b39f094dc00608acb2d20ff274cb3e0c022ccb0ce558ea7c1a2d3a32cd54b42cc30d32406bcfbb7f2f86d05d2032848be15b178e3ad776f8b1bc56a671400d","delegatePk":"6MA6A8Cy3b6kGVyvOfQeZp99JR7PIh+7LydcCl1+BdGQ3MJG9WyOM6wANwZuL2ZN2qmF6lKECCZDMI3eT1v+3w==","issuerPk":"UHMxYf2vtsjLb64OJb35VVEFs2eO+wjxd1uekN5PXHe8yM7/+NkBHLJ4so/dyG2bqwmWVtd6eFbHYZEIy/ZXUg==","omega":0},
         "65904a89e6d0e5f881513d1736945e051b76f095eca138ee869d543d":{"cert":"552741f728196e62f218047b944b24ce4d374300d04b9b281426f55aa000d53ded66989ad5ea0908e6ff6492001ff18ece6c7040a934060759e9ae09863bf203","delegatePk":"X93u2t4nFNbbL54RBHQ9LY2Bjs3cMG4XYQjbFMqt1EG0V9WEDGD4hAuZyPeMKQriKdT4Qx5ni6elRcNWB7lN2w==","issuerPk":"C9sfXvPZlAN1k/ImYlXxNKVkZYuy34FLO5zvuW2jT6nIiFkchbdw/TZybV89mRxmiCiv/Hu+CHL9aZE25mTZ2A==","omega":0},
-        "5411c7bf87c252609831a337a713e4859668cba7bba70a9c3ef7c398":{"cert":"c946fd596bdb31949aa435390de19a549c9698cad1813e34ff2431bc06190188188f4e84001380713e3f916c7526096e7c4855904bff40385007b81e1e657d0e","delegatePk":"i1Mgdin5ow5LIBUETzN8AXNavmckPBlHDJ2ujHtzJ5gJiHufQg1vcO4enVDBYFKHjlRLZctdRL1pF1ayhM2Cmw==","issuerPk":"mm+jQ8jGw23ho1Vv60Eb/fhwjVr4jehibQ/Gv6Tuu22Zq4PZDWZTGtkSLT+ctLydBbJkSGclMqaNp5b5MoQx/Q==","omega":0}
+        "5411c7bf87c252609831a337a713e4859668cba7bba70a9c3ef7c398":{"cert":"c946fd596bdb31949aa435390de19a549c9698cad1813e34ff2431bc06190188188f4e84001380713e3f916c7526096e7c4855904bff40385007b81e1e657d0e","delegatePk":"i1Mgdin5ow5LIBUETzN8AXNavmckPBlHDJ2ujHtzJ5gJiHufQg1vcO4enVDBYFKHjlRLZctdRL1pF1ayhM2Cmw==","issuerPk":"mm+jQ8jGw23ho1Vv60Eb/fhwjVr4jehibQ/Gv6Tuu22Zq4PZDWZTGtkSLT+ctLydBbJkSGclMqaNp5b5MoQx/Q==","omega":0},
+        "af2800c124e599d6dec188a75f8bfde397ebb778163a18240371f2d1":{"cert":"e03e62f083df5576360e60a32e22bbb07b3c8df4fcab8079f1d6f61af3954d242ba8a06516c395939f24096f3df14e103a7d9c2b80a68a9363cf1f27c7a4e307","delegatePk":"YSYalbdhPua/IGfa13twNJcpsMUNV7wc8w3g20oec6iF0AVK98I/xsN5GdukHGAqV+LQ+TKaeVS4ZzONb7LJRQ==","issuerPk":"G8l6L+AsKXiAzo7P2Zf+TB7AnuEP7u6faGdgFmsFKB1ig0aP/ZO+ywyVbM3dZC35sSRMkVkRGF+kk1X28iv6uQ==","omega":0}
     },
     "nonAvvmBalances": {},
     "vssCerts": {}
@@ -1780,14 +1781,14 @@ func TestNewByronConfigFromGenesis(t *testing.T) {
 	}
 
 	// Verify number of genesis keys
-	if config.NumGenesisKeys != 3 {
-		t.Errorf("NumGenesisKeys: got %d, want 3", config.NumGenesisKeys)
+	if config.NumGenesisKeys != 4 {
+		t.Errorf("NumGenesisKeys: got %d, want 4", config.NumGenesisKeys)
 	}
 
 	// Verify key hashes are populated
-	if len(config.GenesisKeyHashes) != 3 {
+	if len(config.GenesisKeyHashes) != 4 {
 		t.Errorf(
-			"GenesisKeyHashes length: got %d, want 3",
+			"GenesisKeyHashes length: got %d, want 4",
 			len(config.GenesisKeyHashes),
 		)
 	}
@@ -1801,7 +1802,7 @@ func TestNewByronConfigFromGenesis(t *testing.T) {
 
 	// Verify slot leader calculation works
 	for slot := range uint64(6) {
-		expectedIndex := int(slot % 3)
+		expectedIndex := int(slot % 4)
 		index, keyHash := config.SlotLeader(slot)
 		if index != expectedIndex {
 			t.Errorf(


### PR DESCRIPTION
## Summary

- validates Byron PBFT heavyweight proxy signatures, configured genesis issuers, and the ordered active-delegate view
- adds immutable issuer-window and heavyweight-delegation state with `2k` activation, replacement, and self-delegation revocation
- exposes parse-only genesis/delegate identity resolution for trusted canonical replay

## Compatibility

- keeps Byron wire encoding unchanged and derives both identities from the existing header and proxy-certificate fields
- provides the consensus primitives consumed by blinklabs-io/dingo#3322

The full race suite, conformance harness, lint, vet, and current-head CI pass.

Supports blinklabs-io/dingo#3285.
