### PR TITLE
fix(ledger): preserve wire CBOR for Shelley/Allegra tx bodies and witness sets

### DIFF
--- a/ledger/allegra/allegra.go
+++ b/ledger/allegra/allegra.go
@@ -234,6 +234,13 @@ func (b *AllegraTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	return nil
 }
 
+func (b *AllegraTransactionBody) MarshalCBOR() ([]byte, error) {
+	if b.Cbor() != nil {
+		return b.Cbor(), nil
+	}
+	return cbor.EncodeGeneric(b)
+}
+
 func (b *AllegraTransactionBody) Inputs() []common.TransactionInput {
 	ret := make([]common.TransactionInput, 0, len(b.TxInputs.Items()))
 	for _, input := range b.TxInputs.Items() {

--- a/ledger/allegra/tx_test.go
+++ b/ledger/allegra/tx_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,57 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shelley_test
+package allegra_test
 
 import (
 	"bytes"
-	"encoding/hex"
-	"math/big"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
-	"github.com/blinklabs-io/plutigo/data"
 )
 
-func TestShelleyTransactionInputToPlutusData(t *testing.T) {
-	testTxIdHex := "1639f61ed08f5e489dd64db20f86451a0db06e83d21ea39c73ea0a93b478a370"
-	testTxOutputIdx := 2
-	testInput := shelley.NewShelleyTransactionInput(
-		testTxIdHex,
-		testTxOutputIdx,
-	)
-	testTxId, err := hex.DecodeString(testTxIdHex)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-	expectedData := data.NewConstr(
-		0,
-		data.NewByteString(testTxId),
-		data.NewInteger(big.NewInt(int64(testTxOutputIdx))),
-	)
-	tmpData := testInput.ToPlutusData()
-	if !reflect.DeepEqual(tmpData, expectedData) {
-		t.Fatalf(
-			"did not get expected PlutusData\n     got: %#v\n  wanted: %#v",
-			tmpData,
-			expectedData,
-		)
-	}
-}
-
-// TestShelleyTransactionBody_MarshalCBOR_PreservesWireBytes reproduces
-// https://github.com/blinklabs-io/gouroboros/issues/1990: a decoded
-// ShelleyTransactionBody carrying a protocol parameter update must
-// re-marshal to its preserved wire bytes instead of falling through to
-// the generic encoder, which would emit an explicit CBOR null for each
-// of the 15 unset ShelleyProtocolParameterUpdate fields.
-func TestShelleyTransactionBody_MarshalCBOR_PreservesWireBytes(t *testing.T) {
+// TestAllegraTransactionBody_MarshalCBOR_PreservesWireBytes reproduces
+// https://github.com/blinklabs-io/gouroboros/issues/1990 for Allegra: a
+// decoded AllegraTransactionBody carrying a protocol parameter update
+// must re-marshal to its preserved wire bytes instead of falling
+// through to the generic encoder, which would emit an explicit CBOR
+// null for each of the 15 unset ShelleyProtocolParameterUpdate fields.
+// It also rebuilds a transaction from the decoded body and a witness
+// set fixture whose generic encoding cannot reproduce its wire bytes
+// (see newIndefLengthWitnessSetFixture), the same pattern
+// AllegraBlock.Transactions() uses.
+func TestAllegraTransactionBody_MarshalCBOR_PreservesWireBytes(t *testing.T) {
 	genesisHash := common.NewBlake2b224(bytes.Repeat([]byte{0xAB}, 28))
 	// Minimal wire-format body: a fee, a TTL, and a protocol param
 	// update proposal with only MinFeeA (key 0) populated, as a real
@@ -80,7 +55,7 @@ func TestShelleyTransactionBody_MarshalCBOR_PreservesWireBytes(t *testing.T) {
 	wireBytes, err := cbor.Encode(rawBody)
 	require.NoError(t, err, "unexpected error encoding wire bytes")
 
-	body, err := shelley.NewShelleyTransactionBodyFromCbor(wireBytes)
+	body, err := allegra.NewAllegraTransactionBodyFromCbor(wireBytes)
 	require.NoError(t, err, "unexpected error decoding transaction body")
 	require.NotNil(t, body.Update, "expected a protocol param update")
 	require.Len(
@@ -105,12 +80,8 @@ func TestShelleyTransactionBody_MarshalCBOR_PreservesWireBytes(t *testing.T) {
 	)
 
 	// Rebuilding a transaction from the decoded body and witness set --
-	// the same pattern ShelleyBlock.Transactions() uses -- must not
-	// inflate the encoded transaction size. The witness set fixture uses
-	// an indefinite-length VkeyWitnesses array, whose generic
-	// (re-)encoding as a Go slice can never reproduce the indefinite-
-	// length wire form, so this exercises
-	// ShelleyTransactionWitnessSet.MarshalCBOR as well as the body.
+	// the same pattern AllegraBlock.Transactions() uses -- must not
+	// inflate the encoded transaction size.
 	wsBytes, witnessSet := newIndefLengthWitnessSetFixture(t)
 
 	wireTxBytes, err := cbor.Encode(
@@ -118,7 +89,7 @@ func TestShelleyTransactionBody_MarshalCBOR_PreservesWireBytes(t *testing.T) {
 	)
 	require.NoError(t, err, "unexpected error encoding wire transaction")
 
-	rebuilt := &shelley.ShelleyTransaction{
+	rebuilt := &allegra.AllegraTransaction{
 		Body:       *body,
 		WitnessSet: witnessSet,
 	}
@@ -132,12 +103,13 @@ func TestShelleyTransactionBody_MarshalCBOR_PreservesWireBytes(t *testing.T) {
 }
 
 // newIndefLengthWitnessSetFixture builds wire bytes for a
-// ShelleyTransactionWitnessSet whose sole VkeyWitnesses entry is encoded
-// as an indefinite-length CBOR array, then decodes it. Re-encoding a
-// decoded []common.VkeyWitness generically always produces a
-// definite-length array, so this fixture's generic encoding necessarily
-// differs from its wire bytes -- making it load-bearing for verifying
-// that ShelleyTransactionWitnessSet.MarshalCBOR prefers preserved bytes.
+// shelley.ShelleyTransactionWitnessSet (shared by Allegra and Mary)
+// whose sole VkeyWitnesses entry is encoded as an indefinite-length
+// CBOR array, then decodes it. Re-encoding a decoded
+// []common.VkeyWitness generically always produces a definite-length
+// array, so this fixture's generic encoding necessarily differs from
+// its wire bytes -- making it load-bearing for verifying that
+// ShelleyTransactionWitnessSet.MarshalCBOR prefers preserved bytes.
 func newIndefLengthWitnessSetFixture(
 	t *testing.T,
 ) ([]byte, shelley.ShelleyTransactionWitnessSet) {

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -318,6 +318,13 @@ func (b *ShelleyTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	return nil
 }
 
+func (b *ShelleyTransactionBody) MarshalCBOR() ([]byte, error) {
+	if b.Cbor() != nil {
+		return b.Cbor(), nil
+	}
+	return cbor.EncodeGeneric(b)
+}
+
 func (b *ShelleyTransactionBody) Inputs() []common.TransactionInput {
 	items := b.TxInputs.Items()
 	ret := make([]common.TransactionInput, len(items))
@@ -610,6 +617,13 @@ func (w *ShelleyTransactionWitnessSet) UnmarshalCBOR(cborData []byte) error {
 	*w = ShelleyTransactionWitnessSet(tmp)
 	w.SetCbor(cborData)
 	return nil
+}
+
+func (w *ShelleyTransactionWitnessSet) MarshalCBOR() ([]byte, error) {
+	if w.Cbor() != nil {
+		return w.Cbor(), nil
+	}
+	return cbor.EncodeGeneric(w)
 }
 
 func (w ShelleyTransactionWitnessSet) Vkey() []common.VkeyWitness {

--- a/ledger/shelley/tx_test.go
+++ b/ledger/shelley/tx_test.go
@@ -15,11 +15,14 @@
 package shelley_test
 
 import (
+	"bytes"
 	"encoding/hex"
 	"math/big"
 	"reflect"
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/blinklabs-io/plutigo/data"
 )
@@ -46,6 +49,98 @@ func TestShelleyTransactionInputToPlutusData(t *testing.T) {
 			"did not get expected PlutusData\n     got: %#v\n  wanted: %#v",
 			tmpData,
 			expectedData,
+		)
+	}
+}
+
+// TestShelleyTransactionBody_MarshalCBOR_PreservesWireBytes reproduces
+// https://github.com/blinklabs-io/gouroboros/issues/1990: a decoded
+// ShelleyTransactionBody carrying a protocol parameter update must
+// re-marshal to its preserved wire bytes instead of falling through to
+// the generic encoder, which would emit an explicit CBOR null for each
+// of the 15 unset ShelleyProtocolParameterUpdate fields.
+func TestShelleyTransactionBody_MarshalCBOR_PreservesWireBytes(t *testing.T) {
+	genesisHash := common.NewBlake2b224(bytes.Repeat([]byte{0xAB}, 28))
+	// Minimal wire-format body: a fee, a TTL, and a protocol param
+	// update proposal with only MinFeeA (key 0) populated, as a real
+	// node would emit it.
+	rawBody := map[uint64]any{
+		2: uint64(206245),  // fee
+		3: uint64(5000000), // ttl
+		6: []any{
+			map[common.Blake2b224]any{
+				genesisHash: map[uint64]any{0: uint64(44)}, // MinFeeA only
+			},
+			uint64(4), // epoch
+		},
+	}
+	wireBytes, err := cbor.Encode(rawBody)
+	if err != nil {
+		t.Fatalf("unexpected error encoding wire bytes: %s", err)
+	}
+
+	body, err := shelley.NewShelleyTransactionBodyFromCbor(wireBytes)
+	if err != nil {
+		t.Fatalf("unexpected error decoding transaction body: %s", err)
+	}
+	if body.Update == nil || len(body.Update.ProtocolParamUpdates) != 1 {
+		t.Fatalf(
+			"expected a single protocol param update, got %#v",
+			body.Update,
+		)
+	}
+	update, ok := body.Update.ProtocolParamUpdates[genesisHash]
+	if !ok {
+		t.Fatalf("expected update entry for genesis hash %s", genesisHash)
+	}
+	if update.MinFeeA == nil || *update.MinFeeA != 44 {
+		t.Fatalf("expected MinFeeA == 44, got %#v", update.MinFeeA)
+	}
+	if update.MinFeeB != nil {
+		t.Fatalf("expected MinFeeB to remain unset, got %#v", update.MinFeeB)
+	}
+
+	marshaled, err := body.MarshalCBOR()
+	if err != nil {
+		t.Fatalf("unexpected error marshaling body: %s", err)
+	}
+	if !bytes.Equal(marshaled, wireBytes) {
+		t.Fatalf(
+			"MarshalCBOR() did not return preserved wire bytes: got %d bytes, wanted %d bytes",
+			len(marshaled),
+			len(wireBytes),
+		)
+	}
+
+	// Rebuilding a transaction from the decoded body and an empty
+	// witness set -- the same pattern ShelleyBlock.Transactions() uses
+	// -- must not inflate the encoded transaction size.
+	wsBytes, err := cbor.Encode(map[uint64]any{})
+	if err != nil {
+		t.Fatalf("unexpected error encoding witness set: %s", err)
+	}
+	var witnessSet shelley.ShelleyTransactionWitnessSet
+	if _, err := cbor.Decode(wsBytes, &witnessSet); err != nil {
+		t.Fatalf("unexpected error decoding witness set: %s", err)
+	}
+
+	wireTxBytes, err := cbor.Encode(
+		[]any{cbor.RawMessage(wireBytes), cbor.RawMessage(wsBytes), nil},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error encoding wire transaction: %s", err)
+	}
+
+	rebuilt := &shelley.ShelleyTransaction{
+		Body:       *body,
+		WitnessSet: witnessSet,
+	}
+	rebuiltBytes := rebuilt.Cbor()
+	if !bytes.Equal(rebuiltBytes, wireTxBytes) {
+		t.Fatalf(
+			"rebuilt transaction CBOR does not match wire bytes: got %d bytes, wanted %d bytes",
+			len(rebuiltBytes),
+			len(wireTxBytes),
 		)
 	}
 }

--- a/ledger/shelley/tx_test.go
+++ b/ledger/shelley/tx_test.go
@@ -21,6 +21,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
@@ -75,72 +78,55 @@ func TestShelleyTransactionBody_MarshalCBOR_PreservesWireBytes(t *testing.T) {
 		},
 	}
 	wireBytes, err := cbor.Encode(rawBody)
-	if err != nil {
-		t.Fatalf("unexpected error encoding wire bytes: %s", err)
-	}
+	require.NoError(t, err, "unexpected error encoding wire bytes")
 
 	body, err := shelley.NewShelleyTransactionBodyFromCbor(wireBytes)
-	if err != nil {
-		t.Fatalf("unexpected error decoding transaction body: %s", err)
-	}
-	if body.Update == nil || len(body.Update.ProtocolParamUpdates) != 1 {
-		t.Fatalf(
-			"expected a single protocol param update, got %#v",
-			body.Update,
-		)
-	}
+	require.NoError(t, err, "unexpected error decoding transaction body")
+	require.NotNil(t, body.Update, "expected a protocol param update")
+	require.Len(
+		t,
+		body.Update.ProtocolParamUpdates,
+		1,
+		"expected a single protocol param update",
+	)
 	update, ok := body.Update.ProtocolParamUpdates[genesisHash]
-	if !ok {
-		t.Fatalf("expected update entry for genesis hash %s", genesisHash)
-	}
-	if update.MinFeeA == nil || *update.MinFeeA != 44 {
-		t.Fatalf("expected MinFeeA == 44, got %#v", update.MinFeeA)
-	}
-	if update.MinFeeB != nil {
-		t.Fatalf("expected MinFeeB to remain unset, got %#v", update.MinFeeB)
-	}
+	require.True(t, ok, "expected update entry for genesis hash %s", genesisHash)
+	require.NotNil(t, update.MinFeeA, "expected MinFeeA to be set")
+	assert.Equal(t, uint(44), *update.MinFeeA)
+	assert.Nil(t, update.MinFeeB, "expected MinFeeB to remain unset")
 
 	marshaled, err := body.MarshalCBOR()
-	if err != nil {
-		t.Fatalf("unexpected error marshaling body: %s", err)
-	}
-	if !bytes.Equal(marshaled, wireBytes) {
-		t.Fatalf(
-			"MarshalCBOR() did not return preserved wire bytes: got %d bytes, wanted %d bytes",
-			len(marshaled),
-			len(wireBytes),
-		)
-	}
+	require.NoError(t, err, "unexpected error marshaling body")
+	assert.Equal(
+		t,
+		wireBytes,
+		marshaled,
+		"MarshalCBOR() did not return preserved wire bytes",
+	)
 
 	// Rebuilding a transaction from the decoded body and an empty
 	// witness set -- the same pattern ShelleyBlock.Transactions() uses
 	// -- must not inflate the encoded transaction size.
 	wsBytes, err := cbor.Encode(map[uint64]any{})
-	if err != nil {
-		t.Fatalf("unexpected error encoding witness set: %s", err)
-	}
+	require.NoError(t, err, "unexpected error encoding witness set")
 	var witnessSet shelley.ShelleyTransactionWitnessSet
-	if _, err := cbor.Decode(wsBytes, &witnessSet); err != nil {
-		t.Fatalf("unexpected error decoding witness set: %s", err)
-	}
+	_, err = cbor.Decode(wsBytes, &witnessSet)
+	require.NoError(t, err, "unexpected error decoding witness set")
 
 	wireTxBytes, err := cbor.Encode(
 		[]any{cbor.RawMessage(wireBytes), cbor.RawMessage(wsBytes), nil},
 	)
-	if err != nil {
-		t.Fatalf("unexpected error encoding wire transaction: %s", err)
-	}
+	require.NoError(t, err, "unexpected error encoding wire transaction")
 
 	rebuilt := &shelley.ShelleyTransaction{
 		Body:       *body,
 		WitnessSet: witnessSet,
 	}
 	rebuiltBytes := rebuilt.Cbor()
-	if !bytes.Equal(rebuiltBytes, wireTxBytes) {
-		t.Fatalf(
-			"rebuilt transaction CBOR does not match wire bytes: got %d bytes, wanted %d bytes",
-			len(rebuiltBytes),
-			len(wireTxBytes),
-		)
-	}
+	assert.Equal(
+		t,
+		wireTxBytes,
+		rebuiltBytes,
+		"rebuilt transaction CBOR does not match wire bytes",
+	)
 }


### PR DESCRIPTION
## Summary

`ShelleyTransactionBody` and `AllegraTransactionBody` store their decoded CBOR via `SetCbor()` but had no `MarshalCBOR()`, so re-encoding a decoded body (as `ShelleyBlock.Transactions()` / `AllegraBlock.Transactions()` do when constructing a transaction from a block's parallel body/witness/metadata arrays) fell through to the generic encoder instead of returning the preserved bytes. `ShelleyTransactionWitnessSet` had the same gap and is shared by Allegra and Mary.

The generic re-encode inflates size because `ShelleyProtocolParameterUpdate` has no `omitempty` tags on its 16 fields, so re-encoding an update proposal emits an explicit CBOR null for every unset field. This overstates `len(tx.Cbor())`, which `common.TxSizeForFee` uses for pre-Alonzo fee/size checks, so `shelley.UtxoValidateFeeTooSmallUtxo` and `UtxoValidateMaxTxSizeUtxo` can reject a transaction whose declared fee/size were actually correct.

## Fix

Add the same `Cbor()`-first `MarshalCBOR()` shape already used by `MaryTransactionBody` to:
- `ShelleyTransactionBody`
- `AllegraTransactionBody`
- `ShelleyTransactionWitnessSet` (shared by Shelley, Allegra, and Mary)

## Testing

- Added `TestShelleyTransactionBody_MarshalCBOR_PreservesWireBytes`, which builds minimal wire bytes for a body carrying a protocol-parameter-update proposal, decodes it, and asserts `MarshalCBOR()` returns the preserved bytes verbatim and that a transaction rebuilt from the decoded body/witness set (the same pattern `ShelleyBlock.Transactions()` uses) round-trips without inflation.
  - Confirmed this test fails to compile against the pre-fix code (`ShelleyTransactionBody` had no `MarshalCBOR` method), then passes with the fix.
- `go build ./...`
- `go test ./...` (all packages pass, including `internal/test/conformance`)
- `gofmt -l` clean

Fixes #1990

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves wire CBOR for Shelley and Allegra transaction bodies and the shared witness set to prevent size inflation that breaks pre-Alonzo fee/size validation. Before: generic re-encoding emitted CBOR nulls for unset protocol-parameter-update fields; after: MarshalCBOR returns preserved bytes when present.

- Add MarshalCBOR to ShelleyTransactionBody, AllegraTransactionBody, and ShelleyTransactionWitnessSet (shared by Shelley/Allegra/Mary); prefer preserved Cbor() bytes, else fall back to generic encoding.
- Keep rebuilt transaction size equal to wire size, restoring accurate len(tx.Cbor()) for fee and max-size checks.
- Add regression tests for Shelley and Allegra bodies and a witness-set fixture using an indefinite-length VkeyWitnesses array to guarantee the preserved-bytes path is exercised; update tests to use `testify` require/assert.

<sup>Written for commit c4719f71145ce36b5c257fd2f3ea442ec2970f6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction re-encoding to preserve original CBOR data when available.
  * Fixed handling of Shelley transactions with sparse protocol parameter updates.
  * Ensured rebuilding transactions with empty witness sets does not alter encoded data.

* **Tests**
  * Added regression coverage for preserving transaction wire bytes during re-marshaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->