### PR TITLE
fix(ledger): encode pool relays as CBOR arrays

### DIFF
--- a/ledger/common/certs.go
+++ b/ledger/common/certs.go
@@ -545,6 +545,62 @@ func (p *PoolRelay) UnmarshalCBOR(data []byte) error {
 	return nil
 }
 
+func (p PoolRelay) MarshalCBOR() ([]byte, error) {
+	switch p.Type {
+	case PoolRelayTypeSingleHostAddress:
+		ipv4 := p.Ipv4
+		if ipv4 != nil {
+			normalized := ipv4.To4()
+			if normalized == nil {
+				return nil, errors.New("invalid IPv4 relay address")
+			}
+			ipv4 = &normalized
+		}
+		ipv6 := p.Ipv6
+		if ipv6 != nil {
+			normalized := ipv6.To16()
+			if normalized == nil {
+				return nil, errors.New("invalid IPv6 relay address")
+			}
+			ipv6 = &normalized
+		}
+		return cbor.Encode(struct {
+			cbor.StructAsArray
+			Type uint
+			Port *uint32
+			Ipv4 *net.IP
+			Ipv6 *net.IP
+		}{
+			Type: uint(p.Type),
+			Port: p.Port,
+			Ipv4: ipv4,
+			Ipv6: ipv6,
+		})
+	case PoolRelayTypeSingleHostName:
+		return cbor.Encode(struct {
+			cbor.StructAsArray
+			Type     uint
+			Port     *uint32
+			Hostname *string
+		}{
+			Type:     uint(p.Type),
+			Port:     p.Port,
+			Hostname: p.Hostname,
+		})
+	case PoolRelayTypeMultiHostName:
+		return cbor.Encode(struct {
+			cbor.StructAsArray
+			Type     uint
+			Hostname *string
+		}{
+			Type:     uint(p.Type),
+			Hostname: p.Hostname,
+		})
+	default:
+		return nil, fmt.Errorf("invalid relay type: %d", p.Type)
+	}
+}
+
 func (p *PoolRelay) Utxorpc() (*utxorpc.Relay, error) {
 	ret := &utxorpc.Relay{}
 	if p.Port != nil {

--- a/ledger/common/certs.go
+++ b/ledger/common/certs.go
@@ -577,6 +577,9 @@ func (p PoolRelay) MarshalCBOR() ([]byte, error) {
 			Ipv6: ipv6,
 		})
 	case PoolRelayTypeSingleHostName:
+		if p.Hostname == nil {
+			return nil, errors.New("single-host-name relay requires hostname")
+		}
 		return cbor.Encode(struct {
 			cbor.StructAsArray
 			Type     uint
@@ -588,6 +591,9 @@ func (p PoolRelay) MarshalCBOR() ([]byte, error) {
 			Hostname: p.Hostname,
 		})
 	case PoolRelayTypeMultiHostName:
+		if p.Hostname == nil {
+			return nil, errors.New("multi-host-name relay requires hostname")
+		}
 		return cbor.Encode(struct {
 			cbor.StructAsArray
 			Type     uint

--- a/ledger/common/certs_test.go
+++ b/ledger/common/certs_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"net"
 	"reflect"
 	"strings"
 	"testing"
@@ -273,6 +274,118 @@ func TestPoolRegistrationCertificateLeiosKey(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, encoded, reencoded)
 	})
+}
+
+func TestPoolRelayCBORRoundTrip(t *testing.T) {
+	port := uint32(3001)
+	ipv4 := net.IPv4(10, 0, 0, 1).To4()
+	ipv6 := net.ParseIP("2001:db8::1")
+	hostname := "relay.example"
+	tests := []struct {
+		name string
+		raw  string
+		want PoolRelay
+	}{
+		{
+			name: "single host address",
+			raw:  "8400190bb9440a000001f6",
+			want: PoolRelay{
+				Type: PoolRelayTypeSingleHostAddress,
+				Port: &port,
+				Ipv4: &ipv4,
+			},
+		},
+		{
+			name: "single host name",
+			raw:  "8301190bb96d72656c61792e6578616d706c65",
+			want: PoolRelay{
+				Type:     PoolRelayTypeSingleHostName,
+				Port:     &port,
+				Hostname: &hostname,
+			},
+		},
+		{
+			name: "multi host name",
+			raw:  "82026d72656c61792e6578616d706c65",
+			want: PoolRelay{
+				Type:     PoolRelayTypeMultiHostName,
+				Hostname: &hostname,
+			},
+		},
+		{
+			name: "single host address with ipv6",
+			raw:  "8400190bb9f65020010db8000000000000000000000001",
+			want: PoolRelay{
+				Type: PoolRelayTypeSingleHostAddress,
+				Port: &port,
+				Ipv6: &ipv6,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			raw, err := hex.DecodeString(test.raw)
+			require.NoError(t, err)
+
+			var decoded PoolRelay
+			_, err = cbor.Decode(raw, &decoded)
+			require.NoError(t, err)
+			assert.Equal(t, test.want, decoded)
+
+			reencoded, err := cbor.Encode(decoded)
+			require.NoError(t, err)
+			assert.Equal(t, raw, reencoded)
+		})
+	}
+}
+
+func TestPoolRelayCBORMarshalFreshValues(t *testing.T) {
+	port := uint32(3001)
+	ipv4 := net.ParseIP("10.0.0.1")
+	hostname := "relay.example"
+	tests := []struct {
+		name  string
+		relay PoolRelay
+		want  string
+	}{
+		{
+			name: "single host address",
+			relay: PoolRelay{
+				Type: PoolRelayTypeSingleHostAddress,
+				Port: &port,
+				Ipv4: &ipv4,
+			},
+			want: "8400190bb9440a000001f6",
+		},
+		{
+			name: "single host name",
+			relay: PoolRelay{
+				Type:     PoolRelayTypeSingleHostName,
+				Port:     &port,
+				Hostname: &hostname,
+			},
+			want: "8301190bb96d72656c61792e6578616d706c65",
+		},
+		{
+			name: "multi host name",
+			relay: PoolRelay{
+				Type:     PoolRelayTypeMultiHostName,
+				Hostname: &hostname,
+			},
+			want: "82026d72656c61792e6578616d706c65",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			encoded, err := cbor.Encode(test.relay)
+			require.NoError(t, err)
+			assert.Equal(t, test.want, hex.EncodeToString(encoded))
+
+			encoded, err = cbor.Encode(&test.relay)
+			require.NoError(t, err)
+			assert.Equal(t, test.want, hex.EncodeToString(encoded))
+		})
+	}
 }
 
 func TestPoolRegistrationCertificateRejectsShortOperatorKey(t *testing.T) {

--- a/ledger/common/certs_test.go
+++ b/ledger/common/certs_test.go
@@ -388,6 +388,38 @@ func TestPoolRelayCBORMarshalFreshValues(t *testing.T) {
 	}
 }
 
