### PR TITLE
fix(protocol): keep optional responders non-fatal

### DIFF
--- a/protocol/leiosfetch/README.md
+++ b/protocol/leiosfetch/README.md
@@ -188,13 +188,13 @@ whole node-to-node connection.
 
 ## Optional server responders
 
-Leios fetch is optional, but its server responder is available on every
-node-to-node connection that supports the mini-protocol. If a callback is not
-configured, the server declines each request with a state-machine-valid empty
-response: `NoBlock`, `NoBlockTxs`, an empty `Votes`, or an empty
-`LastBlockAndTxsInRange`, respectively. These responses return the protocol to
-`Idle` without producing a connection-level error. Errors from configured
-callbacks and transport failures are still propagated.
+Leios fetch is optional, but not every request has a safe empty response. An
+unconfigured `VotesRequestFunc` returns `Votes` with an empty CBOR array,
+returning the protocol to `Idle` without a connection-level error. The block,
+block-transactions, and block-range requests require their callbacks: their
+absence replies are either placeholder wire IDs or ambiguous with a real
+response. Errors from configured callbacks and transport failures are still
+propagated.
 
 ## Notes
 

--- a/protocol/leiosfetch/README.md
+++ b/protocol/leiosfetch/README.md
@@ -186,6 +186,16 @@ whole node-to-node connection.
   error to the caller, who can distinguish "not available" from a real protocol
   error with `errors.Is`.
 
+## Optional server responders
+
+Leios fetch is optional, but its server responder is available on every
+node-to-node connection that supports the mini-protocol. If a callback is not
+configured, the server declines each request with a state-machine-valid empty
+response: `NoBlock`, `NoBlockTxs`, an empty `Votes`, or an empty
+`LastBlockAndTxsInRange`, respectively. These responses return the protocol to
+`Idle` without producing a connection-level error. Errors from configured
+callbacks and transport failures are still propagated.
+
 ## Notes
 
 - Part of the experimental Leios protocol suite

--- a/protocol/leiosfetch/messages.go
+++ b/protocol/leiosfetch/messages.go
@@ -315,6 +315,9 @@ type MsgVotes struct {
 }
 
 func NewMsgVotes(votes []cbor.RawMessage) *MsgVotes {
+	if votes == nil {
+		votes = []cbor.RawMessage{}
+	}
 	m := &MsgVotes{
 		MessageBase: protocol.MessageBase{
 			MessageType: MessageTypeVotes,

--- a/protocol/leiosfetch/messages_test.go
+++ b/protocol/leiosfetch/messages_test.go
@@ -501,3 +501,9 @@ func TestMsgVotesEmpty(t *testing.T) {
 	decodedMsg := decoded.(*MsgVotes)
 	assert.Equal(t, 0, len(decodedMsg.VotesRaw))
 }
+
+func TestMsgVotesNilUsesEmptyArray(t *testing.T) {
+	encoded, err := cbor.Encode(NewMsgVotes(nil))
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x82, MessageTypeVotes, 0x80}, encoded)
+}

--- a/protocol/leiosfetch/server.go
+++ b/protocol/leiosfetch/server.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/protocol"
 )
 
