### PR TITLE
fix(ledger): reject invalid Conway wire values

### DIFF
--- a/ledger/common/certs.go
+++ b/ledger/common/certs.go
@@ -379,6 +379,9 @@ func (c *StakeDelegationCertificate) UnmarshalCBOR(cborData []byte) error {
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
 		return err
 	}
+	if tmp.StakeCredential == nil {
+		return errors.New("stake delegation contains a nil credential")
+	}
 	*c = StakeDelegationCertificate(tmp)
 	c.SetCbor(cborData)
 	return nil

--- a/ledger/common/certs_test.go
+++ b/ledger/common/certs_test.go
@@ -27,6 +27,50 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestStakeDelegationCertificateUnmarshalCBORCredential(t *testing.T) {
+	credential := Credential{
+		CredType: CredentialTypeAddrKeyHash,
+	}
+	testCases := []struct {
+		name       string
+		credential *Credential
+		wantErr    bool
+	}{
+		{
+			name:       "valid credential",
+			credential: &credential,
+		},
+		{
+			name:    "null credential",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := cbor.Encode([]any{
+				uint(CertificateTypeStakeDelegation),
+				tc.credential,
+				make([]byte, Blake2b224Size),
+			})
+			require.NoError(t, err)
+
+			var certificate StakeDelegationCertificate
+			_, err = cbor.Decode(encoded, &certificate)
+			if tc.wantErr {
+				require.ErrorContains(
+					t,
+					err,
+					"stake delegation contains a nil credential",
+				)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, certificate.StakeCredential)
+		})
+	}
+}
+
 // TestDrepString tests CIP-0129 bech32 encoding for DRep identifiers.
 func TestDrepString(t *testing.T) {
 	var zeroHash = make([]byte, 28)

--- a/ledger/common/credentials.go
+++ b/ledger/common/credentials.go
@@ -42,10 +42,16 @@ type Credential struct {
 }
 
 func (c *Credential) UnmarshalCBOR(cborData []byte) error {
+	if len(cborData) == 1 && (cborData[0] == 0xf6 || cborData[0] == 0xf7) {
+		return errors.New("credential cannot be CBOR null or undefined")
+	}
 	type tCredential Credential
 	var tmp tCredential
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
 		return err
+	}
+	if tmp.CredType > CredentialTypeScriptHash {
+		return fmt.Errorf("invalid credential type: %d", tmp.CredType)
 	}
 	*c = Credential(tmp)
 	c.SetCbor(cborData)

--- a/ledger/common/credentials_test.go
+++ b/ledger/common/credentials_test.go
@@ -17,11 +17,58 @@ package common_test
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestCredentialUnmarshalCBORValidTypes(t *testing.T) {
+	for _, credentialType := range []uint{
+		common.CredentialTypeAddrKeyHash,
+		common.CredentialTypeScriptHash,
+	} {
+		t.Run(fmt.Sprintf("type_%d", credentialType), func(t *testing.T) {
+			encoded, err := cbor.Encode([]any{
+				credentialType,
+				make([]byte, common.Blake2b224Size),
+			})
+			require.NoError(t, err)
+
+			var credential common.Credential
+			_, err = cbor.Decode(encoded, &credential)
+			require.NoError(t, err)
+			assert.Equal(t, credentialType, credential.CredType)
+		})
+	}
+}
+
+func TestCredentialUnmarshalCBORRejectsInvalidTypes(t *testing.T) {
+	for _, credentialType := range []uint{2, 255} {
+		t.Run(fmt.Sprintf("type_%d", credentialType), func(t *testing.T) {
+			encoded, err := cbor.Encode([]any{
+				credentialType,
+				make([]byte, common.Blake2b224Size),
+			})
+			require.NoError(t, err)
+
+			var credential common.Credential
+			_, err = cbor.Decode(encoded, &credential)
+			require.ErrorContains(t, err, "invalid credential type")
+		})
+	}
+}
+
+func TestCredentialUnmarshalCBORRejectsNullAndUndefined(t *testing.T) {
+	for _, cborData := range [][]byte{{0xf6}, {0xf7}} {
+		var credential common.Credential
+		require.Error(t, credential.UnmarshalCBOR(cborData))
+	}
+}
 
 func TestCredentialFromJson(t *testing.T) {
 	testDefs := []struct {

--- a/ledger/common/gov.go
+++ b/ledger/common/gov.go
@@ -29,6 +29,35 @@ import (
 // VotingProcedures is a convenience type to avoid needing to duplicate the full type definition everywhere
 type VotingProcedures map[*Voter]map[*GovActionId]VotingProcedure
 
+func (vps *VotingProcedures) UnmarshalCBOR(cborData []byte) error {
+	if len(cborData) == 1 && (cborData[0] == 0xf6 || cborData[0] == 0xf7) {
+		return errors.New("voting procedures cannot be CBOR null or undefined")
+	}
+	type tVotingProcedures VotingProcedures
+	var tmp tVotingProcedures
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	if len(tmp) == 0 {
+		return errors.New("voting procedures cannot be empty")
+	}
+	for voter, procedures := range tmp {
+		if voter == nil {
+			return errors.New("voting procedures contain a nil voter")
+		}
+		if len(procedures) == 0 {
+			return errors.New("voting procedures contain an empty action map")
+		}
+		for actionId := range procedures {
+			if actionId == nil {
+				return errors.New("voting procedures contain a nil action id")
+			}
+		}
+	}
+	*vps = VotingProcedures(tmp)
+	return nil
+}
+
 // AddOrReplace adds or replaces a vote using Voter and GovActionId value
 // equality. It returns the map so callers can assign the result when adding to
 // a nil VotingProcedures value.
@@ -154,6 +183,22 @@ type Voter struct {
 	cbor.StructAsArray
 	Type uint8
 	Hash [28]byte
+}
+
+func (v *Voter) UnmarshalCBOR(cborData []byte) error {
+	if len(cborData) == 1 && (cborData[0] == 0xf6 || cborData[0] == 0xf7) {
+		return errors.New("voter cannot be CBOR null or undefined")
+	}
+	type tVoter Voter
+	var tmp tVoter
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	if tmp.Type > VoterTypeStakingPoolKeyHash {
+		return fmt.Errorf("invalid voter type: %d", tmp.Type)
+	}
+	*v = Voter(tmp)
+	return nil
 }
 
 // Equal reports whether two voters have the same logical value.
@@ -387,6 +432,22 @@ type VotingProcedure struct {
 	cbor.StructAsArray
 	Vote   uint8
 	Anchor *GovAnchor
+}
+
+func (vp *VotingProcedure) UnmarshalCBOR(cborData []byte) error {
+	if len(cborData) == 1 && (cborData[0] == 0xf6 || cborData[0] == 0xf7) {
+		return errors.New("voting procedure cannot be CBOR null or undefined")
+	}
+	type tVotingProcedure VotingProcedure
+	var tmp tVotingProcedure
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	if tmp.Vote > GovVoteAbstain {
+		return fmt.Errorf("invalid vote type: %d", tmp.Vote)
+	}
+	*vp = VotingProcedure(tmp)
+	return nil
 }
 
 func cloneVotingProcedure(vp VotingProcedure) VotingProcedure {
@@ -652,6 +713,21 @@ type TreasuryWithdrawalGovAction struct {
 	PolicyHash  []byte
 }
 
+func (a *TreasuryWithdrawalGovAction) UnmarshalCBOR(cborData []byte) error {
+	type tTreasuryWithdrawalGovAction TreasuryWithdrawalGovAction
+	var tmp tTreasuryWithdrawalGovAction
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	for address := range tmp.Withdrawals {
+		if address == nil {
+			return errors.New("treasury withdrawal contains a nil address")
+		}
+	}
+	*a = TreasuryWithdrawalGovAction(tmp)
+	return nil
+}
+
 func (a *TreasuryWithdrawalGovAction) ToPlutusData() data.PlutusData {
 	pairs := make([][2]data.PlutusData, 0, len(a.Withdrawals))
 	for addr, amount := range a.Withdrawals {
@@ -750,6 +826,21 @@ type UpdateCommitteeGovAction struct {
 	Credentials []Credential
 	CredEpochs  map[*Credential]uint
 	Quorum      cbor.Rat
+}
+
+func (a *UpdateCommitteeGovAction) UnmarshalCBOR(cborData []byte) error {
+	type tUpdateCommitteeGovAction UpdateCommitteeGovAction
+	var tmp tUpdateCommitteeGovAction
+	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	for credential := range tmp.CredEpochs {
+		if credential == nil {
+			return errors.New("update committee contains a nil credential")
+		}
+	}
+	*a = UpdateCommitteeGovAction(tmp)
+	return nil
 }
 
 func (a *UpdateCommitteeGovAction) ToPlutusData() data.PlutusData {

--- a/ledger/common/gov_constructors_test.go
+++ b/ledger/common/gov_constructors_test.go
@@ -184,6 +184,19 @@ func TestNewUpdateCommitteeGovAction(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestUpdateCommitteeGovActionUnmarshalCBORRejectsNilCredEpochKey(t *testing.T) {
+	encoded, err := cbor.Encode(UpdateCommitteeGovAction{
+		Type:       uint(GovActionTypeUpdateCommittee),
+		CredEpochs: map[*Credential]uint{nil: 42},
+		Quorum:     cbor.Rat{Rat: big.NewRat(2, 3)},
+	})
+	require.NoError(t, err)
+
+	var action UpdateCommitteeGovAction
+	_, err = cbor.Decode(encoded, &action)
+	require.Error(t, err)
+}
+
 func TestNewNewConstitutionGovAction(t *testing.T) {
 	dataHash := make([]byte, 32)
 	anchor, err := NewGovAnchor("https://example.com/constitution.json", dataHash)

--- a/ledger/common/gov_test.go
+++ b/ledger/common/gov_test.go
@@ -15,6 +15,7 @@
 package common
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -23,6 +24,295 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestVoterUnmarshalCBORValidTypes(t *testing.T) {
+	for voterType := uint8(0); voterType <= VoterTypeStakingPoolKeyHash; voterType++ {
+		t.Run(fmt.Sprintf("type_%d", voterType), func(t *testing.T) {
+			encoded, err := cbor.Encode([]any{
+				voterType,
+				make([]byte, Blake2b224Size),
+			})
+			require.NoError(t, err)
+
+			var voter Voter
+			_, err = cbor.Decode(encoded, &voter)
+			require.NoError(t, err)
+			assert.Equal(t, voterType, voter.Type)
+		})
+	}
+}
+
+func TestVoterUnmarshalCBORRejectsInvalidTypes(t *testing.T) {
+	for _, voterType := range []uint8{5, 255} {
+		t.Run(fmt.Sprintf("type_%d", voterType), func(t *testing.T) {
+			encoded, err := cbor.Encode([]any{
+				voterType,
+				make([]byte, Blake2b224Size),
+			})
+			require.NoError(t, err)
+
+			var voter Voter
+			_, err = cbor.Decode(encoded, &voter)
+			require.ErrorContains(t, err, "invalid voter type")
+		})
+	}
+}
+
+func TestGovernanceValueUnmarshalCBORRejectsNullAndUndefined(t *testing.T) {
+	testCases := []struct {
+		name   string
+		decode func([]byte) error
+	}{
+		{
+			name: "voter",
+			decode: func(encoded []byte) error {
+				var voter Voter
+				return voter.UnmarshalCBOR(encoded)
+			},
+		},
+		{
+			name: "voting procedure",
+			decode: func(encoded []byte) error {
+				var procedure VotingProcedure
+				return procedure.UnmarshalCBOR(encoded)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, cborData := range [][]byte{{0xf6}, {0xf7}} {
+				require.Error(t, tc.decode(cborData))
+			}
+		})
+	}
+}
+
+func TestVotingProcedureUnmarshalCBORVoteTypes(t *testing.T) {
+	testCases := []struct {
+		name    string
+		vote    uint8
+		wantErr bool
+	}{
+		{name: "no", vote: GovVoteNo},
+		{name: "yes", vote: GovVoteYes},
+		{name: "abstain", vote: GovVoteAbstain},
+		{name: "invalid 3", vote: 3, wantErr: true},
+		{name: "invalid 255", vote: 255, wantErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := cbor.Encode([]any{tc.vote, nil})
+			require.NoError(t, err)
+
+			var procedure VotingProcedure
+			_, err = cbor.Decode(encoded, &procedure)
+			if tc.wantErr {
+				require.ErrorContains(t, err, "invalid vote type")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.vote, procedure.Vote)
+		})
+	}
+}
+
+func TestVotingProceduresUnmarshalCBORVoterKeys(t *testing.T) {
+	voter := Voter{Type: VoterTypeDRepKeyHash}
+	actionId := GovActionId{}
+	testCases := []struct {
+		name    string
+		votes   VotingProcedures
+		wantErr bool
+	}{
+		{
+			name: "valid voter",
+			votes: VotingProcedures{
+				&voter: {
+					&actionId: {Vote: GovVoteYes},
+				},
+			},
+		},
+		{
+			name: "nil voter",
+			votes: VotingProcedures{
+				nil: {},
+			},
+			wantErr: true,
+		},
+		{
+			name: "nil action id",
+			votes: VotingProcedures{
+				&voter: {
+					nil: {Vote: GovVoteYes},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := cbor.Encode(tc.votes)
+			require.NoError(t, err)
+
+			var votes VotingProcedures
+			_, err = cbor.Decode(encoded, &votes)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, votes, 1)
+		})
+	}
+}
+
+func TestVotingProceduresUnmarshalCBORRejectsNullProcedure(t *testing.T) {
+	voter := Voter{Type: VoterTypeDRepKeyHash}
+	actionId := GovActionId{}
+	encoded, err := cbor.Encode(map[*Voter]map[*GovActionId]any{
+		&voter: {
+			&actionId: nil,
+		},
+	})
+	require.NoError(t, err)
+
+	var votes VotingProcedures
+	_, err = cbor.Decode(encoded, &votes)
+	require.Error(t, err)
+}
+
+func TestVotingProceduresUnmarshalCBORRequiresNonEmptyMaps(t *testing.T) {
+	voter := Voter{Type: VoterTypeDRepKeyHash}
+	actionId := GovActionId{}
+	testCases := []struct {
+		name    string
+		encode  func() ([]byte, error)
+		wantErr bool
+	}{
+		{
+			name: "valid nonempty maps",
+			encode: func() ([]byte, error) {
+				return cbor.Encode(VotingProcedures{
+					&voter: {
+						&actionId: {Vote: GovVoteYes},
+					},
+				})
+			},
+		},
+		{
+			name: "top level null",
+			encode: func() ([]byte, error) {
+				return []byte{0xf6}, nil
+			},
+			wantErr: true,
+		},
+		{
+			name: "top level undefined",
+			encode: func() ([]byte, error) {
+				return []byte{0xf7}, nil
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty outer map",
+			encode: func() ([]byte, error) {
+				return cbor.Encode(VotingProcedures{})
+			},
+			wantErr: true,
+		},
+		{
+			name: "null inner map",
+			encode: func() ([]byte, error) {
+				return cbor.Encode(map[*Voter]map[*GovActionId]VotingProcedure{
+					&voter: nil,
+				})
+			},
+			wantErr: true,
+		},
+		{
+			name: "undefined inner map",
+			encode: func() ([]byte, error) {
+				return cbor.Encode(map[*Voter]cbor.RawMessage{
+					&voter: {0xf7},
+				})
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty inner map",
+			encode: func() ([]byte, error) {
+				return cbor.Encode(map[*Voter]map[*GovActionId]VotingProcedure{
+					&voter: {},
+				})
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := tc.encode()
+			require.NoError(t, err)
+
+			var votes VotingProcedures
+			_, err = cbor.Decode(encoded, &votes)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, votes, 1)
+		})
+	}
+}
+
+func TestTreasuryWithdrawalGovActionUnmarshalCBORAddressKeys(t *testing.T) {
+	addressBytes := append([]byte{0xe0}, make([]byte, AddressHashSize)...)
+	address, err := NewAddressFromBytes(addressBytes)
+	require.NoError(t, err)
+	testCases := []struct {
+		name        string
+		withdrawals map[*Address]uint64
+		wantErr     bool
+	}{
+		{
+			name: "valid address",
+			withdrawals: map[*Address]uint64{
+				&address: 1,
+			},
+		},
+		{
+			name: "nil address",
+			withdrawals: map[*Address]uint64{
+				nil: 1,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := cbor.Encode([]any{
+				uint(GovActionTypeTreasuryWithdrawal),
+				tc.withdrawals,
+				nil,
+			})
+			require.NoError(t, err)
+
+			var action TreasuryWithdrawalGovAction
+			_, err = cbor.Decode(encoded, &action)
+			if tc.wantErr {
+				require.ErrorContains(t, err, "nil address")
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, action.Withdrawals, 1)
+		})
+	}
+}
 
 // Ttests the ToPlutusData method for Voter types
 func TestVoterToPlutusData(t *testing.T) {

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -128,6 +128,23 @@ func (b *ConwayBlock) UnmarshalCBOR(cborData []byte) error {
 	return nil
 }
 
+func validateConwayCertificateTypes(
+	certificates []common.CertificateWrapper,
+) error {
+	for idx, certificate := range certificates {
+		certType := common.CertificateType(certificate.Type)
+		if certType == common.CertificateTypeGenesisKeyDelegation ||
+			certType == common.CertificateTypeMoveInstantaneousRewards {
+			return fmt.Errorf(
+				"certificate type is not valid in Conway: index %d type %d",
+				idx,
+				certificate.Type,
+			)
+		}
+	}
+	return nil
+}
+
 func (b *ConwayBlock) MarshalCBOR() ([]byte, error) {
 	// Return stored CBOR if available
 	if b.Cbor() != nil {
@@ -612,6 +629,9 @@ func (b *ConwayTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	type tConwayTransactionBody ConwayTransactionBody
 	var tmp tConwayTransactionBody
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	if err := validateConwayCertificateTypes(tmp.TxCertificates); err != nil {
 		return err
 	}
 	// Reject duplicate members in any tag-258 set field on the transaction body.

--- a/ledger/conway/conway_test.go
+++ b/ledger/conway/conway_test.go
@@ -17,6 +17,8 @@ package conway
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
+	"math/big"
 	"reflect"
 	"strings"
 	"testing"
@@ -122,6 +124,184 @@ func TestConwayRedeemersIter(t *testing.T) {
 			)
 		}
 		iterIdx++
+	}
+}
+
+func TestConwayTransactionBodyUnmarshalCBORCertificateTypes(t *testing.T) {
+	testCases := []struct {
+		name            string
+		certificate     []any
+		wantErr         bool
+		wantCertificate common.CertificateType
+	}{
+		{
+			name: "pool retirement",
+			certificate: []any{
+				uint(common.CertificateTypePoolRetirement),
+				make([]byte, common.Blake2b224Size),
+				uint64(0),
+			},
+			wantCertificate: common.CertificateTypePoolRetirement,
+		},
+		{
+			name: "registration",
+			certificate: []any{
+				uint(common.CertificateTypeRegistration),
+				[]any{
+					uint(common.CredentialTypeAddrKeyHash),
+					make([]byte, common.Blake2b224Size),
+				},
+				int64(0),
+			},
+			wantCertificate: common.CertificateTypeRegistration,
+		},
+		{
+			name: "genesis key delegation",
+			certificate: []any{
+				uint(common.CertificateTypeGenesisKeyDelegation),
+				make([]byte, common.Blake2b224Size),
+				make([]byte, common.Blake2b224Size),
+				make([]byte, common.Blake2b256Size),
+			},
+			wantErr: true,
+		},
+		{
+			name: "move instantaneous rewards",
+			certificate: []any{
+				uint(common.CertificateTypeMoveInstantaneousRewards),
+				[]any{uint(0), uint64(0)},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := cbor.Encode(map[uint]any{
+				4: []any{tc.certificate},
+			})
+			require.NoError(t, err)
+
+			var body ConwayTransactionBody
+			err = body.UnmarshalCBOR(encoded)
+			if tc.wantErr {
+				require.ErrorContains(
+					t,
+					err,
+					"certificate type is not valid in Conway",
+				)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, body.TxCertificates, 1)
+			assert.Equal(
+				t,
+				uint(tc.wantCertificate),
+				body.TxCertificates[0].Type,
+			)
+		})
+	}
+}
+
+func TestConwayTransactionBodyUnmarshalCBORCertificateTagRange(t *testing.T) {
+	certificates := conwayCertificateFixturesByType()
+	for certType := common.CertificateTypeStakeRegistration; certType <= common.CertificateTypeUpdateDrep; certType++ {
+		certType := certType
+		t.Run(fmt.Sprintf("type %d", certType), func(t *testing.T) {
+			encoded, err := cbor.Encode(map[uint]any{
+				4: []any{certificates[certType]},
+			})
+			require.NoError(t, err)
+
+			var body ConwayTransactionBody
+			err = body.UnmarshalCBOR(encoded)
+			if certType == common.CertificateTypeGenesisKeyDelegation ||
+				certType == common.CertificateTypeMoveInstantaneousRewards {
+				require.ErrorContains(
+					t,
+					err,
+					"certificate type is not valid in Conway",
+				)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, body.TxCertificates, 1)
+			assert.Equal(t, uint(certType), body.TxCertificates[0].Type)
+		})
+	}
+}
+
+func conwayCertificateFixturesByType() map[common.CertificateType]any {
+	credential := common.Credential{
+		CredType: common.CredentialTypeAddrKeyHash,
+	}
+	return map[common.CertificateType]any{
+		common.CertificateTypeStakeRegistration: &common.StakeRegistrationCertificate{
+			CertType: uint(common.CertificateTypeStakeRegistration),
+		},
+		common.CertificateTypeStakeDeregistration: &common.StakeDeregistrationCertificate{
+			CertType: uint(common.CertificateTypeStakeDeregistration),
+		},
+		common.CertificateTypeStakeDelegation: &common.StakeDelegationCertificate{
+			CertType:        uint(common.CertificateTypeStakeDelegation),
+			StakeCredential: &credential,
+		},
+		common.CertificateTypePoolRegistration: &common.PoolRegistrationCertificate{
+			CertType: uint(common.CertificateTypePoolRegistration),
+			Margin:   cbor.Rat{Rat: big.NewRat(0, 1)},
+		},
+		common.CertificateTypePoolRetirement: &common.PoolRetirementCertificate{
+			CertType: uint(common.CertificateTypePoolRetirement),
+		},
+		common.CertificateTypeGenesisKeyDelegation: &common.GenesisKeyDelegationCertificate{
+			CertType: uint(common.CertificateTypeGenesisKeyDelegation),
+		},
+		common.CertificateTypeMoveInstantaneousRewards: []any{
+			uint(common.CertificateTypeMoveInstantaneousRewards),
+			[]any{uint(0), uint64(0)},
+		},
+		common.CertificateTypeRegistration: &common.RegistrationCertificate{
+			CertType: uint(common.CertificateTypeRegistration),
+		},
+		common.CertificateTypeDeregistration: &common.DeregistrationCertificate{
+			CertType: uint(common.CertificateTypeDeregistration),
+		},
+		common.CertificateTypeVoteDelegation: &common.VoteDelegationCertificate{
+			CertType: uint(common.CertificateTypeVoteDelegation),
+			Drep:     common.Drep{Type: common.DrepTypeAbstain},
+		},
+		common.CertificateTypeStakeVoteDelegation: &common.StakeVoteDelegationCertificate{
+			CertType: uint(common.CertificateTypeStakeVoteDelegation),
+			Drep:     common.Drep{Type: common.DrepTypeAbstain},
+		},
+		common.CertificateTypeStakeRegistrationDelegation: &common.StakeRegistrationDelegationCertificate{
+			CertType: uint(common.CertificateTypeStakeRegistrationDelegation),
+		},
+		common.CertificateTypeVoteRegistrationDelegation: &common.VoteRegistrationDelegationCertificate{
+			CertType: uint(common.CertificateTypeVoteRegistrationDelegation),
+			Drep:     common.Drep{Type: common.DrepTypeAbstain},
+		},
+		common.CertificateTypeStakeVoteRegistrationDelegation: &common.StakeVoteRegistrationDelegationCertificate{
+			CertType: uint(
+				common.CertificateTypeStakeVoteRegistrationDelegation,
+			),
+			Drep: common.Drep{Type: common.DrepTypeAbstain},
+		},
+		common.CertificateTypeAuthCommitteeHot: &common.AuthCommitteeHotCertificate{
+			CertType: uint(common.CertificateTypeAuthCommitteeHot),
+		},
+		common.CertificateTypeResignCommitteeCold: &common.ResignCommitteeColdCertificate{
+			CertType: uint(common.CertificateTypeResignCommitteeCold),
+		},
+		common.CertificateTypeRegistrationDrep: &common.RegistrationDrepCertificate{
+			CertType: uint(common.CertificateTypeRegistrationDrep),
+		},
+		common.CertificateTypeDeregistrationDrep: &common.DeregistrationDrepCertificate{
+			CertType: uint(common.CertificateTypeDeregistrationDrep),
+		},
+		common.CertificateTypeUpdateDrep: &common.UpdateDrepCertificate{
+			CertType: uint(common.CertificateTypeUpdateDrep),
+		},
 	}
 }
 

--- a/ledger/dijkstra/dijkstra.go
+++ b/ledger/dijkstra/dijkstra.go
@@ -761,6 +761,9 @@ func (b *DijkstraTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
 		return err
 	}
+	if err := validateDijkstraCertificateTypes(tmp.TxCertificates); err != nil {
+		return err
+	}
 	// Reject duplicate members in any tag-258 set field on the transaction body.
 	type duplicateChecker interface {
 		CheckForDuplicates() error
@@ -787,6 +790,25 @@ func (b *DijkstraTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	}
 	*b = DijkstraTransactionBody(tmp)
 	b.SetCborReference(cborData)
+	return nil
+}
+
+func validateDijkstraCertificateTypes(
+	certificates []common.CertificateWrapper,
+) error {
+	for idx, certificate := range certificates {
+		certType := common.CertificateType(certificate.Type)
+		if certType == common.CertificateTypeStakeRegistration ||
+			certType == common.CertificateTypeStakeDeregistration ||
+			certType == common.CertificateTypeGenesisKeyDelegation ||
+			certType == common.CertificateTypeMoveInstantaneousRewards {
+			return fmt.Errorf(
+				"certificate type is not valid in Dijkstra: index %d type %d",
+				idx,
+				certificate.Type,
+			)
+		}
+	}
 	return nil
 }
 
@@ -997,6 +1019,9 @@ func (b *DijkstraSubTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	type tDijkstraSubTransactionBody DijkstraSubTransactionBody
 	var tmp tDijkstraSubTransactionBody
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	if err := validateDijkstraCertificateTypes(tmp.TxCertificates); err != nil {
 		return err
 	}
 	if err := tmp.TxInputs.CheckForDuplicates(); err != nil {

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -17,6 +17,7 @@ package dijkstra
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
 	"math/big"
 	"strings"
 	"testing"
@@ -32,6 +33,153 @@ import (
 
 func testPlutusInteger(v int64) data.PlutusData {
 	return data.NewInteger(big.NewInt(v))
+}
+
+func TestDijkstraTransactionBodiesUnmarshalCBORCertificateTypes(t *testing.T) {
+	decoders := []struct {
+		name   string
+		decode func([]byte) ([]common.CertificateWrapper, error)
+	}{
+		{
+			name: "top level",
+			decode: func(encoded []byte) ([]common.CertificateWrapper, error) {
+				var body DijkstraTransactionBody
+				err := body.UnmarshalCBOR(encoded)
+				return body.TxCertificates, err
+			},
+		},
+		{
+			name: "sub transaction",
+			decode: func(encoded []byte) ([]common.CertificateWrapper, error) {
+				var body DijkstraSubTransactionBody
+				err := body.UnmarshalCBOR(encoded)
+				return body.TxCertificates, err
+			},
+		},
+	}
+	certificates := certificateFixturesByType()
+	testCases := make([]struct {
+		name     string
+		certType common.CertificateType
+		wantErr  bool
+	}, 0, len(certificates))
+	for certType := common.CertificateTypeStakeRegistration; certType <= common.CertificateTypeUpdateDrep; certType++ {
+		testCases = append(testCases, struct {
+			name     string
+			certType common.CertificateType
+			wantErr  bool
+		}{
+			name:     fmt.Sprintf("type %d", certType),
+			certType: certType,
+			wantErr: certType <= common.CertificateTypeStakeDeregistration ||
+				certType == common.CertificateTypeGenesisKeyDelegation ||
+				certType == common.CertificateTypeMoveInstantaneousRewards,
+		})
+	}
+
+	for _, decoder := range decoders {
+		t.Run(decoder.name, func(t *testing.T) {
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					encoded, err := cbor.Encode(map[uint]any{
+						4: []any{certificates[tc.certType]},
+					})
+					require.NoError(t, err)
+
+					certificates, err := decoder.decode(encoded)
+					if tc.wantErr {
+						require.ErrorContains(
+							t,
+							err,
+							"certificate type is not valid in Dijkstra",
+						)
+						return
+					}
+					require.NoError(t, err)
+					require.Len(t, certificates, 1)
+					require.Equal(
+						t,
+						uint(tc.certType),
+						certificates[0].Type,
+					)
+				})
+			}
+		})
+	}
+}
+
+func certificateFixturesByType() map[common.CertificateType]any {
+	credential := common.Credential{
+		CredType: common.CredentialTypeAddrKeyHash,
+	}
+	return map[common.CertificateType]any{
+		common.CertificateTypeStakeRegistration: &common.StakeRegistrationCertificate{
+			CertType: uint(common.CertificateTypeStakeRegistration),
+		},
+		common.CertificateTypeStakeDeregistration: &common.StakeDeregistrationCertificate{
+			CertType: uint(common.CertificateTypeStakeDeregistration),
+		},
+		common.CertificateTypeStakeDelegation: &common.StakeDelegationCertificate{
+			CertType:        uint(common.CertificateTypeStakeDelegation),
+			StakeCredential: &credential,
+		},
+		common.CertificateTypePoolRegistration: &common.PoolRegistrationCertificate{
+			CertType: uint(common.CertificateTypePoolRegistration),
+			Margin:   cbor.Rat{Rat: big.NewRat(0, 1)},
+		},
+		common.CertificateTypePoolRetirement: &common.PoolRetirementCertificate{
+			CertType: uint(common.CertificateTypePoolRetirement),
+		},
+		common.CertificateTypeGenesisKeyDelegation: &common.GenesisKeyDelegationCertificate{
+			CertType: uint(common.CertificateTypeGenesisKeyDelegation),
+		},
+		common.CertificateTypeMoveInstantaneousRewards: []any{
+			uint(common.CertificateTypeMoveInstantaneousRewards),
+			[]any{uint(0), uint64(0)},
+		},
+		common.CertificateTypeRegistration: &common.RegistrationCertificate{
+			CertType: uint(common.CertificateTypeRegistration),
+		},
+		common.CertificateTypeDeregistration: &common.DeregistrationCertificate{
+			CertType: uint(common.CertificateTypeDeregistration),
+		},
+		common.CertificateTypeVoteDelegation: &common.VoteDelegationCertificate{
+			CertType: uint(common.CertificateTypeVoteDelegation),
+			Drep:     common.Drep{Type: common.DrepTypeAbstain},
+		},
+		common.CertificateTypeStakeVoteDelegation: &common.StakeVoteDelegationCertificate{
+			CertType: uint(common.CertificateTypeStakeVoteDelegation),
+			Drep:     common.Drep{Type: common.DrepTypeAbstain},
+		},
+		common.CertificateTypeStakeRegistrationDelegation: &common.StakeRegistrationDelegationCertificate{
+			CertType: uint(common.CertificateTypeStakeRegistrationDelegation),
+		},
+		common.CertificateTypeVoteRegistrationDelegation: &common.VoteRegistrationDelegationCertificate{
+			CertType: uint(common.CertificateTypeVoteRegistrationDelegation),
+			Drep:     common.Drep{Type: common.DrepTypeAbstain},
+		},
+		common.CertificateTypeStakeVoteRegistrationDelegation: &common.StakeVoteRegistrationDelegationCertificate{
+			CertType: uint(
+				common.CertificateTypeStakeVoteRegistrationDelegation,
+			),
+			Drep: common.Drep{Type: common.DrepTypeAbstain},
+		},
+		common.CertificateTypeAuthCommitteeHot: &common.AuthCommitteeHotCertificate{
+			CertType: uint(common.CertificateTypeAuthCommitteeHot),
+		},
+		common.CertificateTypeResignCommitteeCold: &common.ResignCommitteeColdCertificate{
+			CertType: uint(common.CertificateTypeResignCommitteeCold),
+		},
+		common.CertificateTypeRegistrationDrep: &common.RegistrationDrepCertificate{
+			CertType: uint(common.CertificateTypeRegistrationDrep),
+		},
+		common.CertificateTypeDeregistrationDrep: &common.DeregistrationDrepCertificate{
+			CertType: uint(common.CertificateTypeDeregistrationDrep),
+		},
+		common.CertificateTypeUpdateDrep: &common.UpdateDrepCertificate{
+			CertType: uint(common.CertificateTypeUpdateDrep),
+		},
+	}
 }
 
 func minimalTxBody() map[uint]any {


### PR DESCRIPTION
## Summary

- Reject invalid, null, and undefined credential, voter, vote, and
  governance-map values during CBOR decoding.
- Enforce Conway and Dijkstra certificate-tag domains without changing
  earlier-era decoding.
- Preserve existing exported conversion signatures and valid encodings.

Closes #2044

## Review summary (Cubic)

- Invalid governance values now fail during decoding rather than reaching
  conversion and validation paths.
- Certificate types are restricted to the target era.
