### PR TITLE
fix(ledger): enforce pool relay CDDL bounds

### DIFF
--- a/ledger/common/certs.go
+++ b/ledger/common/certs.go
@@ -483,9 +483,11 @@ func (p *PoolMetadata) Utxorpc() (*utxorpc.PoolMetadata, error) {
 }
 
 const (
-	PoolRelayTypeSingleHostAddress = 0
-	PoolRelayTypeSingleHostName    = 1
-	PoolRelayTypeMultiHostName     = 2
+	PoolRelayTypeSingleHostAddress        = 0
+	PoolRelayTypeSingleHostName           = 1
+	PoolRelayTypeMultiHostName            = 2
+	poolRelayMaxPort               uint32 = 65535
+	poolRelayMaxHostnameLen               = 128
 )
 
 type PoolRelay struct {
@@ -494,6 +496,28 @@ type PoolRelay struct {
 	Ipv4     *net.IP `json:"ipv4,omitempty"`
 	Ipv6     *net.IP `json:"ipv6,omitempty"`
 	Hostname *string `json:"hostname,omitempty"`
+}
+
+func (p PoolRelay) validateCBORBounds() error {
+	switch p.Type {
+	case PoolRelayTypeSingleHostAddress, PoolRelayTypeSingleHostName:
+		if p.Port != nil && *p.Port > poolRelayMaxPort {
+			return fmt.Errorf(
+				"pool relay port must not exceed %d",
+				poolRelayMaxPort,
+			)
+		}
+	}
+	switch p.Type {
+	case PoolRelayTypeSingleHostName, PoolRelayTypeMultiHostName:
+		if p.Hostname != nil && len(*p.Hostname) > poolRelayMaxHostnameLen {
+			return fmt.Errorf(
+				"pool relay hostname must not exceed %d bytes",
+				poolRelayMaxHostnameLen,
+			)
+		}
+	}
+	return nil
 }
 
 func (p *PoolRelay) UnmarshalCBOR(data []byte) error {
@@ -542,10 +566,13 @@ func (p *PoolRelay) UnmarshalCBOR(data []byte) error {
 	default:
 		return fmt.Errorf("invalid relay type: %d", tmpId)
 	}
-	return nil
+	return p.validateCBORBounds()
 }
 
 func (p PoolRelay) MarshalCBOR() ([]byte, error) {
+	if err := p.validateCBORBounds(); err != nil {
+		return nil, err
+	}
 	switch p.Type {
 	case PoolRelayTypeSingleHostAddress:
 		ipv4 := p.Ipv4

--- a/ledger/common/certs_test.go
+++ b/ledger/common/certs_test.go
@@ -420,6 +420,150 @@ func TestPoolRelayCBORMarshalRejectsMissingHostname(t *testing.T) {
 	}
 }
 
+func TestPoolRelayCBORBounds(t *testing.T) {
+	maxPort := uint32(65535)
+	overPort := uint32(65536)
+	ipv4 := net.IPv4(10, 0, 0, 1).To4()
+	hostname := "relay.example"
+	maxHostname := strings.Repeat("a", 128)
+	overHostname := strings.Repeat("a", 129)
+	tests := []struct {
+		name    string
+		relay   PoolRelay
+		raw     []any
+		wantErr string
+	}{
+		{
+			name: "address max port",
+			relay: PoolRelay{
+				Type: PoolRelayTypeSingleHostAddress,
+				Port: &maxPort,
+				Ipv4: &ipv4,
+			},
+			raw: []any{
+				uint(PoolRelayTypeSingleHostAddress),
+				maxPort,
+				[]byte(ipv4),
+				nil,
+			},
+		},
+		{
+			name: "address over max port",
+			relay: PoolRelay{
+				Type: PoolRelayTypeSingleHostAddress,
+				Port: &overPort,
+				Ipv4: &ipv4,
+			},
+			raw: []any{
+				uint(PoolRelayTypeSingleHostAddress),
+				overPort,
+				[]byte(ipv4),
+				nil,
+			},
+			wantErr: "pool relay port must not exceed 65535",
+		},
+		{
+			name: "single host name max port",
+			relay: PoolRelay{
+				Type:     PoolRelayTypeSingleHostName,
+				Port:     &maxPort,
+				Hostname: &hostname,
+			},
+			raw: []any{
+				uint(PoolRelayTypeSingleHostName),
+				maxPort,
+				hostname,
+			},
+		},
+		{
+			name: "single host name over max port",
+			relay: PoolRelay{
+				Type:     PoolRelayTypeSingleHostName,
+				Port:     &overPort,
+				Hostname: &hostname,
+			},
+			raw: []any{
+				uint(PoolRelayTypeSingleHostName),
+				overPort,
+				hostname,
+			},
+			wantErr: "pool relay port must not exceed 65535",
+		},
+		{
+			name: "single host name max length",
+			relay: PoolRelay{
+				Type:     PoolRelayTypeSingleHostName,
+				Hostname: &maxHostname,
+			},
+			raw: []any{
+				uint(PoolRelayTypeSingleHostName),
+				nil,
+				maxHostname,
+			},
+		},
+		{
+			name: "single host name over max length",
+			relay: PoolRelay{
+				Type:     PoolRelayTypeSingleHostName,
+				Hostname: &overHostname,
+			},
+			raw: []any{
+				uint(PoolRelayTypeSingleHostName),
+				nil,
+				overHostname,
+			},
+			wantErr: "pool relay hostname must not exceed 128 bytes",
+		},
+		{
+			name: "multi host name max length",
+			relay: PoolRelay{
+				Type:     PoolRelayTypeMultiHostName,
+				Hostname: &maxHostname,
+			},
+			raw: []any{
+				uint(PoolRelayTypeMultiHostName),
+				maxHostname,
+			},
+		},
+		{
+			name: "multi host name over max length",
+			relay: PoolRelay{
+				Type:     PoolRelayTypeMultiHostName,
+				Hostname: &overHostname,
+			},
+			raw: []any{
+				uint(PoolRelayTypeMultiHostName),
+				overHostname,
+			},
+			wantErr: "pool relay hostname must not exceed 128 bytes",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Run("marshal", func(t *testing.T) {
+				_, err := cbor.Encode(test.relay)
+				if test.wantErr == "" {
+					require.NoError(t, err)
+				} else {
+					require.ErrorContains(t, err, test.wantErr)
+				}
+			})
+
+			t.Run("unmarshal", func(t *testing.T) {
+				raw, err := cbor.Encode(test.raw)
+				require.NoError(t, err)
+				var decoded PoolRelay
+				_, err = cbor.Decode(raw, &decoded)
+				if test.wantErr == "" {
+					require.NoError(t, err)
+				} else {
+					require.ErrorContains(t, err, test.wantErr)
+				}
+			})
+		})
+	}
+}
+
 func TestPoolRegistrationCertificateRejectsShortOperatorKey(t *testing.T) {
 	var cert PoolRegistrationCertificate
 	err := json.Unmarshal([]byte(`{"publicKey":"01"}`), &cert)


### PR DESCRIPTION
Reject pool relay ports above 65535 and DNS names above 128 bytes during CBOR encoding and decoding.

Cover the exact limits and first invalid values for every affected relay variant.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces pool relay CDDL bounds during CBOR encode/decode. Previously, out-of-spec ports and hostnames were accepted; now they are rejected with clear errors.

- Port must be <= 65535 for `SingleHostAddress` and `SingleHostName`; first invalid port is 65536.
- Hostname length must be <= 128 bytes for `SingleHostName` and `MultiHostName`; first invalid length is 129 bytes.
- Validation runs in both `MarshalCBOR` and `UnmarshalCBOR`; errors are "pool relay port must not exceed 65535" and "pool relay hostname must not exceed 128 bytes".
- Adds table-driven tests for max and over-limit values across all relay variants.

<sup>Written for commit c24c0b417887eb87bf3e827a83dba6864eb801f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for relay ports and hostnames when encoding and decoding.
  * Ports above 65,535 and hostnames longer than 128 bytes are now rejected with clear errors.
  * Valid boundary values continue to work across supported relay types.

* **Tests**
  * Added coverage for valid limits and out-of-bounds port and hostname values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->