### PR TITLE
fix(cbor): handle non-shortest list headers

### DIFF
--- a/cbor/decode.go
+++ b/cbor/decode.go
@@ -177,9 +177,9 @@ func DecodeIdFromList(cborData []byte) (int, error) {
 	if len(cborData) < 2 {
 		return 0, errors.New("CBOR data too short for list with ID")
 	}
-	// If the list length is <= the max simple uint and the first list value
-	// is <= the max simple uint, then we can extract the value straight from
-	// the byte slice
+	// If both the list header and first value use their canonical one-byte
+	// forms, then we can extract the value straight from the byte slice.
+	// A non-shortest list header puts its length at byte one instead.
 	listLen, err := ListLength(cborData)
 	if err != nil {
 		return 0, err
@@ -187,10 +187,10 @@ func DecodeIdFromList(cborData []byte) (int, error) {
 	if listLen == 0 {
 		return 0, errors.New("cannot return first item from empty list")
 	}
-	if listLen < int(CborMaxUintSimple) {
-		if cborData[1] <= CborMaxUintSimple {
-			return int(cborData[1]), nil
-		}
+	if cborData[0] >= CborTypeArray &&
+		cborData[0] <= (CborTypeArray+CborMaxUintSimple) &&
+		cborData[1] <= CborMaxUintSimple {
+		return int(cborData[1]), nil
 	}
 	// If we couldn't use the shortcut above, actually decode the list
 	var tmp Value

--- a/cbor/dispatch_test.go
+++ b/cbor/dispatch_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cbor_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	test "github.com/blinklabs-io/gouroboros/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeByIdAcceptsListLengthEncodings(t *testing.T) {
+	canonical := test.DecodeHexString("8403010203")
+	for _, encoding := range test.CanonicalAndNonShortestList(canonical) {
+		t.Run(encoding.Name, func(t *testing.T) {
+			objects := map[int]any{
+				1: &decodeByIdObjectA{},
+				2: &decodeByIdObjectB{},
+				3: &decodeByIdObjectC{},
+			}
+			decoded, err := cbor.DecodeById(encoding.Data, objects)
+			require.NoError(t, err)
+			require.Equal(
+				t,
+				&decodeByIdObjectC{Type: 3, Foo: 1, Bar: 2, Baz: 3},
+				decoded,
+			)
+		})
+	}
+}

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -21,6 +21,43 @@ func DecodeHexString(hexData string) []byte {
 	return decoded
 }
 
+// ListEncoding pairs a CBOR list encoding with a descriptive test name.
+type ListEncoding struct {
+	Name string
+	Data []byte
+}
+
+// CanonicalAndNonShortestList returns the provided canonical short-form CBOR
+// list and equivalent encodings using every wider definite-length form.
+// Cardano decoders accept all of these forms, so tagged-union dispatch must not
+// assume that the first item always starts at byte one.
+func CanonicalAndNonShortestList(canonical []byte) []ListEncoding {
+	if len(canonical) == 0 || canonical[0] < 0x80 || canonical[0] > 0x97 {
+		panic("expected a canonical short-form CBOR list")
+	}
+	canonicalCopy := bytes.Clone(canonical)
+	listLen := canonical[0] - 0x80
+	withHeader := func(name string, header []byte) ListEncoding {
+		data := make([]byte, len(header)+len(canonical)-1)
+		copy(data, header)
+		copy(data[len(header):], canonical[1:])
+		return ListEncoding{Name: name, Data: data}
+	}
+	return []ListEncoding{
+		{Name: "canonical", Data: canonicalCopy},
+		withHeader("non-shortest-uint8-list-length", []byte{0x98, listLen}),
+		withHeader("non-shortest-uint16-list-length", []byte{0x99, 0, listLen}),
+		withHeader(
+			"non-shortest-uint32-list-length",
+			[]byte{0x9a, 0, 0, 0, listLen},
+		),
+		withHeader(
+			"non-shortest-uint64-list-length",
+			[]byte{0x9b, 0, 0, 0, 0, 0, 0, 0, listLen},
+		),
+	}
+}
+
 // JsonStringsEqual is a helper function for tests that compares JSON strings. To account for
 // differences in whitespace, map key ordering, etc., we unmarshal the JSON strings into
 // objects and then compare the objects

--- a/ledger/babbage/dispatch_test.go
+++ b/ledger/babbage/dispatch_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package babbage
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	test "github.com/blinklabs-io/gouroboros/internal/test"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDatumOptionAcceptsListLengthEncodings(t *testing.T) {
+	hash := common.Blake2b256{1, 2, 3}
+	canonical, err := cbor.Encode([]any{DatumOptionTypeHash, hash})
+	require.NoError(t, err)
+	for _, encoding := range test.CanonicalAndNonShortestList(canonical) {
+		t.Run(encoding.Name, func(t *testing.T) {
+			var decoded BabbageTransactionOutputDatumOption
+			require.NoError(t, decoded.UnmarshalCBOR(encoding.Data))
+			require.NotNil(t, decoded.hash)
+			require.Equal(t, hash, *decoded.hash)
+		})
+	}
+}

--- a/ledger/byron/dispatch_test.go
+++ b/ledger/byron/dispatch_test.go
@@ -21,6 +21,7 @@ import (
 	test "github.com/blinklabs-io/gouroboros/internal/test"
 	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,8 +35,8 @@ func TestByronTransactionInputAcceptsListLengthEncodings(t *testing.T) {
 		t.Run(encoding.Name, func(t *testing.T) {
 			var decoded byron.ByronTransactionInput
 			require.NoError(t, decoded.UnmarshalCBOR(encoding.Data))
-			require.Equal(t, hash, decoded.TxId)
-			require.Equal(t, uint32(7), decoded.OutputIndex)
+			assert.Equal(t, hash, decoded.TxId)
+			assert.Equal(t, uint32(7), decoded.OutputIndex)
 		})
 	}
 }

--- a/ledger/byron/dispatch_test.go
+++ b/ledger/byron/dispatch_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package byron_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	test "github.com/blinklabs-io/gouroboros/internal/test"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestByronTransactionInputAcceptsListLengthEncodings(t *testing.T) {
+	hash := common.Blake2b256{1, 2, 3}
+	inner, err := cbor.Encode([]any{hash, uint32(7)})
+	require.NoError(t, err)
+	canonical, err := cbor.Encode([]any{0, inner})
+	require.NoError(t, err)
+	for _, encoding := range test.CanonicalAndNonShortestList(canonical) {
+		t.Run(encoding.Name, func(t *testing.T) {
+			var decoded byron.ByronTransactionInput
+			require.NoError(t, decoded.UnmarshalCBOR(encoding.Data))
+			require.Equal(t, hash, decoded.TxId)
+			require.Equal(t, uint32(7), decoded.OutputIndex)
+		})
+	}
+}

--- a/ledger/common/dispatch_test.go
+++ b/ledger/common/dispatch_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	test "github.com/blinklabs-io/gouroboros/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommonDispatchersAcceptListLengthEncodings(t *testing.T) {
+	credential := Credential{
+		CredType:   CredentialTypeAddrKeyHash,
+		Credential: Blake2b224{1, 2, 3},
+	}
+
+	t.Run("CertificateWrapper", func(t *testing.T) {
+		canonical, err := cbor.Encode(&StakeRegistrationCertificate{
+			CertType:        uint(CertificateTypeStakeRegistration),
+			StakeCredential: credential,
+		})
+		require.NoError(t, err)
+		for _, encoding := range test.CanonicalAndNonShortestList(canonical) {
+			t.Run(encoding.Name, func(t *testing.T) {
+				var decoded CertificateWrapper
+				require.NoError(t, decoded.UnmarshalCBOR(encoding.Data))
+				require.IsType(t, &StakeRegistrationCertificate{}, decoded.Certificate)
+			})
+		}
+	})
+
+	t.Run("Drep", func(t *testing.T) {
+		canonical, err := cbor.Encode(Drep{Type: DrepTypeAbstain})
+		require.NoError(t, err)
+		for _, encoding := range test.CanonicalAndNonShortestList(canonical) {
+			t.Run(encoding.Name, func(t *testing.T) {
+				var decoded Drep
+				require.NoError(t, decoded.UnmarshalCBOR(encoding.Data))
+				require.Equal(t, DrepTypeAbstain, decoded.Type)
+			})
+		}
+	})
+
+	t.Run("PoolRelay", func(t *testing.T) {
+		canonical, err := cbor.Encode([]any{1, uint32(3001), "relay.example"})
+		require.NoError(t, err)
+		for _, encoding := range test.CanonicalAndNonShortestList(canonical) {
+			t.Run(encoding.Name, func(t *testing.T) {
+				var decoded PoolRelay
+				require.NoError(t, decoded.UnmarshalCBOR(encoding.Data))
+				require.Equal(t, PoolRelayTypeSingleHostName, decoded.Type)
+				require.NotNil(t, decoded.Hostname)
+				require.Equal(t, "relay.example", *decoded.Hostname)
+			})
+		}
+	})
+
+	t.Run("Nonce", func(t *testing.T) {
+		canonical, err := cbor.Encode([]any{NonceTypeNeutral})
+		require.NoError(t, err)
+		for _, encoding := range test.CanonicalAndNonShortestList(canonical) {
+			t.Run(encoding.Name, func(t *testing.T) {
+				var decoded Nonce
+				require.NoError(t, decoded.UnmarshalCBOR(encoding.Data))
+				require.Equal(t, uint(NonceTypeNeutral), decoded.Type)
+			})
+		}
+	})
+
+	t.Run("NativeScript", func(t *testing.T) {
+		canonical, err := cbor.Encode(NativeScriptInvalidBefore{Type: 4, Slot: 5})
+		require.NoError(t, err)
+		for _, encoding := range test.CanonicalAndNonShortestList(canonical) {
+			t.Run(encoding.Name, func(t *testing.T) {
+				var decoded NativeScript
+				require.NoError(t, decoded.UnmarshalCBOR(encoding.Data))
+				require.IsType(t, &NativeScriptInvalidBefore{}, decoded.Item())
+			})
+		}
+	})
+}

--- a/ledger/common/dispatch_test.go
+++ b/ledger/common/dispatch_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	test "github.com/blinklabs-io/gouroboros/internal/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -62,9 +63,9 @@ func TestCommonDispatchersAcceptListLengthEncodings(t *testing.T) {
 			t.Run(encoding.Name, func(t *testing.T) {
 				var decoded PoolRelay
 				require.NoError(t, decoded.UnmarshalCBOR(encoding.Data))
-				require.Equal(t, PoolRelayTypeSingleHostName, decoded.Type)
+				assert.Equal(t, PoolRelayTypeSingleHostName, decoded.Type)
 				require.NotNil(t, decoded.Hostname)
-				require.Equal(t, "relay.example", *decoded.Hostname)
+				assert.Equal(t, "relay.example", *decoded.Hostname)
 			})
 		}
 	})

