### PR TITLE
fix(ledger): preserve validity upper-bound presence

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -137,6 +137,14 @@ type TransactionBody interface {
 }
 ```
 
+`TTL()` is retained for compatibility, but its zero value cannot distinguish an
+absent upper validity bound from an explicitly encoded bound of zero. Consensus
+consumers use `common.TransactionValidityIntervalUpperBound`, which detects the
+additive `TransactionWithValidityIntervalUpperBound` capability and returns
+both the value and its presence. Allegra through Dijkstra transaction bodies
+record that presence during decode; their `SetValidityIntervalUpperBound` and
+`ClearValidityIntervalUpperBound` methods preserve it for constructed bodies.
+
 ### Era Hierarchy
 
 Post-Byron eras build on their predecessors and may delegate individual

--- a/ledger/allegra/allegra.go
+++ b/ledger/allegra/allegra.go
@@ -230,15 +230,18 @@ func (b *AllegraTransactionBody) UnmarshalCBOR(cborData []byte) error {
 		return err
 	}
 	*b = AllegraTransactionBody(tmp)
+	if err := b.DecodeValidityIntervalUpperBoundPresence(cborData, b.Ttl); err != nil {
+		return err
+	}
 	b.SetCbor(cborData)
 	return nil
 }
 
-func (b *AllegraTransactionBody) MarshalCBOR() ([]byte, error) {
+func (b AllegraTransactionBody) MarshalCBOR() ([]byte, error) {
 	if b.Cbor() != nil {
 		return b.Cbor(), nil
 	}
-	return cbor.EncodeGeneric(b)
+	return common.EncodeTransactionBodyWithValidityIntervalUpperBound(&b)
 }
 
 func (b *AllegraTransactionBody) Inputs() []common.TransactionInput {
@@ -263,6 +266,22 @@ func (b *AllegraTransactionBody) Fee() *big.Int {
 
 func (b *AllegraTransactionBody) TTL() uint64 {
 	return b.Ttl
+}
+
+func (b *AllegraTransactionBody) ValidityIntervalUpperBound() (uint64, bool) {
+	return b.Ttl, b.Ttl != 0 || b.ValidityIntervalUpperBoundPresent()
+}
+
+func (b *AllegraTransactionBody) SetValidityIntervalUpperBound(
+	upperBound uint64,
+) {
+	b.Ttl = upperBound
+	b.SetValidityIntervalUpperBoundPresence(true)
+}
+
+func (b *AllegraTransactionBody) ClearValidityIntervalUpperBound() {
+	b.Ttl = 0
+	b.SetValidityIntervalUpperBoundPresence(false)
 }
 
 func (b *AllegraTransactionBody) ValidityIntervalStart() uint64 {
@@ -418,6 +437,10 @@ func (t AllegraTransaction) Fee() *big.Int {
 
 func (t AllegraTransaction) TTL() uint64 {
 	return t.Body.TTL()
+}
+
+func (t AllegraTransaction) ValidityIntervalUpperBound() (uint64, bool) {
+	return t.Body.ValidityIntervalUpperBound()
 }
 
 func (t AllegraTransaction) ValidityIntervalStart() uint64 {

--- a/ledger/allegra/rules.go
+++ b/ledger/allegra/rules.go
@@ -252,8 +252,10 @@ func UtxoValidateNativeScripts(
 
 	// Get transaction validity interval
 	validityStart := tx.ValidityIntervalStart()
-	validityEnd := tx.TTL()
-	if validityEnd == 0 {
+	validityEnd, validityEndPresent := common.TransactionValidityIntervalUpperBound(
+		tx,
+	)
+	if !validityEndPresent {
 		validityEnd = ^uint64(0) // Max uint64 if not set
 	}
 

--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -281,8 +281,18 @@ func (b *AlonzoTransactionBody) UnmarshalCBOR(cborData []byte) error {
 		return fmt.Errorf("required signers: %w", err)
 	}
 	*b = AlonzoTransactionBody(tmp)
+	if err := b.DecodeValidityIntervalUpperBoundPresence(cborData, b.Ttl); err != nil {
+		return err
+	}
 	b.SetCborReference(cborData)
 	return nil
+}
+
+func (b AlonzoTransactionBody) MarshalCBOR() ([]byte, error) {
+	if b.Cbor() != nil {
+		return b.Cbor(), nil
+	}
+	return common.EncodeTransactionBodyWithValidityIntervalUpperBound(&b)
 }
 
 func coalesceUntaggedTransactionInputs(
@@ -335,6 +345,22 @@ func (b *AlonzoTransactionBody) Fee() *big.Int {
 
 func (b *AlonzoTransactionBody) TTL() uint64 {
 	return b.Ttl
+}
+
+func (b *AlonzoTransactionBody) ValidityIntervalUpperBound() (uint64, bool) {
+	return b.Ttl, b.Ttl != 0 || b.ValidityIntervalUpperBoundPresent()
+}
+
+func (b *AlonzoTransactionBody) SetValidityIntervalUpperBound(
+	upperBound uint64,
+) {
+	b.Ttl = upperBound
+	b.SetValidityIntervalUpperBoundPresence(true)
+}
+
+func (b *AlonzoTransactionBody) ClearValidityIntervalUpperBound() {
+	b.Ttl = 0
+	b.SetValidityIntervalUpperBoundPresence(false)
 }
 
 func (b *AlonzoTransactionBody) ValidityIntervalStart() uint64 {
@@ -917,6 +943,10 @@ func (t AlonzoTransaction) Fee() *big.Int {
 
 func (t AlonzoTransaction) TTL() uint64 {
 	return t.Body.TTL()
+}
+
+func (t AlonzoTransaction) ValidityIntervalUpperBound() (uint64, bool) {
+	return t.Body.ValidityIntervalUpperBound()
 }
 
 func (t AlonzoTransaction) ValidityIntervalStart() uint64 {

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -396,8 +396,18 @@ func (b *BabbageTransactionBody) UnmarshalCBOR(cborData []byte) error {
 		return fmt.Errorf("reference inputs: %w", err)
 	}
 	*b = BabbageTransactionBody(tmp)
+	if err := b.DecodeValidityIntervalUpperBoundPresence(cborData, b.Ttl); err != nil {
+		return err
+	}
 	b.SetCborReference(cborData)
 	return nil
+}
+
+func (b BabbageTransactionBody) MarshalCBOR() ([]byte, error) {
+	if b.Cbor() != nil {
+		return b.Cbor(), nil
+	}
+	return common.EncodeTransactionBodyWithValidityIntervalUpperBound(&b)
 }
 
 func coalesceUntaggedTransactionInputs(
@@ -458,6 +468,24 @@ func (b *BabbageTransactionBody) Fee() *big.Int {
 
 func (b *BabbageTransactionBody) TTL() uint64 {
 	return b.Ttl
+}
+
+func (b *BabbageTransactionBody) ValidityIntervalUpperBound() (uint64, bool) {
+	return b.Ttl, b.Ttl != 0 || b.ValidityIntervalUpperBoundPresent()
+}
+
+func (b *BabbageTransactionBody) SetValidityIntervalUpperBound(
+	upperBound uint64,
+) {
+	b.Ttl = upperBound
+	b.hash = nil
+	b.SetValidityIntervalUpperBoundPresence(true)
+}
+
+func (b *BabbageTransactionBody) ClearValidityIntervalUpperBound() {
+	b.Ttl = 0
+	b.hash = nil
+	b.SetValidityIntervalUpperBoundPresence(false)
 }
 
 func (b *BabbageTransactionBody) ValidityIntervalStart() uint64 {
@@ -1109,6 +1137,10 @@ func (t BabbageTransaction) Fee() *big.Int {
 
 func (t BabbageTransaction) TTL() uint64 {
 	return t.Body.TTL()
+}
+
+func (t BabbageTransaction) ValidityIntervalUpperBound() (uint64, bool) {
+	return t.Body.ValidityIntervalUpperBound()
 }
 
 func (t BabbageTransaction) ValidityIntervalStart() uint64 {

--- a/ledger/common/script/context.go
+++ b/ledger/common/script/context.go
@@ -601,8 +601,11 @@ func validityRangeInfo(
 ) (TimeRange, error) {
 	var ret TimeRange
 	startSlot := tx.ValidityIntervalStart()
-	endSlot := tx.TTL()
-	ret.lowerBoundPresent, ret.upperBoundPresent = validityBoundPresence(tx)
+	endSlot, upperBoundPresent := lcommon.TransactionValidityIntervalUpperBound(
+		tx,
+	)
+	ret.lowerBoundPresent = validityLowerBoundPresent(tx)
+	ret.upperBoundPresent = upperBoundPresent
 	if ret.lowerBoundPresent {
 		startTime, err := slotState.SlotToTime(startSlot)
 		if err != nil {
@@ -620,25 +623,23 @@ func validityRangeInfo(
 	return ret, nil
 }
 
-func validityBoundPresence(tx lcommon.Transaction) (bool, bool) {
+func validityLowerBoundPresent(tx lcommon.Transaction) bool {
 	startPresent := tx.ValidityIntervalStart() > 0
-	endPresent := tx.TTL() > 0
 	txCbor := tx.Cbor()
 	if len(txCbor) == 0 {
-		return startPresent, endPresent
+		return startPresent
 	}
 	var txFields []cbor.RawMessage
 	if _, err := cbor.Decode(txCbor, &txFields); err != nil ||
 		len(txFields) == 0 {
-		return startPresent, endPresent
+		return startPresent
 	}
 	var bodyFields map[uint]cbor.RawMessage
 	if _, err := cbor.Decode(txFields[0], &bodyFields); err != nil {
-		return startPresent, endPresent
+		return startPresent
 	}
 	_, startPresent = bodyFields[8]
-	_, endPresent = bodyFields[3]
-	return startPresent, endPresent
+	return startPresent
 }
 
 func withdrawalsInfo(

--- a/ledger/common/tx.go
+++ b/ledger/common/tx.go
@@ -237,7 +237,7 @@ func EncodeTransactionBodyWithValidityIntervalUpperBound(
 	if !present || upperBound != 0 {
 		return cborData, nil
 	}
-	var bodyFields map[uint]cbor.RawMessage
+	bodyFields := make(map[uint]cbor.RawMessage)
 	if _, err := cbor.Decode(cborData, &bodyFields); err != nil {
 		return nil, err
 	}

--- a/ledger/common/tx.go
+++ b/ledger/common/tx.go
@@ -70,6 +70,30 @@ type TransactionBody interface {
 	Utxorpc() (*utxorpc.Tx, error)
 }
 
+// TransactionWithValidityIntervalUpperBound is implemented by transactions
+// and transaction bodies that can distinguish an absent upper validity bound
+// from an explicitly encoded bound of zero.
+//
+// TTL predates optional validity intervals and cannot represent that
+// distinction by itself. Consumers should use
+// TransactionValidityIntervalUpperBound when presence affects validation.
+type TransactionWithValidityIntervalUpperBound interface {
+	ValidityIntervalUpperBound() (uint64, bool)
+}
+
+// TransactionValidityIntervalUpperBound returns the upper validity bound and
+// whether it is present. Implementations that do not expose presence retain the
+// legacy behavior where a non-zero TTL is treated as present.
+func TransactionValidityIntervalUpperBound(
+	tx TransactionBody,
+) (uint64, bool) {
+	if txWithUpperBound, ok := tx.(TransactionWithValidityIntervalUpperBound); ok {
+		return txWithUpperBound.ValidityIntervalUpperBound()
+	}
+	upperBound := tx.TTL()
+	return upperBound, upperBound != 0
+}
+
 type TransactionInput interface {
 	Id() Blake2b256
 	Index() uint32
@@ -156,7 +180,73 @@ type Utxo struct {
 // and storing/retrieving the original CBOR
 type TransactionBodyBase struct {
 	cbor.DecodeStoreCbor
-	hash *Blake2b256
+	hash                              *Blake2b256
+	validityIntervalUpperBoundPresent bool
+}
+
+// SetValidityIntervalUpperBoundPresence records whether transaction-body key 3
+// is present. Era-specific transaction body decoders use this to preserve the
+// distinction between an absent upper bound and an explicit zero. Calling it
+// for a programmatically constructed body invalidates any stored CBOR.
+func (b *TransactionBodyBase) SetValidityIntervalUpperBoundPresence(
+	present bool,
+) {
+	b.validityIntervalUpperBoundPresent = present
+	b.hash = nil
+	b.SetCbor(nil)
+}
+
+// ValidityIntervalUpperBoundPresent reports whether transaction-body key 3 is
+// present.
+func (b *TransactionBodyBase) ValidityIntervalUpperBoundPresent() bool {
+	return b.validityIntervalUpperBoundPresent
+}
+
+// DecodeValidityIntervalUpperBoundPresence records the presence of
+// transaction-body key 3 from decoded CBOR. It must be called by era-specific
+// body decoders after their typed decode succeeds.
+func (b *TransactionBodyBase) DecodeValidityIntervalUpperBoundPresence(
+	cborData []byte,
+	upperBound uint64,
+) error {
+	if upperBound != 0 {
+		b.validityIntervalUpperBoundPresent = true
+		return nil
+	}
+	var bodyFields map[uint]cbor.RawMessage
+	if _, err := cbor.Decode(cborData, &bodyFields); err != nil {
+		return err
+	}
+	_, present := bodyFields[3]
+	b.validityIntervalUpperBoundPresent = present
+	return nil
+}
+
+// EncodeTransactionBodyWithValidityIntervalUpperBound encodes a constructed
+// transaction body while retaining an explicitly present zero upper bound.
+// Non-zero and absent bounds retain the normal generic transaction-body
+// encoding.
+func EncodeTransactionBodyWithValidityIntervalUpperBound(
+	body TransactionBody,
+) ([]byte, error) {
+	cborData, err := cbor.EncodeGeneric(body)
+	if err != nil {
+		return nil, err
+	}
+	upperBound, present := TransactionValidityIntervalUpperBound(body)
+	if !present || upperBound != 0 {
+		return cborData, nil
+	}
+	var bodyFields map[uint]cbor.RawMessage
+	if _, err := cbor.Decode(cborData, &bodyFields); err != nil {
+		return nil, err
+	}
+	encodedUpperBound, err := cbor.Encode(upperBound)
+	if err != nil {
+		return nil, err
+	}
+	bodyFields[3] = encodedUpperBound
+	return cbor.Encode(bodyFields)
 }
 
 func (b *TransactionBodyBase) Id() Blake2b256 {

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -664,8 +664,18 @@ func (b *ConwayTransactionBody) UnmarshalCBOR(cborData []byte) error {
 		}
 	}
 	*b = ConwayTransactionBody(tmp)
+	if err := b.DecodeValidityIntervalUpperBoundPresence(cborData, b.Ttl); err != nil {
+		return err
+	}
 	b.SetCborReference(cborData)
 	return nil
+}
+
+func (b ConwayTransactionBody) MarshalCBOR() ([]byte, error) {
+	if b.Cbor() != nil {
+		return b.Cbor(), nil
+	}
+	return common.EncodeTransactionBodyWithValidityIntervalUpperBound(&b)
 }
 
 func checkMultiAssetDuplicateKeys[T int64 | uint64 | *big.Int](
@@ -699,6 +709,22 @@ func (b *ConwayTransactionBody) Fee() *big.Int {
 
 func (b *ConwayTransactionBody) TTL() uint64 {
 	return b.Ttl
+}
+
+func (b *ConwayTransactionBody) ValidityIntervalUpperBound() (uint64, bool) {
+	return b.Ttl, b.Ttl != 0 || b.ValidityIntervalUpperBoundPresent()
+}
+
+func (b *ConwayTransactionBody) SetValidityIntervalUpperBound(
+	upperBound uint64,
+) {
+	b.Ttl = upperBound
+	b.SetValidityIntervalUpperBoundPresence(true)
+}
+
+func (b *ConwayTransactionBody) ClearValidityIntervalUpperBound() {
+	b.Ttl = 0
+	b.SetValidityIntervalUpperBoundPresence(false)
 }
 
 func (b *ConwayTransactionBody) ValidityIntervalStart() uint64 {
@@ -943,6 +969,10 @@ func (t ConwayTransaction) Fee() *big.Int {
 
 func (t ConwayTransaction) TTL() uint64 {
 	return t.Body.TTL()
+}
+
+func (t ConwayTransaction) ValidityIntervalUpperBound() (uint64, bool) {
+	return t.Body.ValidityIntervalUpperBound()
 }
 
 func (t ConwayTransaction) ValidityIntervalStart() uint64 {

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -2910,8 +2910,10 @@ func UtxoValidateNativeScripts(
 
 	// Get transaction validity interval
 	validityStart := tx.ValidityIntervalStart()
-	validityEnd := tx.TTL()
-	if validityEnd == 0 {
+	validityEnd, validityEndPresent := common.TransactionValidityIntervalUpperBound(
+		tx,
+	)
+	if !validityEndPresent {
 		validityEnd = ^uint64(0) // Max uint64 if not set
 	}
 

--- a/ledger/dijkstra/dijkstra.go
+++ b/ledger/dijkstra/dijkstra.go
@@ -789,8 +789,18 @@ func (b *DijkstraTransactionBody) UnmarshalCBOR(cborData []byte) error {
 		}
 	}
 	*b = DijkstraTransactionBody(tmp)
+	if err := b.DecodeValidityIntervalUpperBoundPresence(cborData, b.Ttl); err != nil {
+		return err
+	}
 	b.SetCborReference(cborData)
 	return nil
+}
+
+func (b DijkstraTransactionBody) MarshalCBOR() ([]byte, error) {
+	if b.Cbor() != nil {
+		return b.Cbor(), nil
+	}
+	return common.EncodeTransactionBodyWithValidityIntervalUpperBound(&b)
 }
 
 func validateDijkstraCertificateTypes(
@@ -835,6 +845,22 @@ func (b *DijkstraTransactionBody) Fee() *big.Int {
 
 func (b *DijkstraTransactionBody) TTL() uint64 {
 	return b.Ttl
+}
+
+func (b *DijkstraTransactionBody) ValidityIntervalUpperBound() (uint64, bool) {
+	return b.Ttl, b.Ttl != 0 || b.ValidityIntervalUpperBoundPresent()
+}
+
+func (b *DijkstraTransactionBody) SetValidityIntervalUpperBound(
+	upperBound uint64,
+) {
+	b.Ttl = upperBound
+	b.SetValidityIntervalUpperBoundPresence(true)
+}
+
+func (b *DijkstraTransactionBody) ClearValidityIntervalUpperBound() {
+	b.Ttl = 0
+	b.SetValidityIntervalUpperBoundPresence(false)
 }
 
 func (b *DijkstraTransactionBody) ValidityIntervalStart() uint64 {
@@ -1034,8 +1060,18 @@ func (b *DijkstraSubTransactionBody) UnmarshalCBOR(cborData []byte) error {
 		return err
 	}
 	*b = DijkstraSubTransactionBody(tmp)
+	if err := b.DecodeValidityIntervalUpperBoundPresence(cborData, b.Ttl); err != nil {
+		return err
+	}
 	b.SetCborReference(cborData)
 	return nil
+}
+
+func (b DijkstraSubTransactionBody) MarshalCBOR() ([]byte, error) {
+	if b.Cbor() != nil {
+		return b.Cbor(), nil
+	}
+	return common.EncodeTransactionBodyWithValidityIntervalUpperBound(&b)
 }
 
 func (b *DijkstraSubTransactionBody) Inputs() []common.TransactionInput {
@@ -1048,6 +1084,22 @@ func (b *DijkstraSubTransactionBody) Outputs() []common.TransactionOutput {
 
 func (b *DijkstraSubTransactionBody) TTL() uint64 {
 	return b.Ttl
+}
+
+func (b *DijkstraSubTransactionBody) ValidityIntervalUpperBound() (uint64, bool) {
+	return b.Ttl, b.Ttl != 0 || b.ValidityIntervalUpperBoundPresent()
+}
+
+func (b *DijkstraSubTransactionBody) SetValidityIntervalUpperBound(
+	upperBound uint64,
+) {
+	b.Ttl = upperBound
+	b.SetValidityIntervalUpperBoundPresence(true)
+}
+
+func (b *DijkstraSubTransactionBody) ClearValidityIntervalUpperBound() {
+	b.Ttl = 0
+	b.SetValidityIntervalUpperBoundPresence(false)
 }
 
 func (b *DijkstraSubTransactionBody) ValidityIntervalStart() uint64 {
@@ -1313,6 +1365,10 @@ func (t DijkstraTransaction) Fee() *big.Int {
 
 func (t DijkstraTransaction) TTL() uint64 {
 	return t.Body.TTL()
+}
+
+func (t DijkstraTransaction) ValidityIntervalUpperBound() (uint64, bool) {
+	return t.Body.ValidityIntervalUpperBound()
 }
 
 func (t DijkstraTransaction) ValidityIntervalStart() uint64 {

--- a/ledger/dijkstra/rules.go
+++ b/ledger/dijkstra/rules.go
@@ -1576,8 +1576,10 @@ func UtxoValidateNativeScripts(
 		keyHashes[common.Blake2b224Hash(bw.PublicKey)] = true
 	}
 	validityStart := tx.ValidityIntervalStart()
-	validityEnd := tx.TTL()
-	if validityEnd == 0 {
+	validityEnd, validityEndPresent := common.TransactionValidityIntervalUpperBound(
+		tx,
+	)
+	if !validityEndPresent {
 		validityEnd = ^uint64(0)
 	}
 	guardCredentials := nativeScriptGuardCredentials(tx)

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -234,15 +234,18 @@ func (b *MaryTransactionBody) UnmarshalCBOR(cborData []byte) error {
 		return err
 	}
 	*b = MaryTransactionBody(tmp)
+	if err := b.DecodeValidityIntervalUpperBoundPresence(cborData, b.Ttl); err != nil {
+		return err
+	}
 	b.SetCborReference(cborData)
 	return nil
 }
 
-func (b *MaryTransactionBody) MarshalCBOR() ([]byte, error) {
+func (b MaryTransactionBody) MarshalCBOR() ([]byte, error) {
 	if b.Cbor() != nil {
 		return b.Cbor(), nil
 	}
-	return cbor.EncodeGeneric(b)
+	return common.EncodeTransactionBodyWithValidityIntervalUpperBound(&b)
 }
 
 func (b *MaryTransactionBody) Inputs() []common.TransactionInput {
@@ -267,6 +270,22 @@ func (b *MaryTransactionBody) Fee() *big.Int {
 
 func (b *MaryTransactionBody) TTL() uint64 {
 	return b.Ttl
+}
+
+func (b *MaryTransactionBody) ValidityIntervalUpperBound() (uint64, bool) {
+	return b.Ttl, b.Ttl != 0 || b.ValidityIntervalUpperBoundPresent()
+}
+
+func (b *MaryTransactionBody) SetValidityIntervalUpperBound(
+	upperBound uint64,
+) {
+	b.Ttl = upperBound
+	b.SetValidityIntervalUpperBoundPresence(true)
+}
+
+func (b *MaryTransactionBody) ClearValidityIntervalUpperBound() {
+	b.Ttl = 0
+	b.SetValidityIntervalUpperBoundPresence(false)
 }
 
 func (b *MaryTransactionBody) ValidityIntervalStart() uint64 {
@@ -443,6 +462,10 @@ func (t MaryTransaction) Fee() *big.Int {
 
 func (t MaryTransaction) TTL() uint64 {
 	return t.Body.TTL()
+}
+
+func (t MaryTransaction) ValidityIntervalUpperBound() (uint64, bool) {
+	return t.Body.ValidityIntervalUpperBound()
 }
 
 func (t MaryTransaction) ValidityIntervalStart() uint64 {

--- a/ledger/validity_interval_test.go
+++ b/ledger/validity_interval_test.go
@@ -1,0 +1,209 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/stretchr/testify/require"
+)
+
+type validityUpperBoundBody interface {
+	common.TransactionBody
+	UnmarshalCBOR([]byte) error
+	MarshalCBOR() ([]byte, error)
+	SetCbor([]byte)
+	SetValidityIntervalUpperBound(uint64)
+	ClearValidityIntervalUpperBound()
+}
+
+type validityUpperBoundTestCase struct {
+	name    string
+	newBody func() validityUpperBoundBody
+	newTx   func(validityUpperBoundBody) common.TransactionBody
+}
+
+func validityUpperBoundTestCases() []validityUpperBoundTestCase {
+	return []validityUpperBoundTestCase{
+		{
+			name: "Allegra",
+			newBody: func() validityUpperBoundBody {
+				return &allegra.AllegraTransactionBody{}
+			},
+			newTx: func(body validityUpperBoundBody) common.TransactionBody {
+				return &allegra.AllegraTransaction{
+					Body: *(body.(*allegra.AllegraTransactionBody)),
+				}
+			},
+		},
+		{
+			name: "Mary",
+			newBody: func() validityUpperBoundBody {
+				return &mary.MaryTransactionBody{}
+			},
+			newTx: func(body validityUpperBoundBody) common.TransactionBody {
+				return &mary.MaryTransaction{
+					Body: *(body.(*mary.MaryTransactionBody)),
+				}
+			},
+		},
+		{
+			name: "Alonzo",
+			newBody: func() validityUpperBoundBody {
+				return &alonzo.AlonzoTransactionBody{}
+			},
+			newTx: func(body validityUpperBoundBody) common.TransactionBody {
+				return &alonzo.AlonzoTransaction{
+					Body: *(body.(*alonzo.AlonzoTransactionBody)),
+				}
+			},
+		},
+		{
+			name: "Babbage",
+			newBody: func() validityUpperBoundBody {
+				return &babbage.BabbageTransactionBody{}
+			},
+			newTx: func(body validityUpperBoundBody) common.TransactionBody {
+				return &babbage.BabbageTransaction{
+					Body: *(body.(*babbage.BabbageTransactionBody)),
+				}
+			},
+		},
+		{
+			name: "Conway",
+			newBody: func() validityUpperBoundBody {
+				return &conway.ConwayTransactionBody{}
+			},
+			newTx: func(body validityUpperBoundBody) common.TransactionBody {
+				return &conway.ConwayTransaction{
+					Body: *(body.(*conway.ConwayTransactionBody)),
+				}
+			},
+		},
+		{
+			name: "Dijkstra",
+			newBody: func() validityUpperBoundBody {
+				return &dijkstra.DijkstraTransactionBody{}
+			},
+			newTx: func(body validityUpperBoundBody) common.TransactionBody {
+				return &dijkstra.DijkstraTransaction{
+					Body: *(body.(*dijkstra.DijkstraTransactionBody)),
+				}
+			},
+		},
+		{
+			name: "Dijkstra sub-transaction",
+			newBody: func() validityUpperBoundBody {
+				return &dijkstra.DijkstraSubTransactionBody{}
+			},
+		},
+	}
+}
+
+func TestValidityIntervalUpperBoundDecodedPresence(t *testing.T) {
+	for _, test := range validityUpperBoundTestCases() {
+		t.Run(test.name, func(t *testing.T) {
+			body := test.newBody()
+			require.NoError(t, body.UnmarshalCBOR([]byte{0xa1, 0x03, 0x00}))
+			requireValidityUpperBound(t, body, 0, true)
+			if test.newTx != nil {
+				requireValidityUpperBound(t, test.newTx(body), 0, true)
+			}
+
+			// Presence is decoded state, not a query-time heuristic over stored
+			// CBOR. Clearing stored bytes must not lose an explicit zero.
+			body.SetCbor(nil)
+			requireValidityUpperBound(t, body, 0, true)
+
+			// Reusing a receiver must not retain presence from the prior body.
+			require.NoError(t, body.UnmarshalCBOR([]byte{0xa0}))
+			requireValidityUpperBound(t, body, 0, false)
+		})
+	}
+}
+
+func TestValidityIntervalUpperBoundConstructedZeroRoundTrip(t *testing.T) {
+	for _, test := range validityUpperBoundTestCases() {
+		t.Run(test.name, func(t *testing.T) {
+			body := test.newBody()
+			requireValidityUpperBound(t, body, 0, false)
+
+			body.SetValidityIntervalUpperBound(0)
+			requireValidityUpperBound(t, body, 0, true)
+			if test.newTx != nil {
+				tx := test.newTx(body)
+				requireValidityUpperBound(t, tx, 0, true)
+				txMarshaler := tx.(interface {
+					MarshalCBOR() ([]byte, error)
+				})
+				encodedTx, err := txMarshaler.MarshalCBOR()
+				require.NoError(t, err)
+				var txFields []cbor.RawMessage
+				_, err = cbor.Decode(encodedTx, &txFields)
+				require.NoError(t, err)
+				require.NotEmpty(t, txFields)
+				var txBodyFields map[uint]cbor.RawMessage
+				_, err = cbor.Decode(txFields[0], &txBodyFields)
+				require.NoError(t, err)
+				require.Contains(t, txBodyFields, uint(3))
+			}
+
+			encoded, err := body.MarshalCBOR()
+			require.NoError(t, err)
+			var fields map[uint]cbor.RawMessage
+			_, err = cbor.Decode(encoded, &fields)
+			require.NoError(t, err)
+			require.Contains(t, fields, uint(3))
+
+			body.ClearValidityIntervalUpperBound()
+			requireValidityUpperBound(t, body, 0, false)
+			encoded, err = body.MarshalCBOR()
+			require.NoError(t, err)
+			fields = nil
+			_, err = cbor.Decode(encoded, &fields)
+			require.NoError(t, err)
+			require.NotContains(t, fields, uint(3))
+		})
+	}
+}
+
+func TestTransactionValidityIntervalUpperBoundLegacyFallback(t *testing.T) {
+	body := &shelley.ShelleyTransactionBody{}
+	requireValidityUpperBound(t, body, 0, false)
+
+	body.Ttl = 42
+	requireValidityUpperBound(t, body, 42, true)
+}
+
+func requireValidityUpperBound(
+	t *testing.T,
+	tx common.TransactionBody,
+	wantUpperBound uint64,
+	wantPresent bool,
+) {
+	t.Helper()
+	upperBound, present := common.TransactionValidityIntervalUpperBound(tx)
+	require.Equal(t, wantUpperBound, upperBound)
+	require.Equal(t, wantPresent, present)
+}


### PR DESCRIPTION
Summary:
- add an optional presence-aware upper validity-bound API without changing TransactionBody
- preserve explicit key-3 zero values across decode, construction, and CBOR encoding for Allegra through Dijkstra
- use the presence-aware bound in native-script and Plutus-context consumers

Compatibility:
- existing TransactionBody implementations continue to compile
- implementations without the optional capability retain the legacy non-zero TTL fallback

Validation:
- make test
- make lint
- go build ./...
- go vet ./ledger/...
- go test -race -count=20 -run validity-upper-bound focused tests ./ledger
- go test -race ./internal/test/conformance/...

Supports the explicit-zero validity-bound fix in blinklabs-io/dingo#3457.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the presence of the transaction upper validity bound and adds a presence-aware API. Previously `TTL()` could not distinguish an absent end from an explicitly encoded 0; now explicit zero is retained across decode/encode and consumers can read both value and presence, fixing validation and script-context behavior.

**Bug Fixes**
- Retains explicit zero upper bound across decode, construction, and CBOR encoding for Allegra through Dijkstra.
- Native script and Plutus context validation now uses a presence-aware upper bound and treats an absent end as unbounded.

**Migration**
- When presence matters, use `common.TransactionValidityIntervalUpperBound(tx)`; `TTL()` remains for compatibility but does not convey presence.
- Custom bodies can opt in by implementing `common.TransactionWithValidityIntervalUpperBound` (or using era body `SetValidityIntervalUpperBound`/`ClearValidityIntervalUpperBound`); others keep legacy semantics where non-zero `TTL()` implies presence.

<sup>Written for commit 5bc0ff75470886ae7bc3f59ef80bc675697224e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

