### PR TITLE
fix(muxer): unblock protocol unregistration

### DIFF
--- a/muxer/muxer.go
+++ b/muxer/muxer.go
@@ -76,8 +76,26 @@ type Muxer struct {
 }
 
 type segmentChannel struct {
-	mu sync.Mutex
-	ch chan *Segment
+	mu       sync.Mutex
+	ch       chan *Segment
+	done     chan struct{}
+	onceStop sync.Once
+}
+
+func (s *segmentChannel) stop() {
+	// Wake a delivery that is waiting for channel capacity before taking the
+	// mutex needed to close the receiver. Otherwise unregistration can wait
+	// forever behind that delivery while the protocol waits for
+	// unregistration to finish.
+	s.onceStop.Do(func() {
+		close(s.done)
+	})
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.ch != nil {
+		close(s.ch)
+		s.ch = nil
+	}
 }
 
 type ConnectionClosedError struct {
@@ -198,7 +216,10 @@ func (m *Muxer) RegisterProtocol(
 	// Generate channels
 	senderChan := make(chan *Segment, 10)
 	receiver := make(chan *Segment, 10)
-	receiverChan := &segmentChannel{ch: receiver}
+	receiverChan := &segmentChannel{
+		ch:   receiver,
+		done: make(chan struct{}),
+	}
 	// Record channels in protocol sender/receiver maps
 	m.protocolReceiversMutex.Lock()
 	if _, ok := m.protocolSenders[protocolId]; !ok {
@@ -251,12 +272,7 @@ func (m *Muxer) UnregisterProtocol(
 	}
 	// Signal shutdown to protocol
 
-	recvChan.mu.Lock()
-	defer recvChan.mu.Unlock()
-	if recvChan.ch != nil {
-		close(recvChan.ch)
-		recvChan.ch = nil
-	}
+	recvChan.stop()
 
 	// Remove mapping
 	delete(protocolRoles, protocolRole)
@@ -297,12 +313,7 @@ func (m *Muxer) readLoop() {
 		for _, protocolRoles := range m.protocolReceivers {
 			for protocolRole, recvChan := range protocolRoles {
 				// Signal shutdown to protocol
-				recvChan.mu.Lock()
-				if recvChan.ch != nil {
-					close(recvChan.ch)
-					recvChan.ch = nil
-				}
-				recvChan.mu.Unlock()
+				recvChan.stop()
 
 				// Remove mapping
 				delete(protocolRoles, protocolRole)
@@ -429,13 +440,16 @@ func (m *Muxer) readLoop() {
 		recvChan.mu.Lock()
 		if recvChan.ch == nil {
 			recvChan.mu.Unlock()
-			return
+			continue
 		}
 
 		select {
 		case <-m.doneChan:
 			recvChan.mu.Unlock()
 			return
+		case <-recvChan.done:
+			recvChan.mu.Unlock()
+			continue
 		case recvChan.ch <- msg:
 			recvChan.mu.Unlock()
 		}

--- a/muxer/muxer.go
+++ b/muxer/muxer.go
@@ -274,8 +274,10 @@ func (m *Muxer) UnregisterProtocol(
 
 	recvChan.stop()
 
-	// Remove mapping
-	delete(protocolRoles, protocolRole)
+	// Keep the stopped receiver as a tombstone until a subsequent registration
+	// replaces it. Segments already queued for a protocol that is restarting can
+	// then be discarded without treating the brief registration gap as an
+	// unknown-protocol error and closing the shared connection.
 }
 
 // Send takes a populated Segment and writes it to the connection. A mutex is used to prevent more than

--- a/muxer/unregister_liveness_test.go
+++ b/muxer/unregister_liveness_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package muxer
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeUnregisterTestSegment(conn net.Conn, segment *Segment) error {
+	buf := bytes.NewBuffer(nil)
+	if err := binary.Write(buf, binary.BigEndian, segment.SegmentHeader); err != nil {
+		return err
+	}
+	if _, err := buf.Write(segment.Payload); err != nil {
+		return err
+	}
+	data := buf.Bytes()
+	for len(data) > 0 {
+		n, err := conn.Write(data)
+		if err != nil {
+			return err
+		}
+		data = data[n:]
+	}
+	return nil
+}
+
+func TestUnregisterProtocolWakesBlockedDelivery(t *testing.T) {
+	const protocolId = 10
+
+	localConn, remoteConn := net.Pipe()
+	m := New(localConn)
+	_, recvChan, _ := m.RegisterProtocol(protocolId, ProtocolRoleResponder)
+	m.Start()
+	t.Cleanup(func() {
+		m.Stop()
+		_ = remoteConn.Close()
+		_ = localConn.Close()
+	})
+
+	segment := NewSegment(protocolId, []byte{0x81, 0x02}, false)
+	require.NotNil(t, segment)
+	for range cap(recvChan) {
+		require.NoError(t, writeUnregisterTestSegment(remoteConn, segment))
+	}
+	require.Eventually(t, func() bool {
+		return len(recvChan) == cap(recvChan)
+	}, time.Second, time.Millisecond)
+
+	m.protocolReceiversMutex.Lock()
+	receiver := m.protocolReceivers[protocolId][ProtocolRoleResponder]
+	m.protocolReceiversMutex.Unlock()
+	require.NotNil(t, receiver)
+
+	require.NoError(t, writeUnregisterTestSegment(remoteConn, segment))
+	require.Eventually(t, func() bool {
+		if receiver.mu.TryLock() {
+			receiver.mu.Unlock()
+			return false
+		}
+		return true
+	}, time.Second, time.Millisecond)
+
+	unregistered := make(chan struct{})
+	go func() {
+		m.UnregisterProtocol(protocolId, ProtocolRoleResponder)
+		close(unregistered)
+	}()
+	select {
+	case <-unregistered:
+	case <-time.After(time.Second):
+		t.Fatal("protocol unregistration blocked behind receiver delivery")
+	}
+	for range cap(recvChan) {
+		_, ok := <-recvChan
+		require.True(t, ok)
+	}
+	_, ok := <-recvChan
+	require.False(t, ok, "unregistration must close the receiver channel")
+
+	_, replacementRecv, _ := m.RegisterProtocol(
+		protocolId,
+		ProtocolRoleResponder,
+	)
+	require.NoError(t, writeUnregisterTestSegment(remoteConn, segment))
+	select {
+	case replacement := <-replacementRecv:
+		require.Equal(t, uint16(protocolId), replacement.GetProtocolId())
+	case <-time.After(time.Second):
+		t.Fatal("muxer did not deliver after protocol re-registration")
+	}
+}

--- a/protocol/peersharing/server_liveness_test.go
+++ b/protocol/peersharing/server_liveness_test.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package peersharing
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/muxer"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+func writeLivenessSegment(conn net.Conn, segment *muxer.Segment) error {
+	buf := bytes.NewBuffer(nil)
+	if err := binary.Write(buf, binary.BigEndian, segment.SegmentHeader); err != nil {
+		return err
+	}
+	if _, err := buf.Write(segment.Payload); err != nil {
+		return err
+	}
+	data := buf.Bytes()
+	for len(data) > 0 {
+		n, err := conn.Write(data)
+		if err != nil {
+			return err
+		}
+		data = data[n:]
+	}
+	return nil
+}
+
+func TestRepeatedDoneDoesNotStallSharedMuxer(t *testing.T) {
+	const (
+		segmentCount    = 20
+		messagesPerSeg  = 2000
+		probeProtocolId = 42
+	)
+
+	localConn, remoteConn := net.Pipe()
+	m := muxer.New(localConn)
+	protocolErrors := make(chan error, 1)
+	cfg := NewConfig(WithLocalDisabled(true))
+	server := NewServer(
+		protocol.ProtocolOptions{
+			ConnectionId: connection.ConnectionId{
+				LocalAddr:  localConn.LocalAddr(),
+				RemoteAddr: localConn.RemoteAddr(),
+			},
+			ErrorChan: protocolErrors,
+			Muxer:     m,
+		},
+		&cfg,
+	)
+	_, probeRecv, _ := m.RegisterProtocol(
+		probeProtocolId,
+		muxer.ProtocolRoleResponder,
+	)
+	server.Start()
+	m.Start()
+	t.Cleanup(func() {
+		m.Stop()
+		_ = remoteConn.Close()
+		_ = localConn.Close()
+		server.ProtocolInstance().Stop()
+	})
+
+	doneCbor, err := cbor.Encode(NewMsgDone())
+	require.NoError(t, err)
+	donePayload := bytes.Repeat(doneCbor, messagesPerSeg)
+	writeDone := make(chan error, 1)
+	go func() {
+		for range segmentCount {
+			segment := muxer.NewSegment(ProtocolId, donePayload, false)
+			if segment == nil {
+				writeDone <- fmt.Errorf("failed to create peer-sharing segment")
+				return
+			}
+			if err := writeLivenessSegment(remoteConn, segment); err != nil {
+				writeDone <- err
+				return
+			}
+		}
+		probe := muxer.NewSegment(probeProtocolId, []byte{0x81, 0x00}, false)
+		if probe == nil {
+			writeDone <- fmt.Errorf("failed to create probe segment")
+			return
+		}
+		writeDone <- writeLivenessSegment(remoteConn, probe)
+	}()
+
+	probeDelivered := false
+	connectionClosed := false
+	select {
+	case segment, ok := <-probeRecv:
+		require.True(t, ok, "probe receiver closed before delivery")
+		require.Equal(t, uint16(probeProtocolId), segment.GetProtocolId())
+		probeDelivered = true
+	case err := <-protocolErrors:
+		require.NoError(t, err)
+	case err := <-m.ErrorChan():
+		require.EqualError(
+			t,
+			err,
+			"received message for unknown protocol ID 10",
+		)
+		connectionClosed = true
+	case <-time.After(2 * time.Second):
+		t.Fatal("shared muxer stalled after repeated peer-sharing Done messages")
+	}
+	writerErr := <-writeDone
+	if probeDelivered {
+		require.NoError(t, writerErr)
+		select {
+		case err := <-protocolErrors:
+			require.NoError(t, err)
+		default:
+		}
+	} else if connectionClosed {
+		require.Error(t, writerErr)
+	}
+}

--- a/protocol/peersharing/server_liveness_test.go
+++ b/protocol/peersharing/server_liveness_test.go
@@ -107,34 +107,22 @@ func TestRepeatedDoneDoesNotStallSharedMuxer(t *testing.T) {
 		writeDone <- writeLivenessSegment(remoteConn, probe)
 	}()
 
-	probeDelivered := false
-	connectionClosed := false
 	select {
 	case segment, ok := <-probeRecv:
 		require.True(t, ok, "probe receiver closed before delivery")
 		require.Equal(t, uint16(probeProtocolId), segment.GetProtocolId())
-		probeDelivered = true
 	case err := <-protocolErrors:
 		require.NoError(t, err)
-	case err := <-m.ErrorChan():
-		require.EqualError(
-			t,
-			err,
-			"received message for unknown protocol ID 10",
-		)
-		connectionClosed = true
+	case err, ok := <-m.ErrorChan():
+		require.True(t, ok, "muxer error channel closed before probe delivery")
+		require.NoError(t, err)
 	case <-time.After(2 * time.Second):
 		t.Fatal("shared muxer stalled after repeated peer-sharing Done messages")
 	}
-	writerErr := <-writeDone
-	if probeDelivered {
-		require.NoError(t, writerErr)
-		select {
-		case err := <-protocolErrors:
-			require.NoError(t, err)
-		default:
-		}
-	} else if connectionClosed {
-		require.Error(t, writerErr)
+	require.NoError(t, <-writeDone)
+	select {
+	case err := <-protocolErrors:
+		require.NoError(t, err)
+	default:
 	}
 }


### PR DESCRIPTION
## Summary

- wake capacity-blocked mux deliveries when a mini-protocol unregisters
- preserve stopped receivers during restart gaps so queued stale segments do not close the shared connection
- require the peer-sharing liveness regression to deliver traffic on the other protocol

## Testing

- `go test -race ./protocol/peersharing -run '^TestRepeatedDoneDoesNotStallSharedMuxer$' -count=100`
- `go test -race ./muxer -run '^(TestUnregisterProtocolWakesBlockedDelivery|TestUnregisterProtocolBehavior|TestMuxerErrorHandling)$' -count=50`
- `go test -race ./muxer ./protocol/peersharing`
- `make test`
- `go test -v ./internal/test/conformance/...`
- `make lint`
- `make nilaway`
- `go vet ./...`
- `go build ./...`

Closes #2056
