### PR TITLE
fix(leios): keep unconfigured responders pending

### DIFF
--- a/protocol/leiosfetch/README.md
+++ b/protocol/leiosfetch/README.md
@@ -190,11 +190,14 @@ whole node-to-node connection.
 
 Leios fetch is optional, but not every request has a safe empty response. An
 unconfigured `VotesRequestFunc` returns `Votes` with an empty CBOR array,
-returning the protocol to `Idle` without a connection-level error. The block,
-block-transactions, and block-range requests require their callbacks: their
-absence replies are either placeholder wire IDs or ambiguous with a real
-response. Errors from configured callbacks and transport failures are still
-propagated.
+returning the protocol to `Idle` without a connection-level error. When a
+block, block-transactions, or block-range callback is unconfigured, the server
+enters the corresponding server-agency state and leaves the request pending.
+It sends no response because the available absence replies are either
+placeholder wire IDs or ambiguous with a real response. The requester cannot
+start another Leios fetch exchange, but other mini-protocols on the bearer
+remain usable. Errors from configured callbacks and transport failures are
+still propagated.
 
 ## Notes
 

--- a/protocol/leiosfetch/server.go
+++ b/protocol/leiosfetch/server.go
@@ -234,7 +234,8 @@ func (s *Server) handleBlockRangeRequest(msg protocol.Message) error {
 		)
 	if s.config == nil || s.config.BlockRangeRequestFunc == nil {
 		// The protocol has no empty range response. Keep server agency in
-		// StateBlockRange instead of fabricating a payload or failing the bearer.
+		// StateBlockRange instead of fabricating a payload or failing the
+		// bearer.
 		return nil
 	}
 	msgBlockRangeRequest := msg.(*MsgBlockRangeRequest)