--- a/ledger/conway/dispatch_test.go
+++ b/ledger/conway/dispatch_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conway
+
+import (
+	"testing"
+
+	test "github.com/blinklabs-io/gouroboros/internal/test"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConwayGovActionAcceptsListLengthEncodings(t *testing.T) {
+	action := &common.InfoGovAction{Type: uint(common.GovActionTypeInfo)}
+	canonical, err := (&ConwayGovAction{Action: action}).MarshalCBOR()
+	require.NoError(t, err)
+	for _, encoding := range test.CanonicalAndNonShortestList(canonical) {
+		t.Run(encoding.Name, func(t *testing.T) {
+			var decoded ConwayGovAction
+			require.NoError(t, decoded.UnmarshalCBOR(encoding.Data))
+			require.IsType(t, &common.InfoGovAction{}, decoded.Action)
+		})
+	}
+}

--- a/ledger/dijkstra/dispatch_test.go
+++ b/ledger/dijkstra/dispatch_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dijkstra
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	test "github.com/blinklabs-io/gouroboros/internal/test"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDijkstraGovActionAcceptsListLengthEncodings(t *testing.T) {
+	canonical, err := cbor.Encode(&DijkstraGovAction{
+		Action: &common.InfoGovAction{Type: uint(common.GovActionTypeInfo)},
+	})
+	require.NoError(t, err)
+	for _, encoding := range test.CanonicalAndNonShortestList(canonical) {
+		t.Run(encoding.Name, func(t *testing.T) {
+			var decoded DijkstraGovAction
+			require.NoError(t, decoded.UnmarshalCBOR(encoding.Data))
+			require.IsType(t, &common.InfoGovAction{}, decoded.Action)
+		})
+	}
+}

--- a/ledger/dispatch_test.go
+++ b/ledger/dispatch_test.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	test "github.com/blinklabs-io/gouroboros/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorDispatchersAcceptListLengthEncodings(t *testing.T) {
+	t.Run("ApplyTxError", func(t *testing.T) {
+		failure, err := cbor.Encode([]any{42})
+		require.NoError(t, err)
+		for _, encoding := range test.CanonicalAndNonShortestList(failure) {
+			t.Run(encoding.Name, func(t *testing.T) {
+				data, err := cbor.Encode([]cbor.RawMessage{encoding.Data})
+				require.NoError(t, err)
+				decoded := ApplyTxError{era: EraIdConway}
+				require.NoError(t, decoded.UnmarshalCBOR(data))
+				require.Len(t, decoded.Failures, 1)
+				unknown, ok := decoded.Failures[0].(*UnknownApplyTxFailureError)
+				require.True(t, ok)
+				require.Equal(t, 42, unknown.FailureType)
+			})
+		}
+	})
+
+	t.Run("UtxowFailure", func(t *testing.T) {
+		canonical, err := cbor.Encode([]any{ConwayUtxowInvalidMetadata})
+		require.NoError(t, err)
+		for _, encoding := range test.CanonicalAndNonShortestList(canonical) {
+			t.Run(encoding.Name, func(t *testing.T) {
+				decoded := UtxowFailure{era: EraIdConway}
+				require.NoError(t, decoded.UnmarshalCBOR(encoding.Data))
+				require.IsType(t, &InvalidMetadata{}, decoded.Err)
+			})
+		}
+	})
+
+	t.Run("UtxoFailure", func(t *testing.T) {
+		inner, err := cbor.Encode([]any{42})
+		require.NoError(t, err)
+		for _, encoding := range test.CanonicalAndNonShortestList(inner) {
+			t.Run(encoding.Name, func(t *testing.T) {
+				data, err := cbor.Encode([]any{
+					uint8(EraIdConway),
+					cbor.RawMessage(encoding.Data),
+				})
+				require.NoError(t, err)
+				var decoded UtxoFailure
+				require.NoError(t, decoded.UnmarshalCBOR(data))
+				unknown, ok := decoded.Err.(*UnknownUtxoFailureError)
+				require.True(t, ok)
+				require.Equal(t, 42, unknown.FailureType)
+			})
+		}
+	})
+
+	directCases := []struct {
+		name      string
+		canonical []byte
+		decode    func(*testing.T, []byte) error
+	}{
+		{
+			name:      "ShelleyUtxowFailure",
+			canonical: mustEncodeDispatchFixture(t, []any{ShelleyUtxowInvalidMetadata}),
+			decode: func(t *testing.T, data []byte) error {
+				var decoded ShelleyUtxowFailure
+				err := decoded.UnmarshalCBOR(data)
+				if err == nil {
+					require.IsType(t, &InvalidMetadata{}, decoded.Err)
+				}
+				return err
+			},
+		},
+		{
+			name:      "AlonzoUtxowFailure",
+			canonical: mustEncodeDispatchFixture(t, []any{42, nil}),
+			decode: func(t *testing.T, data []byte) error {
+				var decoded AlonzoUtxowFailure
+				err := decoded.UnmarshalCBOR(data)
+				if err == nil {
+					unknown, ok := decoded.Err.(*UnknownUtxowFailureError)
+					require.True(t, ok)
+					require.Equal(t, 42, unknown.FailureType)
+				}
+				return err
+			},
+		},
+		{
+			name:      "BabbageUtxoFailure",
+			canonical: mustEncodeDispatchFixture(t, []any{42, nil}),
+			decode: func(t *testing.T, data []byte) error {
+				var decoded BabbageUtxoFailure
+				err := decoded.UnmarshalCBOR(data)
+				if err == nil {
+					unknown, ok := decoded.Err.(*UnknownUtxoFailureError)
+					require.True(t, ok)
+					require.Equal(t, 42, unknown.FailureType)
+				}
+				return err
+			},
+		},
+		{
+			name:      "ConwayUtxowFailure",
+			canonical: mustEncodeDispatchFixture(t, []any{ConwayUtxowInvalidMetadata}),
+			decode: func(t *testing.T, data []byte) error {
+				var decoded ConwayUtxowFailure
+				err := decoded.UnmarshalCBOR(data)
+				if err == nil {
+					require.IsType(t, &InvalidMetadata{}, decoded.Err)
+				}
+				return err
+			},
+		},
+	}
+	for _, tc := range directCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, encoding := range test.CanonicalAndNonShortestList(tc.canonical) {
+				t.Run(encoding.Name, func(t *testing.T) {
+					require.NoError(t, tc.decode(t, encoding.Data))
+				})
+			}
+		})
+	}
+}
+
+func mustEncodeDispatchFixture(t *testing.T, value any) []byte {
+	t.Helper()
+	data, err := cbor.Encode(value)
+	require.NoError(t, err)
+	return data
+}

