### PR TITLE
fix(ledger): enforce validity interval upper bound

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,8 @@ require.NoError(t, err)
 
 | Error | Rule | Cause |
 |-------|------|-------|
-| `OutsideValidityIntervalUtxoError` | `UtxoValidateValidityInterval` | slot outside validity range |
+| `OutsideValidityIntervalUtxoError` | `UtxoValidateOutsideValidityIntervalUtxo` | slot before lower validity bound |
+| `OutsideValidityIntervalUpperBoundUtxoError` | `UtxoValidateOutsideValidityIntervalUtxo` | slot at or after exclusive upper validity bound |
 | `NativeScriptFailedError` | script evaluation | native script failed |
 
 ### Alonzo

--- a/ledger/allegra/errors.go
+++ b/ledger/allegra/errors.go
@@ -34,6 +34,21 @@ func (e OutsideValidityIntervalUtxoError) Error() string {
 	)
 }
 
+// OutsideValidityIntervalUpperBoundUtxoError indicates that the current slot
+// reached or passed the transaction's exclusive upper validity bound.
+type OutsideValidityIntervalUpperBoundUtxoError struct {
+	End  uint64
+	Slot uint64
+}
+
+func (e OutsideValidityIntervalUpperBoundUtxoError) Error() string {
+	return fmt.Sprintf(
+		"outside validity interval upper bound: end %d, slot %d",
+		e.End,
+		e.Slot,
+	)
+}
+
 type NativeScriptFailedError struct {
 	ScriptHash common.ScriptHash
 }

--- a/ledger/allegra/rules.go
+++ b/ledger/allegra/rules.go
@@ -65,7 +65,9 @@ func UtxoValidateOutsideValidityIntervalUtxo(
 			Slot:                  slot,
 		}
 	}
