### PR TITLE
fix(ledger): preserve legacy cost model maps

### DIFF
--- a/ledger/alonzo/genesis.go
+++ b/ledger/alonzo/genesis.go
@@ -69,9 +69,9 @@ func (c *AlonzoGenesisCostModels) UnmarshalJSON(data []byte) error {
 		if err := json.Unmarshal(data, &tmpMap); err != nil {
 			return fmt.Errorf("decode cost model: %w", err)
 		}
-		paramNames := lang.GetParamNamesForVersion(langVer)
+		paramNames := costModelParamNamesForMap(langVer, tmpMap)
 		for _, param := range paramNames {
-			val, ok := tmpMap[param]
+			val, ok := costModelParamValue(tmpMap, param)
 			// Stop processing if a param name is not present
 			if !ok {
 				break
@@ -82,6 +82,84 @@ func (c *AlonzoGenesisCostModels) UnmarshalJSON(data []byte) error {
 	}
 	*c = AlonzoGenesisCostModels(tmpCostModels)
 	return nil
+}
+
+// costModelParamValue accepts historical map-form Alonzo genesis spellings
+// while keeping Plutigo's current parameter names canonical. PlutusV1 genesis
+// files used these names before later ledger APIs made the builtin names
+// explicit.
+func costModelParamValue(params map[string]int64, name string) (int64, bool) {
+	if value, ok := params[name]; ok {
+		return value, true
+	}
+	var legacyName string
+	switch name {
+	case "blake2b_256-cpu-arguments-intercept":
+		legacyName = "blake2b-cpu-arguments-intercept"
+	case "blake2b_256-cpu-arguments-slope":
+		legacyName = "blake2b-cpu-arguments-slope"
+	case "blake2b_256-memory-arguments":
+		legacyName = "blake2b-memory-arguments"
+	case "verifyEd25519Signature-cpu-arguments-intercept":
+		legacyName = "verifySignature-cpu-arguments-intercept"
+	case "verifyEd25519Signature-cpu-arguments-slope":
+		legacyName = "verifySignature-cpu-arguments-slope"
+	case "verifyEd25519Signature-memory-arguments":
+		legacyName = "verifySignature-memory-arguments"
+	default:
+		return 0, false
+	}
+	value, ok := params[legacyName]
+	return value, ok
+}
+
+// costModelParamNamesForMap preserves the ordering of the older Value cost
+// models. The canonical model replaces five legacy parameters with nine, so
+// those entries cannot be handled as one-for-one aliases. A map using the old
+// valueData spelling is decoded in its original order and length; a shorter
+// model that ends before this section still stops at its first absent key.
+func costModelParamNamesForMap(
+	version lang.LanguageVersion,
+	params map[string]int64,
+) []string {
+	paramNames := lang.GetParamNamesForVersion(version)
+	if _, ok := params["valueData-cpu-arguments"]; !ok {
+		return paramNames
+	}
+	if _, ok := params["valueData-cpu-arguments-intercept"]; ok {
+		return paramNames
+	}
+	const (
+		canonicalStart = "valueData-cpu-arguments-intercept"
+		canonicalEnd   = "unValueData-memory-arguments-slope"
+	)
+	start, end := -1, -1
+	for i, name := range paramNames {
+		if name == canonicalStart {
+			start = i
+		}
+		if name == canonicalEnd {
+			end = i
+			break
+		}
+	}
+	// Released Plutigo versions already expose the legacy table, so there is
+	// nothing to rewrite when the canonical replacement range is absent.
+	if start < 0 || end < start {
+		return paramNames
+	}
+	legacyNames := []string{
+		"valueData-cpu-arguments",
+		"valueData-memory-arguments",
+		"unValueData-cpu-arguments-intercept",
+		"unValueData-cpu-arguments-slope",
+		"unValueData-memory-arguments",
+	}
+	ret := make([]string, 0, len(paramNames)-(end-start+1)+len(legacyNames))
+	ret = append(ret, paramNames[:start]...)
+	ret = append(ret, legacyNames...)
+	ret = append(ret, paramNames[end+1:]...)
+	return ret
 }
 
 func NewAlonzoGenesisFromReader(r io.Reader) (AlonzoGenesis, error) {

--- a/ledger/alonzo/genesis_test.go
+++ b/ledger/alonzo/genesis_test.go
@@ -15,6 +15,7 @@
 package alonzo_test
 
 import (
+	"encoding/json"
 	"math/big"
 	"reflect"
 	"strings"
@@ -22,6 +23,7 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/plutigo/lang"
 )
 
 const alonzoGenesisConfig = `
@@ -430,4 +432,293 @@ func TestGenesisFromJson(t *testing.T) {
 			expectedGenesisObj,
 		)
 	}
+}
+
+func TestGenesisMapCostModelPreservesLegacyMainnetNames(t *testing.T) {
+	genesis, err := alonzo.NewAlonzoGenesisFromReader(
+		strings.NewReader(alonzoGenesisConfig),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	model := genesis.CostModels["PlutusV1"]
+	if len(model) != 166 {
+		t.Fatalf(
+			"legacy PlutusV1 cost model length = %d, want 166",
+			len(model),
+		)
+	}
+	for _, tc := range []struct {
+		name  string
+		index int
+		want  int64
+	}{
+		{name: "blake2b intercept", index: 14, want: 2477736},
+		{name: "blake2b slope", index: 15, want: 29175},
+		{name: "blake2b memory", index: 16, want: 4},
+		{name: "verifySignature intercept", index: 163, want: 3345831},
+		{name: "verifySignature slope", index: 164, want: 1},
+		{name: "verifySignature memory", index: 165, want: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := model[tc.index]; got != tc.want {
+				t.Fatalf("cost model[%d] = %d, want %d", tc.index, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGenesisMapCostModelsPreserveLegacyParameterTables(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		version     lang.LanguageVersion
+		wantLength  int
+		legacyStart int
+	}{
+		{
+			name:        "PlutusV1",
+			version:     lang.LanguageVersionV1,
+			wantLength:  328,
+			legacyStart: 319,
+		},
+		{
+			name:        "PlutusV2",
+			version:     lang.LanguageVersionV2,
+			wantLength:  328,
+			legacyStart: 319,
+		},
+		{
+			name:        "PlutusV3",
+			version:     lang.LanguageVersionV3,
+			wantLength:  346,
+			legacyStart: 337,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			paramNames := legacyCostModelParamNamesForTest(
+				lang.GetParamNamesForVersion(tc.version),
+			)
+			params := make(map[string]int64, len(paramNames))
+			want := make([]int64, len(paramNames))
+			for i, name := range paramNames {
+				want[i] = int64(i + 1)
+				params[name] = want[i]
+			}
+			// These zero-based boundary indices come from the exact upstream
+			// legacy tables at aee28e0467be0561de5c2f097f639914d8d7a294.
+			// Fixed sentinels keep this oracle independent of the helper's
+			// production-shaped 9-to-5 rewrite.
+			boundary := []struct {
+				name string
+				want int64
+			}{
+				{name: "valueData-cpu-arguments", want: 10_001},
+				{name: "valueData-memory-arguments", want: 10_002},
+				{
+					name: "unValueData-cpu-arguments-intercept",
+					want: 10_003,
+				},
+				{name: "unValueData-cpu-arguments-slope", want: 10_004},
+				{name: "unValueData-memory-arguments", want: 10_005},
+				{
+					name: "scaleValue-cpu-arguments-intercept",
+					want: 10_006,
+				},
+			}
+			for i, item := range boundary {
+				params[item.name] = item.want
+				want[tc.legacyStart+i] = item.want
+			}
+			data, err := json.Marshal(map[string]any{tc.name: params})
+			if err != nil {
+				t.Fatalf("marshal legacy cost model: %v", err)
+			}
+			var models alonzo.AlonzoGenesisCostModels
+			if err := json.Unmarshal(data, &models); err != nil {
+				t.Fatalf("unmarshal legacy cost model: %v", err)
+			}
+			got := models[tc.name]
+			if len(got) != tc.wantLength {
+				t.Fatalf(
+					"legacy cost model length = %d, want %d",
+					len(got),
+					tc.wantLength,
+				)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("legacy cost model values = %v, want %v", got, want)
+			}
+			for i, item := range boundary {
+				index := tc.legacyStart + i
+				if got[index] != item.want {
+					t.Fatalf(
+						"legacy cost model[%d] = %d, want %d for %s",
+						index,
+						got[index],
+						item.want,
+						item.name,
+					)
+				}
+			}
+		})
+	}
+}
+
+func TestGenesisMapCostModelsPreferCanonicalNames(t *testing.T) {
+	paramNames := lang.GetParamNamesForVersion(lang.LanguageVersionV1)
+	if len(paramNames) != 332 ||
+		paramNames[14] != "blake2b_256-cpu-arguments-intercept" {
+		t.Skip("Plutigo release exposes the legacy parameter table")
+	}
+	params := make(map[string]int64, len(paramNames)+11)
+	for i, name := range paramNames {
+		params[name] = int64(i + 1)
+	}
+	aliases := []struct {
+		canonical string
+		legacy    string
+		index     int
+		want      int64
+	}{
+		{
+			canonical: "blake2b_256-cpu-arguments-intercept",
+			legacy:    "blake2b-cpu-arguments-intercept",
+			index:     14,
+			want:      20_001,
+		},
+		{
+			canonical: "blake2b_256-cpu-arguments-slope",
+			legacy:    "blake2b-cpu-arguments-slope",
+			index:     15,
+			want:      20_002,
+		},
+		{
+			canonical: "blake2b_256-memory-arguments",
+			legacy:    "blake2b-memory-arguments",
+			index:     16,
+			want:      20_003,
+		},
+		{
+			canonical: "verifyEd25519Signature-cpu-arguments-intercept",
+			legacy:    "verifySignature-cpu-arguments-intercept",
+			index:     163,
+			want:      20_004,
+		},
+		{
+			canonical: "verifyEd25519Signature-cpu-arguments-slope",
+			legacy:    "verifySignature-cpu-arguments-slope",
+			index:     164,
+			want:      20_005,
+		},
+		{
+			canonical: "verifyEd25519Signature-memory-arguments",
+			legacy:    "verifySignature-memory-arguments",
+			index:     165,
+			want:      20_006,
+		},
+	}
+	for _, item := range aliases {
+		params[item.canonical] = item.want
+		params[item.legacy] = -item.want
+	}
+	// The exact canonical table at
+	// 3109dc1e6501ecbbed0b7ae27361c255d7a16173 uses nine Value entries.
+	// Supplying all five legacy names as well must not select their ordering.
+	for i, name := range []string{
+		"valueData-cpu-arguments",
+		"valueData-memory-arguments",
+		"unValueData-cpu-arguments-intercept",
+		"unValueData-cpu-arguments-slope",
+		"unValueData-memory-arguments",
+	} {
+		params[name] = -int64(30_001 + i)
+	}
+	data, err := json.Marshal(map[string]any{"PlutusV1": params})
+	if err != nil {
+		t.Fatalf("marshal mixed cost model: %v", err)
+	}
+	var models alonzo.AlonzoGenesisCostModels
+	if err := json.Unmarshal(data, &models); err != nil {
+		t.Fatalf("unmarshal mixed cost model: %v", err)
+	}
+	model := models["PlutusV1"]
+	if len(model) != 332 {
+		t.Fatalf("canonical cost model length = %d, want 332", len(model))
+	}
+	for _, item := range aliases {
+		if model[item.index] != item.want {
+			t.Fatalf(
+				"canonical cost model[%d] = %d, want %d for %s",
+				item.index,
+				model[item.index],
+				item.want,
+				item.canonical,
+			)
+		}
+	}
+	for i := 0; i < 9; i++ {
+		index := 319 + i
+		want := int64(index + 1)
+		if model[index] != want {
+			t.Fatalf(
+				"canonical Value cost model[%d] = %d, want %d",
+				index,
+				model[index],
+				want,
+			)
+		}
+	}
+	if got, want := model[328], int64(329); got != want {
+		t.Fatalf(
+			"first parameter after canonical Value span = %d, want %d",
+			got,
+			want,
+		)
+	}
+}
+
+func TestGenesisMapCostModelsAllowShorterLegacyModels(t *testing.T) {
+	const data = `{"PlutusV1":{"addInteger-cpu-arguments-intercept":123}}`
+	var models alonzo.AlonzoGenesisCostModels
+	if err := json.Unmarshal([]byte(data), &models); err != nil {
+		t.Fatalf("unmarshal short legacy cost model: %v", err)
+	}
+	want := []int64{123}
+	if got := models["PlutusV1"]; !reflect.DeepEqual(got, want) {
+		t.Fatalf("short legacy cost model = %v, want %v", got, want)
+	}
+}
+
+func legacyCostModelParamNamesForTest(paramNames []string) []string {
+	ret := make([]string, 0, len(paramNames))
+	for i := 0; i < len(paramNames); i++ {
+		switch paramNames[i] {
+		case "blake2b_256-cpu-arguments-intercept":
+			ret = append(ret, "blake2b-cpu-arguments-intercept")
+		case "blake2b_256-cpu-arguments-slope":
+			ret = append(ret, "blake2b-cpu-arguments-slope")
+		case "blake2b_256-memory-arguments":
+			ret = append(ret, "blake2b-memory-arguments")
+		case "verifyEd25519Signature-cpu-arguments-intercept":
+			ret = append(ret, "verifySignature-cpu-arguments-intercept")
+		case "verifyEd25519Signature-cpu-arguments-slope":
+			ret = append(ret, "verifySignature-cpu-arguments-slope")
+		case "verifyEd25519Signature-memory-arguments":
+			ret = append(ret, "verifySignature-memory-arguments")
+		case "valueData-cpu-arguments-intercept":
+			ret = append(ret,
+				"valueData-cpu-arguments",
+				"valueData-memory-arguments",
+				"unValueData-cpu-arguments-intercept",
+				"unValueData-cpu-arguments-slope",
+				"unValueData-memory-arguments",
+			)
+			// The canonical table replaces the five legacy entries above with
+			// nine entries ending at unValueData-memory-arguments-slope.
+			i += 8
+		default:
+			ret = append(ret, paramNames[i])
+		}
+	}
+	return ret
 }

--- a/ledger/alonzo/genesis_test.go
+++ b/ledger/alonzo/genesis_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/plutigo/lang"
+	"github.com/stretchr/testify/require"
 )
 
 const alonzoGenesisConfig = `
@@ -438,16 +439,9 @@ func TestGenesisMapCostModelPreservesLegacyMainnetNames(t *testing.T) {
 	genesis, err := alonzo.NewAlonzoGenesisFromReader(
 		strings.NewReader(alonzoGenesisConfig),
 	)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
+	require.NoError(t, err)
 	model := genesis.CostModels["PlutusV1"]
-	if len(model) != 166 {
-		t.Fatalf(
-			"legacy PlutusV1 cost model length = %d, want 166",
-			len(model),
-		)
-	}
+	require.Len(t, model, 166, "legacy PlutusV1 cost model")
 	for _, tc := range []struct {
 		name  string
 		index int
@@ -461,9 +455,13 @@ func TestGenesisMapCostModelPreservesLegacyMainnetNames(t *testing.T) {
 		{name: "verifySignature memory", index: 165, want: 1},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := model[tc.index]; got != tc.want {
-				t.Fatalf("cost model[%d] = %d, want %d", tc.index, got, tc.want)
-			}
+			require.Equal(
+				t,
+				tc.want,
+				model[tc.index],
+				"cost model[%d]",
+				tc.index,
+			)
 		})
 	}
 }


### PR DESCRIPTION
Legacy map-form Alonzo genesis cost models can truncate when Plutigo exposes canonical parameter names.

- Prefer canonical `blake2b_256` and `verifyEd25519Signature` names, with fallbacks for legacy `blake2b` and `verifySignature` spellings.
- Preserve the legacy five-parameter `valueData`/`unValueData` ordering when the canonical nine-parameter keys are absent.
- Continue accepting legitimate shorter legacy models.

Validation:

- Released `github.com/blinklabs-io/plutigo` v0.4.0: `ledger/alonzo` race suite passes.
- Exact `blinklabs-io/plutigo#389` head `00a2df585ab186bccfb231c9065c587a323715ad`: `ledger/alonzo` race suite passes.
- Regression tests fail against the prior parser at the intended legacy model length and boundary assertions, then pass with this change.

Related: blinklabs-io/plutigo#389

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes legacy map-form Alonzo genesis cost models so parsing no longer truncates when Plutigo exposes canonical parameter names.

- Accepts legacy `blake2b` and `verifySignature` spellings as fallbacks for the canonical `blake2b_256` and `verifyEd25519Signature` names.
- Preserves the legacy five-parameter `valueData`/`unValueData` ordering when the canonical nine-parameter keys are absent.
- Continues accepting shorter legitimate legacy models that end before the replaced section.

<sup>Written for commit 460ef46a2678cf55db0aa4cf00c01d050011cc33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when loading legacy Alonzo genesis cost models.
  * Supports historical Plutus parameter names and older `valueData` layouts.
  * Prefers canonical parameter names when both canonical and legacy names are available.
  * Allows shorter legacy cost-model definitions to be decoded correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->