--- a/protocol/localstatequery/dispatch_test.go
+++ b/protocol/localstatequery/dispatch_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	test "github.com/blinklabs-io/gouroboros/internal/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -64,9 +65,9 @@ func TestLocalStateQueryDispatchersAcceptListLengthEncodings(t *testing.T) {
 			decode: func(t *testing.T, data []byte) {
 				var decoded RelayAccessPoint
 				require.NoError(t, decoded.UnmarshalCBOR(data))
-				require.Equal(t, RelayKindSRV, decoded.Kind)
+				assert.Equal(t, RelayKindSRV, decoded.Kind)
 				require.NotNil(t, decoded.Domain)
-				require.Equal(t, "relay.example", *decoded.Domain)
+				assert.Equal(t, "relay.example", *decoded.Domain)
 			},
 		},
 	}

--- a/protocol/localstatequery/dispatch_test.go
+++ b/protocol/localstatequery/dispatch_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localstatequery
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	test "github.com/blinklabs-io/gouroboros/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalStateQueryDispatchersAcceptListLengthEncodings(t *testing.T) {
+	tests := []struct {
+		name      string
+		canonical []byte
+		decode    func(*testing.T, []byte)
+	}{
+		{
+			name:      "QueryWrapper",
+			canonical: mustEncodeLocalStateQueryFixture(t, []any{QueryTypeChainPoint}),
+			decode: func(t *testing.T, data []byte) {
+				var decoded QueryWrapper
+				require.NoError(t, decoded.UnmarshalCBOR(data))
+				require.IsType(t, &ChainPointQuery{}, decoded.Query)
+			},
+		},
+		{
+			name:      "HotCredAuthStatusValue",
+			canonical: mustEncodeLocalStateQueryFixture(t, []any{0}),
+			decode: func(t *testing.T, data []byte) {
+				var decoded HotCredAuthStatusValue
+				require.NoError(t, decoded.UnmarshalCBOR(data))
+				require.Equal(t, HotCredNotAuthorized, decoded.Status)
+			},
+		},
+		{
+			name:      "WithOriginSlot",
+			canonical: mustEncodeLocalStateQueryFixture(t, []any{0}),
+			decode: func(t *testing.T, data []byte) {
+				var decoded WithOriginSlot
+				require.NoError(t, decoded.UnmarshalCBOR(data))
+				require.False(t, decoded.HasSlot)
+			},
+		},
+		{
+			name: "RelayAccessPoint",
+			canonical: mustEncodeLocalStateQueryFixture(
+				t,
+				[]any{int(RelayKindSRV), []byte("relay.example")},
+			),
+			decode: func(t *testing.T, data []byte) {
+				var decoded RelayAccessPoint
+				require.NoError(t, decoded.UnmarshalCBOR(data))
+				require.Equal(t, RelayKindSRV, decoded.Kind)
+				require.NotNil(t, decoded.Domain)
+				require.Equal(t, "relay.example", *decoded.Domain)
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, encoding := range test.CanonicalAndNonShortestList(tc.canonical) {
+				t.Run(encoding.Name, func(t *testing.T) {
+					tc.decode(t, encoding.Data)
+				})
+			}
+		})
+	}
+}
+
+func mustEncodeLocalStateQueryFixture(t *testing.T, value any) []byte {
+	t.Helper()
+	data, err := cbor.Encode(value)
+	require.NoError(t, err)
+	return data
+}

