### PR TITLE
fix(connection): make error forwarding shutdown-safe

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -69,6 +69,7 @@ type Connection struct {
 	logger                *slog.Logger
 	muxer                 *muxer.Muxer
 	errorChan             chan error
+	ownsErrorChan         bool
 	protoErrorChan        chan error
 	handshakeFinishedChan chan any
 	handshakeVersion      uint16
@@ -136,6 +137,7 @@ func NewConnection(options ...ConnectionOptionFunc) (*Connection, error) {
 	}
 	if c.errorChan == nil {
 		c.errorChan = make(chan error, 10)
+		c.ownsErrorChan = true
 	}
 	if c.conn != nil {
 		if err := c.setupConnection(); err != nil {
@@ -160,7 +162,9 @@ func (c *Connection) Muxer() *muxer.Muxer {
 	return c.muxer
 }
 
-// ErrorChan returns the channel for asynchronous errors
+// ErrorChan returns the channel for asynchronous errors. A channel created by
+// the Connection is closed during shutdown; a channel supplied with
+// WithErrorChan remains open and caller-owned.
 func (c *Connection) ErrorChan() chan error {
 	return c.errorChan
 }
@@ -310,9 +314,22 @@ func (c *Connection) shutdown() {
 		close(c.connClosedChan)
 		// Wait for other goroutines to finish
 		c.waitGroup.Wait()
-		// Close consumer error channel to signify connection shutdown
-		close(c.errorChan)
+		// Signal shutdown only on the channel created by this connection.
+		// A channel supplied with WithErrorChan remains caller-owned.
+		if c.ownsErrorChan {
+			close(c.errorChan)
+		}
 	})
+}
+
+// forwardError attempts immediate delivery without allowing an undrained
+// consumer channel to prevent connection shutdown.
+func (c *Connection) forwardError(err error) {
+	select {
+	case c.errorChan <- err:
+	case <-c.doneChan:
+	default:
+	}
 }
 
 // allProtocolsIdle returns true if every active protocol is in a terminal or
@@ -492,10 +509,10 @@ func (c *Connection) setupConnection() error {
 			}
 			if errors.As(err, &connErr) {
 				// Pass through ConnectionClosedError from muxer
-				c.errorChan <- err
+				c.forwardError(err)
 			} else {
 				// Wrap error message to denote it comes from the muxer
-				c.errorChan <- fmt.Errorf("muxer error: %w", err)
+				c.forwardError(fmt.Errorf("muxer error: %w", err))
 			}
 			// Close connection on muxer errors
 			c.Close()
@@ -600,7 +617,7 @@ func (c *Connection) setupConnection() error {
 			if !ok {
 				return
 			}
-			c.errorChan <- fmt.Errorf("protocol error: %w", err)
+			c.forwardError(fmt.Errorf("protocol error: %w", err))
 			// Close connection on mini-protocol errors
 			c.Close()
 		}

--- a/connection.go
+++ b/connection.go
@@ -164,7 +164,10 @@ func (c *Connection) Muxer() *muxer.Muxer {
 
 // ErrorChan returns the channel for asynchronous errors. A channel created by
 // the Connection is closed during shutdown; a channel supplied with
-// WithErrorChan remains open and caller-owned.
+// WithErrorChan remains open and caller-owned. Delivery is non-blocking. A
+// supplied channel should have capacity of at least one for reliable delivery
+// while the connection is active; errors may be dropped when the channel is
+// full or has no receiver ready.
 func (c *Connection) ErrorChan() chan error {
 	return c.errorChan
 }
@@ -200,16 +203,23 @@ func (c *Connection) DialTimeout(
 
 // Close will shutdown the Ouroboros connection
 func (c *Connection) Close() error {
-	c.onceClose.Do(func() {
-		if c.doneChan == nil {
-			return
-		}
-		// Close doneChan to signify that we're shutting down
-		close(c.doneChan)
-		// Wait for connection to be closed
-		<-c.connClosedChan
-	})
+	if c.doneChan == nil {
+		return nil
+	}
+	c.requestClose()
+	// Wait until all connection-owned goroutines have stopped. After this
+	// returns, a caller may safely close a channel supplied with WithErrorChan.
+	<-c.connClosedChan
 	return nil
+}
+
+// requestClose initiates shutdown without waiting for it to complete. Tracked
+// connection goroutines use this method so shutdown can wait for them without
+// deadlocking.
+func (c *Connection) requestClose() {
+	c.onceClose.Do(func() {
+		close(c.doneChan)
+	})
 }
 
 // BlockFetch returns the block-fetch protocol handler
@@ -310,8 +320,6 @@ func (c *Connection) shutdown() {
 		if c.muxer != nil {
 			c.muxer.Stop()
 		}
-		// Close channel to let Close() know that it can return
-		close(c.connClosedChan)
 		// Wait for other goroutines to finish
 		c.waitGroup.Wait()
 		// Signal shutdown only on the channel created by this connection.
@@ -319,11 +327,14 @@ func (c *Connection) shutdown() {
 		if c.ownsErrorChan {
 			close(c.errorChan)
 		}
+		// Signal completion only after all connection-owned goroutines and
+		// channels have finished shutting down.
+		close(c.connClosedChan)
 	})
 }
 
-// forwardError attempts immediate delivery without allowing an undrained
-// consumer channel to prevent connection shutdown.
+// forwardError attempts immediate best-effort delivery without allowing a full
+// or undrained consumer channel to prevent connection shutdown.
 func (c *Connection) forwardError(err error) {
 	select {
 	case c.errorChan <- err:
@@ -504,7 +515,7 @@ func (c *Connection) setupConnection() error {
 			var connErr *muxer.ConnectionClosedError
 			if errors.As(err, &connErr) && c.allProtocolsIdle() {
 				// All protocols finished gracefully; suppress the error
-				c.Close()
+				c.requestClose()
 				return
 			}
 			if errors.As(err, &connErr) {
@@ -515,7 +526,7 @@ func (c *Connection) setupConnection() error {
 				c.forwardError(fmt.Errorf("muxer error: %w", err))
 			}
 			// Close connection on muxer errors
-			c.Close()
+			c.requestClose()
 		}
 	})
 	protoOptions := protocol.ProtocolOptions{
@@ -619,7 +630,7 @@ func (c *Connection) setupConnection() error {
 			}
 			c.forwardError(fmt.Errorf("protocol error: %w", err))
 			// Close connection on mini-protocol errors
-			c.Close()
+			c.requestClose()
 		}
 	})
 	// Configure the relevant mini-protocols

--- a/connection_error_channel_internal_test.go
+++ b/connection_error_channel_internal_test.go
@@ -1,0 +1,275 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ouroboros
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+	"github.com/stretchr/testify/require"
+)
+
+const errorForwardingTestTimeout = 5 * time.Second
+
+type injectableReadErrorConn struct {
+	net.Conn
+	injectedError chan error
+	errorReturned chan struct{}
+}
+
+func newInjectableReadErrorConn(conn net.Conn) *injectableReadErrorConn {
+	return &injectableReadErrorConn{
+		Conn:          conn,
+		injectedError: make(chan error, 1),
+		errorReturned: make(chan struct{}),
+	}
+}
+
+func (c *injectableReadErrorConn) Read(buf []byte) (int, error) {
+	type readResult struct {
+		count int
+		err   error
+	}
+	resultChan := make(chan readResult, 1)
+	go func() {
+		count, err := c.Conn.Read(buf)
+		resultChan <- readResult{count: count, err: err}
+	}()
+	select {
+	case err := <-c.injectedError:
+		_ = c.Conn.Close()
+		<-resultChan
+		close(c.errorReturned)
+		return 0, err
+	case result := <-resultChan:
+		return result.count, result.err
+	}
+}
+
+func (c *injectableReadErrorConn) injectReadError(err error) {
+	c.injectedError <- err
+}
+
+func newErrorForwardingTestConnection(
+	t *testing.T,
+	errorChan chan error,
+) (*Connection, *injectableReadErrorConn) {
+	t.Helper()
+	mockConn := ouroboros_mock.NewConnection(
+		ouroboros_mock.ProtocolRoleClient,
+		[]ouroboros_mock.ConversationEntry{
+			ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+			ouroboros_mock.ConversationEntryHandshakeNtCResponse,
+		},
+	)
+	transport := newInjectableReadErrorConn(mockConn)
+	conn, err := New(
+		WithConnection(transport),
+		WithNetworkMagic(ouroboros_mock.MockNetworkMagic),
+		WithErrorChan(errorChan),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = conn.Close()
+		_ = mockConn.Close()
+	})
+	return conn, transport
+}
+
+func requireChannelSignal[T any](
+	t *testing.T,
+	signal <-chan T,
+	message string,
+) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(errorForwardingTestTimeout):
+		t.Fatal(message)
+	}
+}
+
+func requireInjectedReadError(
+	t *testing.T,
+	conn *injectableReadErrorConn,
+	err error,
+) {
+	t.Helper()
+	conn.injectReadError(err)
+	requireChannelSignal(
+		t,
+		conn.errorReturned,
+		"injected read error was not returned",
+	)
+}
+
+func requireUndrainedErrorDoesNotBlockShutdown(
+	t *testing.T,
+	conn *Connection,
+	errorChan <-chan error,
+) {
+	t.Helper()
+	select {
+	case <-conn.doneChan:
+	case <-time.After(errorForwardingTestTimeout):
+		// Release an implementation with a blocking send so the failed
+		// regression does not leave teardown goroutines behind.
+		select {
+		case <-errorChan:
+		case <-time.After(errorForwardingTestTimeout):
+			t.Fatal("error forwarding did not reach the caller channel")
+		}
+		requireChannelSignal(
+			t,
+			conn.doneChan,
+			"error delivery did not initiate connection shutdown after resuming",
+		)
+		conn.shutdown()
+		t.Fatal("undrained error channel prevented error-triggered shutdown")
+	}
+
+	// A second call blocks in sync.Once until the shutdown initiated above
+	// has waited for all forwarding goroutines.
+	shutdownDone := make(chan struct{})
+	go func() {
+		conn.shutdown()
+		close(shutdownDone)
+	}()
+	select {
+	case <-shutdownDone:
+		return
+	case <-time.After(errorForwardingTestTimeout):
+		t.Fatal("connection shutdown did not wait for error forwarding")
+	}
+}
+
+func TestMuxerErrorForwardingCancelsDuringShutdown(t *testing.T) {
+	errorChan := make(chan error)
+	conn, transport := newErrorForwardingTestConnection(t, errorChan)
+	requireInjectedReadError(t, transport, errors.New("muxer failure"))
+	requireUndrainedErrorDoesNotBlockShutdown(t, conn, errorChan)
+}
+
+func TestProtocolErrorForwardingCancelsDuringShutdown(t *testing.T) {
+	errorChan := make(chan error)
+	conn, _ := newErrorForwardingTestConnection(t, errorChan)
+	forwardingStarted := make(chan struct{})
+	go func() {
+		conn.protoErrorChan <- errors.New("protocol failure")
+		close(forwardingStarted)
+	}()
+	requireChannelSignal(
+		t,
+		forwardingStarted,
+		"connection did not consume a protocol error",
+	)
+	requireUndrainedErrorDoesNotBlockShutdown(t, conn, errorChan)
+}
+
+func TestConnectionsDoNotCloseCallerErrorChannel(t *testing.T) {
+	errorChan := make(chan error, 1)
+	connections := make([]*Connection, 2)
+	for i := range connections {
+		var err error
+		connections[i], err = New(WithErrorChan(errorChan))
+		require.NoError(t, err)
+	}
+
+	require.NotPanics(t, func() {
+		for _, conn := range connections {
+			conn.shutdown()
+		}
+	})
+
+	wantErr := errors.New("caller still owns channel")
+	require.NotPanics(t, func() {
+		errorChan <- wantErr
+	})
+	require.ErrorIs(t, <-errorChan, wantErr)
+}
+
+func TestConnectionClosesInternalErrorChannel(t *testing.T) {
+	conn, err := New()
+	require.NoError(t, err)
+	errorChan := conn.ErrorChan()
+	conn.shutdown()
+
+	select {
+	case _, ok := <-errorChan:
+		require.False(t, ok, "internally-created error channel should close")
+	case <-time.After(errorForwardingTestTimeout):
+		t.Fatal("internally-created error channel remained open")
+	}
+}
+
+func TestConnectionErrorForwardingDeliversNormally(t *testing.T) {
+	testCases := []struct {
+		name    string
+		trigger func(
+			*testing.T,
+			*Connection,
+			*injectableReadErrorConn,
+			error,
+		)
+		wantErr string
+	}{
+		{
+			name: "muxer",
+			trigger: func(
+				t *testing.T,
+				_ *Connection,
+				transport *injectableReadErrorConn,
+				err error,
+			) {
+				requireInjectedReadError(t, transport, err)
+			},
+			wantErr: "muxer error: delivery failure",
+		},
+		{
+			name: "protocol",
+			trigger: func(
+				_ *testing.T,
+				conn *Connection,
+				_ *injectableReadErrorConn,
+				err error,
+			) {
+				conn.protoErrorChan <- err
+			},
+			wantErr: "protocol error: delivery failure",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			errorChan := make(chan error, 1)
+			conn, transport := newErrorForwardingTestConnection(t, errorChan)
+			testCase.trigger(
+				t,
+				conn,
+				transport,
+				errors.New("delivery failure"),
+			)
+
+			select {
+			case err := <-errorChan:
+				require.EqualError(t, err, testCase.wantErr)
+			case <-time.After(errorForwardingTestTimeout):
+				t.Fatalf("%s error was not delivered", testCase.name)
+			}
+		})
+	}
+}

