### PR TITLE
fix(ledger): exempt script withdrawals from DRep gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,7 +205,8 @@ Error files: `ledger/{shelley,allegra,alonzo,babbage,conway,common}/errors.go`.
    Dijkstra, while Dijkstra permits qualifying partial withdrawals. At
    PV10/PV11, the DRep gate applies only to key-hash reward credentials;
    script-hash reward credentials still undergo registration and amount
-   validation.
+   validation. The DRep gate is amount-independent, so a zero withdrawal from
+   a registered zero-balance key-hash account still requires delegation.
 9. Read code before claiming "just delegates" or "missing check". `NOTE:` comments mark deliberate decisions.
 10. Mutating a decoded `DecodeStoreCbor`-embedding struct and re-marshaling does not pick up the change — `MarshalCBOR()` returns the stored bytes as-is. Call `SetCbor(nil)` first.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,7 +201,11 @@ Error files: `ledger/{shelley,allegra,alonzo,babbage,conway,common}/errors.go`.
 5. Era delegation is not universal — read the function body. Conway `UtxoValidateWithdrawals` has a custom impl.
 6. Hash from preserved CBOR bytes, not re-encoded data.
 7. `DecodeStoreCbor` requires a custom `UnmarshalCBOR` calling `SetCbor()`.
-8. Withdrawal amount validation is intentionally disabled (see `NOTE:` at `conway/rules.go` `UtxoValidateWithdrawals`). Spec requires `amount == balance`, not `amount > 0`; zero-amount withdrawals from zero-balance accounts are spec-valid. Multi-tx balance tracking is deferred.
+8. Withdrawal amount validation requires the exact reward balance before
+   Dijkstra, while Dijkstra permits qualifying partial withdrawals. At
+   PV10/PV11, the DRep gate applies only to key-hash reward credentials;
+   script-hash reward credentials still undergo registration and amount
+   validation.
 9. Read code before claiming "just delegates" or "missing check". `NOTE:` comments mark deliberate decisions.
 10. Mutating a decoded `DecodeStoreCbor`-embedding struct and re-marshaling does not pick up the change — `MarshalCBOR()` returns the stored bytes as-is. Call `SetCbor(nil)` first.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -205,6 +205,8 @@ the remaining behavior is selected by the active major protocol version:
 | PV10 (Plomin) and PV11 (Van Rossem) | Yes |
 | PV12 (Dijkstra) and later | No, per CIP-181 |
 