+func TestPoolRelayCBORMarshalRejectsMissingHostname(t *testing.T) {
+	tests := []struct {
+		name    string
+		relay   PoolRelay
+		wantErr string
+	}{
+		{
+			name: "single host name",
+			relay: PoolRelay{
+				Type: PoolRelayTypeSingleHostName,
+			},
+			wantErr: "single-host-name relay requires hostname",
+		},
+		{
+			name: "multi host name",
+			relay: PoolRelay{
+				Type: PoolRelayTypeMultiHostName,
+			},
+			wantErr: "multi-host-name relay requires hostname",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := cbor.Encode(test.relay)
+			require.ErrorContains(t, err, test.wantErr)
+
+			_, err = cbor.Encode(&test.relay)
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
 func TestPoolRegistrationCertificateRejectsShortOperatorKey(t *testing.T) {
 	var cert PoolRegistrationCertificate
 	err := json.Unmarshal([]byte(`{"publicKey":"01"}`), &cert)


### PR DESCRIPTION
## Summary

- encode all pool relay variants using their ledger CBOR array shapes
- normalize parsed IP addresses to the CDDL byte widths
- cover decoded round trips and freshly constructed value and pointer encodings

## Testing

- `make test`
- `make lint`
- `go test -race -count=1 ./ledger/common`
- `go vet ./ledger/common`
- `git diff --check`

Fixes #1997.
