### PR TITLE
fix(ledger): reject trailing bytes in V3 and V4 script wrappers

### DIFF
--- a/ledger/common/script.go
+++ b/ledger/common/script.go
@@ -69,6 +69,21 @@ type ScriptRef struct {
 	Script Script
 }
 
+func decodePlutusScript(script []byte, rejectTrailing bool) ([]byte, error) {
+	var innerScript []byte
+	bytesRead, err := cbor.Decode(script, &innerScript)
+	if err != nil {
+		return nil, err
+	}
+	if rejectTrailing && bytesRead != len(script) {
+		return nil, fmt.Errorf(
+			"trailing bytes after CBOR script wrapper: %d",
+			len(script)-bytesRead,
+		)
+	}
+	return innerScript, nil
+}
+
 func (s *ScriptRef) UnmarshalCBOR(data []byte) error {
 	// Unwrap outer CBOR tag
 	var tmpTag cbor.Tag
@@ -182,8 +197,8 @@ func (s PlutusV1Script) Evaluate(
 		}
 	}
 	// Decode raw script as bytestring to get actual script bytes
-	var innerScript []byte
-	if _, err = cbor.Decode([]byte(s), &innerScript); err != nil {
+	innerScript, err := decodePlutusScript([]byte(s), false)
+	if err != nil {
 		return usedExUnits, fmt.Errorf("decode cbor: %w", err)
 	}
 	// Decode program
@@ -264,8 +279,8 @@ func (s PlutusV2Script) Evaluate(
 		}
 	}
 	// Decode raw script as bytestring to get actual script bytes
-	var innerScript []byte
-	if _, err = cbor.Decode([]byte(s), &innerScript); err != nil {
+	innerScript, err := decodePlutusScript([]byte(s), false)
+	if err != nil {
 		return usedExUnits, fmt.Errorf("decode cbor: %w", err)
 	}
 	// Decode program
@@ -342,8 +357,8 @@ func (s PlutusV3Script) Evaluate(
 		}
 	}
 	// Decode raw script as bytestring to get actual script bytes
-	var innerScript []byte
-	if _, err = cbor.Decode([]byte(s), &innerScript); err != nil {
+	innerScript, err := decodePlutusScript([]byte(s), true)
+	if err != nil {
 		return usedExUnits, fmt.Errorf("decode cbor: %w", err)
 	}
 	// Decode program
@@ -411,8 +426,8 @@ func (s PlutusV4Script) Evaluate(
 			Mem: budget.Memory,
 		}
 	}
-	var innerScript []byte
-	if _, err = cbor.Decode([]byte(s), &innerScript); err != nil {
+	innerScript, err := decodePlutusScript([]byte(s), true)
+	if err != nil {
 		return usedExUnits, fmt.Errorf("decode cbor: %w", err)
 	}
 	program, err = syn.Decode[syn.DeBruijn]([]byte(innerScript))

--- a/ledger/common/script_test.go
+++ b/ledger/common/script_test.go
@@ -22,6 +22,9 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/plutigo/data"
+	"github.com/blinklabs-io/plutigo/lang"
+	"github.com/blinklabs-io/plutigo/syn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -60,6 +63,57 @@ func TestScriptRefDecodeEncode(t *testing.T) {
 			scriptRefCbor,
 			testCborHex,
 		)
+	}
+}
+
+func TestPlutusScriptWrapperTrailingBytes(t *testing.T) {
+	flatScript, err := syn.Encode(&syn.Program[syn.DeBruijn]{
+		Version: lang.LanguageVersionV3,
+		Term:    &syn.Error{},
+	})
+	require.NoError(t, err)
+	wrappedScript, err := cbor.Encode(flatScript)
+	require.NoError(t, err)
+	malformedScript := append(append([]byte(nil), wrappedScript...), 0)
+
+	context := &data.Constr{Tag: 0}
+	tests := []struct {
+		name       string
+		script     common.Script
+		wantReject bool
+	}{
+		{"PlutusV1 exact wrapper", common.PlutusV1Script(wrappedScript), false},
+		{"PlutusV2 exact wrapper", common.PlutusV2Script(wrappedScript), false},
+		{"PlutusV3 exact wrapper", common.PlutusV3Script(wrappedScript), false},
+		{"PlutusV4 exact wrapper", common.PlutusV4Script(wrappedScript), false},
+		{"PlutusV1", common.PlutusV1Script(malformedScript), false},
+		{"PlutusV2", common.PlutusV2Script(malformedScript), false},
+		{"PlutusV3", common.PlutusV3Script(malformedScript), true},
+		{"PlutusV4", common.PlutusV4Script(malformedScript), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			switch script := tt.script.(type) {
+			case common.PlutusV1Script:
+				_, err = script.Evaluate(context, context, context, common.ExUnits{}, nil)
+			case common.PlutusV2Script:
+				_, err = script.Evaluate(context, context, context, common.ExUnits{}, nil)
+			case common.PlutusV3Script:
+				_, err = script.Evaluate(context, common.ExUnits{}, nil)
+			case common.PlutusV4Script:
+				_, err = script.Evaluate(context, common.ExUnits{}, nil)
+			default:
+				t.Fatalf("unsupported script type %T", tt.script)
+			}
+			require.Error(t, err)
+			if tt.wantReject {
+				assert.Contains(t, err.Error(), "trailing bytes")
+			} else {
+				assert.NotContains(t, err.Error(), "trailing bytes")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Reject trailing bytes after the outer CBOR bytestring for Plutus V3 and V4 scripts before FLAT decoding.
- Preserve the existing wrapper behavior for Plutus V1 and V2 scripts.
- Add evaluation coverage for exact wrappers and trailing-byte inputs across all four script versions.

Fixes #2061

## Validation

- `go test -race ./cbor ./ledger/...`
- `go vet ./...`
- `golangci-lint run ./ledger/common`