--- a/connection_error_channel_internal_test.go
+++ b/connection_error_channel_internal_test.go
@@ -217,6 +217,66 @@ func TestConnectionClosesInternalErrorChannel(t *testing.T) {
 	}
 }
 
+func TestCloseWaitsForErrorForwardersBeforeCallerClosesChannel(t *testing.T) {
+	errorChan := make(chan error, 1)
+	conn := &Connection{
+		errorChan:      errorChan,
+		doneChan:       make(chan any),
+		connClosedChan: make(chan struct{}),
+	}
+	go func() {
+		<-conn.doneChan
+		conn.shutdown()
+	}()
+
+	forwarderStarted := make(chan struct{})
+	releaseForwarder := make(chan struct{})
+	forwarderDone := make(chan struct{})
+	conn.waitGroup.Go(func() {
+		defer close(forwarderDone)
+		close(forwarderStarted)
+		<-releaseForwarder
+		conn.forwardError(errors.New("late connection error"))
+	})
+	requireChannelSignal(
+		t,
+		forwarderStarted,
+		"error forwarder did not start",
+	)
+
+	closeResult := make(chan error, 1)
+	go func() {
+		closeResult <- conn.Close()
+	}()
+	requireChannelSignal(t, conn.doneChan, "connection shutdown did not start")
+	select {
+	case <-conn.connClosedChan:
+		close(releaseForwarder)
+		err := <-closeResult
+		conn.shutdown()
+		require.NoError(t, err)
+		t.Fatal("shutdown signaled completion before error forwarding stopped")
+	case <-time.After(100 * time.Millisecond):
+		// Shutdown must remain blocked while the tracked forwarder is blocked.
+	}
+
+	close(releaseForwarder)
+	select {
+	case err := <-closeResult:
+		require.NoError(t, err)
+	case <-time.After(errorForwardingTestTimeout):
+		t.Fatal("Close did not return after error forwarding stopped")
+	}
+	select {
+	case <-forwarderDone:
+	default:
+		t.Fatal("Close returned before the error forwarder finished")
+	}
+	require.NotPanics(t, func() {
+		close(errorChan)
+	})
+}
+
 func TestConnectionErrorForwardingDeliversNormally(t *testing.T) {
 	testCases := []struct {
 		name    string

--- a/connection_options.go
+++ b/connection_options.go
@@ -58,7 +58,9 @@ func WithNetworkMagic(networkMagic uint32) ConnectionOptionFunc {
 	}
 }
 
-// WithErrorChan specifies the error channel to use. If none is provided, one will be created
+// WithErrorChan specifies the caller-owned error channel to use. The Connection
+// sends errors to this channel but never closes it. If none is provided, the
+// Connection creates and closes its own channel.
 func WithErrorChan(errorChan chan error) ConnectionOptionFunc {
 	return func(c *Connection) {
 		c.errorChan = errorChan

--- a/connection_options.go
+++ b/connection_options.go
@@ -59,8 +59,11 @@ func WithNetworkMagic(networkMagic uint32) ConnectionOptionFunc {
 }
 
 // WithErrorChan specifies the caller-owned error channel to use. The Connection
-// sends errors to this channel but never closes it. If none is provided, the
-// Connection creates and closes its own channel.
+// sends errors to this channel but never closes it. Delivery is non-blocking;
+// use a channel with capacity of at least one for reliable delivery while the
+// connection is active. Errors may be dropped when the channel is full or has
+// no receiver ready. If none is provided, the Connection creates and closes
+// its own channel.
 func WithErrorChan(errorChan chan error) ConnectionOptionFunc {
 	return func(c *Connection) {
 		c.errorChan = errorChan

--- a/examples/block-fetch/main.go
+++ b/examples/block-fetch/main.go
@@ -75,7 +75,7 @@ func main() {
 		cfg.NetworkMagic = network.NetworkMagic
 	}
 	// Create error channel
-	errorChan := make(chan error)
+	errorChan := make(chan error, 1)
 	// start error handler
 	go func() {
 		for {

--- a/examples/chain-sync/main.go
+++ b/examples/chain-sync/main.go
@@ -256,7 +256,7 @@ func main() {
 	}
 
 	// Create error channel
-	errorChan := make(chan error)
+	errorChan := make(chan error, 1)
 	// Start error handler
 	go func() {
 		for {

--- a/examples/chain-tip/main.go
+++ b/examples/chain-tip/main.go
@@ -40,13 +40,7 @@ func main() {
 		panic(err)
 	}
 	// Create error channel
-	errorChan := make(chan error)
-	// start error handler
-	go func() {
-		for err := range errorChan {
-			panic(err)
-		}
-	}()
+	errorChan := make(chan error, 1)
 
 	isNtN := cfg.Address != ""
 	networkType := "unix"
@@ -63,8 +57,21 @@ func main() {
 		ouroboros.WithNodeToNode(isNtN),
 	)
 	if err != nil {
+		close(errorChan)
 		panic(err)
 	}
+	errorHandlerDone := make(chan struct{})
+	go func() {
+		defer close(errorHandlerDone)
+		for err := range errorChan {
+			panic(err)
+		}
+	}()
+	defer func() {
+		_ = o.Close()
+		close(errorChan)
+		<-errorHandlerDone
+	}()
 	// Connect to Node socket
 	if err = o.Dial(networkType, address); err != nil {
 		panic(err)

--- a/examples/peer-sharing/main.go
+++ b/examples/peer-sharing/main.go
@@ -64,7 +64,7 @@ func main() {
 		cfg.NetworkMagic = network.NetworkMagic
 	}
 	// Create error channel
-	errorChan := make(chan error)
+	errorChan := make(chan error, 1)
 	// start error handler
 	go func() {
 		for {

--- a/examples/ping/main.go
+++ b/examples/ping/main.go
@@ -55,7 +55,10 @@ func GetConnectionDetails(cfg *Config) (string, string, bool) {
 	return "", "", false
 }
 
-func NewConnection(cfg *Config) (NodeConnection, error) {
+func NewConnection(
+	cfg *Config,
+	errorChan chan error,
+) (NodeConnection, error) {
 	if cfg.Magic == 0 {
 		network, ok := ouroboros.NetworkByName(cfg.Network)
 		if !ok {
@@ -63,13 +66,6 @@ func NewConnection(cfg *Config) (NodeConnection, error) {
 		}
 		cfg.Magic = network.NetworkMagic
 	}
-
-	errorChan := make(chan error)
-	go func() {
-		for err := range errorChan {
-			fmt.Printf("connection error: %v\n", err)
-		}
-	}()
 
 	_, _, isTcp := GetConnectionDetails(cfg)
 
@@ -124,12 +120,25 @@ func main() {
 		os.Exit(1)
 	}
 
-	conn, err := NewConnection(&cfg)
+	errorChan := make(chan error, 1)
+	conn, err := NewConnection(&cfg, errorChan)
 	if err != nil {
+		close(errorChan)
 		fmt.Printf("Connection error: %v\n", err)
 		os.Exit(1)
 	}
-	defer conn.Close()
+	errorHandlerDone := make(chan struct{})
+	go func() {
+		defer close(errorHandlerDone)
+		for err := range errorChan {
+			fmt.Printf("connection error: %v\n", err)
+		}
+	}()
+	defer func() {
+		_ = conn.Close()
+		close(errorChan)
+		<-errorHandlerDone
+	}()
 
 	result := PingNode(conn, &cfg)
 	if result.Error != nil {

--- a/examples/ping/main_test.go
+++ b/examples/ping/main_test.go
@@ -151,9 +151,13 @@ func TestPingNode_Integration(t *testing.T) {
 		Network:    network,
 	}
 
-	conn, err := NewConnection(cfg)
+	errorChan := make(chan error, 1)
+	conn, err := NewConnection(cfg, errorChan)
 	require.NoError(t, err, "failed to create connection")
-	defer conn.Close()
+	defer func() {
+		require.NoError(t, conn.Close())
+		close(errorChan)
+	}()
 
 	resultChan := make(chan PingResult, 1)
 	go func() {

--- a/examples/tx-monitor/main.go
+++ b/examples/tx-monitor/main.go
@@ -44,7 +44,7 @@ func main() {
 		panic(err)
 	}
 	// Create error channel
-	errorChan := make(chan error)
+	errorChan := make(chan error, 1)
 	// start error handler
 	go func() {
 		for {

--- a/examples/tx-submission/main.go
+++ b/examples/tx-submission/main.go
@@ -79,7 +79,7 @@ func main() {
 	}
 
 	// Create error channel
-	errorChan := make(chan error)
+	errorChan := make(chan error, 1)
 	// Start error handler
 	go func() {
 		for {


### PR DESCRIPTION
## Summary

- prevent muxer and protocol error delivery from blocking connection shutdown
- wait for error forwarding to stop before `Close` returns while keeping supplied channels caller-owned
- document best-effort delivery and use buffered supplied channels in examples
- close chain-tip and ping consumer channels only after their connections close
- cover undrained cancellation, buffered delivery, shared channel reuse, and post-`Close` ownership

## Testing

- `make test`
- `golangci-lint run` for the root and example modules
- `nilaway -include-pkgs=github.com/blinklabs-io/gouroboros ./...`
- `go vet` for the root and example modules
- `make build`

Closes #2007