--- a/protocol/leiosfetch/server.go
+++ b/protocol/leiosfetch/server.go
@@ -103,9 +103,10 @@ func (s *Server) handleBlockRequest(msg protocol.Message) error {
 			"connection_id", s.callbackContext.ConnectionId.String(),
 		)
 	if s.config == nil || s.config.BlockRequestFunc == nil {
-		return errors.New(
-			"received leios-fetch BlockRequest message but no callback function is defined",
-		)
+		// The unconfirmed NoBlock wire ID cannot safely be emitted by default.
+		// Keep server agency in StateBlock so the optional protocol remains
+		// pending without terminating the shared bearer.
+		return nil
 	}
 	msgBlockRequest := msg.(*MsgBlockRequest)
 	resp, err := s.config.BlockRequestFunc(
@@ -152,9 +153,9 @@ func (s *Server) handleBlockTxsRequest(msg protocol.Message) error {
 			"connection_id", s.callbackContext.ConnectionId.String(),
 		)
 	if s.config == nil || s.config.BlockTxsRequestFunc == nil {
-		return errors.New(
-			"received leios-fetch BlockTxsRequest message but no callback function is defined",
-		)
+		// The unconfirmed NoBlockTxs wire ID cannot safely be emitted by
+		// default. Keep server agency without failing the shared bearer.
+		return nil
 	}
 	msgBlockTxsRequest := msg.(*MsgBlockTxsRequest)
 	resp, err := s.config.BlockTxsRequestFunc(
@@ -232,9 +233,9 @@ func (s *Server) handleBlockRangeRequest(msg protocol.Message) error {
 			"connection_id", s.callbackContext.ConnectionId.String(),
 		)
 	if s.config == nil || s.config.BlockRangeRequestFunc == nil {
-		return errors.New(
-			"received leios-fetch BlockRangeRequest message but no callback function is defined",
-		)
+		// The protocol has no empty range response. Keep server agency in
+		// StateBlockRange instead of fabricating a payload or failing the bearer.
+		return nil
 	}
 	msgBlockRangeRequest := msg.(*MsgBlockRangeRequest)
 	err := s.config.BlockRangeRequestFunc(

--- a/protocol/leiosfetch/server_test.go
+++ b/protocol/leiosfetch/server_test.go
@@ -75,6 +75,132 @@ func writeLeiosFetchTestSegment(
 	require.NoError(t, err)
 }
 
+func TestUnconfiguredRequestsRemainPendingAndPreserveSharedBearer(t *testing.T) {
+	tests := []struct {
+		name    string
+		request protocol.Message
+	}{
+		{
+			name: "block",
+			request: NewMsgBlockRequest(
+				pcommon.NewPoint(12345, []byte{0x01, 0x02}),
+			),
+		},
+		{
+			name: "block transactions",
+			request: NewMsgBlockTxsRequest(
+				pcommon.NewPoint(12345, []byte{0x01, 0x02}),
+				nil,
+			),
+		},
+		{
+			name: "block range",
+			request: NewMsgBlockRangeRequest(
+				pcommon.NewPoint(12345, []byte{0x01, 0x02}),
+				pcommon.NewPoint(23456, []byte{0x03, 0x04}),
+			),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			connId := testLeiosFetchConnectionId()
+			connA, connB := net.Pipe()
+			m := muxer.New(connA)
+			protocolErrors := make(chan error, 1)
+			leiosServer := NewServer(
+				protocol.ProtocolOptions{
+					ConnectionId: connId,
+					ErrorChan:    protocolErrors,
+					Muxer:        m,
+				},
+				nil,
+			)
+			peerSharingCfg := peersharing.NewConfig(
+				peersharing.WithShareRequestFunc(
+					func(
+						peersharing.CallbackContext,
+						int,
+					) ([]peersharing.PeerAddress, error) {
+						return []peersharing.PeerAddress{}, nil
+					},
+				),
+			)
+			peerSharingServer := peersharing.NewServer(
+				protocol.ProtocolOptions{
+					ConnectionId: connId,
+					ErrorChan:    protocolErrors,
+					Muxer:        m,
+				},
+				&peerSharingCfg,
+			)
+			leiosServer.Start()
+			peerSharingServer.Start()
+			m.Start()
+			t.Cleanup(func() {
+				leiosServer.Stop()
+				peerSharingServer.Stop()
+				m.Stop()
+				_ = connA.Close()
+				_ = connB.Close()
+			})
+
+			requestData, err := cbor.Encode(test.request)
+			require.NoError(t, err)
+			writeLeiosFetchTestSegment(
+				t,
+				connB,
+				muxer.NewSegment(ProtocolId, requestData, false),
+			)
+			require.Never(t, func() bool {
+				select {
+				case <-protocolErrors:
+					return true
+				default:
+					return false
+				}
+			}, 20*time.Millisecond, time.Millisecond,
+				"unconfigured request reported a protocol error",
+			)
+			require.Eventually(t, func() bool {
+				return !leiosServer.ProtocolInstance().
+					IsInTerminalOrIdleState()
+			}, time.Second, time.Millisecond,
+				"request did not enter its server-agency state",
+			)
+
+			peerRequestData, err := cbor.Encode(
+				peersharing.NewMsgShareRequest(1),
+			)
+			require.NoError(t, err)
+			writeLeiosFetchTestSegment(
+				t,
+				connB,
+				muxer.NewSegment(
+					peersharing.ProtocolId,
+					peerRequestData,
+					false,
+				),
+			)
+			require.NoError(
+				t,
+				connB.SetReadDeadline(time.Now().Add(time.Second)),
+			)
+			segment, err := readLeiosFetchTestSegment(t, connB)
+			require.NoError(t, err)
+			require.Equal(
+				t,
+				uint16(peersharing.ProtocolId),
+				segment.GetProtocolId(),
+			)
+			require.Equal(
+				t,
+				[]byte{0x82, peersharing.MessageTypeSharePeers, 0x80},
+				segment.Payload,
+			)
+		})
+	}
+}
+
 // sendNotFoundTest drives a real server over a muxer, sends the given request
 // twice, and returns the message type of the server's response segments. The
 // second exchange proves that the fallback returns the protocol to Idle and
@@ -230,7 +356,7 @@ func TestHandleBlockRequest_NilCallback(t *testing.T) {
 	err := server.handleBlockRequest(
 		NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02})),
 	)
-	require.ErrorContains(t, err, "no callback function is defined")
+	require.NoError(t, err)
 }
 
 func TestHandleBlockRequest_NilConfig(t *testing.T) {
@@ -241,7 +367,7 @@ func TestHandleBlockRequest_NilConfig(t *testing.T) {
 	err := server.handleBlockRequest(
 		NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02})),
 	)
-	require.ErrorContains(t, err, "no callback function is defined")
+	require.NoError(t, err)
 }
 
 func TestHandleBlockRequest_CallbackError(t *testing.T) {
@@ -415,7 +541,7 @@ func TestHandleBlockTxsRequest_NilCallback(t *testing.T) {
 	err := server.handleBlockTxsRequest(
 		NewMsgBlockTxsRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02}), nil),
 	)