+At PV10/PV11, every key-hash credential present in the withdrawal map is
+checked, including a zero withdrawal from a registered zero-balance account.
 Script-hash reward credentials never require a DRep vote delegation. They
 still undergo the Shelley reward-account registration and withdrawal-amount
 checks.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -189,7 +189,7 @@ func UtxoValidateTimeToLive(tx, slot, ls, pp) error {
 | Mary | Multi-asset support (native tokens) |
 | Alonzo | Plutus smart contracts, redeemers, datums |
 | Babbage | Reference scripts, inline datums |
-| Conway | Governance; PV10/PV11 DRep-gated reward withdrawals |
+| Conway | Governance; PV10/PV11 DRep-gated key-hash reward withdrawals |
 | Dijkstra | PV12; CIP-181 removes the reward-withdrawal DRep gate |
 
 ### Conway Reward Withdrawal Gate
@@ -199,16 +199,21 @@ withdrawal validation for phase-2-invalid transactions, then applies the
 Shelley reward-account registration check. For transactions with withdrawals,
 the remaining behavior is selected by the active major protocol version:
 
-| Protocol version | DRep vote delegation required? |
-|------------------|-------------------------------|
+| Protocol version | Key-hash DRep vote delegation required? |
+|------------------|----------------------------------------|
 | PV9 and earlier | No |
 | PV10 (Plomin) and PV11 (Van Rossem) | Yes |
 | PV12 (Dijkstra) and later | No, per CIP-181 |
 
+Script-hash reward credentials never require a DRep vote delegation. They
+still undergo the Shelley reward-account registration and withdrawal-amount
+checks.
+
 The active protocol version comes from
 `conway.ConwayProtocolParameters.ProtocolMajorVersion`; Dijkstra protocol
-parameters inherit that method. At PV10/PV11, ledger states must additionally
-implement the optional `common.DRepDelegationState` capability:
+parameters inherit that method. At PV10/PV11, ledger states validating a
+key-hash reward withdrawal must additionally implement the optional
+`common.DRepDelegationState` capability:
 
 ```go
 type DRepDelegationState interface {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ grep -cE "^    --- FAIL: TestRulesConformanceVectors/" /tmp/conformance.txt
 
 ## Rules Claude gets wrong without being told
 
-1. Era delegation is not universal — grep the era's function body before describing behavior; don't assume it forwards to the previous era. E.g. `conway.UtxoValidateWithdrawals` (`ledger/conway/rules.go`) skips phase-2-invalid txs, checks reward-account registration, requires key-hash reward credentials to have a DRep vote delegation at PV10/PV11, exempts script-hash reward credentials, and removes the requirement at PV12 per CIP-181.
+1. Era delegation is not universal — grep the era's function body before describing behavior; don't assume it forwards to the previous era. E.g. `conway.UtxoValidateWithdrawals` (`ledger/conway/rules.go`) skips phase-2-invalid txs, checks reward-account registration, requires every key-hash reward credential present in withdrawals (including zero amounts) to have a DRep vote delegation at PV10/PV11, exempts script-hash reward credentials, and removes the requirement at PV12 per CIP-181.
 2. `DecodeStoreCbor` requires a custom `UnmarshalCBOR` that calls `SetCbor(cborData)`. Missing → `Cbor()` returns nil → hashing breaks.
 3. Hash from preserved `.Cbor()` bytes. Never re-encode and hash.
 4. CBOR `EncMode`/`DecMode` are globally cached via `sync.Once` in `cbor/{encode,decode}.go`. Don't construct per call.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,13 @@ grep -cE "^    --- FAIL: TestRulesConformanceVectors/" /tmp/conformance.txt
 
 ## Rules Claude gets wrong without being told
 
-1. Era delegation is not universal — grep the era's function body before describing behavior; don't assume it forwards to the previous era. E.g. `conway.UtxoValidateWithdrawals` (`ledger/conway/rules.go`) skips phase-2-invalid txs, checks reward-account registration, requires every key-hash reward credential present in withdrawals (including zero amounts) to have a DRep vote delegation at PV10/PV11, exempts script-hash reward credentials, and removes the requirement at PV12 per CIP-181.
+1. Era delegation is not universal — grep the era's function body before
+   describing behavior; don't assume it forwards to the previous era. E.g.
+   `conway.UtxoValidateWithdrawals` (`ledger/conway/rules.go`) skips
+   phase-2-invalid txs, checks reward-account registration, requires every
+   key-hash reward credential present in withdrawals (including zero amounts)
+   to have a DRep vote delegation at PV10/PV11, exempts script-hash reward
+   credentials, and removes the requirement at PV12 per CIP-181.
 2. `DecodeStoreCbor` requires a custom `UnmarshalCBOR` that calls `SetCbor(cborData)`. Missing → `Cbor()` returns nil → hashing breaks.
 3. Hash from preserved `.Cbor()` bytes. Never re-encode and hash.
 4. CBOR `EncMode`/`DecMode` are globally cached via `sync.Once` in `cbor/{encode,decode}.go`. Don't construct per call.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ grep -cE "^    --- FAIL: TestRulesConformanceVectors/" /tmp/conformance.txt
 
 ## Rules Claude gets wrong without being told
 
-1. Era delegation is not universal — grep the era's function body before describing behavior; don't assume it forwards to the previous era. E.g. `conway.UtxoValidateWithdrawals` (`ledger/conway/rules.go`) skips phase-2-invalid txs, checks reward-account registration, requires a DRep vote delegation at PV10/PV11, and removes that requirement at PV12 per CIP-181.
+1. Era delegation is not universal — grep the era's function body before describing behavior; don't assume it forwards to the previous era. E.g. `conway.UtxoValidateWithdrawals` (`ledger/conway/rules.go`) skips phase-2-invalid txs, checks reward-account registration, requires key-hash reward credentials to have a DRep vote delegation at PV10/PV11, exempts script-hash reward credentials, and removes the requirement at PV12 per CIP-181.
 2. `DecodeStoreCbor` requires a custom `UnmarshalCBOR` that calls `SetCbor(cborData)`. Missing → `Cbor()` returns nil → hashing breaks.
 3. Hash from preserved `.Cbor()` bytes. Never re-encode and hash.
 4. CBOR `EncMode`/`DecMode` are globally cached via `sync.Once` in `cbor/{encode,decode}.go`. Don't construct per call.

--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ This is not an exhaustive list of existing and planned features, but it covers t
       - [X] TX inputs
       - [X] TX outputs
       - [X] Parameter updates
-      - [X] Key-hash reward withdrawals require a DRep vote delegation at
-        PV10/PV11
+      - [X] Every key-hash reward credential present in withdrawals requires a
+        DRep vote delegation at PV10/PV11, including zero amounts
     - [X] Dijkstra
       - [X] Blocks
       - [X] Transactions

--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ This is not an exhaustive list of existing and planned features, but it covers t
       - [X] TX inputs
       - [X] TX outputs
       - [X] Parameter updates
-      - [X] Reward withdrawals require a DRep vote delegation at PV10/PV11
+      - [X] Key-hash reward withdrawals require a DRep vote delegation at
+        PV10/PV11
     - [X] Dijkstra
       - [X] Blocks
       - [X] Transactions

--- a/ledger/common/state.go
+++ b/ledger/common/state.go
@@ -143,7 +143,7 @@ type DRepRegistration struct {
 
 // DRepDelegationState is the optional ledger-state capability used to query
 // governance vote delegations. Ledger states used to validate PV10 or PV11
-// reward withdrawals must implement this interface.
+// key-hash reward withdrawals must implement this interface.
 type DRepDelegationState interface {
 	DRepDelegation(Credential) (*Drep, error)
 }

--- a/ledger/conway/errors.go
+++ b/ledger/conway/errors.go
@@ -337,7 +337,7 @@ func (e InvalidDRepTypeError) Error() string {
 type WithdrawalFromUnregisteredRewardAccountError = shelley.WithdrawalFromUnregisteredRewardAccountError
 
 // WithdrawalNotDelegatedToDRepError indicates a PV10/PV11 reward withdrawal
-// whose stake credential has no governance vote delegation.
+// whose key-hash stake credential has no governance vote delegation.
 type WithdrawalNotDelegatedToDRepError struct {
 	RewardAddress common.Address
 }

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -3168,9 +3168,10 @@ func UtxoValidateDelegation(
 // UtxoValidateWithdrawals validates withdrawals against ledger state.
 // For phase-2 invalid transactions (IsValid=false), withdrawal validation is
 // skipped since their effects are reverted and only collateral rules apply.
-// PV10 and PV11 also require each key-hash stake credential withdrawing a
-// non-zero amount to have a DRep vote delegation. Script-hash stake
-// credentials are exempt. PV12 removes the requirement per CIP-181.
+// PV10 and PV11 also require each key-hash stake credential present in the
+// withdrawal map to have a DRep vote delegation, including zero-amount
+// withdrawals. Script-hash stake credentials are exempt. PV12 removes the
+// requirement per CIP-181.
 func UtxoValidateWithdrawals(
 	tx common.Transaction,
 	slot uint64,
@@ -3199,10 +3200,7 @@ func UtxoValidateWithdrawals(
 		return nil
 	}
 	var delegationState common.DRepDelegationState
-	for addr, amount := range withdrawals {
-		if amount == nil || amount.Sign() == 0 {
-			continue
-		}
+	for addr := range withdrawals {
 		credential, ok := addr.StakeCredential()
 		if !ok || credential.CredType != common.CredentialTypeAddrKeyHash {
 			continue

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -3168,9 +3168,9 @@ func UtxoValidateDelegation(
 // UtxoValidateWithdrawals validates withdrawals against ledger state.
 // For phase-2 invalid transactions (IsValid=false), withdrawal validation is
 // skipped since their effects are reverted and only collateral rules apply.
-// PV10 and PV11 also require each stake credential withdrawing a non-zero
-// amount to have a DRep vote delegation. PV12 removes that requirement per
-// CIP-181.
+// PV10 and PV11 also require each key-hash stake credential withdrawing a
+// non-zero amount to have a DRep vote delegation. Script-hash stake
+// credentials are exempt. PV12 removes the requirement per CIP-181.
 func UtxoValidateWithdrawals(
 	tx common.Transaction,
 	slot uint64,
@@ -3203,16 +3203,16 @@ func UtxoValidateWithdrawals(
 		if amount == nil || amount.Sign() == 0 {
 			continue
 		}
+		credential, ok := addr.StakeCredential()
+		if !ok || credential.CredType != common.CredentialTypeAddrKeyHash {
+			continue
+		}
 		if delegationState == nil {
 			var ok bool
 			delegationState, ok = ls.(common.DRepDelegationState)
 			if !ok {
 				return DRepDelegationStateUnavailableError{}
 			}
-		}
-		credential, ok := addr.StakeCredential()
-		if !ok {
-			continue
 		}
 		delegation, err := delegationState.DRepDelegation(credential)
 		if err != nil {

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -382,6 +382,86 @@ func TestUtxoValidateWithdrawals_DRepDelegationProtocolGate(t *testing.T) {
 	})
 }
 
+func TestUtxoValidateWithdrawals_ScriptCredentialDRepBoundary(t *testing.T) {
+	stakeKeyHash := common.Blake2b224Hash([]byte("withdrawal-stake-key"))
+	keyRewardAddr := makeConwayRewardAddress(t, stakeKeyHash)
+	scriptRewardAddr, err := common.NewAddress(
+		"stake17xt4n07cnlafzefqvne69mmxmnzu2t9gtd27jw9d9yvc7uscsd3d3",
+	)
+	require.NoError(t, err)
+	scriptCredential, ok := scriptRewardAddr.StakeCredential()
+	require.True(t, ok)
+	pp := &conway.ConwayProtocolParameters{
+		ProtocolVersion: common.ProtocolParametersProtocolVersion{
+			Major: common.ProtocolVersionVanRossem,
+		},
+	}
+
+	t.Run("script credential needs no DRep state", func(t *testing.T) {
+		state := mockledger.NewLedgerStateBuilder().
+			WithRewardAccountCredentialBalance(scriptCredential, 1_000_000).
+			Build()
+		tx := &conway.ConwayTransaction{
+			Body: conway.ConwayTransactionBody{
+				TxWithdrawals: map[*common.Address]uint64{
+					&scriptRewardAddr: 1_000_000,
+				},
+			},
+			TxIsValid: true,
+		}
+
+		require.NoError(t, conway.UtxoValidateWithdrawals(
+			tx,
+			0,
+			struct{ common.LedgerState }{LedgerState: state},
+			pp,
+		))
+	})
+
+	t.Run("mixed script and undelegated key credentials", func(t *testing.T) {
+		tx := &conway.ConwayTransaction{
+			Body: conway.ConwayTransactionBody{
+				TxWithdrawals: map[*common.Address]uint64{
+					&keyRewardAddr:    1_000_000,
+					&scriptRewardAddr: 1_000_000,
+				},
+			},
+			TxIsValid: true,
+		}
+		delegatedState := mockledger.NewLedgerStateBuilder().
+			WithRewardAccountBalance(stakeKeyHash, 1_000_000).
+			WithRewardAccountCredentialBalance(scriptCredential, 1_000_000).
+			WithDRepDelegation(func(
+				credential common.Credential,
+			) (*common.Drep, error) {
+				assert.Equal(t, stakeKeyHash, credential.Credential)
+				return &common.Drep{}, nil
+			}).
+			Build()
+		require.NoError(t, conway.UtxoValidateWithdrawals(
+			tx,
+			0,
+			delegatedState,
+			pp,
+		))
+
+		undelegatedState := mockledger.NewLedgerStateBuilder().
+			WithRewardAccountBalance(stakeKeyHash, 1_000_000).
+			WithRewardAccountCredentialBalance(scriptCredential, 1_000_000).
+			WithDRepDelegation(func(
+				credential common.Credential,
+			) (*common.Drep, error) {
+				assert.Equal(t, stakeKeyHash, credential.Credential)
+				return nil, nil
+			}).
+			Build()
+		err = conway.UtxoValidateWithdrawals(tx, 0, undelegatedState, pp)
+		var target conway.WithdrawalNotDelegatedToDRepError
+		require.ErrorAs(t, err, &target)
+		assert.Equal(t, keyRewardAddr, target.RewardAddress)
+	})
+}
+
 func TestUtxoValidateWitnessRules_Conway(t *testing.T) {
 	// Required vkey witnesses
 	t.Run("no required signers", func(t *testing.T) {

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -175,16 +175,12 @@ func TestUtxoValidateWithdrawals_DRepDelegationProtocolGate(t *testing.T) {
 				credential.CredType,
 			)
 
-			lookups := 0
 			state := mockledger.NewLedgerStateBuilder().
 				WithRewardAccountCredentialBalance(credential, 1_000_000).
-				WithDRepDelegation(func(
-					common.Credential,
-				) (*common.Drep, error) {
-					lookups++
-					return nil, nil
-				}).
 				Build()
+			stateWithoutDRepDelegation := struct{ common.LedgerState }{
+				LedgerState: state,
+			}
 			tx := &conway.ConwayTransaction{
 				Body: conway.ConwayTransactionBody{
 					TxWithdrawals: map[*common.Address]uint64{
@@ -202,13 +198,54 @@ func TestUtxoValidateWithdrawals_DRepDelegationProtocolGate(t *testing.T) {
 			require.NoError(t, conway.UtxoValidateWithdrawals(
 				tx,
 				0,
-				state,
+				stateWithoutDRepDelegation,
 				pp,
 			))
-			assert.Zero(t, lookups,
-				"script credentials must not enter the DRep lookup")
 		})
 	}
+
+	t.Run(
+		"PV10 script and undelegated key check the key every time",
+		func(t *testing.T) {
+			scriptRewardAddr, err := common.NewAddress(
+				"stake17xt4n07cnlafzefqvne69mmxmnzu2t9gtd27jw9d9yvc7uscsd3d3",
+			)
+			require.NoError(t, err)
+			scriptCredential, ok := scriptRewardAddr.StakeCredential()
+			require.True(t, ok)
+			keyRewardAddr := makeConwayRewardAddress(t, stakeKeyHash)
+			mixedTx := &conway.ConwayTransaction{
+				Body: conway.ConwayTransactionBody{
+					TxWithdrawals: map[*common.Address]uint64{
+						&scriptRewardAddr: 1_000_000,
+						&keyRewardAddr:    1_000_000,
+					},
+				},
+				TxIsValid: true,
+			}
+			state := mockledger.NewLedgerStateBuilder().
+				WithRewardAccountCredentialBalance(scriptCredential, 1_000_000).
+				WithRewardAccountBalance(stakeKeyHash, 1_000_000).
+				WithDRepDelegation(func(
+					common.Credential,
+				) (*common.Drep, error) {
+					return nil, nil
+				}).
+				Build()
+			pp := &conway.ConwayProtocolParameters{
+				ProtocolVersion: common.ProtocolParametersProtocolVersion{
+					Major: common.ProtocolVersionPlomin,
+				},
+			}
+
+			for range 100 {
+				err := conway.UtxoValidateWithdrawals(mixedTx, 0, state, pp)
+				var target conway.WithdrawalNotDelegatedToDRepError
+				require.ErrorAs(t, err, &target)
+				require.Equal(t, keyRewardAddr, target.RewardAddress)
+			}
+		},
+	)
 
 	t.Run("PV11 unregistered script credential", func(t *testing.T) {
 		rewardAddr, err := common.NewAddress(

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -156,6 +156,86 @@ func TestUtxoValidateWithdrawals_DRepDelegationProtocolGate(t *testing.T) {
 		))
 	})
 
+	for _, major := range []uint{
+		common.ProtocolVersionPlomin,
+		common.ProtocolVersionVanRossem,
+	} {
+		t.Run(fmt.Sprintf("PV%d script credential", major), func(t *testing.T) {
+			// cardano-ledger applies the PV10/PV11 DRep requirement only to
+			// key-hash reward credentials.
+			rewardAddr, err := common.NewAddress(
+				"stake17xt4n07cnlafzefqvne69mmxmnzu2t9gtd27jw9d9yvc7uscsd3d3",
+			)
+			require.NoError(t, err)
+			credential, ok := rewardAddr.StakeCredential()
+			require.True(t, ok)
+			require.Equal(
+				t,
+				uint(common.CredentialTypeScriptHash),
+				credential.CredType,
+			)
+
+			lookups := 0
+			state := mockledger.NewLedgerStateBuilder().
+				WithRewardAccountCredentialBalance(credential, 1_000_000).
+				WithDRepDelegation(func(
+					common.Credential,
+				) (*common.Drep, error) {
+					lookups++
+					return nil, nil
+				}).
+				Build()
+			tx := &conway.ConwayTransaction{
+				Body: conway.ConwayTransactionBody{
+					TxWithdrawals: map[*common.Address]uint64{
+						&rewardAddr: 1_000_000,
+					},
+				},
+				TxIsValid: true,
+			}
+			pp := &conway.ConwayProtocolParameters{
+				ProtocolVersion: common.ProtocolParametersProtocolVersion{
+					Major: major,
+				},
+			}
+
+			require.NoError(t, conway.UtxoValidateWithdrawals(
+				tx,
+				0,
+				state,
+				pp,
+			))
+			assert.Zero(t, lookups,
+				"script credentials must not enter the DRep lookup")
+		})
+	}
+
+	t.Run("PV11 unregistered script credential", func(t *testing.T) {
+		rewardAddr, err := common.NewAddress(
+			"stake17xt4n07cnlafzefqvne69mmxmnzu2t9gtd27jw9d9yvc7uscsd3d3",
+		)
+		require.NoError(t, err)
+		tx := &conway.ConwayTransaction{
+			Body: conway.ConwayTransactionBody{
+				TxWithdrawals: map[*common.Address]uint64{
+					&rewardAddr: 1_000_000,
+				},
+			},
+			TxIsValid: true,
+		}
+		pp := &conway.ConwayProtocolParameters{
+			ProtocolVersion: common.ProtocolParametersProtocolVersion{
+				Major: common.ProtocolVersionVanRossem,
+			},
+		}
+		state := mockledger.NewLedgerStateBuilder().Build()
+
+		err = conway.UtxoValidateWithdrawals(tx, 0, state, pp)
+		var target shelley.WithdrawalFromUnregisteredRewardAccountError
+		require.ErrorAs(t, err, &target)
+		assert.Equal(t, rewardAddr, target.RewardAddress)
+	})
+
 	t.Run("PV12 permits a partial withdrawal", func(t *testing.T) {
 		partialTx := *tx
 		partialTx.Body.TxWithdrawals = map[*common.Address]uint64{

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -277,29 +277,41 @@ func TestUtxoValidateWithdrawals_DRepDelegationProtocolGate(t *testing.T) {
 		common.ProtocolVersionPlomin,
 		common.ProtocolVersionVanRossem,
 	} {
-		t.Run(fmt.Sprintf("PV%d zero amount", major), func(t *testing.T) {
+		t.Run(fmt.Sprintf("PV%d undelegated zero amount", major), func(t *testing.T) {
 			zeroTx := *tx
 			zeroTx.Body.TxWithdrawals = map[*common.Address]uint64{
 				&rewardAddr: 0,
 			}
+			lookups := 0
 			zeroBalanceState := mockledger.NewLedgerStateBuilder().
 				WithRewardAccountBalance(stakeKeyHash, 0).
+				WithDRepDelegation(func(
+					credential common.Credential,
+				) (*common.Drep, error) {
+					lookups++
+					assert.Equal(t, stakeKeyHash, credential.Credential)
+					return nil, nil
+				}).
 				Build()
 			pp := &conway.ConwayProtocolParameters{
 				ProtocolVersion: common.ProtocolParametersProtocolVersion{
 					Major: major,
 				},
 			}
-			require.NoError(t, conway.UtxoValidateWithdrawals(
+			err := conway.UtxoValidateWithdrawals(
 				&zeroTx,
 				0,
-				struct{ common.LedgerState }{LedgerState: zeroBalanceState},
+				zeroBalanceState,
 				pp,
-			))
+			)
+			var target conway.WithdrawalNotDelegatedToDRepError
+			require.ErrorAs(t, err, &target)
+			assert.Equal(t, rewardAddr, target.RewardAddress)
+			assert.Equal(t, 1, lookups)
 		})
 	}
 
-	t.Run("PV10 mixed amounts checks non-zero withdrawal", func(t *testing.T) {
+	t.Run("PV10 mixed amounts check every key credential", func(t *testing.T) {
 		otherStakeKeyHash := common.Blake2b224Hash(
 			[]byte("other-withdrawal-stake-key"),
 		)
@@ -309,14 +321,15 @@ func TestUtxoValidateWithdrawals_DRepDelegationProtocolGate(t *testing.T) {
 			&rewardAddr:      0,
 			&otherRewardAddr: 1_000_000,
 		}
+		lookups := make(map[common.Blake2b224]int)
 		mixedState := mockledger.NewLedgerStateBuilder().
 			WithRewardAccountBalance(stakeKeyHash, 0).
 			WithRewardAccountBalance(otherStakeKeyHash, 1_000_000).
 			WithDRepDelegation(func(
 				credential common.Credential,
 			) (*common.Drep, error) {
-				assert.Equal(t, otherStakeKeyHash, credential.Credential)
-				return nil, nil
+				lookups[credential.Credential]++
+				return &common.Drep{}, nil
 			}).
 			Build()
 		pp := &conway.ConwayProtocolParameters{
@@ -324,15 +337,16 @@ func TestUtxoValidateWithdrawals_DRepDelegationProtocolGate(t *testing.T) {
 				Major: common.ProtocolVersionPlomin,
 			},
 		}
-		err := conway.UtxoValidateWithdrawals(
+		require.NoError(t, conway.UtxoValidateWithdrawals(
 			&mixedTx,
 			0,
 			mixedState,
 			pp,
-		)
-		var target conway.WithdrawalNotDelegatedToDRepError
-		require.ErrorAs(t, err, &target)
-		assert.Equal(t, otherRewardAddr, target.RewardAddress)
+		))
+		assert.Equal(t, map[common.Blake2b224]int{
+			stakeKeyHash:      1,
+			otherStakeKeyHash: 1,
+		}, lookups)
 	})
 
 	t.Run("PV10 requires delegation lookup support", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- apply the Conway PV10/PV11 withdrawal DRep check only to key-hash reward credentials
- check every key-hash credential present in withdrawals, including zero amounts
- preserve reward-account registration and amount validation for script credentials
- retain undelegated key-hash rejection and PV12 behavior

## Tests

- `make test`
- `make lint`
- `GOFLAGS=-buildvcs=false make build`

Related: blinklabs-io/dingo#3376
