### PR TITLE
fix(ledger): reject duplicate stake registrations

### DIFF
--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -2939,8 +2939,20 @@ func UtxoValidateDelegation(
 	ls common.LedgerState,
 	pp common.ProtocolParameters,
 ) error {
-	// Track credentials/pools/DReps registered within this transaction
-	inTxStakeRegs := make(map[common.Blake2b224]bool)
+	// Track credential registration state changes within this transaction.
+	// The bool records both registrations and deregistrations so later
+	// certificates observe the state produced by earlier certificates.
+	type stakeCredentialKey struct {
+		credType uint
+		hash     common.Blake2b224
+	}
+	stakeKey := func(cred common.Credential) stakeCredentialKey {
+		return stakeCredentialKey{
+			credType: cred.CredType,
+			hash:     cred.Credential,
+		}
+	}
+	inTxStakeState := make(map[stakeCredentialKey]bool)
 	inTxPoolRegs := make(map[common.PoolKeyHash]bool)
 	inTxDRepRegs := make(map[common.Blake2b224]bool)
 	// Track VRF keys seen in this transaction (for PV11+ duplicate detection)
@@ -2948,8 +2960,20 @@ func UtxoValidateDelegation(
 
 	// Helper to check if stake credential is registered (in state or in-tx)
 	isStakeRegistered := func(cred common.Credential) bool {
-		return ls.IsStakeCredentialRegistered(cred) ||
-			inTxStakeRegs[cred.Credential]
+		if registered, ok := inTxStakeState[stakeKey(cred)]; ok {
+			return registered
+		}
+		return ls.IsStakeCredentialRegistered(cred)
+	}
+
+	registerStakeCredential := func(cred common.Credential) error {
+		if isStakeRegistered(cred) {
+			return StakeCredentialAlreadyRegisteredError{
+				Credential: cred,
+			}
+		}
+		inTxStakeState[stakeKey(cred)] = true
+		return nil
 	}
 
 	// Helper to check if pool is registered (in state or in-tx)
@@ -3009,10 +3033,14 @@ func UtxoValidateDelegation(
 		switch c := cert.(type) {
 		// Track registrations for in-tx state
 		case *common.RegistrationCertificate:
-			inTxStakeRegs[c.StakeCredential.Credential] = true
+			if err := registerStakeCredential(c.StakeCredential); err != nil {
+				return err
+			}
 
 		case *common.StakeRegistrationCertificate:
-			inTxStakeRegs[c.StakeCredential.Credential] = true
+			if err := registerStakeCredential(c.StakeCredential); err != nil {
+				return err
+			}
 
 		case *common.PoolRegistrationCertificate:
 			inTxPoolRegs[c.Operator] = true
@@ -3043,10 +3071,10 @@ func UtxoValidateDelegation(
 
 		// Track deregistrations for in-tx state
 		case *common.StakeDeregistrationCertificate:
-			delete(inTxStakeRegs, c.StakeCredential.Credential)
+			inTxStakeState[stakeKey(c.StakeCredential)] = false
 
 		case *common.DeregistrationCertificate:
-			delete(inTxStakeRegs, c.StakeCredential.Credential)
+			inTxStakeState[stakeKey(c.StakeCredential)] = false
 
 		case *common.PoolRetirementCertificate:
 			delete(inTxPoolRegs, c.PoolKeyHash)
@@ -3112,16 +3140,18 @@ func UtxoValidateDelegation(
 			}
 
 		case *common.StakeRegistrationDelegationCertificate:
-			// This cert registers AND delegates, so mark as registered first
-			inTxStakeRegs[c.StakeCredential.Credential] = true
+			if err := registerStakeCredential(c.StakeCredential); err != nil {
+				return err
+			}
 			// Check if pool is registered
 			if !isPoolRegistered(c.PoolKeyHash) {
 				return DelegateToUnregisteredPoolError{PoolKeyHash: c.PoolKeyHash}
 			}
 
 		case *common.VoteRegistrationDelegationCertificate:
-			// This cert registers AND delegates, so mark as registered first
-			inTxStakeRegs[c.StakeCredential.Credential] = true
+			if err := registerStakeCredential(c.StakeCredential); err != nil {
+				return err
+			}
 			// Check if target DRep is registered (except for Abstain/NoConfidence)
 			drepRegistered, err := isDRepRegistered(c.Drep)
 			if err != nil {
@@ -3139,8 +3169,9 @@ func UtxoValidateDelegation(
 			}
 
 		case *common.StakeVoteRegistrationDelegationCertificate:
-			// This cert registers AND delegates, so mark as registered first
-			inTxStakeRegs[c.StakeCredential.Credential] = true
+			if err := registerStakeCredential(c.StakeCredential); err != nil {
+				return err
+			}
 			// Check if pool is registered
 			if !isPoolRegistered(c.PoolKeyHash) {
 				return DelegateToUnregisteredPoolError{PoolKeyHash: c.PoolKeyHash}

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -3203,6 +3203,193 @@ func TestPoolValidateVrfKeyUniqueness(t *testing.T) {
 	})
 }
 
+func TestUtxoValidateDelegation_RejectsDuplicateStakeRegistrations(
+	t *testing.T,
+) {
+	stakeKeyHash := common.Blake2b224Hash(
+		[]byte("duplicate-registration-stake-key"),
+	)
+	stakeCred := common.Credential{
+		CredType:   common.CredentialTypeAddrKeyHash,
+		Credential: stakeKeyHash,
+	}
+	poolKeyHash := common.PoolKeyHash{0x01, 0x02, 0x03}
+	poolCert := &common.PoolRegistrationCertificate{
+		Operator: poolKeyHash,
+	}
+	newLedgerState := func(registered bool) common.LedgerState {
+		return mockledger.NewLedgerStateBuilder().
+			WithStakeCredentialRegistered(stakeKeyHash, registered).
+			WithPools([]*common.PoolRegistrationCertificate{poolCert}).
+			Build()
+	}
+	newTx := func(certs ...common.Certificate) *conway.ConwayTransaction {
+		wrappers := make([]common.CertificateWrapper, len(certs))
+		for i, cert := range certs {
+			wrappers[i] = common.CertificateWrapper{Certificate: cert}
+		}
+		return &conway.ConwayTransaction{
+			Body: conway.ConwayTransactionBody{
+				TxCertificates: wrappers,
+			},
+		}
+	}
+
+	registrationCases := []struct {
+		name string
+		cert func() common.Certificate
+	}{
+		{
+			name: "stake registration",
+			cert: func() common.Certificate {
+				return &common.StakeRegistrationCertificate{
+					StakeCredential: stakeCred,
+				}
+			},
+		},
+		{
+			name: "registration",
+			cert: func() common.Certificate {
+				return &common.RegistrationCertificate{
+					StakeCredential: stakeCred,
+				}
+			},
+		},
+		{
+			name: "stake registration delegation",
+			cert: func() common.Certificate {
+				return &common.StakeRegistrationDelegationCertificate{
+					StakeCredential: stakeCred,
+					PoolKeyHash:     poolKeyHash,
+				}
+			},
+		},
+		{
+			name: "vote registration delegation",
+			cert: func() common.Certificate {
+				return &common.VoteRegistrationDelegationCertificate{
+					StakeCredential: stakeCred,
+					Drep: common.Drep{
+						Type: common.DrepTypeAbstain,
+					},
+				}
+			},
+		},
+		{
+			name: "stake vote registration delegation",
+			cert: func() common.Certificate {
+				return &common.StakeVoteRegistrationDelegationCertificate{
+					StakeCredential: stakeCred,
+					PoolKeyHash:     poolKeyHash,
+					Drep: common.Drep{
+						Type: common.DrepTypeNoConfidence,
+					},
+				}
+			},
+		},
+	}
+
+	for _, tc := range registrationCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Run("ledger state duplicate", func(t *testing.T) {
+				err := conway.UtxoValidateDelegation(
+					newTx(tc.cert()),
+					0,
+					newLedgerState(true),
+					&conway.ConwayProtocolParameters{},
+				)
+				require.Error(t, err)
+				var duplicateErr conway.StakeCredentialAlreadyRegisteredError
+				require.ErrorAs(t, err, &duplicateErr)
+				assert.Equal(t, stakeCred, duplicateErr.Credential)
+			})
+
+			t.Run("same transaction duplicate", func(t *testing.T) {
+				firstRegistration := &common.RegistrationCertificate{
+					StakeCredential: stakeCred,
+				}
+				err := conway.UtxoValidateDelegation(
+					newTx(firstRegistration, tc.cert()),
+					0,
+					newLedgerState(false),
+					&conway.ConwayProtocolParameters{},
+				)
+				require.Error(t, err)
+				var duplicateErr conway.StakeCredentialAlreadyRegisteredError
+				require.ErrorAs(t, err, &duplicateErr)
+				assert.Equal(t, stakeCred, duplicateErr.Credential)
+			})
+
+			t.Run("unregistered", func(t *testing.T) {
+				err := conway.UtxoValidateDelegation(
+					newTx(tc.cert()),
+					0,
+					newLedgerState(false),
+					&conway.ConwayProtocolParameters{},
+				)
+				require.NoError(t, err)
+			})
+
+			t.Run("registered then deregistered", func(t *testing.T) {
+				deregistration := &common.DeregistrationCertificate{
+					StakeCredential: stakeCred,
+				}
+				err := conway.UtxoValidateDelegation(
+					newTx(deregistration, tc.cert()),
+					0,
+					newLedgerState(true),
+					&conway.ConwayProtocolParameters{},
+				)
+				require.NoError(t, err)
+			})
+		})
+	}
+
+	t.Run("same hash distinct credential types", func(t *testing.T) {
+		scriptCred := stakeCred
+		scriptCred.CredType = common.CredentialTypeScriptHash
+		err := conway.UtxoValidateDelegation(
+			newTx(
+				&common.RegistrationCertificate{
+					StakeCredential: stakeCred,
+				},
+				&common.RegistrationCertificate{
+					StakeCredential: scriptCred,
+				},
+			),
+			0,
+			newLedgerState(false),
+			&conway.ConwayProtocolParameters{},
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("deregistration preserves the other credential type", func(t *testing.T) {
+		scriptCred := stakeCred
+		scriptCred.CredType = common.CredentialTypeScriptHash
+		err := conway.UtxoValidateDelegation(
+			newTx(
+				&common.RegistrationCertificate{
+					StakeCredential: scriptCred,
+				},
+				&common.DeregistrationCertificate{
+					StakeCredential: stakeCred,
+				},
+				&common.RegistrationCertificate{
+					StakeCredential: scriptCred,
+				},
+			),
+			0,
+			newLedgerState(false),
+			&conway.ConwayProtocolParameters{},
+		)
+		require.Error(t, err)
+		var duplicateErr conway.StakeCredentialAlreadyRegisteredError
+		require.ErrorAs(t, err, &duplicateErr)
+		assert.Equal(t, scriptCred, duplicateErr.Credential)
+	})
+}
+
 func TestUtxoValidateDelegation_InTxVrfKeyDuplicates(t *testing.T) {
 	pool1 := common.PoolKeyHash{0x01, 0x02, 0x03}
 	pool2 := common.PoolKeyHash{0x04, 0x05, 0x06}


### PR DESCRIPTION
## Summary

- reject duplicate stake registration across all Conway registration certificate variants
- track transaction-local registration and deregistration by full credential identity
- preserve valid deregistration followed by registration in the same transaction

## Checks

- focused duplicate-registration regressions under `-race`
- full ledger race suite
- race-enabled conformance suite
- repository and example-module race tests
- lint, vet, build, NilAway, module verification, and formatting

Closes #2069


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate stake registrations within a transaction.
  * Correctly handles stake credentials by type, including key-hash and script-hash credentials.
  * Allows re-registration after a same-transaction deregistration.
* **Tests**
  * Added coverage for registration, deregistration, and delegation certificate validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->