-	validityIntervalEnd, validityIntervalEndPresent := common.TransactionValidityIntervalUpperBound(tx)
+	validityIntervalEnd, validityIntervalEndPresent := common.TransactionValidityIntervalUpperBound(
+		tx,
+	)
 	if validityIntervalEndPresent && slot >= validityIntervalEnd {
 		return OutsideValidityIntervalUpperBoundUtxoError{
 			End:  validityIntervalEnd,

--- a/ledger/allegra/rules.go
+++ b/ledger/allegra/rules.go
@@ -50,7 +50,8 @@ func UtxoValidateRequiredVKeyWitnesses(
 	return shelley.UtxoValidateRequiredVKeyWitnesses(tx, slot, ls, pp)
 }
 
-// UtxoValidateOutsideValidityIntervalUtxo ensures that the current tip slot has reached the specified validity interval
+// UtxoValidateOutsideValidityIntervalUtxo ensures that the current tip slot is
+// within the transaction's half-open validity interval.
 func UtxoValidateOutsideValidityIntervalUtxo(
 	tx common.Transaction,
 	slot uint64,
@@ -58,13 +59,20 @@ func UtxoValidateOutsideValidityIntervalUtxo(
 	_ common.ProtocolParameters,
 ) error {
 	validityIntervalStart := tx.ValidityIntervalStart()
-	if validityIntervalStart == 0 || slot >= validityIntervalStart {
-		return nil
+	if validityIntervalStart != 0 && slot < validityIntervalStart {
+		return OutsideValidityIntervalUtxoError{
+			ValidityIntervalStart: validityIntervalStart,
+			Slot:                  slot,
+		}
 	}
-	return OutsideValidityIntervalUtxoError{
-		ValidityIntervalStart: validityIntervalStart,
-		Slot:                  slot,
+	validityIntervalEnd, validityIntervalEndPresent := common.TransactionValidityIntervalUpperBound(tx)
+	if validityIntervalEndPresent && slot >= validityIntervalEnd {
+		return OutsideValidityIntervalUpperBoundUtxoError{
+			End:  validityIntervalEnd,
+			Slot: slot,
+		}
 	}
+	return nil
 }
 
 func UtxoValidateInputSetEmptyUtxo(

--- a/ledger/validity_interval_test.go
+++ b/ledger/validity_interval_test.go
@@ -44,6 +44,12 @@ type validityUpperBoundTestCase struct {
 	newTx   func(validityUpperBoundBody) common.TransactionBody
 }
 
+type validityIntervalValidationTestCase struct {
+	name      string
+	newTx     func(uint64, *uint64) common.Transaction
+	validator common.UtxoValidationRuleFunc
+}
+
 func validityUpperBoundTestCases() []validityUpperBoundTestCase {
 	return []validityUpperBoundTestCase{
 		{
@@ -194,6 +200,238 @@ func TestTransactionValidityIntervalUpperBoundLegacyFallback(t *testing.T) {
 
 	body.Ttl = 42
 	requireValidityUpperBound(t, body, 42, true)
+}
+
+func TestUtxoValidateOutsideValidityInterval(t *testing.T) {
+	testCases := []validityIntervalValidationTestCase{
+		{
+			name: "Allegra",
+			newTx: func(start uint64, end *uint64) common.Transaction {
+				body := allegra.AllegraTransactionBody{
+					TxValidityIntervalStart: start,
+				}
+				setValidityIntervalUpperBound(&body, end)
+				return &allegra.AllegraTransaction{Body: body}
+			},
+			validator: allegra.UtxoValidateOutsideValidityIntervalUtxo,
+		},
+		{
+			name: "Mary",
+			newTx: func(start uint64, end *uint64) common.Transaction {
+				body := mary.MaryTransactionBody{}
+				if start != 0 {
+					body.TxValidityIntervalStart = &start
+				}
+				setValidityIntervalUpperBound(&body, end)
+				return &mary.MaryTransaction{Body: body}
+			},
+			validator: mary.UtxoValidateOutsideValidityIntervalUtxo,
+		},
+		{
+			name: "Alonzo",
+			newTx: func(start uint64, end *uint64) common.Transaction {
+				body := alonzo.AlonzoTransactionBody{
+					TxValidityIntervalStart: start,
+				}
+				setValidityIntervalUpperBound(&body, end)
+				return &alonzo.AlonzoTransaction{Body: body}
+			},
+			validator: alonzo.UtxoValidateOutsideValidityIntervalUtxo,
+		},
+		{
+			name: "Babbage",
+			newTx: func(start uint64, end *uint64) common.Transaction {
+				body := babbage.BabbageTransactionBody{
+					TxValidityIntervalStart: start,
+				}
+				setValidityIntervalUpperBound(&body, end)
+				return &babbage.BabbageTransaction{Body: body}
+			},
+			validator: babbage.UtxoValidateOutsideValidityIntervalUtxo,
+		},
+		{
+			name: "Conway",
+			newTx: func(start uint64, end *uint64) common.Transaction {
+				body := conway.ConwayTransactionBody{
+					TxValidityIntervalStart: start,
+				}
+				setValidityIntervalUpperBound(&body, end)
+				return &conway.ConwayTransaction{Body: body}
+			},
+			validator: conway.UtxoValidateOutsideValidityIntervalUtxo,
+		},
+		{
+			name: "Dijkstra",
+			newTx: func(start uint64, end *uint64) common.Transaction {
+				body := dijkstra.DijkstraTransactionBody{
+					TxValidityIntervalStart: start,
+				}
+				setValidityIntervalUpperBound(&body, end)
+				return &dijkstra.DijkstraTransaction{Body: body}
+			},
+			validator: conway.UtxoValidateOutsideValidityIntervalUtxo,
+		},
+	}
+	scenarios := []struct {
+		name        string
+		start       uint64
+		end         *uint64
+		slot        uint64
+		wantError   bool
+		wantUpper   bool
+		wantMessage string
+	}{
+		{
+			name: "absent upper bound at slot zero",
+			slot: 0,
+		},
+		{
+			name: "absent upper bound after slot zero",
+			slot: 123,
+		},
+		{
+			name:        "before lower bound",
+			start:       50,
+			slot:        49,
+			wantError:   true,
+			wantMessage: "outside validity interval: start 50, slot 49",
+		},
+		{
+			name:  "at lower bound",
+			start: 50,
+			slot:  50,
+		},
+		{
+			name:        "lower bound failure takes precedence",
+			start:       50,
+			end:         uint64Pointer(0),
+			slot:        0,
+			wantError:   true,
+			wantMessage: "outside validity interval: start 50, slot 0",
+		},
+		{
+			name: "before upper bound",
+			end:  uint64Pointer(100),
+			slot: 99,
+		},
+		{
+			name:        "at upper bound",
+			end:         uint64Pointer(100),
+			slot:        100,
+			wantError:   true,
+			wantUpper:   true,
+			wantMessage: "outside validity interval upper bound: end 100, slot 100",
+		},
+		{
+			name:        "after upper bound",
+			end:         uint64Pointer(100),
+			slot:        101,
+			wantError:   true,
+			wantUpper:   true,
+			wantMessage: "outside validity interval upper bound: end 100, slot 101",
+		},
+		{
+			name:  "inside bounded interval",
+			start: 50,
+			end:   uint64Pointer(100),
+			slot:  75,
+		},
+		{
+			name:        "explicit zero upper bound",
+			end:         uint64Pointer(0),
+			slot:        0,
+			wantError:   true,
+			wantUpper:   true,
+			wantMessage: "outside validity interval upper bound: end 0, slot 0",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			for _, scenario := range scenarios {
+				t.Run(scenario.name, func(t *testing.T) {
+					err := test.validator(
+						test.newTx(scenario.start, scenario.end),
+						scenario.slot,
+						nil,
+						nil,
+					)
+					if !scenario.wantError {
+						require.NoError(t, err)
+						return
+					}
+
+					require.Error(t, err)
+					require.Equal(t, scenario.wantMessage, err.Error())
+					if scenario.wantUpper {
+						var intervalError allegra.OutsideValidityIntervalUpperBoundUtxoError
+						require.ErrorAs(t, err, &intervalError)
+						require.Equal(t, *scenario.end, intervalError.End)
+						require.Equal(t, scenario.slot, intervalError.Slot)
+						return
+					}
+					var intervalError allegra.OutsideValidityIntervalUtxoError
+					require.ErrorAs(t, err, &intervalError)
+					require.Equal(t, scenario.start, intervalError.ValidityIntervalStart)
+					require.Equal(t, scenario.slot, intervalError.Slot)
+				})
+			}
+		})
+	}
+}
+
+func TestUtxoValidateOutsideValidityIntervalDecodedZeroUpperBound(t *testing.T) {
+	testCases := []struct {
+		name      string
+		bodyCBOR  []byte
+		wantError bool
+	}{
+		{
+			name:     "omitted key 3",
+			bodyCBOR: []byte{0xa0},
+		},
+		{
+			name:      "explicit key 3 zero",
+			bodyCBOR:  []byte{0xa1, 0x03, 0x00},
+			wantError: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			var body allegra.AllegraTransactionBody
+			require.NoError(t, body.UnmarshalCBOR(test.bodyCBOR))
+			err := allegra.UtxoValidateOutsideValidityIntervalUtxo(
+				&allegra.AllegraTransaction{Body: body},
+				0,
+				nil,
+				nil,
+			)
+			if !test.wantError {
+				require.NoError(t, err)
+				return
+			}
+			var intervalError allegra.OutsideValidityIntervalUpperBoundUtxoError
+			require.ErrorAs(t, err, &intervalError)
+			require.Zero(t, intervalError.End)
+			require.Zero(t, intervalError.Slot)
+		})
+	}
+}
+
+func setValidityIntervalUpperBound(
+	body validityUpperBoundBody,
+	upperBound *uint64,
+) {
+	if upperBound == nil {
+		body.ClearValidityIntervalUpperBound()
+		return
+	}
+	body.SetValidityIntervalUpperBound(*upperBound)
+}
+
+func uint64Pointer(value uint64) *uint64 {
+	return &value
 }
 
 func requireValidityUpperBound(

--- a/ledger/validity_interval_test.go
+++ b/ledger/validity_interval_test.go
@@ -372,7 +372,11 @@ func TestUtxoValidateOutsideValidityInterval(t *testing.T) {
 					}
 					var intervalError allegra.OutsideValidityIntervalUtxoError
 					require.ErrorAs(t, err, &intervalError)
-					require.Equal(t, scenario.start, intervalError.ValidityIntervalStart)
+					require.Equal(
+						t,
+						scenario.start,
+						intervalError.ValidityIntervalStart,
+					)
 					require.Equal(t, scenario.slot, intervalError.Slot)
 				})
 			}
@@ -380,7 +384,9 @@ func TestUtxoValidateOutsideValidityInterval(t *testing.T) {
 	}
 }
 
-func TestUtxoValidateOutsideValidityIntervalDecodedZeroUpperBound(t *testing.T) {
+func TestUtxoValidateOutsideValidityIntervalDecodedZeroUpperBound(
+	t *testing.T,
+) {
 	testCases := []struct {
 		name      string
 		bodyCBOR  []byte


### PR DESCRIPTION
## Summary

- Enforce Allegra validity intervals as half-open `[start, end)` ranges.
- Preserve the distinction between an omitted upper bound and an explicitly encoded zero, with later eras continuing to delegate to the Allegra rule.
- Return a separate typed upper-bound error without changing the existing lower-bound error shape.

## Validation

- Focused regression test failed before the fix and passed with race detection after it.
- `go test -race ./ledger/...`
- `go test -v ./internal/test/conformance/...` (315/315 vectors passed)
- `make lint`
- `go vet ./...`
- `nilaway -include-pkgs=github.com/blinklabs-io/gouroboros ./...`

Related: blinklabs-io/dingo#3454

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the Allegra validity interval upper bound so transactions at or after the exclusive end slot are now rejected, where previously only the lower bound was checked.

- Adds a dedicated `OutsideValidityIntervalUpperBoundUtxoError` without changing the existing lower-bound error shape.
- Preserves the distinction between an omitted upper bound and an explicitly encoded zero, with later eras delegating to the Allegra rule.
- Adds cross-era regression tests covering bounded, unbounded, and explicit-zero upper bounds and updates the docs error reference.

<sup>Written for commit 4c82be2c38c7cac143cca6590fbc31dd020ec2b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Transactions now correctly reject validity intervals when the current slot reaches or exceeds the specified upper bound.
  - Validity checks now consistently handle lower and upper bounds across supported ledger eras.
  - Explicitly encoded zero upper bounds are distinguished from omitted upper bounds.

- **Tests**
  - Added comprehensive coverage for open, bounded, and invalid validity intervals, including boundary and precedence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->