@@ -102,10 +103,9 @@ func (s *Server) handleBlockRequest(msg protocol.Message) error {
 			"connection_id", s.callbackContext.ConnectionId.String(),
 		)
 	if s.config == nil || s.config.BlockRequestFunc == nil {
-		// Leios is optional and its server responder is registered for every
-		// node-to-node connection. An unconfigured responder declines the
-		// request without treating it as a bearer-level protocol error.
-		return s.SendMessage(NewMsgNoBlock())
+		return errors.New(
+			"received leios-fetch BlockRequest message but no callback function is defined",
+		)
 	}
 	msgBlockRequest := msg.(*MsgBlockRequest)
 	resp, err := s.config.BlockRequestFunc(
@@ -152,7 +152,9 @@ func (s *Server) handleBlockTxsRequest(msg protocol.Message) error {
 			"connection_id", s.callbackContext.ConnectionId.String(),
 		)
 	if s.config == nil || s.config.BlockTxsRequestFunc == nil {
-		return s.SendMessage(NewMsgNoBlockTxs())
+		return errors.New(
+			"received leios-fetch BlockTxsRequest message but no callback function is defined",
+		)
 	}
 	msgBlockTxsRequest := msg.(*MsgBlockTxsRequest)
 	resp, err := s.config.BlockTxsRequestFunc(
@@ -200,7 +202,7 @@ func (s *Server) handleVotesRequest(msg protocol.Message) error {
 			"connection_id", s.callbackContext.ConnectionId.String(),
 		)
 	if s.config == nil || s.config.VotesRequestFunc == nil {
-		return s.SendMessage(NewMsgVotes(nil))
+		return s.SendMessage(NewMsgVotes([]cbor.RawMessage{}))
 	}
 	msgVotesRequest := msg.(*MsgVotesRequest)
 	resp, err := s.config.VotesRequestFunc(
@@ -230,7 +232,9 @@ func (s *Server) handleBlockRangeRequest(msg protocol.Message) error {
 			"connection_id", s.callbackContext.ConnectionId.String(),
 		)
 	if s.config == nil || s.config.BlockRangeRequestFunc == nil {
-		return s.SendMessage(NewMsgLastBlockAndTxsInRange(nil, nil))
+		return errors.New(
+			"received leios-fetch BlockRangeRequest message but no callback function is defined",
+		)
 	}
 	msgBlockRangeRequest := msg.(*MsgBlockRangeRequest)
 	err := s.config.BlockRangeRequestFunc(

--- a/protocol/leiosfetch/server.go
+++ b/protocol/leiosfetch/server.go
@@ -102,9 +102,10 @@ func (s *Server) handleBlockRequest(msg protocol.Message) error {
 			"connection_id", s.callbackContext.ConnectionId.String(),
 		)
 	if s.config == nil || s.config.BlockRequestFunc == nil {
-		return errors.New(
-			"received leios-fetch BlockRequest message but no callback function is defined",
-		)
+		// Leios is optional and its server responder is registered for every
+		// node-to-node connection. An unconfigured responder declines the
+		// request without treating it as a bearer-level protocol error.
+		return s.SendMessage(NewMsgNoBlock())
 	}
 	msgBlockRequest := msg.(*MsgBlockRequest)
 	resp, err := s.config.BlockRequestFunc(
@@ -151,9 +152,7 @@ func (s *Server) handleBlockTxsRequest(msg protocol.Message) error {
 			"connection_id", s.callbackContext.ConnectionId.String(),
 		)
 	if s.config == nil || s.config.BlockTxsRequestFunc == nil {
-		return errors.New(
-			"received leios-fetch BlockTxsRequest message but no callback function is defined",
-		)
+		return s.SendMessage(NewMsgNoBlockTxs())
 	}
 	msgBlockTxsRequest := msg.(*MsgBlockTxsRequest)
 	resp, err := s.config.BlockTxsRequestFunc(
@@ -201,9 +200,7 @@ func (s *Server) handleVotesRequest(msg protocol.Message) error {
 			"connection_id", s.callbackContext.ConnectionId.String(),
 		)
 	if s.config == nil || s.config.VotesRequestFunc == nil {
-		return errors.New(
-			"received leios-fetch VotesRequest message but no callback function is defined",
-		)
+		return s.SendMessage(NewMsgVotes(nil))
 	}
 	msgVotesRequest := msg.(*MsgVotesRequest)
 	resp, err := s.config.VotesRequestFunc(
@@ -233,9 +230,7 @@ func (s *Server) handleBlockRangeRequest(msg protocol.Message) error {
 			"connection_id", s.callbackContext.ConnectionId.String(),
 		)
 	if s.config == nil || s.config.BlockRangeRequestFunc == nil {
-		return errors.New(
-			"received leios-fetch BlockRangeRequest message but no callback function is defined",
-		)
+		return s.SendMessage(NewMsgLastBlockAndTxsInRange(nil, nil))
 	}
 	msgBlockRangeRequest := msg.(*MsgBlockRangeRequest)
 	err := s.config.BlockRangeRequestFunc(

--- a/protocol/leiosfetch/server_test.go
+++ b/protocol/leiosfetch/server_test.go
@@ -29,9 +29,17 @@ import (
 	"github.com/blinklabs-io/gouroboros/muxer"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/blinklabs-io/gouroboros/protocol/peersharing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func testLeiosFetchConnectionId() connection.ConnectionId {
+	return connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+}
 
 func readLeiosFetchTestSegment(
 	t *testing.T,
@@ -75,7 +83,7 @@ func sendNotFoundTest(
 	t *testing.T,
 	cfg Config,
 	request protocol.Message,
-) uint {
+) (uint, []byte) {
 	t.Helper()
 	connId := connection.ConnectionId{
 		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
@@ -86,16 +94,36 @@ func sendNotFoundTest(
 	defer connB.Close()
 	m := muxer.New(connA)
 	defer m.Stop()
+	errs := make(chan error, 1)
 
 	server := NewServer(protocol.ProtocolOptions{
 		ConnectionId: connId,
+		ErrorChan:    errs,
 		Muxer:        m,
 	}, &cfg)
+	peerSharingCfg := peersharing.NewConfig(
+		peersharing.WithShareRequestFunc(
+			func(peersharing.CallbackContext, int) ([]peersharing.PeerAddress, error) {
+				return []peersharing.PeerAddress{}, nil
+			},
+		),
+	)
+	peerSharingServer := peersharing.NewServer(
+		protocol.ProtocolOptions{
+			ConnectionId: connId,
+			ErrorChan:    errs,
+			Muxer:        m,
+		},
+		&peerSharingCfg,
+	)
 	server.Start()
 	defer server.Protocol.Stop()
+	peerSharingServer.Start()
+	defer peerSharingServer.Protocol.Stop()
 	m.Start()
 
 	var msgType uint
+	var responsePayload []byte
 	for range 2 {
 		requestData, err := cbor.Encode(request)
 		require.NoError(t, err)
@@ -116,8 +144,30 @@ func sendNotFoundTest(
 		require.NotEmpty(t, elems)
 		_, err = cbor.Decode(elems[0], &msgType)
 		require.NoError(t, err)
+		responsePayload = append(responsePayload[:0], segment.Payload...)
 	}
-	return msgType
+
+	peerData, err := cbor.Encode(peersharing.NewMsgShareRequest(1))
+	require.NoError(t, err)
+	writeLeiosFetchTestSegment(
+		t,
+		connB,
+		muxer.NewSegment(peersharing.ProtocolId, peerData, false),
+	)
+	require.NoError(t, connB.SetReadDeadline(time.Now().Add(time.Second)))
+	peerResponse, err := readLeiosFetchTestSegment(t, connB)
+	require.NoError(t, err)
+	require.True(t, peerResponse.IsResponse())
+	require.Equal(t, uint16(peersharing.ProtocolId), peerResponse.GetProtocolId())
+	require.Never(t, func() bool {
+		select {
+		case <-errs:
+			return true
+		default:
+			return false
+		}
+	}, 50*time.Millisecond, time.Millisecond)
+	return msgType, responsePayload
 }
 
 func TestNewServer(t *testing.T) {
@@ -173,21 +223,25 @@ func TestHandleBlockRequest_CallbackIsCalled(t *testing.T) {
 
 func TestHandleBlockRequest_NilCallback(t *testing.T) {
 	cfg := NewConfig()
-	msgType := sendNotFoundTest(
-		t,
-		cfg,
+	server := NewServer(
+		protocol.ProtocolOptions{ConnectionId: testLeiosFetchConnectionId()},
+		&cfg,
+	)
+	err := server.handleBlockRequest(
 		NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02})),
 	)
-	require.Equal(t, uint(MessageTypeNoBlock), msgType)
+	require.ErrorContains(t, err, "no callback function is defined")
 }
 
 func TestHandleBlockRequest_NilConfig(t *testing.T) {
-	msgType := sendNotFoundTest(
-		t,
-		Config{},
+	server := NewServer(
+		protocol.ProtocolOptions{ConnectionId: testLeiosFetchConnectionId()},
+		nil,
+	)
+	err := server.handleBlockRequest(
 		NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02})),
 	)
-	require.Equal(t, uint(MessageTypeNoBlock), msgType)
+	require.ErrorContains(t, err, "no callback function is defined")
 }
 
 func TestHandleBlockRequest_CallbackError(t *testing.T) {
@@ -247,7 +301,7 @@ func TestHandleBlockRequestNotFoundSendsMsgNoBlock(t *testing.T) {
 			return nil, ErrBlockNotFound
 		}),
 	)
-	msgType := sendNotFoundTest(
+	msgType, _ := sendNotFoundTest(
 		t,
 		cfg,
 		NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02})),
@@ -265,7 +319,7 @@ func TestHandleBlockRequestWrappedNotFoundSendsMsgNoBlock(t *testing.T) {
 			)
 		}),
 	)
-	msgType := sendNotFoundTest(
+	msgType, _ := sendNotFoundTest(
 		t,
 		cfg,
 		NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02})),
@@ -279,7 +333,7 @@ func TestHandleBlockTxsRequestNotFoundSendsMsgNoBlockTxs(t *testing.T) {
 			return nil, ErrBlockTxsNotFound
 		}),
 	)
-	msgType := sendNotFoundTest(
+	msgType, _ := sendNotFoundTest(
 		t,
 		cfg,
 		NewMsgBlockTxsRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02}), nil),
@@ -354,12 +408,14 @@ func TestHandleBlockTxsRequest_CallbackIsCalled(t *testing.T) {
 
 func TestHandleBlockTxsRequest_NilCallback(t *testing.T) {
 	cfg := NewConfig()
-	msgType := sendNotFoundTest(
-		t,
-		cfg,
+	server := NewServer(
+		protocol.ProtocolOptions{ConnectionId: testLeiosFetchConnectionId()},
+		&cfg,
+	)
+	err := server.handleBlockTxsRequest(
 		NewMsgBlockTxsRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02}), nil),
 	)
-	assert.Equal(t, uint(MessageTypeNoBlockTxs), msgType)
+	require.ErrorContains(t, err, "no callback function is defined")
 }
 
 func TestHandleVotesRequest_CallbackIsCalled(t *testing.T) {
@@ -398,8 +454,9 @@ func TestHandleVotesRequest_CallbackIsCalled(t *testing.T) {
 
 func TestHandleVotesRequest_NilCallback(t *testing.T) {
 	cfg := NewConfig()
-	msgType := sendNotFoundTest(t, cfg, NewMsgVotesRequest(nil))
+	msgType, responsePayload := sendNotFoundTest(t, cfg, NewMsgVotesRequest(nil))
 	require.Equal(t, uint(MessageTypeVotes), msgType)
+	require.Equal(t, []byte{0x82, MessageTypeVotes, 0x80}, responsePayload)
 }
 
 func TestHandleBlockRangeRequest_Callback(t *testing.T) {
@@ -436,12 +493,14 @@ func TestHandleBlockRangeRequest_Callback(t *testing.T) {
 
 func TestHandleBlockRangeRequest_NilCallback(t *testing.T) {
 	cfg := NewConfig()
-	msgType := sendNotFoundTest(
-		t,
-		cfg,
+	server := NewServer(
+		protocol.ProtocolOptions{ConnectionId: testLeiosFetchConnectionId()},
+		&cfg,
+	)
+	err := server.handleBlockRangeRequest(
 		NewMsgBlockRangeRequest(pcommon.Point{}, pcommon.Point{}),
 	)
-	require.Equal(t, uint(MessageTypeLastBlockAndTxsInRange), msgType)
+	require.ErrorContains(t, err, "no callback function is defined")
 }
 
 func TestServerMessageHandler_UnexpectedType(t *testing.T) {

--- a/protocol/leiosfetch/server_test.go
+++ b/protocol/leiosfetch/server_test.go
@@ -67,10 +67,10 @@ func writeLeiosFetchTestSegment(
 	require.NoError(t, err)
 }
 
-// sendNotFoundTest drives a real server over a muxer, sending it the given
-// request and returning the message type of the server's response segment. It
-// is used to verify that a not-found callback signal produces the graceful
-// MsgNoBlock/MsgNoBlockTxs response instead of tearing down the connection.
+// sendNotFoundTest drives a real server over a muxer, sends the given request
+// twice, and returns the message type of the server's response segments. The
+// second exchange proves that the fallback returns the protocol to Idle and
+// leaves the bearer usable.
 func sendNotFoundTest(
 	t *testing.T,
 	cfg Config,
@@ -95,26 +95,28 @@ func sendNotFoundTest(
 	defer server.Protocol.Stop()
 	m.Start()
 
-	requestData, err := cbor.Encode(request)
-	require.NoError(t, err)
-	writeLeiosFetchTestSegment(
-		t,
-		connB,
-		muxer.NewSegment(ProtocolId, requestData, false),
-	)
-	require.NoError(t, connB.SetReadDeadline(time.Now().Add(time.Second)))
-	segment, err := readLeiosFetchTestSegment(t, connB)
-	require.NoError(t, err)
-	assert.True(t, segment.IsResponse())
-	assert.Equal(t, ProtocolId, segment.GetProtocolId())
-
-	var elems []cbor.RawMessage
-	_, err = cbor.Decode(segment.Payload, &elems)
-	require.NoError(t, err)
-	require.NotEmpty(t, elems)
 	var msgType uint
-	_, err = cbor.Decode(elems[0], &msgType)
-	require.NoError(t, err)
+	for range 2 {
+		requestData, err := cbor.Encode(request)
+		require.NoError(t, err)
+		writeLeiosFetchTestSegment(
+			t,
+			connB,
+			muxer.NewSegment(ProtocolId, requestData, false),
+		)
+		require.NoError(t, connB.SetReadDeadline(time.Now().Add(time.Second)))
+		segment, err := readLeiosFetchTestSegment(t, connB)
+		require.NoError(t, err)
+		assert.True(t, segment.IsResponse())
+		assert.Equal(t, ProtocolId, segment.GetProtocolId())
+
+		var elems []cbor.RawMessage
+		_, err = cbor.Decode(segment.Payload, &elems)
+		require.NoError(t, err)
+		require.NotEmpty(t, elems)
+		_, err = cbor.Decode(elems[0], &msgType)
+		require.NoError(t, err)
+	}
 	return msgType
 }
 
@@ -170,42 +172,22 @@ func TestHandleBlockRequest_CallbackIsCalled(t *testing.T) {
 }
 
 func TestHandleBlockRequest_NilCallback(t *testing.T) {
-	connId := connection.ConnectionId{
-		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
-		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
-	}
-
 	cfg := NewConfig()
-	server := &Server{
-		config:          &cfg,
-		callbackContext: CallbackContext{ConnectionId: connId},
-	}
-	server.initProtocol()
-
-	msg := NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02}))
-	err := server.handleBlockRequest(msg)
-
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "no callback function is defined")
+	msgType := sendNotFoundTest(
+		t,
+		cfg,
+		NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02})),
+	)
+	assert.Equal(t, uint(MessageTypeNoBlock), msgType)
 }
 
 func TestHandleBlockRequest_NilConfig(t *testing.T) {
-	connId := connection.ConnectionId{
-		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
-		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
-	}
-
-	server := &Server{
-		config:          nil,
-		callbackContext: CallbackContext{ConnectionId: connId},
-	}
-	server.initProtocol()
-
-	msg := NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02}))
-	err := server.handleBlockRequest(msg)
-
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "no callback function is defined")
+	msgType := sendNotFoundTest(
+		t,
+		Config{},
+		NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02})),
+	)
+	assert.Equal(t, uint(MessageTypeNoBlock), msgType)
 }
 
 func TestHandleBlockRequest_CallbackError(t *testing.T) {
@@ -371,23 +353,13 @@ func TestHandleBlockTxsRequest_CallbackIsCalled(t *testing.T) {
 }
 
 func TestHandleBlockTxsRequest_NilCallback(t *testing.T) {
-	connId := connection.ConnectionId{
-		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
-		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
-	}
-
 	cfg := NewConfig()
-	server := &Server{
-		config:          &cfg,
-		callbackContext: CallbackContext{ConnectionId: connId},
-	}
-	server.initProtocol()
-
-	msg := NewMsgBlockTxsRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02}), nil)
-	err := server.handleBlockTxsRequest(msg)
-
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "no callback function is defined")
+	msgType := sendNotFoundTest(
+		t,
+		cfg,
+		NewMsgBlockTxsRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02}), nil),
+	)
+	assert.Equal(t, uint(MessageTypeNoBlockTxs), msgType)
 }
 
 func TestHandleVotesRequest_CallbackIsCalled(t *testing.T) {
@@ -425,23 +397,9 @@ func TestHandleVotesRequest_CallbackIsCalled(t *testing.T) {
 }
 
 func TestHandleVotesRequest_NilCallback(t *testing.T) {
-	connId := connection.ConnectionId{
-		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
-		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
-	}
-
 	cfg := NewConfig()
-	server := &Server{
-		config:          &cfg,
-		callbackContext: CallbackContext{ConnectionId: connId},
-	}
-	server.initProtocol()
-
-	msg := NewMsgVotesRequest(nil)
-	err := server.handleVotesRequest(msg)
-
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "no callback function is defined")
+	msgType := sendNotFoundTest(t, cfg, NewMsgVotesRequest(nil))
+	assert.Equal(t, uint(MessageTypeVotes), msgType)
 }
 
 func TestHandleBlockRangeRequest_Callback(t *testing.T) {
@@ -477,23 +435,13 @@ func TestHandleBlockRangeRequest_Callback(t *testing.T) {
 }
 
 func TestHandleBlockRangeRequest_NilCallback(t *testing.T) {
-	connId := connection.ConnectionId{
-		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
-		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
-	}
-
 	cfg := NewConfig()
-	server := &Server{
-		config:          &cfg,
-		callbackContext: CallbackContext{ConnectionId: connId},
-	}
-	server.initProtocol()
-
-	msg := NewMsgBlockRangeRequest(pcommon.Point{}, pcommon.Point{})
-	err := server.handleBlockRangeRequest(msg)
-
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "no callback function is defined")
+	msgType := sendNotFoundTest(
+		t,
+		cfg,
+		NewMsgBlockRangeRequest(pcommon.Point{}, pcommon.Point{}),
+	)
+	assert.Equal(t, uint(MessageTypeLastBlockAndTxsInRange), msgType)
 }
 
 func TestServerMessageHandler_UnexpectedType(t *testing.T) {

--- a/protocol/leiosfetch/server_test.go
+++ b/protocol/leiosfetch/server_test.go
@@ -178,7 +178,7 @@ func TestHandleBlockRequest_NilCallback(t *testing.T) {
 		cfg,
 		NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02})),
 	)