--- a/protocol/peersharing/dispatch_test.go
+++ b/protocol/peersharing/dispatch_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peersharing
+
+import (
+	"net"
+	"testing"
+
+	test "github.com/blinklabs-io/gouroboros/internal/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPeerAddressAcceptsListLengthEncodings(t *testing.T) {
+	expected := PeerAddress{IP: net.IPv4(1, 2, 3, 4), Port: 3001}
+	canonical, err := expected.MarshalCBOR()
+	require.NoError(t, err)
+	for _, encoding := range test.CanonicalAndNonShortestList(canonical) {
+		t.Run(encoding.Name, func(t *testing.T) {
+			var decoded PeerAddress
+			require.NoError(t, decoded.UnmarshalCBOR(encoding.Data))
+			require.True(t, decoded.IP.Equal(expected.IP))
+			require.Equal(t, expected.Port, decoded.Port)
+		})
+	}
+}

--- a/protocol/peersharing/dispatch_test.go
+++ b/protocol/peersharing/dispatch_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	test "github.com/blinklabs-io/gouroboros/internal/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,8 +31,8 @@ func TestPeerAddressAcceptsListLengthEncodings(t *testing.T) {
 		t.Run(encoding.Name, func(t *testing.T) {
 			var decoded PeerAddress
 			require.NoError(t, decoded.UnmarshalCBOR(encoding.Data))
-			require.True(t, decoded.IP.Equal(expected.IP))
-			require.Equal(t, expected.Port, decoded.Port)
+			assert.True(t, decoded.IP.Equal(expected.IP))
+			assert.Equal(t, expected.Port, decoded.Port)
 		})
 	}
 }


### PR DESCRIPTION
- decode tagged CBOR lists correctly when list lengths use wider definite encodings
- cover canonical and uint8, uint16, uint32, and uint64 list-length forms across all 22 dispatchers
