### PR TITLE
fix(ledger): coalesce duplicate legacy inputs

### DIFF
--- a/cbor/tags.go
+++ b/cbor/tags.go
@@ -250,8 +250,36 @@ func (t *SetType[T]) MarshalCBOR() ([]byte, error) {
 }
 
 func (t *SetType[T]) Items() []T {
-	ret := make([]T, len(t.items))
-	copy(ret, t.items)
+	if t.useTag {
+		ret := make([]T, len(t.items))
+		copy(ret, t.items)
+		return ret
+	}
+	// Pre-Conway set fields were encoded as plain arrays. cardano-ledger
+	// decodes those arrays with Set.fromList semantics, so preserve the first
+	// occurrence of each member while retaining the wire order of unique items.
+	return uniqueSetItems(t.items)
+}
+
+func uniqueSetItems[T any](items []T) []T {
+	ret := make([]T, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		encoded, err := Encode(item)
+		if err != nil {
+			// Items decoded from CBOR should always be encodable. Keep an item
+			// if a caller constructed an unsupported value, since Items cannot
+			// return an encoding error.
+			ret = append(ret, item)
+			continue
+		}
+		key := string(encoded)
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		ret = append(ret, item)
+	}
 	return ret
 }
 

--- a/cbor/tags.go
+++ b/cbor/tags.go
@@ -250,36 +250,8 @@ func (t *SetType[T]) MarshalCBOR() ([]byte, error) {
 }
 
 func (t *SetType[T]) Items() []T {
-	if t.useTag {
-		ret := make([]T, len(t.items))
-		copy(ret, t.items)
-		return ret
-	}
-	// Pre-Conway set fields were encoded as plain arrays. cardano-ledger
-	// decodes those arrays with Set.fromList semantics, so preserve the first
-	// occurrence of each member while retaining the wire order of unique items.
-	return uniqueSetItems(t.items)
-}
-
-func uniqueSetItems[T any](items []T) []T {
-	ret := make([]T, 0, len(items))
-	seen := make(map[string]struct{}, len(items))
-	for _, item := range items {
-		encoded, err := Encode(item)
-		if err != nil {
-			// Items decoded from CBOR should always be encodable. Keep an item
-			// if a caller constructed an unsupported value, since Items cannot
-			// return an encoding error.
-			ret = append(ret, item)
-			continue
-		}
-		key := string(encoded)
-		if _, exists := seen[key]; exists {
-			continue
-		}
-		seen[key] = struct{}{}
-		ret = append(ret, item)
-	}
+	ret := make([]T, len(t.items))
+	copy(ret, t.items)
 	return ret
 }
 

--- a/cbor/tags_test.go
+++ b/cbor/tags_test.go
@@ -259,6 +259,34 @@ func TestSetTypeWithoutTag(t *testing.T) {
 	}
 }
 
+func TestSetTypeWithoutTagCoalescesItems(t *testing.T) {
+	// [2, 1, 2, 3, 1], with the second 2 encoded non-canonically, matching
+	// Set.fromList while retaining the first-seen order of unique members.
+	origHex := "85020118020301"
+	orig, err := hex.DecodeString(origHex)
+	require.NoError(t, err)
+
+	var setType cbor.SetType[uint64]
+	_, err = cbor.Decode(orig, &setType)
+	require.NoError(t, err)
+	assert.Equal(t, []uint64{2, 1, 3}, setType.Items())
+
+	wire, err := cbor.Encode(&setType)
+	require.NoError(t, err)
+	assert.Equal(t, orig, wire, "decoded SetType must preserve original CBOR")
+}
+
+func TestSetTypeTaggedItemsRetainDuplicates(t *testing.T) {
+	orig, err := hex.DecodeString("d9010283010201")
+	require.NoError(t, err)
+
+	var setType cbor.SetType[uint64]
+	_, err = cbor.Decode(orig, &setType)
+	require.NoError(t, err)
+	assert.Equal(t, []uint64{1, 2, 1}, setType.Items())
+	assert.ErrorContains(t, setType.CheckForDuplicates(), "duplicate member in set")
+}
+
 func TestSetTypeMarshalCBOR(t *testing.T) {
 	// Create SetType with tag
 	setType := cbor.NewSetType([]uint64{1, 2, 3}, true)

--- a/cbor/tags_test.go
+++ b/cbor/tags_test.go
@@ -259,9 +259,9 @@ func TestSetTypeWithoutTag(t *testing.T) {
 	}
 }
 