-	assert.Equal(t, uint(MessageTypeNoBlock), msgType)
+	require.Equal(t, uint(MessageTypeNoBlock), msgType)
 }
 
 func TestHandleBlockRequest_NilConfig(t *testing.T) {
@@ -187,7 +187,7 @@ func TestHandleBlockRequest_NilConfig(t *testing.T) {
 		Config{},
 		NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02})),
 	)
-	assert.Equal(t, uint(MessageTypeNoBlock), msgType)
+	require.Equal(t, uint(MessageTypeNoBlock), msgType)
 }
 
 func TestHandleBlockRequest_CallbackError(t *testing.T) {
@@ -284,7 +284,7 @@ func TestHandleBlockTxsRequestNotFoundSendsMsgNoBlockTxs(t *testing.T) {
 		cfg,
 		NewMsgBlockTxsRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02}), nil),
 	)
-	assert.Equal(t, uint(MessageTypeNoBlockTxs), msgType)
+	require.Equal(t, uint(MessageTypeNoBlockTxs), msgType)
 }
 
 func TestHandleBlockRequest_NonNotFoundErrorPropagates(t *testing.T) {
@@ -399,7 +399,7 @@ func TestHandleVotesRequest_CallbackIsCalled(t *testing.T) {
 func TestHandleVotesRequest_NilCallback(t *testing.T) {
 	cfg := NewConfig()
 	msgType := sendNotFoundTest(t, cfg, NewMsgVotesRequest(nil))
-	assert.Equal(t, uint(MessageTypeVotes), msgType)
+	require.Equal(t, uint(MessageTypeVotes), msgType)
 }
 
 func TestHandleBlockRangeRequest_Callback(t *testing.T) {
@@ -441,7 +441,7 @@ func TestHandleBlockRangeRequest_NilCallback(t *testing.T) {
 		cfg,
 		NewMsgBlockRangeRequest(pcommon.Point{}, pcommon.Point{}),
 	)
-	assert.Equal(t, uint(MessageTypeLastBlockAndTxsInRange), msgType)
+	require.Equal(t, uint(MessageTypeLastBlockAndTxsInRange), msgType)
 }
 
 func TestServerMessageHandler_UnexpectedType(t *testing.T) {

--- a/protocol/leiosvotes/README.md
+++ b/protocol/leiosvotes/README.md
@@ -44,6 +44,17 @@ Busy --Vote, tokens = 1--> Idle
 Idle --Done--> Done
 ```
 
+## Optional server responder
+
+Leios votes is optional, but its server responder is available on every
+node-to-node connection that supports the mini-protocol. If `RequestNextFunc`
+is not configured, a request is accepted and remains in the server's `Busy`
+state without a timeout or connection-level error. This protocol has no empty
+batch response, so leaving the request pending avoids inventing a wire message
+and prevents an optional request from closing the shared bearer. Configured
+callbacks, callback errors, and transport failures retain the normal timeout
+and error behavior.
+
 ## States
 
 | State | ID | Agency | Description |

--- a/protocol/leiosvotes/README.md
+++ b/protocol/leiosvotes/README.md
@@ -46,14 +46,11 @@ Idle --Done--> Done
 
 ## Optional server responder
 
-Leios votes is optional, but its server responder is available on every
-node-to-node connection that supports the mini-protocol. If `RequestNextFunc`
-is not configured, a request is accepted and remains in the server's `Busy`
-state without a timeout or connection-level error. This protocol has no empty
-batch response, so leaving the request pending avoids inventing a wire message
-and prevents an optional request from closing the shared bearer. Configured
-callbacks, callback errors, and transport failures retain the normal timeout
-and error behavior.
+Leios votes has no state-machine-valid empty batch response. Configure
+`RequestNextFunc` before accepting vote requests; an unconfigured responder
+returns a protocol error rather than leaving the shared bearer permanently
+stalled in `Busy`. The client and server retain the normal `Busy` timeout for
+callback and transport failures.
 
 ## States
 

--- a/protocol/leiosvotes/server.go
+++ b/protocol/leiosvotes/server.go
@@ -15,6 +15,7 @@
 package leiosvotes
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -46,17 +47,11 @@ func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 func (s *Server) initProtocol() {
 	stateMap := StateMap.Copy()
 	if entry, ok := stateMap[StateBusy]; ok {
-		// There is no empty-batch response in leios-votes. When no callback is
-		// configured, leave the request in Busy rather than timing out and
-		// tearing down the shared bearer. A configured responder retains the
-		// normal protocol timeout for callback and transport failures.
-		if s.config != nil && s.config.RequestNextFunc != nil {
-			timeout := DefaultTimeout
-			if s.config.Timeout != 0 {
-				timeout = s.config.Timeout
-			}
-			entry.Timeout = timeout
+		timeout := DefaultTimeout
+		if s.config != nil && s.config.Timeout != 0 {
+			timeout = s.config.Timeout
 		}
+		entry.Timeout = timeout
 		stateMap[StateBusy] = entry
 	}
 	protoConfig := protocol.ProtocolConfig{
@@ -119,10 +114,9 @@ func (s *Server) handleRequestNext(msg protocol.Message) error {
 		)
 	}
 	if s.config == nil || s.config.RequestNextFunc == nil {
-		// Leios vote diffusion is optional and has no empty response message.
-		// Keep the request in Busy (with no timeout) so an unconfigured
-		// responder does not turn an optional request into a bearer error.
-		return nil
+		return errors.New(
+			"received leios-votes VotesRequestNext message but no callback function is defined",
+		)
 	}
 	votes, err := s.config.RequestNextFunc(
 		s.callbackContext,

--- a/protocol/leiosvotes/server.go
+++ b/protocol/leiosvotes/server.go
@@ -15,7 +15,6 @@
 package leiosvotes
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
@@ -47,11 +46,17 @@ func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 func (s *Server) initProtocol() {
 	stateMap := StateMap.Copy()
 	if entry, ok := stateMap[StateBusy]; ok {
-		timeout := DefaultTimeout
-		if s.config != nil && s.config.Timeout != 0 {
-			timeout = s.config.Timeout
+		// There is no empty-batch response in leios-votes. When no callback is
+		// configured, leave the request in Busy rather than timing out and
+		// tearing down the shared bearer. A configured responder retains the
+		// normal protocol timeout for callback and transport failures.
+		if s.config != nil && s.config.RequestNextFunc != nil {
+			timeout := DefaultTimeout
+			if s.config.Timeout != 0 {
+				timeout = s.config.Timeout
+			}
+			entry.Timeout = timeout
 		}
-		entry.Timeout = timeout
 		stateMap[StateBusy] = entry
 	}
 	protoConfig := protocol.ProtocolConfig{
@@ -114,9 +119,10 @@ func (s *Server) handleRequestNext(msg protocol.Message) error {
 		)
 	}
 	if s.config == nil || s.config.RequestNextFunc == nil {
-		return errors.New(
-			"received leios-votes VotesRequestNext message but no callback function is defined",
-		)
+		// Leios vote diffusion is optional and has no empty response message.
+		// Keep the request in Busy (with no timeout) so an unconfigured
+		// responder does not turn an optional request into a bearer error.
+		return nil
 	}
 	votes, err := s.config.RequestNextFunc(
 		s.callbackContext,

--- a/protocol/leiosvotes/server_test.go
+++ b/protocol/leiosvotes/server_test.go
@@ -24,12 +24,11 @@ import (
 	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/muxer"
 	"github.com/blinklabs-io/gouroboros/protocol"
-	"github.com/blinklabs-io/gouroboros/protocol/peersharing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestUnconfiguredRequestDoesNotTearDownBearer(t *testing.T) {
+func TestUnconfiguredRequestReportsBearerError(t *testing.T) {
 	connA, connB := net.Pipe()
 	m := muxer.New(connA)
 	errs := make(chan error, 1)
@@ -44,20 +43,10 @@ func TestUnconfiguredRequestDoesNotTearDownBearer(t *testing.T) {
 		},
 		&Config{Timeout: time.Millisecond},
 	)
-	peerSharingCfg := peersharing.NewConfig()
-	peerSharingServer := peersharing.NewServer(
-		protocol.ProtocolOptions{
-			ConnectionId: server.callbackContext.ConnectionId,
-			Muxer:        m,
-		},
-		&peerSharingCfg,
-	)
 	server.Start()
-	peerSharingServer.Start()
 	m.Start()
 	t.Cleanup(func() {
 		server.Stop()
-		peerSharingServer.Stop()
 		m.Stop()
 		connA.Close()
 		connB.Close()
@@ -67,27 +56,14 @@ func TestUnconfiguredRequestDoesNotTearDownBearer(t *testing.T) {
 	require.NoError(t, err)
 	writeTestSegment(t, connB, muxer.NewSegment(ProtocolId, data, false))
 
-	peerData, err := cbor.Encode(peersharing.NewMsgShareRequest(1))
-	require.NoError(t, err)
-	require.NoError(t, connB.SetWriteDeadline(time.Now().Add(time.Second)))
-	writeTestSegment(
-		t,
-		connB,
-		muxer.NewSegment(peersharing.ProtocolId, peerData, false),
-	)
-	require.NoError(t, connB.SetReadDeadline(time.Now().Add(time.Second)))
-	peerResponse := requireReadTestSegment(t, connB)
-	require.True(t, peerResponse.IsResponse())
-	require.Equal(t, uint16(peersharing.ProtocolId), peerResponse.GetProtocolId())
-
-	require.Never(t, func() bool {
+	require.Eventually(t, func() bool {
 		select {
-		case <-errs:
-			return true
+		case err := <-errs:
+			return assert.ErrorContains(t, err, "no callback function is defined")
 		default:
 			return false
 		}
-	}, 50*time.Millisecond, time.Millisecond)
+	}, time.Second, time.Millisecond)
 }
 
 func TestNewServer(t *testing.T) {
@@ -133,7 +109,7 @@ func TestHandleRequestNextNilCallback(t *testing.T) {
 
 	err := server.handleRequestNext(NewMsgVotesRequestNext(1))
 
-	assert.NoError(t, err)
+	assert.ErrorContains(t, err, "no callback function is defined")
 }
 
 func TestHandleRequestNextNilConfig(t *testing.T) {
@@ -145,7 +121,7 @@ func TestHandleRequestNextNilConfig(t *testing.T) {
 
 	err := server.handleRequestNext(NewMsgVotesRequestNext(1))
 
-	assert.NoError(t, err)
+	assert.ErrorContains(t, err, "no callback function is defined")
 }
 
 func TestHandleRequestNextInvalidCount(t *testing.T) {

--- a/protocol/leiosvotes/server_test.go
+++ b/protocol/leiosvotes/server_test.go
@@ -16,12 +16,79 @@ package leiosvotes
 
 import (
 	"errors"
+	"net"
 	"testing"
+	"time"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/muxer"
 	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/blinklabs-io/gouroboros/protocol/peersharing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestUnconfiguredRequestDoesNotTearDownBearer(t *testing.T) {
+	connA, connB := net.Pipe()
+	m := muxer.New(connA)
+	errs := make(chan error, 1)
+	server := NewServer(
+		protocol.ProtocolOptions{
+			ConnectionId: connection.ConnectionId{
+				LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)},
+				RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)},
+			},
+			ErrorChan: errs,
+			Muxer:     m,
+		},
+		&Config{Timeout: time.Millisecond},
+	)
+	peerSharingCfg := peersharing.NewConfig()
+	peerSharingServer := peersharing.NewServer(
+		protocol.ProtocolOptions{
+			ConnectionId: server.callbackContext.ConnectionId,
+			Muxer:        m,
+		},
+		&peerSharingCfg,
+	)
+	server.Start()
+	peerSharingServer.Start()
+	m.Start()
+	t.Cleanup(func() {
+		server.Stop()
+		peerSharingServer.Stop()
+		m.Stop()
+		connA.Close()
+		connB.Close()
+	})
+
+	data, err := cbor.Encode(NewMsgVotesRequestNext(1))
+	require.NoError(t, err)
+	writeTestSegment(t, connB, muxer.NewSegment(ProtocolId, data, false))
+
+	peerData, err := cbor.Encode(peersharing.NewMsgShareRequest(1))
+	require.NoError(t, err)
+	require.NoError(t, connB.SetWriteDeadline(time.Now().Add(time.Second)))
+	writeTestSegment(
+		t,
+		connB,
+		muxer.NewSegment(peersharing.ProtocolId, peerData, false),
+	)
+	require.NoError(t, connB.SetReadDeadline(time.Now().Add(time.Second)))
+	peerResponse := requireReadTestSegment(t, connB)
+	require.True(t, peerResponse.IsResponse())
+	require.Equal(t, uint16(peersharing.ProtocolId), peerResponse.GetProtocolId())
+
+	require.Never(t, func() bool {
+		select {
+		case <-errs:
+			return true
+		default:
+			return false
+		}
+	}, 50*time.Millisecond, time.Millisecond)
+}
 
 func TestNewServer(t *testing.T) {
 	cfg := NewConfig()
@@ -66,8 +133,7 @@ func TestHandleRequestNextNilCallback(t *testing.T) {
 
 	err := server.handleRequestNext(NewMsgVotesRequestNext(1))
 
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "no callback function is defined")
+	assert.NoError(t, err)
 }
 
 func TestHandleRequestNextNilConfig(t *testing.T) {
@@ -79,8 +145,7 @@ func TestHandleRequestNextNilConfig(t *testing.T) {
 
 	err := server.handleRequestNext(NewMsgVotesRequestNext(1))
 
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "no callback function is defined")
+	assert.NoError(t, err)
 }
 
 func TestHandleRequestNextInvalidCount(t *testing.T) {

--- a/protocol/peersharing/README.md
+++ b/protocol/peersharing/README.md
@@ -62,7 +62,8 @@ advertises one of the modes below. The protocol channel is multiplexed onto the
 connection for any version 11+ regardless of the advertised modes. The client
 refuses to send `ShareRequest` when the remote opted out. If the local side
 opted out but still receives an invalid request, the server returns an empty
-`SharePeers` response so the request does not close the shared connection.
+`SharePeers` array (`[1, []]`) so the request does not close the shared
+connection.
 
 ### Mode values per version
 
@@ -174,10 +175,10 @@ oConn, err := ouroboros.New(
 
 When the local node advertises `NoPeerSharing` (the default,
 `WithPeerSharing(false)`), an unexpected incoming `ShareRequest` receives an
-empty `SharePeers` response. A spec-compliant peer would not send the request,
-but declining it at the mini-protocol boundary keeps an invalid optional
-request from closing the shared connection. The same empty response is used
-when no `ShareRequestFunc` is configured.
+empty `SharePeers` array (`[1, []]`). A spec-compliant peer would not send the
+request, but declining it at the mini-protocol boundary keeps an invalid
+optional request from closing the shared connection. The same empty response
+is used when no `ShareRequestFunc` is configured.
 
 ## Peer Address Format
 

--- a/protocol/peersharing/README.md
+++ b/protocol/peersharing/README.md
@@ -59,9 +59,10 @@ be overridden per connection via `peersharing.WithTimeout`.
 
 PeerSharing is gated by the handshake's `PeerSharing` mode field. Each side
 advertises one of the modes below. The protocol channel is multiplexed onto the
-connection for any version 11+ regardless of the advertised modes, but
-gouroboros refuses to send or honour `ShareRequest` messages when either side
-opted out.
+connection for any version 11+ regardless of the advertised modes. The client
+refuses to send `ShareRequest` when the remote opted out. If the local side
+opted out but still receives an invalid request, the server returns an empty
+`SharePeers` response so the request does not close the shared connection.
 
 ### Mode values per version
 

--- a/protocol/peersharing/README.md
+++ b/protocol/peersharing/README.md
@@ -78,7 +78,7 @@ disables peer sharing is `NoPeerSharing`.
 | Local advertised | Remote advertised | Client may send `ShareRequest`? | Server honours incoming `ShareRequest`? |
 |---|---|---|---|
 | any | NoPeerSharing | no — `ErrRemotePeerSharingDisabled` | yes (if local advertised active) |
-| NoPeerSharing | active | no — would be a self-protocol violation; client should not be calling `GetPeers` | no — `ErrLocalPeerSharingDisabled` |
+| NoPeerSharing | active | no — would be a self-protocol violation; client should not be calling `GetPeers` | empty `SharePeers` response |
 | active | active | yes | yes |
 
 Operators flip the local advertisement with `ouroboros.WithPeerSharing(true)`
@@ -172,10 +172,11 @@ oConn, err := ouroboros.New(
 ```
 
 When the local node advertises `NoPeerSharing` (the default,
-`WithPeerSharing(false)`), incoming `ShareRequest` messages are refused with
-`ErrLocalPeerSharingDisabled`, which surfaces as a protocol error and closes
-the connection. A spec-compliant peer would not send `ShareRequest` in that
-case.
+`WithPeerSharing(false)`), an unexpected incoming `ShareRequest` receives an
+empty `SharePeers` response. A spec-compliant peer would not send the request,
+but declining it at the mini-protocol boundary keeps an invalid optional
+request from closing the shared connection. The same empty response is used
+when no `ShareRequestFunc` is configured.
 
 ## Peer Address Format
 

--- a/protocol/peersharing/messages.go
+++ b/protocol/peersharing/messages.go
@@ -78,6 +78,9 @@ type MsgSharePeers struct {
 }
 
 func NewMsgSharePeers(peerAddresses []PeerAddress) *MsgSharePeers {
+	if peerAddresses == nil {
+		peerAddresses = []PeerAddress{}
+	}
 	m := &MsgSharePeers{
 		MessageBase: protocol.MessageBase{
 			MessageType: MessageTypeSharePeers,

--- a/protocol/peersharing/messages_test.go
+++ b/protocol/peersharing/messages_test.go
@@ -152,6 +152,12 @@ func TestEncode(t *testing.T) {
 	}
 }
 
+func TestMsgSharePeersNilUsesEmptyArray(t *testing.T) {
+	encoded, err := cbor.Encode(NewMsgSharePeers(nil))
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x82, MessageTypeSharePeers, 0x80}, encoded)
+}
+
 func TestNewMsgFromCborUnknownType(t *testing.T) {
 	msg, err := NewMsgFromCbor(999, []byte{0x80})
 	require.Error(t, err)

--- a/protocol/peersharing/peersharing.go
+++ b/protocol/peersharing/peersharing.go
@@ -30,9 +30,10 @@ var ErrRemotePeerSharingDisabled = errors.New(
 	"peer sharing: remote peer advertised NoPeerSharing during handshake",
 )
 
-// ErrLocalPeerSharingDisabled is returned by the server when a peer sends a
-// ShareRequest but we advertised NoPeerSharing during the handshake. A
-// spec-compliant peer must not send ShareRequest in that case.
+// ErrLocalPeerSharingDisabled is retained for compatibility with callers that
+// classified the previous server-side behavior. The server now answers an
+// unexpected ShareRequest with an empty SharePeers message so it cannot tear
+// down the shared bearer.
 var ErrLocalPeerSharingDisabled = errors.New(
 	"peer sharing: received ShareRequest but local node advertised NoPeerSharing during handshake",
 )
@@ -156,8 +157,8 @@ func WithTimeout(timeout time.Duration) PeerSharingOptionFunc {
 }
 
 // WithLocalDisabled records that this node advertised NoPeerSharing during
-// the handshake. The server uses this to refuse incoming ShareRequest
-// messages with ErrLocalPeerSharingDisabled.
+// the handshake. The server answers incoming ShareRequest messages with an
+// empty SharePeers response while this flag is set.
 func WithLocalDisabled(disabled bool) PeerSharingOptionFunc {
 	return func(c *Config) {
 		c.LocalDisabled = disabled

--- a/protocol/peersharing/peersharing.go
+++ b/protocol/peersharing/peersharing.go
@@ -31,9 +31,10 @@ var ErrRemotePeerSharingDisabled = errors.New(
 )
 
 // ErrLocalPeerSharingDisabled is retained for compatibility with callers that
-// classified the previous server-side behavior. The server now answers an
-// unexpected ShareRequest with an empty SharePeers message so it cannot tear
-// down the shared bearer.
+// classified the previous server-side behavior.
+//
+// Deprecated: the server now answers an unexpected ShareRequest with an empty
+// SharePeers message so it cannot tear down the shared bearer.
 var ErrLocalPeerSharingDisabled = errors.New(
 	"peer sharing: received ShareRequest but local node advertised NoPeerSharing during handshake",
 )

--- a/protocol/peersharing/server.go
+++ b/protocol/peersharing/server.go
@@ -15,7 +15,6 @@
 package peersharing
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
@@ -91,7 +90,10 @@ func (s *Server) handleMessage(msg protocol.Message) error {
 
 func (s *Server) handleShareRequest(msg protocol.Message) error {
 	if s.config != nil && s.config.LocalDisabled {
-		return ErrLocalPeerSharingDisabled
+		// A peer that sends ShareRequest after we advertised NoPeerSharing is
+		// not following the handshake negotiation. Still answer with an empty
+		// response so an invalid optional request cannot tear down the bearer.
+		return s.SendMessage(NewMsgSharePeers(nil))
 	}
 	s.Protocol.Logger().
 		Debug("share request",
@@ -101,9 +103,9 @@ func (s *Server) handleShareRequest(msg protocol.Message) error {
 			"connection_id", s.callbackContext.ConnectionId.String(),
 		)
 	if s.config == nil || s.config.ShareRequestFunc == nil {
-		return errors.New(
-			"received peer-sharing ShareRequest message but no callback function is defined",
-		)
+		// Peer sharing is optional. Keep the protocol in its normal request /
+		// response cycle when the application has no peer source configured.
+		return s.SendMessage(NewMsgSharePeers(nil))
 	}
 	msgShareRequest := msg.(*MsgShareRequest)
 	peers, err := s.config.ShareRequestFunc(

--- a/protocol/peersharing/server.go
+++ b/protocol/peersharing/server.go
@@ -89,23 +89,31 @@ func (s *Server) handleMessage(msg protocol.Message) error {
 }
 
 func (s *Server) handleShareRequest(msg protocol.Message) error {
-	if s.config != nil && s.config.LocalDisabled {
-		// A peer that sends ShareRequest after we advertised NoPeerSharing is
-		// not following the handshake negotiation. Still answer with an empty
-		// response so an invalid optional request cannot tear down the bearer.
-		return s.SendMessage(NewMsgSharePeers(nil))
-	}
 	s.Protocol.Logger().
 		Debug("share request",
 			"component", "network",
 			"protocol", ProtocolName,
 			"role", "server",
 			"connection_id", s.callbackContext.ConnectionId.String(),
+			"local_disabled", s.config != nil && s.config.LocalDisabled,
 		)
+	if s.config != nil && s.config.LocalDisabled {
+		s.Protocol.Logger().
+			Debug("peer sharing request violates negotiated mode",
+				"component", "network",
+				"protocol", ProtocolName,
+				"role", "server",
+				"connection_id", s.callbackContext.ConnectionId.String(),
+			)
+		// A peer that sends ShareRequest after we advertised NoPeerSharing is
+		// not following the handshake negotiation. Still answer with an empty
+		// response so an invalid optional request cannot tear down the bearer.
+		return s.SendMessage(NewMsgSharePeers([]PeerAddress{}))
+	}
 	if s.config == nil || s.config.ShareRequestFunc == nil {
 		// Peer sharing is optional. Keep the protocol in its normal request /
 		// response cycle when the application has no peer source configured.
-		return s.SendMessage(NewMsgSharePeers(nil))
+		return s.SendMessage(NewMsgSharePeers([]PeerAddress{}))
 	}
 	msgShareRequest := msg.(*MsgShareRequest)
 	peers, err := s.config.ShareRequestFunc(

--- a/protocol/peersharing/server_test.go
+++ b/protocol/peersharing/server_test.go
@@ -15,45 +15,106 @@
 package peersharing
 
 import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"net"
 	"testing"
+	"time"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/muxer"
+	"github.com/blinklabs-io/gouroboros/protocol"
 	"github.com/stretchr/testify/require"
 )
 
-// TestServerHandleShareRequestRefusesWhenLocalDisabled verifies that an
-// incoming ShareRequest message is rejected with ErrLocalPeerSharingDisabled
-// when the handshake recorded that this node advertised NoPeerSharing.
-// A spec-compliant peer must not send ShareRequest in that case, so we treat
-// it as a protocol violation regardless of whether a callback is configured.
-func TestServerHandleShareRequestRefusesWhenLocalDisabled(t *testing.T) {
+func readPeerSharingSegment(t *testing.T, conn net.Conn) *muxer.Segment {
+	t.Helper()
+	header := muxer.SegmentHeader{}
+	require.NoError(t, binary.Read(conn, binary.BigEndian, &header))
+	payload := make([]byte, header.PayloadLength)
+	_, err := io.ReadFull(conn, payload)
+	require.NoError(t, err)
+	return &muxer.Segment{SegmentHeader: header, Payload: payload}
+}
+
+func writePeerSharingSegment(t *testing.T, conn net.Conn, segment *muxer.Segment) {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	require.NoError(t, binary.Write(buf, binary.BigEndian, &segment.SegmentHeader))
+	_, err := buf.Write(segment.Payload)
+	require.NoError(t, err)
+	_, err = conn.Write(buf.Bytes())
+	require.NoError(t, err)
+}
+
+func sendPeerSharingRequest(t *testing.T, conn net.Conn, amount uint8) {
+	t.Helper()
+	data, err := cbor.Encode(NewMsgShareRequest(amount))
+	require.NoError(t, err)
+	writePeerSharingSegment(t, conn, muxer.NewSegment(ProtocolId, data, false))
+}
+
+func responsePeerCount(t *testing.T, segment *muxer.Segment) int {
+	t.Helper()
+	var values []cbor.RawMessage
+	_, err := cbor.Decode(segment.Payload, &values)
+	require.NoError(t, err)
+	require.Len(t, values, 2)
+	var peers []PeerAddress
+	_, err = cbor.Decode(values[1], &peers)
+	require.NoError(t, err)
+	return len(peers)
+}
+
+func testPeerSharingServer(t *testing.T, cfg *Config) net.Conn {
+	t.Helper()
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
+	}
+	connA, connB := net.Pipe()
+	m := muxer.New(connA)
+	server := NewServer(protocol.ProtocolOptions{ConnectionId: connId, Muxer: m}, cfg)
+	server.Start()
+	m.Start()
+	t.Cleanup(func() {
+		server.Stop()
+		m.Stop()
+		connA.Close()
+		connB.Close()
+	})
+	return connB
+}
+
+func TestServerDisabledRequestReturnsEmptyResponseAndRemainsUsable(t *testing.T) {
 	called := false
 	cfg := NewConfig(
 		WithLocalDisabled(true),
-		WithShareRequestFunc(
-			func(CallbackContext, int) ([]PeerAddress, error) {
-				called = true
-				return nil, nil
-			},
-		),
+		WithShareRequestFunc(func(CallbackContext, int) ([]PeerAddress, error) {
+			called = true
+			return nil, nil
+		}),
 	)
-	server := NewServer(testProtocolOptions(), &cfg)
+	connB := testPeerSharingServer(t, &cfg)
 
-	err := server.handleShareRequest(NewMsgShareRequest(5))
-	require.ErrorIs(t, err, ErrLocalPeerSharingDisabled)
-	require.False(t, called, "ShareRequestFunc must not be invoked when local disabled")
+	for range 2 {
+		sendPeerSharingRequest(t, connB, 5)
+		require.NoError(t, connB.SetReadDeadline(time.Now().Add(time.Second)))
+		segment := readPeerSharingSegment(t, connB)
+		require.True(t, segment.IsResponse())
+		require.Equal(t, uint16(ProtocolId), segment.GetProtocolId())
+		require.Equal(t, 0, responsePeerCount(t, segment))
+	}
+	require.False(t, called, "disabled peer sharing must not invoke the callback")
 }
 
-// TestServerHandleShareRequestRequiresCallback verifies that the legacy
-// "no callback configured" safeguard still fires when the local side is not
-// disabled. This also exercises the zero-value (legacy permissive) default
-// for LocalDisabled — the request reaches the callback check rather than
-// being short-circuited by the disabled-guard.
-func TestServerHandleShareRequestRequiresCallback(t *testing.T) {
-	cfg := NewConfig() // zero-value: LocalDisabled is false
-	server := NewServer(testProtocolOptions(), &cfg)
-
-	err := server.handleShareRequest(NewMsgShareRequest(5))
-	require.Error(t, err, "expected an error when no ShareRequestFunc is set")
-	require.NotErrorIs(t, err, ErrLocalPeerSharingDisabled,
-		"zero-value config must not trip ErrLocalPeerSharingDisabled")
+func TestServerUnconfiguredRequestReturnsEmptyResponse(t *testing.T) {
+	cfg := NewConfig()
+	connB := testPeerSharingServer(t, &cfg)
+	sendPeerSharingRequest(t, connB, 5)
+	require.NoError(t, connB.SetReadDeadline(time.Now().Add(time.Second)))
+	segment := readPeerSharingSegment(t, connB)
+	require.Equal(t, 0, responsePeerCount(t, segment))
 }

--- a/protocol/peersharing/server_test.go
+++ b/protocol/peersharing/server_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
+	"log/slog"
 	"net"
 	"testing"
 	"time"
@@ -62,6 +63,7 @@ func sendPeerSharingRequest(t *testing.T, conn net.Conn, amount uint8) {
 
 func responsePeerCount(t *testing.T, segment *muxer.Segment) int {
 	t.Helper()
+	require.Equal(t, []byte{0x82, MessageTypeSharePeers, 0x80}, segment.Payload)
 	var values []cbor.RawMessage
 	_, err := cbor.Decode(segment.Payload, &values)
 	require.NoError(t, err)
@@ -72,7 +74,7 @@ func responsePeerCount(t *testing.T, segment *muxer.Segment) int {
 	return len(peers)
 }
 
-func testPeerSharingServer(t *testing.T, cfg *Config) net.Conn {
+func testPeerSharingServer(t *testing.T, cfg *Config) (net.Conn, *bytes.Buffer) {
 	t.Helper()
 	connId := connection.ConnectionId{
 		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0},
@@ -80,7 +82,19 @@ func testPeerSharingServer(t *testing.T, cfg *Config) net.Conn {
 	}
 	connA, connB := net.Pipe()
 	m := muxer.New(connA)
-	server := NewServer(protocol.ProtocolOptions{ConnectionId: connId, Muxer: m}, cfg)
+	errs := make(chan error, 1)
+	logs := &bytes.Buffer{}
+	server := NewServer(
+		protocol.ProtocolOptions{
+			ConnectionId: connId,
+			ErrorChan:    errs,
+			Logger: slog.New(slog.NewTextHandler(logs, &slog.HandlerOptions{
+				Level: slog.LevelDebug,
+			})),
+			Muxer: m,
+		},
+		cfg,
+	)
 	server.Start()
 	m.Start()
 	t.Cleanup(func() {
@@ -89,7 +103,17 @@ func testPeerSharingServer(t *testing.T, cfg *Config) net.Conn {
 		connA.Close()
 		connB.Close()
 	})
-	return connB
+	t.Cleanup(func() {
+		require.Never(t, func() bool {
+			select {
+			case <-errs:
+				return true
+			default:
+				return false
+			}
+		}, 50*time.Millisecond, time.Millisecond)
+	})
+	return connB, logs
 }
 
 func TestServerDisabledRequestReturnsEmptyResponseAndRemainsUsable(t *testing.T) {
@@ -101,7 +125,7 @@ func TestServerDisabledRequestReturnsEmptyResponseAndRemainsUsable(t *testing.T)
 			return nil, nil
 		}),
 	)
-	connB := testPeerSharingServer(t, &cfg)
+	connB, _ := testPeerSharingServer(t, &cfg)
 
 	for range 2 {
 		sendPeerSharingRequest(t, connB, 5)
@@ -116,9 +140,21 @@ func TestServerDisabledRequestReturnsEmptyResponseAndRemainsUsable(t *testing.T)
 
 func TestServerUnconfiguredRequestReturnsEmptyResponse(t *testing.T) {
 	cfg := NewConfig()
-	connB := testPeerSharingServer(t, &cfg)
+	connB, _ := testPeerSharingServer(t, &cfg)
 	sendPeerSharingRequest(t, connB, 5)
 	require.NoError(t, connB.SetReadDeadline(time.Now().Add(time.Second)))
 	segment := readPeerSharingSegment(t, connB)
 	require.Equal(t, 0, responsePeerCount(t, segment))
+}
+
+func TestServerDisabledRequestLogsNegotiationViolation(t *testing.T) {
+	cfg := NewConfig(WithLocalDisabled(true))
+	connB, logs := testPeerSharingServer(t, &cfg)
+	sendPeerSharingRequest(t, connB, 5)
+	require.NoError(t, connB.SetReadDeadline(time.Now().Add(time.Second)))
+	_ = readPeerSharingSegment(t, connB)
+	require.Contains(t, logs.String(), "peer sharing request violates negotiated mode")
+	require.Contains(t, logs.String(), "local_disabled=true")
+	require.Contains(t, logs.String(), "protocol=peer-sharing")
+	require.Contains(t, logs.String(), "role=server")
 }

--- a/protocol/peersharing/server_test.go
+++ b/protocol/peersharing/server_test.go
@@ -41,6 +41,10 @@ func readPeerSharingSegment(t *testing.T, conn net.Conn) *muxer.Segment {
 
 func writePeerSharingSegment(t *testing.T, conn net.Conn, segment *muxer.Segment) {
 	t.Helper()
+	if segment == nil {
+		t.Fatal("expected non-nil muxer segment")
+		return
+	}
 	buf := &bytes.Buffer{}
 	require.NoError(t, binary.Write(buf, binary.BigEndian, &segment.SegmentHeader))
 	_, err := buf.Write(segment.Payload)


### PR DESCRIPTION
Relates to #2048.

## Summary

- return valid empty arrays for disabled or unconfigured peer sharing and unconfigured Leios fetch vote requests
- preserve shared-bearer liveness for those safe fallbacks while retaining observable errors where the wire protocol has no valid absence message
- keep the Leios votes busy timeout bounded and reject unconfigured requests instead of stalling the shared bearer
- document the exact fallback and error behavior

Issue #2048 remains open because Leios votes and Leios fetch block, block-transaction, and block-range requests have no safe absence messages. Making those paths non-fatal requires a protocol or registration design rather than placeholder or null payloads.

## Validation

- `make test`
- `make lint`
- `go build ./...`
- `go vet ./protocol/leiosfetch ./protocol/leiosvotes ./protocol/peersharing`
- `go test -race -count=1 ./protocol/leiosfetch ./protocol/leiosvotes ./protocol/peersharing`
