### PR TITLE
fix(peersharing): bound response waits

### DIFF
--- a/protocol/peersharing/client.go
+++ b/protocol/peersharing/client.go
@@ -66,6 +66,10 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 	return c
 }
 
+// GetPeers requests peers and waits for either the response or protocol
+// shutdown. When the configured Busy-state timeout expires, the protocol
+// reports the timeout through its error channel and this method returns
+// protocol.ErrProtocolShuttingDown.
 func (c *Client) GetPeers(amount uint8) ([]PeerAddress, error) {
 	if c.config.RemoteDisabled {
 		return nil, ErrRemotePeerSharingDisabled
@@ -81,11 +85,15 @@ func (c *Client) GetPeers(amount uint8) ([]PeerAddress, error) {
 	if err := c.SendMessage(msg); err != nil {
 		return nil, err
 	}
-	peers, ok := <-c.sharePeersChan
-	if !ok {
+	select {
+	case peers, ok := <-c.sharePeersChan:
+		if !ok {
+			return nil, protocol.ErrProtocolShuttingDown
+		}
+		return peers, nil
+	case <-c.DoneChan():
 		return nil, protocol.ErrProtocolShuttingDown
 	}
-	return peers, nil
 }
 
 func (c *Client) messageHandler(msg protocol.Message) error {
@@ -112,5 +120,8 @@ func (c *Client) handleSharePeers(msg protocol.Message) {
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
 	msgSharePeers := msg.(*MsgSharePeers)
-	c.sharePeersChan <- msgSharePeers.PeerAddresses
+	select {
+	case <-c.DoneChan():
+	case c.sharePeersChan <- msgSharePeers.PeerAddresses:
+	}
 }

--- a/protocol/peersharing/client_test.go
+++ b/protocol/peersharing/client_test.go
@@ -15,6 +15,7 @@
 package peersharing
 
 import (
+	"errors"
 	"io"
 	"net"
 	"testing"
@@ -123,6 +124,66 @@ func TestClientGetPeersReturnsAfterBusyTimeout(t *testing.T) {
 	case <-lateHandlerDone:
 	case <-time.After(time.Second):
 		t.Fatal("late SharePeers handler remained blocked after shutdown")
+	}
+}
+
+// TestClientGetPeersReturnsAfterBusyTimeoutWithFullErrorChannel verifies that
+// best-effort error reporting cannot prevent the timeout from stopping the
+// protocol and releasing the caller.
+func TestClientGetPeersReturnsAfterBusyTimeoutWithFullErrorChannel(t *testing.T) {
+	localConn, remoteConn := net.Pipe()
+	m := muxer.New(localConn)
+	errorChan := make(chan error, 1)
+	errorChan <- errors.New("undrained error")
+	peerDone := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, remoteConn)
+		close(peerDone)
+	}()
+
+	cfg := NewConfig(WithTimeout(10 * time.Millisecond))
+	client := NewClient(
+		protocol.ProtocolOptions{
+			ConnectionId: connection.ConnectionId{
+				LocalAddr:  localConn.LocalAddr(),
+				RemoteAddr: localConn.RemoteAddr(),
+			},
+			Muxer:     m,
+			ErrorChan: errorChan,
+			Mode:      protocol.ProtocolModeNodeToNode,
+		},
+		&cfg,
+	)
+	client.Start()
+	m.Start()
+	t.Cleanup(func() {
+		client.Protocol.Stop()
+		m.Stop()
+		_ = remoteConn.Close()
+		select {
+		case <-peerDone:
+		case <-time.After(time.Second):
+			t.Error("peer drain did not stop")
+		}
+	})
+
+	resultChan := make(chan error, 1)
+	go func() {
+		_, err := client.GetPeers(5)
+		resultChan <- err
+	}()
+
+	select {
+	case err := <-resultChan:
+		require.ErrorIs(t, err, protocol.ErrProtocolShuttingDown)
+	case <-time.After(time.Second):
+		client.Protocol.Stop()
+		select {
+		case <-resultChan:
+		case <-time.After(time.Second):
+			t.Fatal("GetPeers remained blocked after explicit protocol stop")
+		}
+		t.Fatal("a full error channel prevented timeout shutdown")
 	}
 }
 

--- a/protocol/peersharing/client_test.go
+++ b/protocol/peersharing/client_test.go
@@ -15,10 +15,13 @@
 package peersharing
 
 import (
+	"io"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/muxer"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	"github.com/stretchr/testify/require"
 )
@@ -42,6 +45,85 @@ func TestClientGetPeersRefusesWhenRemoteDisabled(t *testing.T) {
 	peers, err := client.GetPeers(5)
 	require.ErrorIs(t, err, ErrRemotePeerSharingDisabled)
 	require.Nil(t, peers)
+}
+
+// TestClientGetPeersReturnsAfterBusyTimeout verifies that the protocol's
+// Busy-state timeout releases a caller when the peer accepts the request but
+// never sends SharePeers.
+func TestClientGetPeersReturnsAfterBusyTimeout(t *testing.T) {
+	localConn, remoteConn := net.Pipe()
+	m := muxer.New(localConn)
+	errorChan := make(chan error, 1)
+	peerDone := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, remoteConn)
+		close(peerDone)
+	}()
+
+	cfg := NewConfig(WithTimeout(10 * time.Millisecond))
+	client := NewClient(
+		protocol.ProtocolOptions{
+			ConnectionId: connection.ConnectionId{
+				LocalAddr:  localConn.LocalAddr(),
+				RemoteAddr: localConn.RemoteAddr(),
+			},
+			Muxer:     m,
+			ErrorChan: errorChan,
+			Mode:      protocol.ProtocolModeNodeToNode,
+		},
+		&cfg,
+	)
+	client.Start()
+	m.Start()
+	t.Cleanup(func() {
+		client.Protocol.Stop()
+		m.Stop()
+		_ = remoteConn.Close()
+		select {
+		case <-peerDone:
+		case <-time.After(time.Second):
+			t.Error("peer drain did not stop")
+		}
+	})
+
+	resultChan := make(chan error, 1)
+	go func() {
+		_, err := client.GetPeers(5)
+		resultChan <- err
+	}()
+
+	select {
+	case err := <-errorChan:
+		require.ErrorContains(t, err, "timeout waiting on transition")
+	case <-time.After(time.Second):
+		t.Fatal("protocol did not report the Busy-state timeout")
+	}
+
+	select {
+	case err := <-resultChan:
+		require.ErrorIs(t, err, protocol.ErrProtocolShuttingDown)
+	case <-time.After(time.Second):
+		// Release the pre-fix caller so a fail-before run does not leave a
+		// goroutine behind after reporting the regression.
+		select {
+		case client.sharePeersChan <- nil:
+		case <-time.After(time.Second):
+			t.Fatal("GetPeers remained blocked and could not be released")
+		}
+		<-resultChan
+		t.Fatal("GetPeers remained blocked after the protocol timed out")
+	}
+
+	lateHandlerDone := make(chan struct{})
+	go func() {
+		client.handleSharePeers(NewMsgSharePeers(nil))
+		close(lateHandlerDone)
+	}()
+	select {
+	case <-lateHandlerDone:
+	case <-time.After(time.Second):
+		t.Fatal("late SharePeers handler remained blocked after shutdown")
+	}
 }
 
 // TestConfigDefaultsArePermissive guards the inverted-flag contract: the zero

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -484,7 +484,6 @@ func (p *Protocol) SendError(err error) {
 		// Discard error if the buffer is full
 		// The connection will get closed on the first error, so any
 		// additional errors are unnecessary
-		return
 	}
 	// Stop the protocol on any error to prevent further errors from being generated
 	// and to ensure the connection is properly terminated


