### PR TITLE
fix(ledger): validate decoded array shapes

### DIFF
--- a/ledger/error.go
+++ b/ledger/error.go
@@ -647,6 +647,12 @@ func (e *ApplyTxError) UnmarshalCBOR(data []byte) error {
 		var newErr error
 		switch {
 		case failureType == ApplyTxErrorUtxowFailure:
+			if len(tmpFailure) < 2 {
+				return fmt.Errorf(
+					"ApplyTxError UtxowFailure: expected at least 2 elements, got %d",
+					len(tmpFailure),
+				)
+			}
 			// Use era-aware UTXOW failure decoding
 			utxowErr := &UtxowFailure{era: e.era}
 			if _, err := cbor.Decode(tmpFailure[1], utxowErr); err != nil {
@@ -1168,7 +1174,22 @@ type OutsideValidityIntervalUtxo struct {
 }
 
 func (e *OutsideValidityIntervalUtxo) Error() string {
-	validityInterval := e.ValidityInterval.Value().([]any)
+	value := e.ValidityInterval.Value()
+	validityInterval, ok := value.([]any)
+	if !ok {
+		return fmt.Sprintf(
+			"OutsideValidityIntervalUtxo (invalid ValidityInterval type %T, Slot %d)",
+			value,
+			e.Slot,
+		)
+	}
+	if len(validityInterval) < 2 {
+		return fmt.Sprintf(
+			"OutsideValidityIntervalUtxo (invalid ValidityInterval length %d, Slot %d)",
+			len(validityInterval),
+			e.Slot,
+		)
+	}
 	return fmt.Sprintf(
 		"OutsideValidityIntervalUtxo (ValidityInterval { invalidBefore = %v, invalidHereafter = %v }, Slot %d)",
 		validityInterval[0],

--- a/ledger/error_test.go
+++ b/ledger/error_test.go
@@ -2408,3 +2408,95 @@ func TestUtxowFailure_DijkstraUnknownTagBeyond20(t *testing.T) {
 	assert.Equal(t, uint8(EraIdDijkstra), unknownErr.Era)
 	assert.Equal(t, 21, unknownErr.FailureType)
 }
+
+func TestApplyTxErrorRejectsShortUtxowFailure(t *testing.T) {
+	cborData, err := cbor.Encode([]any{
+		[]any{uint(ApplyTxErrorUtxowFailure)},
+	})
+	require.NoError(t, err)
+
+	applyErr := &ApplyTxError{era: EraIdConway}
+	require.NotPanics(t, func() {
+		err = applyErr.UnmarshalCBOR(cborData)
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected at least 2 elements")
+}
+
+func TestNewTxSubmitErrorFromCborHandlesShortApplyTxFailure(t *testing.T) {
+	// A valid ShelleyTxValidationError envelope containing a short
+	// ApplyTxError constructor must fall back to GenericError instead of
+	// panicking while the typed decoder examines it.
+	cborData, err := cbor.Encode([]any{
+		[]any{
+			uint(EraIdConway),
+			[]any{
+				[]any{uint(ApplyTxErrorUtxowFailure)},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var decodedErr error
+	require.NotPanics(t, func() {
+		decodedErr, err = NewTxSubmitErrorFromCbor(cborData)
+	})
+	require.NoError(t, err)
+	var genericErr *GenericError
+	require.ErrorAs(t, decodedErr, &genericErr)
+}
+
+func TestOutsideValidityIntervalUtxoErrorHandlesMalformedIntervals(
+	t *testing.T,
+) {
+	decodeValue := func(t *testing.T, value any) cbor.Value {
+		t.Helper()
+		data, err := cbor.Encode(value)
+		require.NoError(t, err)
+		var decoded cbor.Value
+		_, err = cbor.Decode(data, &decoded)
+		require.NoError(t, err)
+		return decoded
+	}
+
+	testCases := []struct {
+		name     string
+		interval cbor.Value
+		expected string
+	}{
+		{
+			name:     "valid interval",
+			interval: decodeValue(t, []any{uint64(10), uint64(20)}),
+			expected: "invalidBefore = 10, invalidHereafter = 20",
+		},
+		{
+			name:     "wrong type",
+			interval: decodeValue(t, "not an interval"),
+			expected: "invalid ValidityInterval type string",
+		},
+		{
+			name:     "empty interval",
+			interval: decodeValue(t, []any{}),
+			expected: "invalid ValidityInterval length 0",
+		},
+		{
+			name:     "short interval",
+			interval: decodeValue(t, []any{uint64(10)}),
+			expected: "invalid ValidityInterval length 1",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testErr := &OutsideValidityIntervalUtxo{
+				ValidityInterval: tc.interval,
+				Slot:             30,
+			}
+			var got string
+			require.NotPanics(t, func() {
+				got = testErr.Error()
+			})
+			assert.Contains(t, got, tc.expected)
+		})
+	}
+}

--- a/ledger/verify_block_body.go
+++ b/ledger/verify_block_body.go
@@ -270,6 +270,12 @@ func CalculateBlockBodyHash(
 func GetTxBodies(txsRaw [][]string) ([]BabbageTransactionBody, error) {
 	bodies := make([]BabbageTransactionBody, 0, len(txsRaw))
 	for index, tx := range txsRaw {
+		if len(tx) == 0 {
+			return nil, fmt.Errorf(
+				"CalculateBlockBodyHash: transaction at index %d: expected at least 1 field, got 0",
+				index,
+			)
+		}
 		var tmp BabbageTransactionBody
 		bodyTmpHex := tx[0]
 		bodyTmpBytes, bodyTmpBytesError := hex.DecodeString(bodyTmpHex)

--- a/ledger/verify_block_test.go
+++ b/ledger/verify_block_test.go
@@ -1142,3 +1142,32 @@ func mustBuildOutput(t *testing.T) common.TransactionOutput {
 	require.NoError(t, err)
 	return output
 }
+
+func TestGetTxBodiesRejectsEmptyTransactionRows(t *testing.T) {
+	testCases := []struct {
+		name string
+		row  []string
+	}{
+		{name: "nil row", row: nil},
+		{name: "empty row", row: []string{}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+			require.NotPanics(t, func() {
+				_, err = GetTxBodies([][]string{tc.row})
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "expected at least 1 field")
+		})
+	}
+}
+
+func TestGetTxBodiesAcceptsBodyOnlyRows(t *testing.T) {
+	bodyCbor := []byte{0xa0}
+
+	bodies, err := GetTxBodies([][]string{{hex.EncodeToString(bodyCbor)}})
+	require.NoError(t, err)
+	require.Len(t, bodies, 1)
+}


### PR DESCRIPTION
## Summary

- validate decoded transaction rejection arrays before indexing
- format malformed validity-interval errors without panicking
- reject empty transaction rows before reading the body

## Validation

- exact-parent fail-before regression for all three panic paths
- `go test -race ./ledger/...`
- `go test -race ./protocol/localtxsubmission`
- conformance suite
- `make test`, `make lint`, and `make nilaway`
- root and nested-example builds

Closes #2020


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three panic paths in `ledger` when decoding malformed CBOR, closing #2020. Malformed data now yields descriptive errors instead of panicking during error decoding and block body parsing.

- `ApplyTxError.UnmarshalCBOR` validates that `UtxowFailure` arrays have at least 2 elements before indexing them.
- `OutsideValidityIntervalUtxo.Error` formats validity intervals that are the wrong type or too short without panicking.
- `GetTxBodies` rejects transactions with no fields before reading the body.
- Regression tests cover all three paths; `go test -race ./ledger/...` and the full validation suite pass.

<sup>Written for commit 221d3c7a87d2bd91cc6396443b8b73ef99d521b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed transaction and validity interval data.
  * Invalid or incomplete CBOR entries now return descriptive errors instead of causing panics.
  * Empty transaction rows are rejected safely, while valid body-only rows continue to be accepted.
  * Transaction submission decoding now falls back to a generic error when malformed input cannot be decoded.

* **Tests**
  * Added regression coverage for malformed transaction data, invalid validity intervals, and safe error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->