-func TestSetTypeWithoutTagCoalescesItems(t *testing.T) {
-	// [2, 1, 2, 3, 1], with the second 2 encoded non-canonically, matching
-	// Set.fromList while retaining the first-seen order of unique members.
+func TestSetTypeWithoutTagRetainsItems(t *testing.T) {
+	// [2, 1, 2, 3, 1], with the second 2 encoded non-canonically. Generic
+	// SetType consumers decide whether their era and field coalesce duplicates.
 	origHex := "85020118020301"
 	orig, err := hex.DecodeString(origHex)
 	require.NoError(t, err)
@@ -269,11 +269,34 @@ func TestSetTypeWithoutTagCoalescesItems(t *testing.T) {
 	var setType cbor.SetType[uint64]
 	_, err = cbor.Decode(orig, &setType)
 	require.NoError(t, err)
-	assert.Equal(t, []uint64{2, 1, 3}, setType.Items())
+	assert.Equal(t, []uint64{2, 1, 2, 3, 1}, setType.Items())
 
 	wire, err := cbor.Encode(&setType)
 	require.NoError(t, err)
 	assert.Equal(t, orig, wire, "decoded SetType must preserve original CBOR")
+}
+
+type countingSetItem struct {
+	marshalCalls *int
+}
+
+func (i countingSetItem) MarshalCBOR() ([]byte, error) {
+	(*i.marshalCalls)++
+	return []byte{0}, nil
+}
+
+func TestSetTypeItemsDoesNotEncodeMembers(t *testing.T) {
+	marshalCalls := 0
+	setType := cbor.NewSetType(
+		[]countingSetItem{
+			{marshalCalls: &marshalCalls},
+			{marshalCalls: &marshalCalls},
+		},
+		false,
+	)
+
+	assert.Len(t, setType.Items(), 2)
+	assert.Zero(t, marshalCalls)
 }
 
 func TestSetTypeTaggedItemsRetainDuplicates(t *testing.T) {

--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -273,9 +273,37 @@ func (b *AlonzoTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
 		return err
 	}
+	tmp.TxCollateral = coalesceUntaggedTransactionInputs(tmp.TxCollateral)
 	*b = AlonzoTransactionBody(tmp)
 	b.SetCborReference(cborData)
 	return nil
+}
+
+func coalesceUntaggedTransactionInputs(
+	set cbor.SetType[shelley.ShelleyTransactionInput],
+) cbor.SetType[shelley.ShelleyTransactionInput] {
+	wire := set.Cbor()
+	if wire == nil {
+		return set
+	}
+	var tag cbor.RawTag
+	if _, err := cbor.Decode(wire, &tag); err == nil {
+		return set
+	}
+	items := set.Items()
+	seen := make(map[string]struct{}, len(items))
+	uniqueItems := make([]shelley.ShelleyTransactionInput, 0, len(items))
+	for _, item := range items {
+		key := item.String()
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		uniqueItems = append(uniqueItems, item)
+	}
+	ret := cbor.NewSetType(uniqueItems, false)
+	ret.SetCbor(wire)
+	return ret
 }
 
 func (b *AlonzoTransactionBody) Inputs() []common.TransactionInput {

--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -274,6 +274,12 @@ func (b *AlonzoTransactionBody) UnmarshalCBOR(cborData []byte) error {
 		return err
 	}
 	tmp.TxCollateral = coalesceUntaggedTransactionInputs(tmp.TxCollateral)
+	if err := tmp.TxCollateral.CheckForDuplicates(); err != nil {
+		return fmt.Errorf("collateral inputs: %w", err)
+	}
+	if err := tmp.TxRequiredSigners.CheckForDuplicates(); err != nil {
+		return fmt.Errorf("required signers: %w", err)
+	}
 	*b = AlonzoTransactionBody(tmp)
 	b.SetCborReference(cborData)
 	return nil

--- a/ledger/alonzo/alonzo_test.go
+++ b/ledger/alonzo/alonzo_test.go
@@ -62,6 +62,48 @@ func TestAlonzoUntaggedInputSetsCoalesceBeforeDuplicateValidation(t *testing.T) 
 	assert.NoError(t, shelley.UtxoValidateNoDuplicateInputs(tx, 0, nil, nil))
 }
 
+func TestAlonzoTransactionBodyRejectsDuplicateTaggedSets(t *testing.T) {
+	input := shelley.NewShelleyTransactionInput(
+		"0101010101010101010101010101010101010101010101010101010101010101",
+		0,
+	)
+	var signer common.Blake2b224
+	signer[0] = 3
+	tests := []struct {
+		name string
+		body map[uint]any
+	}{
+		{
+			name: "collateral",
+			body: map[uint]any{
+				13: cbor.NewSetType(
+					[]shelley.ShelleyTransactionInput{input, input},
+					true,
+				),
+			},
+		},
+		{
+			name: "required signers",
+			body: map[uint]any{
+				14: cbor.NewSetType(
+					[]common.Blake2b224{signer, signer},
+					true,
+				),
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bodyCbor, err := cbor.Encode(test.body)
+			require.NoError(t, err)
+
+			var body AlonzoTransactionBody
+			err = body.UnmarshalCBOR(bodyCbor)
+			require.ErrorContains(t, err, "duplicate member in set")
+		})
+	}
+}
+
 func TestAlonzoTransactionOutputToPlutusDataCoinOnly(t *testing.T) {
 	testAddr := "addr_test1vqg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygxrcya6"
 	var testAmount uint64 = 123_456_789

--- a/ledger/alonzo/alonzo_test.go
+++ b/ledger/alonzo/alonzo_test.go
@@ -24,8 +24,43 @@ import (
 	"github.com/blinklabs-io/gouroboros/internal/test"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/blinklabs-io/plutigo/data"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestAlonzoUntaggedInputSetsCoalesceBeforeDuplicateValidation(t *testing.T) {
+	input1 := shelley.NewShelleyTransactionInput(
+		"0101010101010101010101010101010101010101010101010101010101010101",
+		0,
+	)
+	input2 := shelley.NewShelleyTransactionInput(
+		"0202020202020202020202020202020202020202020202020202020202020202",
+		1,
+	)
+	var signer common.Blake2b224
+	signer[0] = 3
+	bodyCbor, err := cbor.Encode(map[uint]any{
+		0: []shelley.ShelleyTransactionInput{input2, input1, input2},
+		13: cbor.NewSetType(
+			[]shelley.ShelleyTransactionInput{input1, input2, input1},
+			false,
+		),
+		14: cbor.NewSetType([]common.Blake2b224{signer, signer}, false),
+	})
+	require.NoError(t, err)
+
+	var body AlonzoTransactionBody
+	require.NoError(t, body.UnmarshalCBOR(bodyCbor))
+	assert.Equal(t, bodyCbor, body.Cbor())
+	assert.Equal(t, []common.TransactionInput{input2, input1}, body.Inputs())
+	assert.Equal(t, []common.TransactionInput{input1, input2}, body.Collateral())
+	assert.Equal(t, []common.Blake2b224{signer, signer}, body.RequiredSigners())
+
+	tx := &AlonzoTransaction{Body: body}
+	assert.NoError(t, shelley.UtxoValidateNoDuplicateInputs(tx, 0, nil, nil))
+}
 
 func TestAlonzoTransactionOutputToPlutusDataCoinOnly(t *testing.T) {
 	testAddr := "addr_test1vqg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygxrcya6"

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -386,6 +386,15 @@ func (b *BabbageTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	tmp.TxReferenceInputs = coalesceUntaggedTransactionInputs(
 		tmp.TxReferenceInputs,
 	)
+	if err := tmp.TxCollateral.CheckForDuplicates(); err != nil {
+		return fmt.Errorf("collateral inputs: %w", err)
+	}
+	if err := tmp.TxRequiredSigners.CheckForDuplicates(); err != nil {
+		return fmt.Errorf("required signers: %w", err)
+	}
+	if err := tmp.TxReferenceInputs.CheckForDuplicates(); err != nil {
+		return fmt.Errorf("reference inputs: %w", err)
+	}
 	*b = BabbageTransactionBody(tmp)
 	b.SetCborReference(cborData)
 	return nil

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -382,9 +382,40 @@ func (b *BabbageTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
 		return err
 	}
+	tmp.TxCollateral = coalesceUntaggedTransactionInputs(tmp.TxCollateral)
+	tmp.TxReferenceInputs = coalesceUntaggedTransactionInputs(
+		tmp.TxReferenceInputs,
+	)
 	*b = BabbageTransactionBody(tmp)
 	b.SetCborReference(cborData)
 	return nil
+}
+
+func coalesceUntaggedTransactionInputs(
+	set cbor.SetType[shelley.ShelleyTransactionInput],
+) cbor.SetType[shelley.ShelleyTransactionInput] {
+	wire := set.Cbor()
+	if wire == nil {
+		return set
+	}
+	var tag cbor.RawTag
+	if _, err := cbor.Decode(wire, &tag); err == nil {
+		return set
+	}
+	items := set.Items()
+	seen := make(map[string]struct{}, len(items))
+	uniqueItems := make([]shelley.ShelleyTransactionInput, 0, len(items))
+	for _, item := range items {
+		key := item.String()
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		uniqueItems = append(uniqueItems, item)
+	}
+	ret := cbor.NewSetType(uniqueItems, false)
+	ret.SetCbor(wire)
+	return ret
 }
 
 func (b *BabbageTransactionBody) Id() common.Blake2b256 {

--- a/ledger/babbage/babbage_test.go
+++ b/ledger/babbage/babbage_test.go
@@ -69,6 +69,57 @@ func TestBabbageUntaggedInputSetsCoalesceBeforeDuplicateValidation(t *testing.T)
 	assert.NoError(t, shelley.UtxoValidateNoDuplicateInputs(tx, 0, nil, nil))
 }
 
+func TestBabbageTransactionBodyRejectsDuplicateTaggedSets(t *testing.T) {
+	input := shelley.NewShelleyTransactionInput(
+		"0101010101010101010101010101010101010101010101010101010101010101",
+		0,
+	)
+	var signer common.Blake2b224
+	signer[0] = 3
+	tests := []struct {
+		name string
+		body map[uint]any
+	}{
+		{
+			name: "collateral",
+			body: map[uint]any{
+				13: cbor.NewSetType(
+					[]shelley.ShelleyTransactionInput{input, input},
+					true,
+				),
+			},
+		},
+		{
+			name: "required signers",
+			body: map[uint]any{
+				14: cbor.NewSetType(
+					[]common.Blake2b224{signer, signer},
+					true,
+				),
+			},
+		},
+		{
+			name: "reference inputs",
+			body: map[uint]any{
+				18: cbor.NewSetType(
+					[]shelley.ShelleyTransactionInput{input, input},
+					true,
+				),
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bodyCbor, err := cbor.Encode(test.body)
+			require.NoError(t, err)
+
+			var body BabbageTransactionBody
+			err = body.UnmarshalCBOR(bodyCbor)
+			require.ErrorContains(t, err, "duplicate member in set")
+		})
+	}
+}
+
 func TestBabbageBlockTransactions(t *testing.T) {
 	b := &BabbageBlock{}
 

--- a/ledger/babbage/babbage_test.go
+++ b/ledger/babbage/babbage_test.go
@@ -38,9 +38,18 @@ func TestBabbageUntaggedInputSetsCoalesceBeforeDuplicateValidation(t *testing.T)
 		"0202020202020202020202020202020202020202020202020202020202020202",
 		1,
 	)
+	var signer common.Blake2b224
+	signer[0] = 3
+	collateralSet := cbor.NewSetType(
+		[]shelley.ShelleyTransactionInput{input1, input2, input1},
+		false,
+	)
+	collateralWire, err := cbor.Encode(&collateralSet)
+	require.NoError(t, err)
 	bodyCbor, err := cbor.Encode(map[uint]any{
 		0:  []shelley.ShelleyTransactionInput{input2, input1, input2},
-		13: cbor.NewSetType([]shelley.ShelleyTransactionInput{input1, input2, input1}, false),
+		13: collateralSet,
+		14: cbor.NewSetType([]common.Blake2b224{signer, signer}, false),
 		18: cbor.NewSetType([]shelley.ShelleyTransactionInput{input2, input1, input2}, false),
 	})
 	require.NoError(t, err)
@@ -51,6 +60,10 @@ func TestBabbageUntaggedInputSetsCoalesceBeforeDuplicateValidation(t *testing.T)
 	assert.Equal(t, []common.TransactionInput{input2, input1}, body.Inputs())
 	assert.Equal(t, []common.TransactionInput{input1, input2}, body.Collateral())
 	assert.Equal(t, []common.TransactionInput{&input2, &input1}, body.ReferenceInputs())
+	assert.Equal(t, []common.Blake2b224{signer, signer}, body.RequiredSigners())
+	decodedCollateralWire, err := cbor.Encode(&body.TxCollateral)
+	require.NoError(t, err)
+	assert.Equal(t, collateralWire, decodedCollateralWire)
 
 	tx := &BabbageTransaction{Body: body}
 	assert.NoError(t, shelley.UtxoValidateNoDuplicateInputs(tx, 0, nil, nil))

--- a/ledger/babbage/babbage_test.go
+++ b/ledger/babbage/babbage_test.go
@@ -23,9 +23,38 @@ import (
 	"github.com/blinklabs-io/gouroboros/internal/test"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/blinklabs-io/plutigo/data"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestBabbageUntaggedInputSetsCoalesceBeforeDuplicateValidation(t *testing.T) {
+	input1 := shelley.NewShelleyTransactionInput(
+		"0101010101010101010101010101010101010101010101010101010101010101",
+		0,
+	)
+	input2 := shelley.NewShelleyTransactionInput(
+		"0202020202020202020202020202020202020202020202020202020202020202",
+		1,
+	)
+	bodyCbor, err := cbor.Encode(map[uint]any{
+		0:  []shelley.ShelleyTransactionInput{input2, input1, input2},
+		13: cbor.NewSetType([]shelley.ShelleyTransactionInput{input1, input2, input1}, false),
+		18: cbor.NewSetType([]shelley.ShelleyTransactionInput{input2, input1, input2}, false),
+	})
+	require.NoError(t, err)
+
+	var body BabbageTransactionBody
+	require.NoError(t, body.UnmarshalCBOR(bodyCbor))
+	assert.Equal(t, bodyCbor, body.Cbor())
+	assert.Equal(t, []common.TransactionInput{input2, input1}, body.Inputs())
+	assert.Equal(t, []common.TransactionInput{input1, input2}, body.Collateral())
+	assert.Equal(t, []common.TransactionInput{&input2, &input1}, body.ReferenceInputs())
+
+	tx := &BabbageTransaction{Body: body}
+	assert.NoError(t, shelley.UtxoValidateNoDuplicateInputs(tx, 0, nil, nil))
+}
 
 func TestBabbageBlockTransactions(t *testing.T) {
 	b := &BabbageBlock{}

--- a/ledger/conway/conway_test.go
+++ b/ledger/conway/conway_test.go
@@ -223,6 +223,39 @@ func TestConwayTransactionBodyRejectsDuplicateTaggedInputs(t *testing.T) {
 	assert.ErrorContains(t, err, "duplicate member in set")
 }
 
+func TestConwayUntaggedInputSetsRetainDuplicatesForValidation(t *testing.T) {
+	input := testConwayShelleyInput()
+	tests := []struct {
+		name  string
+		field uint
+	}{
+		{name: "regular", field: 0},
+		{name: "collateral", field: 13},
+		{name: "reference", field: 18},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bodyCbor, err := cbor.Encode(map[uint]any{
+				tt.field: cbor.NewSetType(
+					[]shelley.ShelleyTransactionInput{input, input},
+					false,
+				),
+			})
+			require.NoError(t, err)
+
+			var body ConwayTransactionBody
+			require.NoError(t, body.UnmarshalCBOR(bodyCbor))
+			tx := &ConwayTransaction{Body: body}
+			require.Error(t, shelley.UtxoValidateNoDuplicateInputs(
+				tx,
+				0,
+				nil,
+				nil,
+			))
+		})
+	}
+}
+
 func TestConwayTransactionBodyRejectsDuplicateMultiAssetKeys(t *testing.T) {
 	tests := []struct {
 		name string

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -601,6 +601,63 @@ func TestDijkstraTransactionBodyRejectsDuplicateTaggedInputs(t *testing.T) {
 	require.ErrorContains(t, err, "duplicate member in set")
 }
 
+func TestDijkstraTransactionBodyRejectsDuplicateTaggedInputSets(t *testing.T) {
+	input := testShelleyInput()
+	for _, tt := range []struct {
+		name  string
+		field uint
+	}{
+		{name: "collateral", field: 13},
+		{name: "reference", field: 18},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			bodyCbor, err := cbor.Encode(map[uint]any{
+				tt.field: cbor.NewSetType(
+					[]shelley.ShelleyTransactionInput{input, input},
+					true,
+				),
+			})
+			require.NoError(t, err)
+
+			var body DijkstraTransactionBody
+			err = body.UnmarshalCBOR(bodyCbor)
+			require.ErrorContains(t, err, "duplicate member in set")
+		})
+	}
+}
+
+func TestDijkstraUntaggedInputSetsRetainDuplicatesForValidation(t *testing.T) {
+	input := testShelleyInput()
+	for _, tt := range []struct {
+		name  string
+		field uint
+	}{
+		{name: "regular", field: 0},
+		{name: "collateral", field: 13},
+		{name: "reference", field: 18},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			bodyCbor, err := cbor.Encode(map[uint]any{
+				tt.field: cbor.NewSetType(
+					[]shelley.ShelleyTransactionInput{input, input},
+					false,
+				),
+			})
+			require.NoError(t, err)
+
+			var body DijkstraTransactionBody
+			require.NoError(t, body.UnmarshalCBOR(bodyCbor))
+			tx := &DijkstraTransaction{Body: body}
+			require.Error(t, shelley.UtxoValidateNoDuplicateInputs(
+				tx,
+				0,
+				nil,
+				nil,
+			))
+		})
+	}
+}
+
 func TestDijkstraTransactionBodyRejectsDuplicateSubTransactionInputs(t *testing.T) {
 	input := testShelleyInput()
 	subTx := []any{

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -382,7 +382,8 @@ func (b *ShelleyTransactionBody) Utxorpc() (*utxorpc.Tx, error) {
 }
 
 type ShelleyTransactionInputSet struct {
-	items []ShelleyTransactionInput
+	items    []ShelleyTransactionInput
+	cborData []byte
 }
 
 func NewShelleyTransactionInputSet(
@@ -405,18 +406,30 @@ func (s *ShelleyTransactionInputSet) UnmarshalCBOR(data []byte) error {
 	if _, err := cbor.Decode(data, &tmpData); err != nil {
 		return err
 	}
-	s.items = tmpData
+	s.items = uniqueShelleyTransactionInputs(tmpData)
+	s.cborData = append(s.cborData[:0], data...)
 	return nil
 }
 
 func (s *ShelleyTransactionInputSet) MarshalCBOR() ([]byte, error) {
+	if s.cborData != nil {
+		return s.cborData, nil
+	}
 	return cbor.Encode(s.items)
 }
 
 func (s *ShelleyTransactionInputSet) Items() []ShelleyTransactionInput {
-	ret := make([]ShelleyTransactionInput, 0, len(s.items))
-	seen := make(map[string]struct{}, len(s.items))
-	for _, item := range s.items {
+	ret := make([]ShelleyTransactionInput, len(s.items))
+	copy(ret, s.items)
+	return ret
+}
+
+func uniqueShelleyTransactionInputs(
+	items []ShelleyTransactionInput,
+) []ShelleyTransactionInput {
+	ret := make([]ShelleyTransactionInput, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
 		key := item.String()
 		if _, exists := seen[key]; exists {
 			continue
@@ -430,6 +443,7 @@ func (s *ShelleyTransactionInputSet) Items() []ShelleyTransactionInput {
 func (s *ShelleyTransactionInputSet) SetItems(items []ShelleyTransactionInput) {
 	s.items = make([]ShelleyTransactionInput, len(items))
 	copy(s.items, items)
+	s.cborData = nil
 }
 
 type ShelleyTransactionInput struct {

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -414,7 +414,17 @@ func (s *ShelleyTransactionInputSet) MarshalCBOR() ([]byte, error) {
 }
 
 func (s *ShelleyTransactionInputSet) Items() []ShelleyTransactionInput {
-	return s.items
+	ret := make([]ShelleyTransactionInput, 0, len(s.items))
+	seen := make(map[string]struct{}, len(s.items))
+	for _, item := range s.items {
+		key := item.String()
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		ret = append(ret, item)
+	}
+	return ret
 }
 
 func (s *ShelleyTransactionInputSet) SetItems(items []ShelleyTransactionInput) {

--- a/ledger/shelley/shelley_test.go
+++ b/ledger/shelley/shelley_test.go
@@ -4,9 +4,34 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestShelleyTransactionInputSetCoalescesUntaggedDuplicates(t *testing.T) {
+	input1 := shelley.NewShelleyTransactionInput(
+		"0101010101010101010101010101010101010101010101010101010101010101",
+		0,
+	)
+	input2 := shelley.NewShelleyTransactionInput(
+		"0202020202020202020202020202020202020202020202020202020202020202",
+		1,
+	)
+	wire, err := cbor.Encode([]shelley.ShelleyTransactionInput{
+		input2,
+		input1,
+		input2,
+	})
+	require.NoError(t, err)
+
+	var set shelley.ShelleyTransactionInputSet
+	_, err = cbor.Decode(wire, &set)
+	require.NoError(t, err)
+	assert.Equal(t, []shelley.ShelleyTransactionInput{input2, input1}, set.Items())
+}
 
 func TestShelleyTransactionOutputString(t *testing.T) {
 	addrStr := "addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd"

--- a/ledger/shelley/shelley_test.go
+++ b/ledger/shelley/shelley_test.go
@@ -12,25 +12,40 @@ import (
 )
 
 func TestShelleyTransactionInputSetCoalescesUntaggedDuplicates(t *testing.T) {
-	input1 := shelley.NewShelleyTransactionInput(
+	txId := make([]byte, common.Blake2b256Size)
+	txId[0] = 1
+	// The first index is the non-minimal encoding 0x1800. The second copy is
+	// canonical, so normalization must not be used for wire round-tripping.
+	wire := []byte{0x82, 0x82, 0x58, 0x20}
+	wire = append(wire, txId...)
+	wire = append(wire, 0x18, 0x00, 0x82, 0x58, 0x20)
+	wire = append(wire, txId...)
+	wire = append(wire, 0x00)
+
+	var set shelley.ShelleyTransactionInputSet
+	_, err := cbor.Decode(wire, &set)
+	require.NoError(t, err)
+	expected := shelley.ShelleyTransactionInput{
+		TxId:        common.Blake2b256(txId),
+		OutputIndex: 0,
+	}
+	assert.Equal(t, []shelley.ShelleyTransactionInput{expected}, set.Items())
+
+	encoded, err := cbor.Encode(&set)
+	require.NoError(t, err)
+	assert.Equal(t, wire, encoded)
+}
+
+func TestShelleyTransactionInputSetOnlyCoalescesOnDecode(t *testing.T) {
+	input := shelley.NewShelleyTransactionInput(
 		"0101010101010101010101010101010101010101010101010101010101010101",
 		0,
 	)
-	input2 := shelley.NewShelleyTransactionInput(
-		"0202020202020202020202020202020202020202020202020202020202020202",
-		1,
+	set := shelley.NewShelleyTransactionInputSet(
+		[]shelley.ShelleyTransactionInput{input, input},
 	)
-	wire, err := cbor.Encode([]shelley.ShelleyTransactionInput{
-		input2,
-		input1,
-		input2,
-	})
-	require.NoError(t, err)
 
-	var set shelley.ShelleyTransactionInputSet
-	_, err = cbor.Decode(wire, &set)
-	require.NoError(t, err)
-	assert.Equal(t, []shelley.ShelleyTransactionInput{input2, input1}, set.Items())
+	assert.Equal(t, []shelley.ShelleyTransactionInput{input, input}, set.Items())
 }
 
 func TestShelleyTransactionOutputString(t *testing.T) {


### PR DESCRIPTION
## Summary

- applies `Set.fromList` semantics only while decoding untagged Shelley-through-Babbage transaction input sets
- rejects duplicate members in tag-258 sets for Conway/Dijkstra and the Alonzo/Babbage collateral, required-signer, and reference-input fields
- preserves exact decoded CBOR and legacy untagged-set compatibility without changing public APIs

## Validation

- fail-before coverage for all five newly guarded Alonzo/Babbage fields
- focused race tests, 10 repetitions
- full race-enabled test suite
- conformance tests
- full lint, vet, and build

Fixes #1989