-	require.ErrorContains(t, err, "no callback function is defined")
+	require.NoError(t, err)
 }
 
 func TestHandleVotesRequest_CallbackIsCalled(t *testing.T) {
@@ -500,7 +626,7 @@ func TestHandleBlockRangeRequest_NilCallback(t *testing.T) {
 	err := server.handleBlockRangeRequest(
 		NewMsgBlockRangeRequest(pcommon.Point{}, pcommon.Point{}),
 	)
-	require.ErrorContains(t, err, "no callback function is defined")
+	require.NoError(t, err)
 }
 
 func TestServerMessageHandler_UnexpectedType(t *testing.T) {

--- a/protocol/leiosvotes/README.md
+++ b/protocol/leiosvotes/README.md
@@ -46,11 +46,15 @@ Idle --Done--> Done
 
 ## Optional server responder
 
-Leios votes has no state-machine-valid empty batch response. Configure
-`RequestNextFunc` before accepting vote requests; an unconfigured responder
-returns a protocol error rather than leaving the shared bearer permanently
-stalled in `Busy`. The client and server retain the normal `Busy` timeout for
-callback and transport failures.
+Leios votes has no state-machine-valid empty batch response. When
+`RequestNextFunc` is unconfigured, the server enters `Busy`, sends no response,
+and leaves the request pending with its `Busy` timeout disabled. This preserves
+the protocol's agency and lets other mini-protocols on the bearer continue
+without a server-side connection error. The requester retains its own `Busy`
+timeout and may eventually close the connection from its side. Invalid request
+counts, configured callback errors, and transport failures still follow the
+normal protocol-error path; configured servers retain the normal `Busy`
+timeout.
 
 ## States
 

--- a/protocol/leiosvotes/server.go
+++ b/protocol/leiosvotes/server.go
@@ -15,7 +15,6 @@
 package leiosvotes
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
@@ -47,11 +46,16 @@ func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 func (s *Server) initProtocol() {
 	stateMap := StateMap.Copy()
 	if entry, ok := stateMap[StateBusy]; ok {
-		timeout := DefaultTimeout
-		if s.config != nil && s.config.Timeout != 0 {
-			timeout = s.config.Timeout
+		// An unconfigured responder has no valid message that can complete a
+		// pending request. Leave its Busy timeout disabled so the optional
+		// protocol cannot turn that request into a bearer-level error.
+		if s.config != nil && s.config.RequestNextFunc != nil {
+			timeout := DefaultTimeout
+			if s.config.Timeout != 0 {
+				timeout = s.config.Timeout
+			}
+			entry.Timeout = timeout
 		}
-		entry.Timeout = timeout
 		stateMap[StateBusy] = entry
 	}
 	protoConfig := protocol.ProtocolConfig{
@@ -114,9 +118,10 @@ func (s *Server) handleRequestNext(msg protocol.Message) error {
 		)
 	}
 	if s.config == nil || s.config.RequestNextFunc == nil {
-		return errors.New(
-			"received leios-votes VotesRequestNext message but no callback function is defined",
-		)
+		// CIP-0164 permits only Vote while the server has agency in Busy.
+		// Keep the request pending rather than inventing a response or failing
+		// the shared bearer.
+		return nil
 	}
 	votes, err := s.config.RequestNextFunc(
 		s.callbackContext,

--- a/protocol/leiosvotes/server_test.go
+++ b/protocol/leiosvotes/server_test.go
@@ -134,14 +134,16 @@ func TestUnconfiguredInvalidRequestReportsStateError(t *testing.T) {
 	data, err := cbor.Encode(NewMsgVotesRequestNext(0))
 	require.NoError(t, err)
 	writeTestSegment(t, connB, muxer.NewSegment(ProtocolId, data, false))
+	var protocolErr error
 	require.Eventually(t, func() bool {
 		select {
-		case err := <-errs:
-			return assert.ErrorContains(t, err, "state transition")
+		case protocolErr = <-errs:
+			return true
 		default:
 			return false
 		}
 	}, time.Second, time.Millisecond)
+	assert.ErrorContains(t, protocolErr, "state transition")
 }
 
 func TestNewServer(t *testing.T) {

--- a/protocol/leiosvotes/server_test.go
+++ b/protocol/leiosvotes/server_test.go
@@ -24,42 +24,120 @@ import (
 	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/muxer"
 	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/blinklabs-io/gouroboros/protocol/peersharing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestUnconfiguredRequestReportsBearerError(t *testing.T) {
+func TestUnconfiguredRequestRemainsBusyAndPreservesSharedBearer(t *testing.T) {
+	connA, connB := net.Pipe()
+	m := muxer.New(connA)
+	errs := make(chan error, 1)
+	connId := connection.ConnectionId{
+		LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)},
+		RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)},
+	}
+	server := NewServer(
+		protocol.ProtocolOptions{
+			ConnectionId: connId,
+			ErrorChan:    errs,
+			Muxer:        m,
+		},
+		&Config{Timeout: time.Millisecond},
+	)
+	peerSharingCfg := peersharing.NewConfig(
+		peersharing.WithShareRequestFunc(
+			func(
+				peersharing.CallbackContext,
+				int,
+			) ([]peersharing.PeerAddress, error) {
+				return []peersharing.PeerAddress{}, nil
+			},
+		),
+	)
+	peerSharingServer := peersharing.NewServer(
+		protocol.ProtocolOptions{
+			ConnectionId: connId,
+			ErrorChan:    errs,
+			Muxer:        m,
+		},
+		&peerSharingCfg,
+	)
+	server.Start()
+	peerSharingServer.Start()
+	m.Start()
+	t.Cleanup(func() {
+		server.Stop()
+		peerSharingServer.Stop()
+		m.Stop()
+		_ = connA.Close()
+		_ = connB.Close()
+	})
+
+	data, err := cbor.Encode(NewMsgVotesRequestNext(1))
+	require.NoError(t, err)
+	writeTestSegment(t, connB, muxer.NewSegment(ProtocolId, data, false))
+	require.Never(t, func() bool {
+		select {
+		case <-errs:
+			return true
+		default:
+			return false
+		}
+	}, 20*time.Millisecond, time.Millisecond,
+		"unconfigured responder timed out or reported an error",
+	)
+	require.Eventually(t, func() bool {
+		return !server.ProtocolInstance().IsInTerminalOrIdleState()
+	}, time.Second, time.Millisecond,
+		"unconfigured request did not enter Busy",
+	)
+
+	peerData, err := cbor.Encode(peersharing.NewMsgShareRequest(1))
+	require.NoError(t, err)
+	writeTestSegment(
+		t,
+		connB,
+		muxer.NewSegment(peersharing.ProtocolId, peerData, false),
+	)
+	require.NoError(t, connB.SetReadDeadline(time.Now().Add(time.Second)))
+	segment := requireReadTestSegment(t, connB)
+	require.Equal(t, uint16(peersharing.ProtocolId), segment.GetProtocolId())
+	require.Equal(
+		t,
+		[]byte{0x82, peersharing.MessageTypeSharePeers, 0x80},
+		segment.Payload,
+	)
+}
+
+func TestUnconfiguredInvalidRequestReportsStateError(t *testing.T) {
 	connA, connB := net.Pipe()
 	m := muxer.New(connA)
 	errs := make(chan error, 1)
 	server := NewServer(
 		protocol.ProtocolOptions{
-			ConnectionId: connection.ConnectionId{
-				LocalAddr:  &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)},
-				RemoteAddr: &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1)},
-			},
-			ErrorChan: errs,
-			Muxer:     m,
+			ConnectionId: testConnectionId(),
+			ErrorChan:    errs,
+			Muxer:        m,
 		},
-		&Config{Timeout: time.Millisecond},
+		nil,
 	)
 	server.Start()
 	m.Start()
 	t.Cleanup(func() {
 		server.Stop()
 		m.Stop()
-		connA.Close()
-		connB.Close()
+		_ = connA.Close()
+		_ = connB.Close()
 	})
 
-	data, err := cbor.Encode(NewMsgVotesRequestNext(1))
+	data, err := cbor.Encode(NewMsgVotesRequestNext(0))
 	require.NoError(t, err)
 	writeTestSegment(t, connB, muxer.NewSegment(ProtocolId, data, false))
-
 	require.Eventually(t, func() bool {
 		select {
 		case err := <-errs:
-			return assert.ErrorContains(t, err, "no callback function is defined")
+			return assert.ErrorContains(t, err, "state transition")
 		default:
 			return false
 		}
@@ -109,7 +187,7 @@ func TestHandleRequestNextNilCallback(t *testing.T) {
 
 	err := server.handleRequestNext(NewMsgVotesRequestNext(1))
 
-	assert.ErrorContains(t, err, "no callback function is defined")
+	assert.NoError(t, err)
 }
 
 func TestHandleRequestNextNilConfig(t *testing.T) {
@@ -121,7 +199,7 @@ func TestHandleRequestNextNilConfig(t *testing.T) {
 
 	err := server.handleRequestNext(NewMsgVotesRequestNext(1))
 
-	assert.ErrorContains(t, err, "no callback function is defined")
+	assert.NoError(t, err)
 }
 
 func TestHandleRequestNextInvalidCount(t *testing.T) {


### PR DESCRIPTION
Unconfigured Leios fetch and votes responders now retain server agency without emitting speculative replies or propagating bearer errors. Configured callback errors and timeouts keep their existing behavior, and sibling mini-protocols remain usable while the optional responder is pending.

Fixes #2048
