### PR TITLE
fix(consensus)!: validate Byron trust and timing configuration

### DIFF
--- a/cbor/tags.go
+++ b/cbor/tags.go
@@ -172,6 +172,9 @@ func (r *Rat) UnmarshalJSON(data []byte) error {
 		Denominator int64 `json:"denominator"`
 	}
 	if err := json.Unmarshal(data, &tmpData); err == nil {
+		if tmpData.Denominator == 0 {
+			return errors.New("invalid cbor.Rat: denominator cannot be zero")
+		}
 		r.Rat = big.NewRat(tmpData.Numerator, tmpData.Denominator)
 		return nil
 	}

--- a/consensus/byron/validate.go
+++ b/consensus/byron/validate.go
@@ -43,6 +43,12 @@ type HeaderValidator struct {
 	AllowSignatureFallback bool
 }
 
+// ErrGenesisIssuerSetEmpty indicates that Byron issuer authorization has no
+// configured trust roots and therefore cannot safely validate a main block.
+var ErrGenesisIssuerSetEmpty = errors.New(
+	"byron genesis issuer set is empty",
+)
+
 // NewHeaderValidator creates a new Byron header validator
 func NewHeaderValidator(config ByronConfig) *HeaderValidator {
 	keyHashes := make(map[string]bool)
@@ -141,6 +147,11 @@ func (v *HeaderValidator) ValidateHeader(
 
 	// For EBBs or envelope-only validation, skip signature checks
 	if input.IsEBB || input.EnvelopeOnly {
+		return result
+	}
+	if len(v.genesisKeyHashes) == 0 {
+		result.Valid = false
+		result.Errors = append(result.Errors, ErrGenesisIssuerSetEmpty)
 		return result
 	}
 
@@ -812,9 +823,9 @@ func (v *HeaderValidator) validateDelegationCertSignature(
 func (v *HeaderValidator) validateGenesisDelegate(
 	input *ValidateHeaderInput,
 ) error {
-	// If no genesis keys configured, skip this check
+	// Missing trust roots cannot authorize any issuer.
 	if len(v.genesisKeyHashes) == 0 {
-		return nil
+		return ErrGenesisIssuerSetEmpty
 	}
 
 	// Hash the issuer public key using the common Blake2b224Hash function
@@ -839,15 +850,15 @@ func (v *HeaderValidator) validateGenesisDelegate(
 func (v *HeaderValidator) validateSlotLeader(
 	input *ValidateHeaderInput,
 ) error {
-	// If no genesis keys configured, skip this check
+	// Missing trust roots cannot authorize any slot leader.
 	if len(v.config.GenesisKeyHashes) == 0 {
-		return nil
+		return ErrGenesisIssuerSetEmpty
 	}
 
 	// Get the expected slot leader
 	expectedIndex, expectedKeyHash := v.config.SlotLeader(input.Slot)
 	if expectedIndex < 0 {
-		return nil // No delegates configured
+		return ErrGenesisIssuerSetEmpty
 	}
 
 	// Hash the issuer public key

--- a/consensus/byron/validate_test.go
+++ b/consensus/byron/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -600,19 +601,14 @@ func TestValidateGenesisDelegate(t *testing.T) {
 		})
 	}
 
-	// Test with no genesis keys configured (should skip check)
+	// An empty trust root must reject every issuer.
 	configNoKeys := testByronConfig()
 	validatorNoKeys := NewHeaderValidator(configNoKeys)
 	input := &ValidateHeaderInput{
 		IssuerPubKey: make([]byte, ed25519.PublicKeySize),
 	}
 	err = validatorNoKeys.validateGenesisDelegate(input)
-	if err != nil {
-		t.Errorf(
-			"expected no error when no genesis keys configured, got: %v",
-			err,
-		)
-	}
+	require.ErrorContains(t, err, "genesis issuer set is empty")
 }
 
 func TestValidateSlotLeader(t *testing.T) {
@@ -711,7 +707,7 @@ func TestValidateSlotLeader(t *testing.T) {
 		})
 	}
 
-	// Test with no genesis keys configured (should skip check)
+	// An empty trust root must not disable slot-leader authorization.
 	configNoKeys := testByronConfig()
 	validatorNoKeys := NewHeaderValidator(configNoKeys)
 	inputNoKeys := &ValidateHeaderInput{
@@ -719,7 +715,26 @@ func TestValidateSlotLeader(t *testing.T) {
 		IssuerPubKey: make([]byte, ed25519.PublicKeySize),
 	}
 	err := validatorNoKeys.validateSlotLeader(inputNoKeys)
-	require.NoError(t, err, "expected no error when no genesis keys configured")
+	require.ErrorContains(t, err, "genesis issuer set is empty")
+}
+
+func TestValidateHeaderRejectsEmptyGenesisIssuerSet(t *testing.T) {
+	validator := NewHeaderValidator(testByronConfig())
+	result := validator.ValidateHeader(&ValidateHeaderInput{
+		Slot:            1,
+		BlockNumber:     1,
+		ProtocolMagic:   testByronProtocolMagicMainnet,
+		IssuerPubKey:    make([]byte, ed25519.PublicKeySize),
+		PrevSlot:        0,
+		PrevBlockNumber: 0,
+	})
+
+	require.False(t, result.Valid)
+	require.ErrorContains(
+		t,
+		errors.Join(result.Errors...),
+		"genesis issuer set is empty",
+	)
 }
 
 func TestSlotLeader(t *testing.T) {
@@ -785,15 +800,18 @@ func TestSlotLeader(t *testing.T) {
 
 func TestValidateHeaderFull(t *testing.T) {
 	config := testByronConfig()
-	validator := NewHeaderValidator(config)
-	// Enable fallback since we're using raw test data, not real CBOR headers
-	validator.AllowSignatureFallback = true
 
 	// Generate test key pair
 	pubKey, privKey, err := ed25519.GenerateKey(nil)
 	if err != nil {
 		t.Fatalf("ed25519.GenerateKey failed: %v", err)
 	}
+	config.GenesisKeyHashes = [][]byte{
+		common.Blake2b224Hash(pubKey).Bytes(),
+	}
+	validator := NewHeaderValidator(config)
+	// Enable fallback since we're using raw test data, not real CBOR headers
+	validator.AllowSignatureFallback = true
 	message := []byte("test header body")
 	signature := ed25519.Sign(privKey, message)
 	prevHash := make([]byte, 32)

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -18,6 +18,8 @@ package consensus
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"math/big"
 	"os"
@@ -100,7 +102,51 @@ func NewNetworkConfigFromReader(r io.Reader) (NetworkConfig, error) {
 	if err := dec.Decode(&ret); err != nil {
 		return ret, err
 	}
+	if err := ret.validate(); err != nil {
+		return NetworkConfig{}, err
+	}
 	return ret, nil
+}
+
+func (c NetworkConfig) validate() error {
+	if c.SecurityParam == 0 {
+		return errors.New(
+			"network security parameter must be greater than zero",
+		)
+	}
+	if c.ActiveSlotCoeff.Rat == nil {
+		return errors.New("network active slot coefficient is required")
+	}
+	if c.ActiveSlotCoeff.Sign() <= 0 ||
+		c.ActiveSlotCoeff.Cmp(big.NewRat(1, 1)) > 0 {
+		return fmt.Errorf(
+			"network active slot coefficient must be greater than zero and at most one: got %s",
+			c.ActiveSlotCoeff.String(),
+		)
+	}
+	if c.SlotLength.Rat == nil {
+		return errors.New("network slot length is required")
+	}
+	if c.SlotLength.Sign() <= 0 {
+		return fmt.Errorf(
+			"network slot length must be greater than zero: got %s",
+			c.SlotLength.String(),
+		)
+	}
+	if c.EpochLength == 0 {
+		return errors.New("network epoch length must be greater than zero")
+	}
+	if c.SlotsPerKESPeriod == 0 {
+		return errors.New(
+			"network slots per KES period must be greater than zero",
+		)
+	}
+	if c.MaxKESEvolutions == 0 {
+		return errors.New(
+			"network maximum KES evolutions must be greater than zero",
+		)
+	}
+	return nil
 }
 
 // NewNetworkConfigFromFile creates a NetworkConfig from a Shelley genesis JSON file.

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -86,13 +86,40 @@ func (c *NetworkConfig) ActiveSlotCoeffRat() *big.Rat {
 }
 
 // SlotDuration returns the slot length as a time.Duration.
+// It returns zero when called on a NetworkConfig that did not pass validation.
 func (c *NetworkConfig) SlotDuration() time.Duration {
-	if c.SlotLength.Rat == nil {
-		return 0
+	duration, _ := slotDuration(c.SlotLength.Rat)
+	return duration
+}
+
+func slotDuration(slotLength *big.Rat) (time.Duration, error) {
+	if slotLength == nil {
+		return 0, errors.New("network slot length is required")
 	}
-	// SlotLength is in seconds as a rational
-	f, _ := c.SlotLength.Float64()
-	return time.Duration(f * float64(time.Second))
+	if slotLength.Sign() <= 0 {
+		return 0, fmt.Errorf(
+			"network slot length must be greater than zero: got %s",
+			slotLength.String(),
+		)
+	}
+
+	nanoseconds := new(big.Rat).Mul(
+		slotLength,
+		big.NewRat(int64(time.Second), 1),
+	)
+	if nanoseconds.Denom().Cmp(big.NewInt(1)) != 0 {
+		return 0, fmt.Errorf(
+			"network slot length must be representable as whole nanoseconds: got %s seconds",
+			slotLength.String(),
+		)
+	}
+	if !nanoseconds.Num().IsInt64() {
+		return 0, fmt.Errorf(
+			"network slot length exceeds time.Duration range: got %s seconds",
+			slotLength.String(),
+		)
+	}
+	return time.Duration(nanoseconds.Num().Int64()), nil
 }
 
 // NewNetworkConfigFromReader creates a NetworkConfig from a Shelley genesis JSON reader.
@@ -124,14 +151,8 @@ func (c NetworkConfig) validate() error {
 			c.ActiveSlotCoeff.String(),
 		)
 	}
-	if c.SlotLength.Rat == nil {
-		return errors.New("network slot length is required")
-	}
-	if c.SlotLength.Sign() <= 0 {
-		return fmt.Errorf(
-			"network slot length must be greater than zero: got %s",
-			c.SlotLength.String(),
-		)
+	if _, err := slotDuration(c.SlotLength.Rat); err != nil {
+		return err
 	}
 	if c.EpochLength == 0 {
 		return errors.New("network epoch length must be greater than zero")

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consensus
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func networkConfigJSON(
+	securityParam uint64,
+	activeSlotCoeff string,
+	slotLength string,
+	epochLength uint64,
+	slotsPerKESPeriod uint64,
+	maxKESEvolutions uint64,
+) string {
+	return fmt.Sprintf(`{
+		"securityParam": %d,
+		"activeSlotsCoeff": %s,
+		"slotLength": %s,
+		"epochLength": %d,
+		"slotsPerKESPeriod": %d,
+		"maxKESEvolutions": %d
+	}`,
+		securityParam,
+		activeSlotCoeff,
+		slotLength,
+		epochLength,
+		slotsPerKESPeriod,
+		maxKESEvolutions,
+	)
+}
+
+func TestNewNetworkConfigFromReaderRejectsInvalidConfig(t *testing.T) {
+	const validRat = `{"numerator": 1, "denominator": 1}`
+	tests := []struct {
+		name        string
+		config      string
+		expectError string
+	}{
+		{
+			name:        "all zero",
+			config:      `{}`,
+			expectError: "security parameter",
+		},
+		{
+			name: "active slot coefficient zero denominator",
+			config: networkConfigJSON(
+				1,
+				`{"numerator": 1, "denominator": 0}`,
+				validRat,
+				1, 1, 1,
+			),
+			expectError: "denominator cannot be zero",
+		},
+		{
+			name: "slot length zero denominator",
+			config: networkConfigJSON(
+				1,
+				validRat,
+				`{"numerator": 1, "denominator": 0}`,
+				1, 1, 1,
+			),
+			expectError: "denominator cannot be zero",
+		},
+		{
+			name: "missing active slot coefficient",
+			config: `{
+				"securityParam": 1,
+				"slotLength": {"numerator": 1, "denominator": 1},
+				"epochLength": 1,
+				"slotsPerKESPeriod": 1,
+				"maxKESEvolutions": 1
+			}`,
+			expectError: "active slot coefficient",
+		},
+		{
+			name: "zero active slot coefficient",
+			config: networkConfigJSON(
+				1,
+				`{"numerator": 0, "denominator": 1}`,
+				validRat,
+				1, 1, 1,
+			),
+			expectError: "active slot coefficient",
+		},
+		{
+			name: "negative active slot coefficient",
+			config: networkConfigJSON(
+				1,
+				`{"numerator": -1, "denominator": 20}`,
+				validRat,
+				1, 1, 1,
+			),
+			expectError: "active slot coefficient",
+		},
+		{
+			name: "active slot coefficient above one",
+			config: networkConfigJSON(
+				1,
+				`{"numerator": 2, "denominator": 1}`,
+				validRat,
+				1, 1, 1,
+			),
+			expectError: "active slot coefficient",
+		},
+		{
+			name: "zero slot length",
+			config: networkConfigJSON(
+				1,
+				validRat,
+				`{"numerator": 0, "denominator": 1}`,
+				1, 1, 1,
+			),
+			expectError: "slot length",
+		},
+		{
+			name: "negative slot length",
+			config: networkConfigJSON(
+				1,
+				validRat,
+				`{"numerator": -1, "denominator": 1}`,
+				1, 1, 1,
+			),
+			expectError: "slot length",
+		},
+		{
+			name:        "zero epoch length",
+			config:      networkConfigJSON(1, validRat, validRat, 0, 1, 1),
+			expectError: "epoch length",
+		},
+		{
+			name:        "zero slots per KES period",
+			config:      networkConfigJSON(1, validRat, validRat, 1, 0, 1),
+			expectError: "slots per KES period",
+		},
+		{
+			name:        "zero maximum KES evolutions",
+			config:      networkConfigJSON(1, validRat, validRat, 1, 1, 0),
+			expectError: "maximum KES evolutions",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var err error
+			require.NotPanics(t, func() {
+				_, err = NewNetworkConfigFromReader(
+					strings.NewReader(test.config),
+				)
+			}, "invalid genesis config must return an error, not panic")
+			require.ErrorContains(t, err, test.expectError)
+		})
+	}
+}
+
+func TestNewNetworkConfigFromReaderAcceptsBoundaryConfig(t *testing.T) {
+	config, err := NewNetworkConfigFromReader(strings.NewReader(`{
+		"securityParam": 1,
+		"activeSlotsCoeff": {"numerator": 1, "denominator": 1},
+		"slotLength": {"numerator": 1, "denominator": 1000000000},
+		"epochLength": 1,
+		"slotsPerKESPeriod": 1,
+		"maxKESEvolutions": 1
+	}`))
+	require.NoError(t, err)
+	require.Equal(t, int64(1), config.ActiveSlotCoeff.Num().Int64())
+	require.Equal(t, int64(1), config.ActiveSlotCoeff.Denom().Int64())
+	require.Equal(t, int64(1), config.SlotLength.Num().Int64())
+	require.Equal(t, int64(1_000_000_000), config.SlotLength.Denom().Int64())
+}

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -141,6 +142,36 @@ func TestNewNetworkConfigFromReaderRejectsInvalidConfig(t *testing.T) {
 			expectError: "slot length",
 		},
 		{
+			name: "slot length below one nanosecond",
+			config: networkConfigJSON(
+				1,
+				validRat,
+				`{"numerator": 1, "denominator": 2000000000}`,
+				1, 1, 1,
+			),
+			expectError: "whole nanoseconds",
+		},
+		{
+			name: "slot length has sub-nanosecond precision",
+			config: networkConfigJSON(
+				1,
+				validRat,
+				`{"numerator": 3, "denominator": 2000000000}`,
+				1, 1, 1,
+			),
+			expectError: "whole nanoseconds",
+		},
+		{
+			name: "slot length exceeds time duration range",
+			config: networkConfigJSON(
+				1,
+				validRat,
+				`9223372036.854775808`,
+				1, 1, 1,
+			),
+			expectError: "time.Duration range",
+		},
+		{
 			name:        "zero epoch length",
 			config:      networkConfigJSON(1, validRat, validRat, 0, 1, 1),
 			expectError: "epoch length",
@@ -184,4 +215,18 @@ func TestNewNetworkConfigFromReaderAcceptsBoundaryConfig(t *testing.T) {
 	require.Equal(t, int64(1), config.ActiveSlotCoeff.Denom().Int64())
 	require.Equal(t, int64(1), config.SlotLength.Num().Int64())
 	require.Equal(t, int64(1_000_000_000), config.SlotLength.Denom().Int64())
+	require.Equal(t, time.Nanosecond, config.SlotDuration())
+}
+
+func TestNewNetworkConfigFromReaderAcceptsMaximumSlotDuration(t *testing.T) {
+	config, err := NewNetworkConfigFromReader(strings.NewReader(
+		networkConfigJSON(
+			1,
+			`{"numerator": 1, "denominator": 1}`,
+			`9223372036.854775807`,
+			1, 1, 1,
+		),
+	))
+	require.NoError(t, err)
+	require.Equal(t, time.Duration(1<<63-1), config.SlotDuration())
 }

--- a/consensus/genesis/genesis.go
+++ b/consensus/genesis/genesis.go
@@ -54,21 +54,32 @@ type GenesisConfig struct {
 	ActiveSlotCoeff *big.Rat
 
 	// GenesisWindow is 3k/f slots - the window for density comparison
-	// If zero, computed from SecurityParam and ActiveSlotCoeff
+	// If zero, it is computed from SecurityParam and ActiveSlotCoeff. A
+	// nonzero value must match that checked computation exactly.
 	GenesisWindow uint64
 }
 
-// ComputeGenesisWindow calculates the genesis window (3k/f) from parameters
+// ComputeGenesisWindow calculates the genesis window (ceiling(3k/f)) from
+// parameters. It returns an error when the parameters are invalid or the
+// result cannot be represented as a uint64.
 func ComputeGenesisWindow(
 	securityParam uint64,
 	activeSlotCoeff *big.Rat,
-) uint64 {
-	// Guard against nil, zero, or negative activeSlotCoeff: zero would
-	// divide by zero, and a negative coefficient is meaningless for an
-	// active-slot probability (and would otherwise produce a garbage
-	// window via truncated negative division).
-	if activeSlotCoeff == nil || activeSlotCoeff.Sign() <= 0 {
-		return 0
+) (uint64, error) {
+	if securityParam == 0 {
+		return 0, errors.New(
+			"genesis security parameter must be greater than zero",
+		)
+	}
+	if activeSlotCoeff == nil {
+		return 0, errors.New("genesis active slot coefficient is required")
+	}
+	if activeSlotCoeff.Sign() <= 0 ||
+		activeSlotCoeff.Cmp(big.NewRat(1, 1)) > 0 {
+		return 0, fmt.Errorf(
+			"genesis active slot coefficient must be greater than zero and at most one: got %s",
+			activeSlotCoeff.String(),
+		)
 	}
 	// Genesis window = 3k/f
 	// With k=2160 and f=0.05, window = 3*2160/0.05 = 129600 slots
@@ -95,11 +106,14 @@ func ComputeGenesisWindow(
 		result.Add(result, big.NewInt(1))
 	}
 
-	// Clamp to uint64 max if result overflows
 	if !result.IsUint64() {
-		return ^uint64(0) // max uint64
+		return 0, fmt.Errorf(
+			"computed genesis window overflows uint64: ceiling(3*%d/%s)",
+			securityParam,
+			activeSlotCoeff.String(),
+		)
 	}
-	return result.Uint64()
+	return result.Uint64(), nil
 }
 
 // ChainFragment represents a fragment of a chain for selection purposes
@@ -125,29 +139,21 @@ type GenesisSelector struct {
 
 // NewGenesisSelector creates a validated Genesis chain selector.
 func NewGenesisSelector(config GenesisConfig) (*GenesisSelector, error) {
-	if config.SecurityParam == 0 {
-		return nil, errors.New(
-			"genesis security parameter must be greater than zero",
-		)
+	computedWindow, err := ComputeGenesisWindow(
+		config.SecurityParam,
+		config.ActiveSlotCoeff,
+	)
+	if err != nil {
+		return nil, err
 	}
-	if config.ActiveSlotCoeff == nil {
-		return nil, errors.New("genesis active slot coefficient is required")
-	}
-	if config.ActiveSlotCoeff.Sign() <= 0 ||
-		config.ActiveSlotCoeff.Cmp(big.NewRat(1, 1)) > 0 {
+	if config.GenesisWindow == 0 {
+		config.GenesisWindow = computedWindow
+	} else if config.GenesisWindow != computedWindow {
 		return nil, fmt.Errorf(
-			"genesis active slot coefficient must be greater than zero and at most one: got %s",
-			config.ActiveSlotCoeff.String(),
+			"configured genesis window %d does not match computed genesis window %d",
+			config.GenesisWindow,
+			computedWindow,
 		)
-	}
-	if config.GenesisWindow == 0 {
-		config.GenesisWindow = ComputeGenesisWindow(
-			config.SecurityParam,
-			config.ActiveSlotCoeff,
-		)
-	}
-	if config.GenesisWindow == 0 {
-		return nil, errors.New("genesis window must be greater than zero")
 	}
 	return &GenesisSelector{config: config}, nil
 }

--- a/consensus/genesis/genesis.go
+++ b/consensus/genesis/genesis.go
@@ -39,6 +39,8 @@
 package genesis
 
 import (
+	"errors"
+	"fmt"
 	"math/big"
 )
 
@@ -121,15 +123,33 @@ type GenesisSelector struct {
 	config GenesisConfig
 }
 
-// NewGenesisSelector creates a new Genesis chain selector
-func NewGenesisSelector(config GenesisConfig) *GenesisSelector {
-	if config.GenesisWindow == 0 && config.ActiveSlotCoeff != nil {
+// NewGenesisSelector creates a validated Genesis chain selector.
+func NewGenesisSelector(config GenesisConfig) (*GenesisSelector, error) {
+	if config.SecurityParam == 0 {
+		return nil, errors.New(
+			"genesis security parameter must be greater than zero",
+		)
+	}
+	if config.ActiveSlotCoeff == nil {
+		return nil, errors.New("genesis active slot coefficient is required")
+	}
+	if config.ActiveSlotCoeff.Sign() <= 0 ||
+		config.ActiveSlotCoeff.Cmp(big.NewRat(1, 1)) > 0 {
+		return nil, fmt.Errorf(
+			"genesis active slot coefficient must be greater than zero and at most one: got %s",
+			config.ActiveSlotCoeff.String(),
+		)
+	}
+	if config.GenesisWindow == 0 {
 		config.GenesisWindow = ComputeGenesisWindow(
 			config.SecurityParam,
 			config.ActiveSlotCoeff,
 		)
 	}
-	return &GenesisSelector{config: config}
+	if config.GenesisWindow == 0 {
+		return nil, errors.New("genesis window must be greater than zero")
+	}
+	return &GenesisSelector{config: config}, nil
 }
 
 // Compare compares two chain fragments using Genesis rules

--- a/consensus/genesis/genesis_test.go
+++ b/consensus/genesis/genesis_test.go
@@ -16,9 +16,11 @@ package genesis
 
 import (
 	"math/big"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // testGenesisConfig returns a GenesisConfig for testing with mainnet-like parameters.
@@ -29,6 +31,16 @@ func testGenesisConfig() GenesisConfig {
 		ActiveSlotCoeff: f,
 		GenesisWindow:   ComputeGenesisWindow(2160, f),
 	}
+}
+
+func mustNewGenesisSelector(
+	t *testing.T,
+	config GenesisConfig,
+) *GenesisSelector {
+	t.Helper()
+	selector, err := NewGenesisSelector(config)
+	require.NoError(t, err)
+	return selector
 }
 
 func TestComputeGenesisWindow(t *testing.T) {
@@ -79,11 +91,101 @@ func TestComputeGenesisWindowDegenerateCoefficients(t *testing.T) {
 	)
 }
 
+// callNewGenesisSelector lets this regression exercise both the historical
+// one-result constructor and the validated two-result constructor. That keeps
+// the invalid-input assertions runnable against the exact pre-fix revision.
+func callNewGenesisSelector(
+	t *testing.T,
+	config GenesisConfig,
+) (*GenesisSelector, error) {
+	t.Helper()
+	results := reflect.ValueOf(NewGenesisSelector).Call(
+		[]reflect.Value{reflect.ValueOf(config)},
+	)
+	require.Contains(t, []int{1, 2}, len(results))
+	selector, _ := results[0].Interface().(*GenesisSelector)
+	if len(results) == 1 || results[1].IsNil() {
+		return selector, nil
+	}
+	err, ok := results[1].Interface().(error)
+	require.True(t, ok, "second constructor result must be an error")
+	return selector, err
+}
+
+func TestNewGenesisSelectorRejectsInvalidConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      GenesisConfig
+		expectError string
+	}{
+		{
+			name: "zero security parameter",
+			config: GenesisConfig{
+				ActiveSlotCoeff: big.NewRat(1, 20),
+				GenesisWindow:   1,
+			},
+			expectError: "security parameter",
+		},
+		{
+			name: "nil active slot coefficient",
+			config: GenesisConfig{
+				SecurityParam: 1,
+				GenesisWindow: 3,
+			},
+			expectError: "active slot coefficient",
+		},
+		{
+			name: "zero active slot coefficient",
+			config: GenesisConfig{
+				SecurityParam:   1,
+				ActiveSlotCoeff: big.NewRat(0, 1),
+				GenesisWindow:   3,
+			},
+			expectError: "active slot coefficient",
+		},
+		{
+			name: "negative active slot coefficient",
+			config: GenesisConfig{
+				SecurityParam:   1,
+				ActiveSlotCoeff: big.NewRat(-1, 20),
+				GenesisWindow:   3,
+			},
+			expectError: "active slot coefficient",
+		},
+		{
+			name: "active slot coefficient above one",
+			config: GenesisConfig{
+				SecurityParam:   1,
+				ActiveSlotCoeff: big.NewRat(2, 1),
+				GenesisWindow:   3,
+			},
+			expectError: "active slot coefficient",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			selector, err := callNewGenesisSelector(t, test.config)
+			require.Nil(t, selector)
+			require.ErrorContains(t, err, test.expectError)
+		})
+	}
+}
+
+func TestNewGenesisSelectorAcceptsBoundaryConfig(t *testing.T) {
+	selector, err := NewGenesisSelector(GenesisConfig{
+		SecurityParam:   1,
+		ActiveSlotCoeff: big.NewRat(1, 1),
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), selector.config.GenesisWindow)
+}
+
 // TestNewGenesisSelectorDerivedWindowCeiling pins the derived-window path
 // through NewGenesisSelector with a non-integral 3k/f, so the constructor
 // inherits the ceiling semantics too.
 func TestNewGenesisSelectorDerivedWindowCeiling(t *testing.T) {
-	selector := NewGenesisSelector(GenesisConfig{
+	selector := mustNewGenesisSelector(t, GenesisConfig{
 		SecurityParam:   2160,
 		ActiveSlotCoeff: big.NewRat(7, 100),
 	})
@@ -113,7 +215,7 @@ func TestGenesisConfig(t *testing.T) {
 
 func TestNewGenesisSelector(t *testing.T) {
 	config := testGenesisConfig()
-	selector := NewGenesisSelector(config)
+	selector := mustNewGenesisSelector(t, config)
 
 	if selector == nil {
 		t.Fatal("expected non-nil selector")
@@ -133,7 +235,7 @@ func TestNewGenesisSelectorComputesWindow(t *testing.T) {
 		GenesisWindow:   0, // Will be computed
 	}
 
-	selector := NewGenesisSelector(config)
+	selector := mustNewGenesisSelector(t, config)
 
 	expectedWindow := uint64(129600)
 	if selector.config.GenesisWindow != expectedWindow {
@@ -144,7 +246,7 @@ func TestNewGenesisSelectorComputesWindow(t *testing.T) {
 
 func TestCompareByDensity(t *testing.T) {
 	config := testGenesisConfig()
-	selector := NewGenesisSelector(config)
+	selector := mustNewGenesisSelector(t, config)
 
 	// Chain A: More blocks (higher density for same tip)
 	chainA := &SimpleChainFragment{
@@ -174,7 +276,7 @@ func TestCompareByDensity(t *testing.T) {
 
 func TestCompareByLength(t *testing.T) {
 	config := testGenesisConfig()
-	selector := NewGenesisSelector(config)
+	selector := mustNewGenesisSelector(t, config)
 
 	// Same tip slot, different block counts - more blocks = higher density
 	chainA := &SimpleChainFragment{
@@ -197,7 +299,7 @@ func TestCompareByLength(t *testing.T) {
 
 func TestCompareEqual(t *testing.T) {
 	config := testGenesisConfig()
-	selector := NewGenesisSelector(config)
+	selector := mustNewGenesisSelector(t, config)
 
 	// Equal chains
 	chain := &SimpleChainFragment{
@@ -214,7 +316,7 @@ func TestCompareEqual(t *testing.T) {
 
 func TestPreferred(t *testing.T) {
 	config := testGenesisConfig()
-	selector := NewGenesisSelector(config)
+	selector := mustNewGenesisSelector(t, config)
 
 	candidates := []ChainFragment{
 		&SimpleChainFragment{
@@ -246,7 +348,7 @@ func TestPreferred(t *testing.T) {
 
 func TestPreferredEmpty(t *testing.T) {
 	config := testGenesisConfig()
-	selector := NewGenesisSelector(config)
+	selector := mustNewGenesisSelector(t, config)
 
 	var candidates []ChainFragment
 	best := selector.Preferred(candidates)
@@ -257,7 +359,7 @@ func TestPreferredEmpty(t *testing.T) {
 
 func TestPreferredSingle(t *testing.T) {
 	config := testGenesisConfig()
-	selector := NewGenesisSelector(config)
+	selector := mustNewGenesisSelector(t, config)
 
 	chain := &SimpleChainFragment{
 		Intersection: 0,
@@ -274,7 +376,7 @@ func TestPreferredSingle(t *testing.T) {
 
 func TestShouldUseGenesis(t *testing.T) {
 	config := testGenesisConfig()
-	selector := NewGenesisSelector(config)
+	selector := mustNewGenesisSelector(t, config)
 
 	tests := []struct {
 		name           string
@@ -336,7 +438,7 @@ func TestShouldUseGenesis(t *testing.T) {
 
 func TestDefaultSyncThreshold(t *testing.T) {
 	config := testGenesisConfig()
-	selector := NewGenesisSelector(config)
+	selector := mustNewGenesisSelector(t, config)
 
 	threshold := selector.DefaultSyncThreshold()
 	if threshold != config.GenesisWindow {
@@ -431,7 +533,7 @@ func TestExpectedDensity(t *testing.T) {
 func TestGenesisVsPraosScenario(t *testing.T) {
 	// Scenario: Compare chains with different densities
 	config := testGenesisConfig()
-	selector := NewGenesisSelector(config)
+	selector := mustNewGenesisSelector(t, config)
 
 	// Honest chain: Higher density (more blocks per slot)
 	honestChain := &SimpleChainFragment{

--- a/consensus/genesis/genesis_test.go
+++ b/consensus/genesis/genesis_test.go
@@ -29,7 +29,7 @@ func testGenesisConfig() GenesisConfig {
 	return GenesisConfig{
 		SecurityParam:   2160,
 		ActiveSlotCoeff: f,
-		GenesisWindow:   ComputeGenesisWindow(2160, f),
+		GenesisWindow:   129600,
 	}
 }
 
@@ -46,7 +46,8 @@ func mustNewGenesisSelector(
 func TestComputeGenesisWindow(t *testing.T) {
 	// With k=2160 and f=0.05, window = 3*2160/0.05 = 129600 slots
 	f := big.NewRat(1, 20)
-	window := ComputeGenesisWindow(2160, f)
+	window, err := ComputeGenesisWindow(2160, f)
+	require.NoError(t, err)
 
 	expected := uint64(129600)
 	if window != expected {
@@ -60,35 +61,79 @@ func TestComputeGenesisWindow(t *testing.T) {
 // the window rounds up, never down.
 func TestComputeGenesisWindowCeiling(t *testing.T) {
 	// k=2160, f=7/100: 3*2160*100/7 = 648000/7 = 92571.43... -> 92572.
-	window := ComputeGenesisWindow(2160, big.NewRat(7, 100))
+	window, err := ComputeGenesisWindow(2160, big.NewRat(7, 100))
+	require.NoError(t, err)
 	assert.Equal(
 		t, uint64(92572), window, "expected ceiling(648000/7) = 92572",
 	)
 
 	// Exact division is unaffected: k=10, f=1/2 -> 3*10*2 = 60.
-	window = ComputeGenesisWindow(10, big.NewRat(1, 2))
+	window, err = ComputeGenesisWindow(10, big.NewRat(1, 2))
+	require.NoError(t, err)
 	assert.Equal(t, uint64(60), window, "expected exact division 60")
 }
 
-// TestComputeGenesisWindowDegenerateCoefficients pins the guard: nil, zero,
-// and negative active-slot coefficients all yield a zero window rather than
-// a garbage value.
-func TestComputeGenesisWindowDegenerateCoefficients(t *testing.T) {
-	assert.Zero(
-		t,
-		ComputeGenesisWindow(2160, nil),
-		"nil coefficient: expected 0",
-	)
-	assert.Zero(
-		t,
-		ComputeGenesisWindow(2160, big.NewRat(0, 1)),
-		"zero coefficient: expected 0",
-	)
-	assert.Zero(
-		t,
-		ComputeGenesisWindow(2160, big.NewRat(-1, 20)),
-		"negative coefficient: expected 0",
-	)
+func TestComputeGenesisWindowAcceptsMaximumWindow(t *testing.T) {
+	window, err := ComputeGenesisWindow(^uint64(0)/3, big.NewRat(1, 1))
+	require.NoError(t, err)
+	require.Equal(t, ^uint64(0), window)
+}
+
+// TestComputeGenesisWindowRejectsInvalidParameters pins the checked contract:
+// invalid parameters and unrepresentable results are rejected explicitly.
+func TestComputeGenesisWindowRejectsInvalidParameters(t *testing.T) {
+	tests := []struct {
+		name            string
+		securityParam   uint64
+		activeSlotCoeff *big.Rat
+		expectError     string
+	}{
+		{
+			name:            "zero security parameter",
+			activeSlotCoeff: big.NewRat(1, 20),
+			expectError:     "security parameter",
+		},
+		{
+			name:          "nil active slot coefficient",
+			securityParam: 2160,
+			expectError:   "active slot coefficient",
+		},
+		{
+			name:            "zero active slot coefficient",
+			securityParam:   2160,
+			activeSlotCoeff: big.NewRat(0, 1),
+			expectError:     "active slot coefficient",
+		},
+		{
+			name:            "negative active slot coefficient",
+			securityParam:   2160,
+			activeSlotCoeff: big.NewRat(-1, 20),
+			expectError:     "active slot coefficient",
+		},
+		{
+			name:            "active slot coefficient above one",
+			securityParam:   2160,
+			activeSlotCoeff: big.NewRat(2, 1),
+			expectError:     "active slot coefficient",
+		},
+		{
+			name:            "window overflows uint64",
+			securityParam:   ^uint64(0),
+			activeSlotCoeff: big.NewRat(1, 1),
+			expectError:     "overflows uint64",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			window, err := ComputeGenesisWindow(
+				test.securityParam,
+				test.activeSlotCoeff,
+			)
+			require.Zero(t, window)
+			require.ErrorContains(t, err, test.expectError)
+		})
+	}
 }
 
 // callNewGenesisSelector lets this regression exercise both the historical
@@ -161,6 +206,32 @@ func TestNewGenesisSelectorRejectsInvalidConfig(t *testing.T) {
 			},
 			expectError: "active slot coefficient",
 		},
+		{
+			name: "genesis window below derived value",
+			config: GenesisConfig{
+				SecurityParam:   2160,
+				ActiveSlotCoeff: big.NewRat(1, 20),
+				GenesisWindow:   129599,
+			},
+			expectError: "does not match computed genesis window",
+		},
+		{
+			name: "genesis window above derived value",
+			config: GenesisConfig{
+				SecurityParam:   2160,
+				ActiveSlotCoeff: big.NewRat(1, 20),
+				GenesisWindow:   129601,
+			},
+			expectError: "does not match computed genesis window",
+		},
+		{
+			name: "derived genesis window overflows uint64",
+			config: GenesisConfig{
+				SecurityParam:   ^uint64(0),
+				ActiveSlotCoeff: big.NewRat(1, 1),
+			},
+			expectError: "overflows uint64",
+		},
 	}
 
 	for _, test := range tests {
@@ -179,6 +250,16 @@ func TestNewGenesisSelectorAcceptsBoundaryConfig(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, uint64(3), selector.config.GenesisWindow)
+}
+
+func TestNewGenesisSelectorAcceptsExactGenesisWindow(t *testing.T) {
+	selector, err := NewGenesisSelector(GenesisConfig{
+		SecurityParam:   2160,
+		ActiveSlotCoeff: big.NewRat(1, 20),
+		GenesisWindow:   129600,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(129600), selector.config.GenesisWindow)
 }
 
 // TestNewGenesisSelectorDerivedWindowCeiling pins the derived-window path

--- a/internal/test/conformance/byron_conformance_test.go
+++ b/internal/test/conformance/byron_conformance_test.go
@@ -771,13 +771,13 @@ func TestByronFullHeaderValidation(t *testing.T) {
 	sigType, _ := header.ConsensusData.BlockSig[0].(uint64)
 	t.Logf("Signature type: %d", sigType)
 
-	// Create validator config
-	// Note: We don't have the genesis delegate keys, so we skip that validation
+	// Configure the fixture issuer as the test's trust root so the full header
+	// path exercises issuer authorization rather than disabling it.
 	config := byronConsensus.ByronConfig{
-		ProtocolMagic:  header.ProtocolMagic,
-		SlotsPerEpoch:  byron.ByronSlotsPerEpoch,
-		NumGenesisKeys: 7, // Mainnet had 7 genesis delegates
-		// GenesisKeyHashes not set - will skip delegate validation
+		ProtocolMagic:    header.ProtocolMagic,
+		SlotsPerEpoch:    byron.ByronSlotsPerEpoch,
+		NumGenesisKeys:   1,
+		GenesisKeyHashes: [][]byte{common.Blake2b224Hash(pubKey).Bytes()},
 	}
 
 	validator := byronConsensus.NewHeaderValidator(config)


### PR DESCRIPTION
## Summary

- reject empty Byron trust roots during full header validation
- validate genesis timing parameters and checked window bounds
- reject slot durations that cannot be represented exactly

## Compatibility

`ComputeGenesisWindow` and `NewGenesisSelector` now return validation errors.
This is a published pre-v1 API change and requires a minor-line release note.

## Validation

- exact-parent red regressions for empty roots and invalid timing boundaries
- focused `-race` consensus, genesis, Byron, and CBOR tests
- full root and nested-example tests and builds
- full lint, formatting, golines, and diff checks

Closes #2041


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects misconfigured Byron consensus and genesis settings so invalid block headers and timing values fail closed instead of silently passing validation.

Previously, empty Byron trust roots skipped issuer authorization, and invalid genesis timing parameters returned zero or garbage values. Now empty trust roots reject headers, and genesis timing must satisfy checked bounds: security parameter, active slot coefficient, slot length (must be whole nanoseconds within `time.Duration` range), epoch length, slots per KES period, and max KES evolutions. `ComputeGenesisWindow` requires a nonzero security parameter, a coefficient in (0, 1], and a result that fits in `uint64`; `NewGenesisSelector` validates the configured window matches the computed value exactly.

- `ComputeGenesisWindow` now returns `(uint64, error)`.
- `NewGenesisSelector` now returns `(*GenesisSelector, error)`.
- Both signature changes are breaking and require a minor-line release note.
- `cbor.Rat` unmarshaling now rejects a zero denominator.
- `SlotDuration` returns zero for configs that failed validation.

<sup>Written for commit 3d37c9fed4ad3aad56bd77f22523bd5f4c3d67fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

