### PR TITLE
fix(ledger): apply governance rules in Dijkstra

### DIFF
--- a/ledger/common/gov.go
+++ b/ledger/common/gov.go
@@ -653,6 +653,14 @@ type GovActionWithPolicy interface {
 	GetPolicyHash() []byte
 }
 
+// ParameterChangeGovAction describes the era-independent parts of a
+// parameter-change governance action needed by shared validation rules.
+type ParameterChangeGovAction interface {
+	GovAction
+	PreviousGovActionId() *GovActionId
+	SecurityGroupFields() []string
+}
+
 type GovActionBase struct{}
 
 //nolint:unused

--- a/ledger/conway/gov.go
+++ b/ledger/conway/gov.go
@@ -141,6 +141,9 @@ func (a *ConwayParameterChangeGovAction) ToPlutusData() data.PlutusData {
 
 // GetPolicyHash returns the policy script hash for this governance action
 func (a *ConwayParameterChangeGovAction) GetPolicyHash() []byte {
+	if a == nil {
+		return nil
+	}
 	return a.PolicyHash
 }
 

--- a/ledger/conway/gov.go
+++ b/ledger/conway/gov.go
@@ -118,6 +118,8 @@ type ConwayParameterChangeGovAction struct {
 	PolicyHash  []byte
 }
 
+var _ common.ParameterChangeGovAction = (*ConwayParameterChangeGovAction)(nil)
+
 func (a *ConwayParameterChangeGovAction) ToPlutusData() data.PlutusData {
 	actionId := data.NewConstr(1)
 	if a.ActionId != nil {
@@ -140,6 +142,23 @@ func (a *ConwayParameterChangeGovAction) ToPlutusData() data.PlutusData {
 // GetPolicyHash returns the policy script hash for this governance action
 func (a *ConwayParameterChangeGovAction) GetPolicyHash() []byte {
 	return a.PolicyHash
+}
+
+// PreviousGovActionId returns the parameter-change action this action follows.
+func (a *ConwayParameterChangeGovAction) PreviousGovActionId() *common.GovActionId {
+	if a == nil {
+		return nil
+	}
+	return a.ActionId
+}
+
+// SecurityGroupFields returns the security-group parameters changed by this
+// action.
+func (a *ConwayParameterChangeGovAction) SecurityGroupFields() []string {
+	if a == nil {
+		return nil
+	}
+	return a.ParamUpdate.SecurityGroupFields()
 }
 
 // NewConwayParameterChangeGovAction builds a parameter change governance
@@ -185,14 +204,7 @@ func NewConwayGovAction(action common.GovAction) (ConwayGovAction, error) {
 // silently defaulting to discriminant 0, which would be indistinguishable from a
 // valid parameter change action.
 func conwayGovActionType(action common.GovAction) (uint, error) {
-	if action == nil {
-		return 0, errors.New("governance action cannot be nil")
-	}
-	// A typed-nil pointer would otherwise match its concrete case below and wrap
-	// a nil action that encodes to CBOR null or panics in ToPlutusData; reject
-	// it before the type switch.
-	if rv := reflect.ValueOf(action); rv.Kind() == reflect.Pointer &&
-		rv.IsNil() {
+	if isNilGovAction(action) {
 		return 0, errors.New("governance action cannot be nil")
 	}
 	switch action.(type) {
@@ -213,6 +225,16 @@ func conwayGovActionType(action common.GovAction) (uint, error) {
 	default:
 		return 0, fmt.Errorf("unsupported governance action type: %T", action)
 	}
+}
+
+// isNilGovAction reports whether action is nil, including an interface that
+// contains a typed-nil pointer.
+func isNilGovAction(action common.GovAction) bool {
+	if action == nil {
+		return true
+	}
+	rv := reflect.ValueOf(action)
+	return rv.Kind() == reflect.Pointer && rv.IsNil()
 }
 
 // NewConwayProposalProcedure builds a Conway proposal procedure from a deposit,

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -209,7 +209,7 @@ func UtxoValidateProposalProcedures(
 ) error {
 	for _, proposal := range tx.ProposalProcedures() {
 		govAction := proposal.GovAction()
-		if govAction == nil {
+		if isNilGovAction(govAction) {
 			continue
 		}
 
@@ -238,12 +238,13 @@ func UtxoValidateEmptyTreasuryWithdrawals(
 ) error {
 	for _, proposal := range tx.ProposalProcedures() {
 		govAction := proposal.GovAction()
-		if govAction == nil {
+		if isNilGovAction(govAction) {
 			continue
 		}
 
 		// Check if this is a TreasuryWithdrawalGovAction with empty withdrawals
-		if twAction, ok := govAction.(*common.TreasuryWithdrawalGovAction); ok {
+		if twAction, ok := govAction.(*common.TreasuryWithdrawalGovAction); ok &&
+			twAction != nil {
 			if len(twAction.Withdrawals) == 0 {
 				return EmptyTreasuryWithdrawalsError{}
 			}
@@ -283,7 +284,7 @@ func UtxoValidateBootstrapAllowedGovActions(
 	}
 	for _, proposal := range tx.ProposalProcedures() {
 		govAction := proposal.GovAction()
-		if govAction == nil {
+		if isNilGovAction(govAction) {
 			continue
 		}
 		// NOTE: closed-set type-switch over the 7 GovActionType constants in
@@ -336,7 +337,7 @@ func UtxoValidateBootstrapParameterGroups(
 	}
 	for _, proposal := range tx.ProposalProcedures() {
 		govAction := proposal.GovAction()
-		if govAction == nil {
+		if isNilGovAction(govAction) {
 			continue
 		}
 		paramChange, ok := govAction.(*ConwayParameterChangeGovAction)
@@ -371,12 +372,13 @@ func UtxoValidateProposalNetworkIds(
 
 		// Check addresses within governance actions
 		govAction := proposal.GovAction()
-		if govAction == nil {
+		if isNilGovAction(govAction) {
 			continue
 		}
 
 		// TreasuryWithdrawalGovAction contains withdrawal addresses
-		if twAction, ok := govAction.(*common.TreasuryWithdrawalGovAction); ok {
+		if twAction, ok := govAction.(*common.TreasuryWithdrawalGovAction); ok &&
+			twAction != nil {
 			for addr := range twAction.Withdrawals {
 				if addr.NetworkId() != networkId {
 					badAddrs = append(badAddrs, *addr)
@@ -565,7 +567,7 @@ func (r *govActionResolver) resolve(
 	actionId common.GovActionId,
 ) (actionType common.GovActionType, action common.GovAction, ok bool) {
 	if proposal, found := r.txProposal(actionId); found {
-		if proposal.action == nil {
+		if isNilGovAction(proposal.action) {
 			return 0, nil, false
 		}
 		resolvedType, ok := govActionValidationType(proposal.action)
@@ -615,7 +617,7 @@ func hardForkProposedVersion(
 	action common.GovAction,
 ) (major, minor uint, ok bool) {
 	hf, isHardFork := action.(*common.HardForkInitiationGovAction)
-	if !isHardFork {
+	if !isHardFork || hf == nil {
 		return 0, 0, false
 	}
 	return hf.ProtocolVersion.Major, hf.ProtocolVersion.Minor, true
@@ -794,7 +796,7 @@ func UtxoValidateHardForkCanFollow(
 	txProposalsLoaded := false
 	for idx, proposal := range tx.ProposalProcedures() {
 		hf, ok := proposal.GovAction().(*common.HardForkInitiationGovAction)
-		if !ok {
+		if !ok || hf == nil {
 			continue
 		}
 		newPV := hf.ProtocolVersion
@@ -827,7 +829,7 @@ func UtxoValidateHardForkCanFollow(
 				}
 				ancestorAction = ancestorState.Action
 			}
-			if ancestorAction == nil {
+			if isNilGovAction(ancestorAction) {
 				continue
 			}
 			major, minor, isHardFork := hardForkProposedVersion(ancestorAction)
@@ -895,7 +897,7 @@ func UtxoValidateProposalAncestry(
 	txProposals := txProposalActions(tx)
 	for idx, proposal := range proposals {
 		govAction := proposal.GovAction()
-		if govAction == nil {
+		if isNilGovAction(govAction) {
 			continue
 		}
 		ancestorId, purpose, hasPurpose := govActionAncestor(govAction)
@@ -1055,7 +1057,7 @@ func UtxoValidateProposalReturnAccounts(
 
 		govAction := proposal.GovAction()
 		twAction, ok := govAction.(*common.TreasuryWithdrawalGovAction)
-		if !ok {
+		if !ok || twAction == nil {
 			continue
 		}
 		var badAddrs []common.Address

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -415,9 +415,12 @@ const (
 func govActionAncestor(
 	ga common.GovAction,
 ) (ancestor *common.GovActionId, purpose govActionPurpose, ok bool) {
+	if isNilGovAction(ga) {
+		return nil, 0, false
+	}
 	switch a := ga.(type) {
-	case *ConwayParameterChangeGovAction:
-		return a.ActionId, govPurposePParamUpdate, true
+	case common.ParameterChangeGovAction:
+		return a.PreviousGovActionId(), govPurposePParamUpdate, true
 	case *common.HardForkInitiationGovAction:
 		return a.ActionId, govPurposeHardFork, true
 	case *common.NoConfidenceGovAction:
@@ -565,11 +568,11 @@ func (r *govActionResolver) resolve(
 		if proposal.action == nil {
 			return 0, nil, false
 		}
-		resolvedType, err := conwayGovActionType(proposal.action)
-		if err != nil {
+		resolvedType, ok := govActionValidationType(proposal.action)
+		if !ok {
 			return 0, nil, false
 		}
-		return common.GovActionType(resolvedType), proposal.action, true
+		return resolvedType, proposal.action, true
 	}
 	if r.ls == nil {
 		return 0, nil, false
@@ -578,7 +581,30 @@ func (r *govActionResolver) resolve(
 	if err != nil || actionState == nil {
 		return 0, nil, false
 	}
-	return actionState.ActionType, actionState.Action, true
+	action = actionState.Action
+	if isNilGovAction(action) {
+		action = nil
+	}
+	return actionState.ActionType, action, true
+}
+
+// govActionValidationType classifies an action for shared governance rules.
+// Unlike the Conway wire constructor, validation accepts the era-independent
+// parameter-change action contract implemented by later eras.
+func govActionValidationType(
+	action common.GovAction,
+) (common.GovActionType, bool) {
+	if isNilGovAction(action) {
+		return 0, false
+	}
+	if _, ok := action.(common.ParameterChangeGovAction); ok {
+		return common.GovActionTypeParameterChange, true
+	}
+	actionType, err := conwayGovActionType(action)
+	if err != nil {
+		return 0, false
+	}
+	return common.GovActionType(actionType), true
 }
 
 // hardForkProposedVersion returns the protocol version proposed by a
@@ -643,8 +669,10 @@ func UtxoValidateGovActionWellFormedness(
 ) error {
 	for _, proposal := range tx.ProposalProcedures() {
 		govAction := proposal.GovAction()
-		if govAction == nil {
-			continue
+		if isNilGovAction(govAction) {
+			return MalformedGovActionError{
+				Reason: "governance action cannot be nil",
+			}
 		}
 
 		// A governance policy hash, when present, must be a 28-byte script
@@ -3613,13 +3641,13 @@ func UtxoValidateStakePoolVotingRestrictions(
 			case common.GovActionTypeTreasuryWithdrawal:
 				restriction = "stake pools cannot vote on TreasuryWithdrawal"
 			case common.GovActionTypeParameterChange:
-				paramChange, ok := action.(*ConwayParameterChangeGovAction)
+				paramChange, ok := action.(common.ParameterChangeGovAction)
 				if !ok {
 					// The action contents are not available, so the
 					// parameter groups it modifies are unknown.
 					continue
 				}
-				if len(paramChange.ParamUpdate.SecurityGroupFields()) > 0 {
+				if len(paramChange.SecurityGroupFields()) > 0 {
 					continue
 				}
 				restriction = "stake pools cannot vote on a parameter change " +

--- a/ledger/conway/rules_gov_transition_test.go
+++ b/ledger/conway/rules_gov_transition_test.go
@@ -89,6 +89,36 @@ func TestUtxoValidateProposalDeposit(t *testing.T) {
 	})
 }
 
+func TestUtxoValidateHardForkCanFollowSkipsTypedNilAncestor(t *testing.T) {
+	ancestorId := common.GovActionId{TransactionId: common.Blake2b256{0x01}}
+	var ancestorAction *common.HardForkInitiationGovAction
+	ls := mockledger.NewLedgerStateBuilder().WithGovActions(
+		map[string]*common.GovActionState{
+			govActionKey(ancestorId): {
+				ActionId:   ancestorId,
+				ActionType: common.GovActionTypeHardForkInitiation,
+				Action:     ancestorAction,
+			},
+		},
+	).Build()
+	tx := mkProposalsTx(
+		t,
+		mkHfAction(&ancestorId, common.ProtocolVersionPlomin, 0),
+	)
+
+	require.NotPanics(t, func() {
+		require.NoError(
+			t,
+			conway.UtxoValidateHardForkCanFollow(
+				tx,
+				0,
+				ls,
+				mkConwayPp(common.ProtocolVersionConway, 0),
+			),
+		)
+	})
+}
+
 func TestUtxoValidateProposalReturnAccounts(t *testing.T) {
 	registeredCred := common.Blake2b224Hash([]byte("registered-return"))
 	unregisteredCred := common.Blake2b224Hash([]byte("unregistered-return"))

--- a/ledger/dijkstra/gov.go
+++ b/ledger/dijkstra/gov.go
@@ -113,6 +113,8 @@ type DijkstraParameterChangeGovAction struct {
 	PolicyHash  []byte
 }
 
+var _ common.ParameterChangeGovAction = (*DijkstraParameterChangeGovAction)(nil)
+
 func (a *DijkstraParameterChangeGovAction) ToPlutusData() data.PlutusData {
 	actionId := data.NewConstr(1)
 	if a.ActionId != nil {
@@ -134,4 +136,34 @@ func (a *DijkstraParameterChangeGovAction) ToPlutusData() data.PlutusData {
 
 func (a *DijkstraParameterChangeGovAction) GetPolicyHash() []byte {
 	return a.PolicyHash
+}
+
+// PreviousGovActionId returns the parameter-change action this action follows.
+func (a *DijkstraParameterChangeGovAction) PreviousGovActionId() *common.GovActionId {
+	if a == nil {
+		return nil
+	}
+	return a.ActionId
+}
+
+// SecurityGroupFields returns the security-group parameters changed by this
+// action.
+func (a *DijkstraParameterChangeGovAction) SecurityGroupFields() []string {
+	if a == nil {
+		return nil
+	}
+	fields := a.ParamUpdate.conwayUpdate().SecurityGroupFields()
+	if a.ParamUpdate.MaxRefScriptSizePerBlock != nil {
+		fields = append(fields, "MaxRefScriptSizePerBlock")
+	}
+	if a.ParamUpdate.MaxRefScriptSizePerTx != nil {
+		fields = append(fields, "MaxRefScriptSizePerTx")
+	}
+	if a.ParamUpdate.RefScriptCostStride != nil {
+		fields = append(fields, "RefScriptCostStride")
+	}
+	if a.ParamUpdate.RefScriptCostMultiplier != nil {
+		fields = append(fields, "RefScriptCostMultiplier")
+	}
+	return fields
 }

--- a/ledger/dijkstra/gov.go
+++ b/ledger/dijkstra/gov.go
@@ -146,6 +146,9 @@ func (a *DijkstraParameterChangeGovAction) ToPlutusData() data.PlutusData {
 }
 
 func (a *DijkstraParameterChangeGovAction) GetPolicyHash() []byte {
+	if a == nil {
+		return nil
+	}
 	return a.PolicyHash
 }
 

--- a/ledger/dijkstra/gov.go
+++ b/ledger/dijkstra/gov.go
@@ -17,6 +17,7 @@ package dijkstra
 import (
 	"fmt"
 	"math/big"
+	"reflect"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
@@ -59,6 +60,16 @@ func (p DijkstraProposalProcedure) Anchor() common.GovAnchor {
 type DijkstraGovAction struct {
 	Type   uint
 	Action common.GovAction
+}
+
+// isNilGovAction reports whether action is nil, including an interface that
+// contains a typed-nil pointer.
+func isNilGovAction(action common.GovAction) bool {
+	if action == nil {
+		return true
+	}
+	rv := reflect.ValueOf(action)
+	return rv.Kind() == reflect.Pointer && rv.IsNil()
 }
 
 func (g DijkstraGovAction) ToPlutusData() data.PlutusData {

--- a/ledger/dijkstra/rules.go
+++ b/ledger/dijkstra/rules.go
@@ -39,7 +39,12 @@ const minUtxoOverheadBytes = 160
 var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	conway.UtxoValidateMetadata,
 	UtxoValidateProposalProcedures,
+	conway.UtxoValidateGovActionWellFormedness,
+	UtxoValidateHardForkCanFollow,
+	conway.UtxoValidateProposalAncestry,
+	UtxoValidateProposalDeposit,
 	conway.UtxoValidateProposalNetworkIds,
+	conway.UtxoValidateProposalReturnAccounts,
 	conway.UtxoValidateEmptyTreasuryWithdrawals,
 	UtxoValidateBootstrapAllowedGovActions,
 	UtxoValidateBootstrapParameterGroups,
@@ -80,6 +85,11 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	conway.UtxoValidateDelegation,
 	conway.UtxoValidateWithdrawals,
 	conway.UtxoValidateCommitteeCertificates,
+	conway.UtxoValidateUnknownVoters,
+	conway.UtxoValidateUnknownGovActionIds,
+	conway.UtxoValidateVotingOnExpiredGovAction,
+	conway.UtxoValidateBootstrapVotingRestrictions,
+	conway.UtxoValidateStakePoolVotingRestrictions,
 	UtxoValidateCCVotingRestrictions,
 	UtxoValidateMalformedReferenceScripts,
 	UtxoValidateRefScriptSizePerTx,
@@ -143,6 +153,32 @@ func UtxoValidateProposalProcedures(
 		}
 	}
 	return nil
+}
+
+func UtxoValidateHardForkCanFollow(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	tmpPparams, err := conwayPparams(pp)
+	if err != nil {
+		return err
+	}
+	return conway.UtxoValidateHardForkCanFollow(tx, slot, ls, tmpPparams)
+}
+
+func UtxoValidateProposalDeposit(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	tmpPparams, err := conwayPparams(pp)
+	if err != nil {
+		return err
+	}
+	return conway.UtxoValidateProposalDeposit(tx, slot, ls, tmpPparams)
 }
 
 func UtxoValidateBootstrapAllowedGovActions(

--- a/ledger/dijkstra/rules.go
+++ b/ledger/dijkstra/rules.go
@@ -88,7 +88,7 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	conway.UtxoValidateUnknownVoters,
 	conway.UtxoValidateUnknownGovActionIds,
 	conway.UtxoValidateVotingOnExpiredGovAction,
-	conway.UtxoValidateBootstrapVotingRestrictions,
+	UtxoValidateBootstrapVotingRestrictions,
 	conway.UtxoValidateStakePoolVotingRestrictions,
 	UtxoValidateCCVotingRestrictions,
 	UtxoValidateMalformedReferenceScripts,
@@ -139,7 +139,7 @@ func UtxoValidateProposalProcedures(
 ) error {
 	for _, proposal := range tx.ProposalProcedures() {
 		govAction := proposal.GovAction()
-		if govAction == nil {
+		if isNilGovAction(govAction) {
 			continue
 		}
 		paramChangeAction, ok := govAction.(*DijkstraParameterChangeGovAction)
@@ -181,6 +181,24 @@ func UtxoValidateProposalDeposit(
 	return conway.UtxoValidateProposalDeposit(tx, slot, ls, tmpPparams)
 }
 
+func UtxoValidateBootstrapVotingRestrictions(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	tmpPparams, err := conwayPparams(pp)
+	if err != nil {
+		return err
+	}
+	return conway.UtxoValidateBootstrapVotingRestrictions(
+		tx,
+		slot,
+		ls,
+		tmpPparams,
+	)
+}
+
 func UtxoValidateBootstrapAllowedGovActions(
 	tx common.Transaction,
 	slot uint64,
@@ -196,7 +214,7 @@ func UtxoValidateBootstrapAllowedGovActions(
 	}
 	for _, proposal := range tx.ProposalProcedures() {
 		govAction := proposal.GovAction()
-		if govAction == nil {
+		if isNilGovAction(govAction) {
 			continue
 		}
 		switch govAction.(type) {
@@ -241,7 +259,7 @@ func UtxoValidateBootstrapParameterGroups(
 	}
 	for _, proposal := range tx.ProposalProcedures() {
 		govAction := proposal.GovAction()
-		if govAction == nil {
+		if isNilGovAction(govAction) {
 			continue
 		}
 		switch paramChange := govAction.(type) {

--- a/ledger/dijkstra/rules_test.go
+++ b/ledger/dijkstra/rules_test.go
@@ -15,6 +15,9 @@
 package dijkstra
 
 import (
+	"reflect"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -27,6 +30,223 @@ import (
 	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
 	"github.com/stretchr/testify/require"
 )
+
+func dijkstraValidationRuleName(rule common.UtxoValidationRuleFunc) string {
+	return runtime.FuncForPC(reflect.ValueOf(rule).Pointer()).Name()
+}
+
+func dijkstraValidationRule(
+	t *testing.T,
+	want string,
+) (common.UtxoValidationRuleFunc, int) {
+	t.Helper()
+	for idx, rule := range UtxoValidationRules {
+		if strings.HasSuffix(dijkstraValidationRuleName(rule), want) {
+			return rule, idx
+		}
+	}
+	t.Fatalf("validation rule %s is not registered", want)
+	return nil, -1
+}
+
+func TestDijkstraGovernanceValidationRules(t *testing.T) {
+	expected := []string{
+		"ledger/dijkstra.UtxoValidateProposalProcedures",
+		"ledger/conway.UtxoValidateGovActionWellFormedness",
+		"ledger/dijkstra.UtxoValidateHardForkCanFollow",
+		"ledger/conway.UtxoValidateProposalAncestry",
+		"ledger/dijkstra.UtxoValidateProposalDeposit",
+		"ledger/conway.UtxoValidateProposalNetworkIds",
+		"ledger/conway.UtxoValidateProposalReturnAccounts",
+		"ledger/conway.UtxoValidateEmptyTreasuryWithdrawals",
+		"ledger/conway.UtxoValidateCommitteeCertificates",
+		"ledger/conway.UtxoValidateUnknownVoters",
+		"ledger/conway.UtxoValidateUnknownGovActionIds",
+		"ledger/conway.UtxoValidateVotingOnExpiredGovAction",
+		"ledger/conway.UtxoValidateBootstrapVotingRestrictions",
+		"ledger/conway.UtxoValidateStakePoolVotingRestrictions",
+		"ledger/dijkstra.UtxoValidateCCVotingRestrictions",
+	}
+
+	previous := -1
+	for _, ruleName := range expected {
+		_, idx := dijkstraValidationRule(t, ruleName)
+		require.Greater(
+			t,
+			idx,
+			previous,
+			"validation rule %s is out of order",
+			ruleName,
+		)
+		previous = idx
+	}
+}
+
+func TestConwayGovActionRejectsDijkstraParameterChange(t *testing.T) {
+	_, err := conway.NewConwayGovAction(&DijkstraParameterChangeGovAction{})
+	require.Error(t, err)
+}
+
+func TestDijkstraGovernanceValidationRejectsTypedNilParameterChange(
+	t *testing.T,
+) {
+	var action *DijkstraParameterChangeGovAction
+	tx := &DijkstraTransaction{Body: DijkstraTransactionBody{
+		TxProposalProcedures: []DijkstraProposalProcedure{{
+			PPGovAction: DijkstraGovAction{Action: action},
+		}},
+	}}
+	var malformedErr conway.MalformedGovActionError
+	require.ErrorAs(
+		t,
+		conway.UtxoValidateGovActionWellFormedness(tx, 0, nil, nil),
+		&malformedErr,
+	)
+
+	require.NotPanics(t, func() {
+		_ = conway.UtxoValidateProposalAncestry(tx, 0, nil, nil)
+	})
+}
+
+func TestDijkstraParameterChangeSecurityGroupFields(t *testing.T) {
+	maxRefScriptSizePerBlock := uint32(1)
+	maxRefScriptSizePerTx := uint32(2)
+	refScriptCostStride := uint32(3)
+	action := DijkstraParameterChangeGovAction{
+		ParamUpdate: DijkstraProtocolParameterUpdate{
+			MaxRefScriptSizePerBlock: &maxRefScriptSizePerBlock,
+			MaxRefScriptSizePerTx:    &maxRefScriptSizePerTx,
+			RefScriptCostStride:      &refScriptCostStride,
+			RefScriptCostMultiplier:  new(cbor.Rat),
+		},
+	}
+	require.Equal(t, []string{
+		"MaxRefScriptSizePerBlock",
+		"MaxRefScriptSizePerTx",
+		"RefScriptCostStride",
+		"RefScriptCostMultiplier",
+	}, action.SecurityGroupFields())
+}
+
+func TestDijkstraGovernanceValidationRulesRejectInvalidProposalsAndVotes(
+	t *testing.T,
+) {
+	pp := &DijkstraProtocolParameters{
+		ConwayProtocolParameters: conway.ConwayProtocolParameters{
+			ProtocolVersion: common.ProtocolParametersProtocolVersion{
+				Major: common.ProtocolVersionDijkstra,
+			},
+			GovActionDeposit: 500,
+		},
+	}
+
+	t.Run("proposal deposit", func(t *testing.T) {
+		tx := &DijkstraTransaction{Body: DijkstraTransactionBody{
+			TxProposalProcedures: []DijkstraProposalProcedure{{
+				PPDeposit:   1,
+				PPGovAction: DijkstraGovAction{Action: &common.InfoGovAction{}},
+			}},
+		}}
+		rule, _ := dijkstraValidationRule(
+			t,
+			"ledger/dijkstra.UtxoValidateProposalDeposit",
+		)
+		err := rule(tx, 0, nil, pp)
+		var depositErr conway.ProposalDepositIncorrectError
+		require.ErrorAs(t, err, &depositErr)
+	})
+
+	t.Run("parameter-change ancestry", func(t *testing.T) {
+		missing := common.GovActionId{TransactionId: common.Blake2b256{0x01}}
+		tx := &DijkstraTransaction{Body: DijkstraTransactionBody{
+			TxProposalProcedures: []DijkstraProposalProcedure{{
+				PPGovAction: DijkstraGovAction{
+					Action: &DijkstraParameterChangeGovAction{
+						ActionId: &missing,
+					},
+				},
+			}},
+		}}
+		ls := mockledger.NewLedgerStateBuilder().Build()
+		rule, _ := dijkstraValidationRule(
+			t,
+			"ledger/conway.UtxoValidateProposalAncestry",
+		)
+		err := rule(tx, 0, ls, pp)
+		var ancestryErr conway.InvalidGovActionAncestorError
+		require.ErrorAs(t, err, &ancestryErr)
+	})
+
+	t.Run("stake-pool parameter-change vote", func(t *testing.T) {
+		keyDeposit := uint(2_000_000)
+		tx := &DijkstraTransaction{Body: DijkstraTransactionBody{
+			TxProposalProcedures: []DijkstraProposalProcedure{{
+				PPGovAction: DijkstraGovAction{
+					Action: &DijkstraParameterChangeGovAction{
+						ParamUpdate: DijkstraProtocolParameterUpdate{
+							KeyDeposit: &keyDeposit,
+						},
+					},
+				},
+			}},
+		}}
+		encodedBody, err := cbor.Encode(&tx.Body)
+		require.NoError(t, err)
+		tx.Body.SetCborReference(encodedBody)
+		actionId := common.GovActionId{TransactionId: tx.Hash()}
+		voter := common.Voter{
+			Type: common.VoterTypeStakingPoolKeyHash,
+			Hash: common.Blake2b224{0x02},
+		}
+		tx.Body.TxVotingProcedures = common.VotingProcedures{
+			&voter: {
+				&actionId: {Vote: common.GovVoteYes},
+			},
+		}
+		ls := mockledger.NewLedgerStateBuilder().Build()
+		rule, _ := dijkstraValidationRule(
+			t,
+			"ledger/conway.UtxoValidateStakePoolVotingRestrictions",
+		)
+		err = rule(tx, 0, ls, pp)
+		var votingErr conway.StakePoolVotingRestrictionError
+		require.ErrorAs(t, err, &votingErr)
+	})
+
+	t.Run("stake-pool Dijkstra security parameter vote", func(t *testing.T) {
+		maxRefScriptSizePerTx := uint32(200_000)
+		tx := &DijkstraTransaction{Body: DijkstraTransactionBody{
+			TxProposalProcedures: []DijkstraProposalProcedure{{
+				PPGovAction: DijkstraGovAction{
+					Action: &DijkstraParameterChangeGovAction{
+						ParamUpdate: DijkstraProtocolParameterUpdate{
+							MaxRefScriptSizePerTx: &maxRefScriptSizePerTx,
+						},
+					},
+				},
+			}},
+		}}
+		encodedBody, err := cbor.Encode(&tx.Body)
+		require.NoError(t, err)
+		tx.Body.SetCborReference(encodedBody)
+		actionId := common.GovActionId{TransactionId: tx.Hash()}
+		voter := common.Voter{
+			Type: common.VoterTypeStakingPoolKeyHash,
+			Hash: common.Blake2b224{0x03},
+		}
+		tx.Body.TxVotingProcedures = common.VotingProcedures{
+			&voter: {
+				&actionId: {Vote: common.GovVoteYes},
+			},
+		}
+		ls := mockledger.NewLedgerStateBuilder().Build()
+		rule, _ := dijkstraValidationRule(
+			t,
+			"ledger/conway.UtxoValidateStakePoolVotingRestrictions",
+		)
+		require.NoError(t, rule(tx, 0, ls, pp))
+	})
+}
 
 func TestUtxoValidateBootstrapAllowedGovActionsRejectsUnknown(t *testing.T) {
 	tx := &DijkstraTransaction{}

--- a/ledger/dijkstra/rules_test.go
+++ b/ledger/dijkstra/rules_test.go
@@ -63,7 +63,7 @@ func TestDijkstraGovernanceValidationRules(t *testing.T) {
 		"ledger/conway.UtxoValidateUnknownVoters",
 		"ledger/conway.UtxoValidateUnknownGovActionIds",
 		"ledger/conway.UtxoValidateVotingOnExpiredGovAction",
-		"ledger/conway.UtxoValidateBootstrapVotingRestrictions",
+		"ledger/dijkstra.UtxoValidateBootstrapVotingRestrictions",
 		"ledger/conway.UtxoValidateStakePoolVotingRestrictions",
 		"ledger/dijkstra.UtxoValidateCCVotingRestrictions",
 	}
@@ -96,16 +96,58 @@ func TestDijkstraGovernanceValidationRejectsTypedNilParameterChange(
 			PPGovAction: DijkstraGovAction{Action: action},
 		}},
 	}}
-	var malformedErr conway.MalformedGovActionError
-	require.ErrorAs(
-		t,
-		conway.UtxoValidateGovActionWellFormedness(tx, 0, nil, nil),
-		&malformedErr,
-	)
-
+	var err error
 	require.NotPanics(t, func() {
-		_ = conway.UtxoValidateProposalAncestry(tx, 0, nil, nil)
+		err = common.VerifyTransaction(
+			tx,
+			0,
+			nil,
+			&DijkstraProtocolParameters{},
+			UtxoValidationRules,
+		)
 	})
+	var malformedErr conway.MalformedGovActionError
+	require.ErrorAs(t, err, &malformedErr)
+}
+
+func TestDijkstraBootstrapVotingRestrictionsAreRegistered(t *testing.T) {
+	newTx := func(action common.GovAction) *DijkstraTransaction {
+		tx := &DijkstraTransaction{Body: DijkstraTransactionBody{
+			TxProposalProcedures: []DijkstraProposalProcedure{{
+				PPGovAction: DijkstraGovAction{Action: action},
+			}},
+		}}
+		encodedBody, err := cbor.Encode(&tx.Body)
+		require.NoError(t, err)
+		tx.Body.SetCborReference(encodedBody)
+		actionId := common.GovActionId{TransactionId: tx.Hash()}
+		voter := common.Voter{
+			Type: common.VoterTypeDRepKeyHash,
+			Hash: common.Blake2b224{0x04},
+		}
+		tx.Body.TxVotingProcedures = common.VotingProcedures{
+			&voter: {
+				&actionId: {Vote: common.GovVoteYes},
+			},
+		}
+		return tx
+	}
+	pp := &DijkstraProtocolParameters{
+		ConwayProtocolParameters: conway.ConwayProtocolParameters{
+			ProtocolVersion: common.ProtocolParametersProtocolVersion{
+				Major: common.ProtocolVersionConway,
+			},
+		},
+	}
+
+	rule, _ := dijkstraValidationRule(
+		t,
+		"ledger/dijkstra.UtxoValidateBootstrapVotingRestrictions",
+	)
+	err := rule(newTx(&DijkstraParameterChangeGovAction{}), 0, nil, pp)
+	var bootstrapErr conway.BootstrapVotingRestrictionError
+	require.ErrorAs(t, err, &bootstrapErr)
+	require.NoError(t, rule(newTx(&common.InfoGovAction{}), 0, nil, pp))
 }
 
 func TestDijkstraParameterChangeSecurityGroupFields(t *testing.T) {


### PR DESCRIPTION
## Summary

- register the applicable governance validation rules in Dijkstra transaction order
- share parameter-change ancestry and voting classification across eras while preserving Conway constructor boundaries
- classify the Dijkstra reference-script parameters in their security voting group
- reject typed-nil governance actions before shared validation dispatch
- cover ordered registration and representative invalid proposals and votes

## Validation

- exact-base regression proof
- focused Dijkstra race tests
- full ledger race tests
- conformance race tests
- `go test ./...`
- golangci-lint
- NilAway
- `go vet`

Closes #2063
