### PR TITLE
fix(ledger): decode null origin previous hashes

### DIFF
--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -279,13 +279,45 @@ type BabbageBlockHeaderBody struct {
 	ProtoVersion  BabbageProtoVersion
 }
 
+type babbageBlockHeaderBodyWire struct {
+	cbor.StructAsArray
+	BlockNumber   uint64
+	Slot          uint64
+	PrevHash      cbor.RawMessage
+	IssuerVkey    common.IssuerVkey
+	VrfKey        []byte
+	VrfResult     common.VrfResult
+	BlockBodySize uint64
+	BlockBodyHash common.Blake2b256
+	OpCert        BabbageOpCert
+	ProtoVersion  BabbageProtoVersion
+}
+
 func (b *BabbageBlockHeaderBody) UnmarshalCBOR(cborData []byte) error {
-	type tBabbageBlockHeaderBody BabbageBlockHeaderBody
-	var tmp tBabbageBlockHeaderBody
+	var tmp babbageBlockHeaderBodyWire
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
 		return err
 	}
-	*b = BabbageBlockHeaderBody(tmp)
+	var prevHash common.Blake2b256
+	// Origin headers encode prev_hash as null. Keep that compatibility scoped
+	// to this field while non-null hashes use the globally strict decoder.
+	if len(tmp.PrevHash) != 1 || tmp.PrevHash[0] != 0xf6 {
+		if _, err := cbor.Decode(tmp.PrevHash, &prevHash); err != nil {
+			return fmt.Errorf("decode previous hash: %w", err)
+		}
+	}
+	*b = BabbageBlockHeaderBody{
+		BlockNumber:   tmp.BlockNumber,
+		Slot:          tmp.Slot,
+		PrevHash:      prevHash,
+		IssuerVkey:    tmp.IssuerVkey,
+		VrfKey:        tmp.VrfKey,
+		VrfResult:     tmp.VrfResult,
+		BlockBodySize: tmp.BlockBodySize,
+		BlockBodyHash: tmp.BlockBodyHash,
+		OpCert:        tmp.OpCert,
+		ProtoVersion:  tmp.ProtoVersion,
+	}
 	b.SetCbor(cborData)
 	return nil
 }

--- a/ledger/babbage/babbage_test.go
+++ b/ledger/babbage/babbage_test.go
@@ -15,6 +15,7 @@
 package babbage
 
 import (
+	"bytes"
 	"math/big"
 	"reflect"
 	"testing"
@@ -28,6 +29,86 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func encodeBabbageHeaderWithPrevHash(
+	t *testing.T,
+	prevHash cbor.RawMessage,
+) ([]byte, []byte) {
+	t.Helper()
+	bodyCbor, err := cbor.Encode([]any{
+		uint64(0),
+		uint64(0),
+		prevHash,
+		common.IssuerVkey{},
+		[]byte{0},
+		common.VrfResult{},
+		uint64(0),
+		common.Blake2b256{},
+		BabbageOpCert{},
+		BabbageProtoVersion{},
+	})
+	require.NoError(t, err)
+	headerCbor, err := cbor.Encode([]any{
+		cbor.RawMessage(bodyCbor),
+		[]byte{0},
+	})
+	require.NoError(t, err)
+	return headerCbor, bodyCbor
+}
+
+func TestBabbageBlockHeaderPreviousHashDecoding(t *testing.T) {
+	t.Run("origin null", func(t *testing.T) {
+		headerCbor, bodyCbor := encodeBabbageHeaderWithPrevHash(
+			t,
+			cbor.RawMessage{0xf6},
+		)
+		header, err := NewBabbageBlockHeaderFromCbor(headerCbor)
+		require.NoError(t, err)
+		assert.Equal(t, common.Blake2b256{}, header.PrevHash())
+		assert.Equal(t, bodyCbor, header.Body.Cbor())
+		assert.Equal(t, headerCbor, header.Cbor())
+		assert.Equal(t, common.Blake2b256Hash(headerCbor), header.Hash())
+	})
+
+	t.Run("exact hash", func(t *testing.T) {
+		expected := common.Blake2b256(bytes.Repeat([]byte{0x42}, 32))
+		prevHash, err := cbor.Encode(expected)
+		require.NoError(t, err)
+		headerCbor, _ := encodeBabbageHeaderWithPrevHash(
+			t,
+			cbor.RawMessage(prevHash),
+		)
+		header, err := NewBabbageBlockHeaderFromCbor(headerCbor)
+		require.NoError(t, err)
+		assert.Equal(t, expected, header.PrevHash())
+	})
+
+	t.Run("short hash", func(t *testing.T) {
+		prevHash, err := cbor.Encode([]byte{0x42})
+		require.NoError(t, err)
+		headerCbor, _ := encodeBabbageHeaderWithPrevHash(
+			t,
+			cbor.RawMessage(prevHash),
+		)
+		_, err = NewBabbageBlockHeaderFromCbor(headerCbor)
+		require.ErrorContains(t, err, "expected 32 bytes, got 1")
+	})
+
+	t.Run("non-byte value", func(t *testing.T) {
+		headerCbor, _ := encodeBabbageHeaderWithPrevHash(
+			t,
+			cbor.RawMessage{0x00},
+		)
+		_, err := NewBabbageBlockHeaderFromCbor(headerCbor)
+		require.ErrorContains(t, err, "expected CBOR byte string")
+	})
+
+	t.Run("global hash remains strict", func(t *testing.T) {
+		var hash common.Blake2b256
+		_, err := cbor.Decode(cbor.RawMessage{0xf6}, &hash)
+		require.ErrorContains(t, err, "expected CBOR byte string")
+	})
+}
 
 func TestBabbageUntaggedInputSetsCoalesceBeforeDuplicateValidation(t *testing.T) {
 	input1 := shelley.NewShelleyTransactionInput(


### PR DESCRIPTION
Accept canonical CBOR `null` only for Babbage-family header previous hashes and map it to the zero hash. Non-null previous hashes and all other hash fields keep strict 32-byte decoding, while the original header bytes remain available for hashing.

Closes #2104


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Babbage block header decoding so origin headers with `null` previous hashes decode correctly, mapping them to the zero hash. Non-null previous hashes and all other hash fields keep strict 32-byte decoding, and original header bytes are preserved for hashing.

Closes #2104.

<sup>Written for commit 51f1cc198e82cecd0ddba2065d73ae6749bd1873. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed decoding of Babbage origin block headers with a null previous hash.
  * Preserved strict validation for non-null previous hashes, including malformed or incorrectly sized values.

* **Tests**
  * Added coverage for valid hashes, null hashes, short hashes, non-byte values, and strict hash decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->