### PR DESCRIPTION
Closes #2055

## Summary

- return the existing protocol-shutdown error when a peer-sharing response wait ends
- release callers after the configured Busy-state timeout or explicit shutdown
- keep late responses from blocking the stopped protocol handler

## Validation

- fail-before proof through a real muxer with a peer that accepts but does not answer
- `go test -race -count=50 -run '^TestClientGetPeersReturnsAfterBusyTimeout$' ./protocol/peersharing`
- `go test -race -count=1 ./protocol/peersharing`
- `make test`
- `make lint`
- `make nilaway`
- `go vet ./...`
- `go build ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds peer-sharing waits to the Busy-state timeout or shutdown, so `GetPeers` no longer hangs when a peer accepts but never sends SharePeers. Also ensures the `protocol` stops even if its error channel is full, so a dropped error cannot block shutdown.

- Bug Fixes
  - `GetPeers` returns `protocol.ErrProtocolShuttingDown` when `DoneChan` closes or the Busy-state timeout fires.
  - `handleSharePeers` drops late sends after shutdown to avoid blocking.
  - `protocol.SendError` now stops the `protocol` even when the error channel is full.
  - Adds tests covering unresponsive peers and full error-channel scenarios.

- Migration
  - Callers must handle `protocol.ErrProtocolShuttingDown` when the Busy-state timeout elapses.

<sup>Written for commit 9e452db763d07f826bb3fca4ddde1ae4fd3b8c7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

