### PR TITLE
fix(txsubmission): synchronize responder protocol access

### DIFF
--- a/protocol/txsubmission/server.go
+++ b/protocol/txsubmission/server.go
@@ -221,7 +221,8 @@ func (s *Server) messageHandler(msg protocol.Message) error {
 }
 
 func (s *Server) handleReplyTxIds(msg protocol.Message) {
-	s.Protocol.Logger().
+	p := s.ProtocolInstance()
+	p.Logger().
 		Debug("reply tx ids",
 			"component", "network",
 			"protocol", ProtocolName,
@@ -235,7 +236,8 @@ func (s *Server) handleReplyTxIds(msg protocol.Message) {
 }
 
 func (s *Server) handleReplyTxs(msg protocol.Message) {
-	s.Protocol.Logger().
+	p := s.ProtocolInstance()
+	p.Logger().
 		Debug("reply txs",
 			"component", "network",
 			"protocol", ProtocolName,

--- a/protocol/txsubmission/server_test.go
+++ b/protocol/txsubmission/server_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package txsubmission
+
+import (
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplyHandlersSynchronizeProtocolAccessDuringRestart(t *testing.T) {
+	const iterations = 10_000
+
+	server := NewServer(protocol.ProtocolOptions{
+		ConnectionId: connection.ConnectionId{
+			LocalAddr:  &net.UnixAddr{Name: "local", Net: "unix"},
+			RemoteAddr: &net.UnixAddr{Name: "remote", Net: "unix"},
+		},
+	}, nil)
+	server.requestTxIdsResultChan = make(
+		chan requestTxIdsResult,
+		iterations,
+	)
+	server.requestTxsResultChan = make(chan []TxBody, iterations)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		<-start
+		for range iterations {
+			server.initProtocol()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for range iterations {
+			server.handleReplyTxIds(NewMsgReplyTxIds(nil))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for range iterations {
+			server.handleReplyTxs(NewMsgReplyTxs(nil))
+		}
+	}()
+
+	close(start)
+	wg.Wait()
+
+	require.Len(t, server.requestTxIdsResultChan, iterations)
+	require.Len(t, server.requestTxsResultChan, iterations)
+}


### PR DESCRIPTION
The transaction-submission responder now uses synchronized protocol access in both reply handlers during protocol replacement. Transaction ID and transaction-body replies retain their existing delivery behavior, with race coverage for concurrent restarts.

Closes #2064
