### PR TITLE
fix(ledger): accept null origin prev_hash in Shelley-family headers

### DIFF
--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -234,13 +234,56 @@ type ShelleyBlockHeaderBody struct {
 	ProtoMinorVersion    uint64
 }
 
+type shelleyBlockHeaderBodyWire struct {
+	cbor.StructAsArray
+	BlockNumber          uint64
+	Slot                 uint64
+	PrevHash             cbor.RawMessage
+	IssuerVkey           common.IssuerVkey
+	VrfKey               []byte
+	NonceVrf             common.VrfResult
+	LeaderVrf            common.VrfResult
+	BlockBodySize        uint64
+	BlockBodyHash        common.Blake2b256
+	OpCertHotVkey        []byte
+	OpCertSequenceNumber uint32
+	OpCertKesPeriod      uint32
+	OpCertSignature      []byte
+	ProtoMajorVersion    uint64
+	ProtoMinorVersion    uint64
+}
+
 func (b *ShelleyBlockHeaderBody) UnmarshalCBOR(cborData []byte) error {
-	type tShelleyBlockHeaderBody ShelleyBlockHeaderBody
-	var tmp tShelleyBlockHeaderBody
+	var tmp shelleyBlockHeaderBodyWire
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
 		return err
 	}
-	*b = ShelleyBlockHeaderBody(tmp)
+	var prevHash common.Blake2b256
+	// Origin headers encode prev_hash as null. Keep that compatibility scoped
+	// to this field while non-null hashes use the globally strict decoder.
+	// Mirrors BabbageBlockHeaderBody; this body serves Shelley through Alonzo.
+	if len(tmp.PrevHash) != 1 || tmp.PrevHash[0] != 0xf6 {
+		if _, err := cbor.Decode(tmp.PrevHash, &prevHash); err != nil {
+			return fmt.Errorf("decode previous hash: %w", err)
+		}
+	}
+	*b = ShelleyBlockHeaderBody{
+		BlockNumber:          tmp.BlockNumber,
+		Slot:                 tmp.Slot,
+		PrevHash:             prevHash,
+		IssuerVkey:           tmp.IssuerVkey,
+		VrfKey:               tmp.VrfKey,
+		NonceVrf:             tmp.NonceVrf,
+		LeaderVrf:            tmp.LeaderVrf,
+		BlockBodySize:        tmp.BlockBodySize,
+		BlockBodyHash:        tmp.BlockBodyHash,
+		OpCertHotVkey:        tmp.OpCertHotVkey,
+		OpCertSequenceNumber: tmp.OpCertSequenceNumber,
+		OpCertKesPeriod:      tmp.OpCertKesPeriod,
+		OpCertSignature:      tmp.OpCertSignature,
+		ProtoMajorVersion:    tmp.ProtoMajorVersion,
+		ProtoMinorVersion:    tmp.ProtoMinorVersion,
+	}
 	b.SetCbor(cborData)
 	return nil
 }

--- a/ledger/shelley/shelley_test.go
+++ b/ledger/shelley/shelley_test.go
@@ -1,6 +1,7 @@
 package shelley_test
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 
@@ -82,4 +83,92 @@ func TestShelleyOutputTooSmallErrorFormatting(t *testing.T) {
 	if errStr != expected {
 		t.Fatalf("unexpected error: %s", errStr)
 	}
+}
+
+func encodeShelleyHeaderWithPrevHash(
+	t *testing.T,
+	prevHash cbor.RawMessage,
+) ([]byte, []byte) {
+	t.Helper()
+	bodyCbor, err := cbor.Encode([]any{
+		uint64(0),
+		uint64(0),
+		prevHash,
+		common.IssuerVkey{},
+		[]byte{0},
+		common.VrfResult{},
+		common.VrfResult{},
+		uint64(0),
+		common.Blake2b256{},
+		[]byte{0},
+		uint32(0),
+		uint32(0),
+		[]byte{0},
+		uint64(0),
+		uint64(0),
+	})
+	require.NoError(t, err)
+	headerCbor, err := cbor.Encode([]any{
+		cbor.RawMessage(bodyCbor),
+		[]byte{0},
+	})
+	require.NoError(t, err)
+	return headerCbor, bodyCbor
+}
+
+// TestShelleyBlockHeaderPreviousHashDecoding mirrors the Babbage coverage: this
+// header body serves Shelley through Alonzo, so an origin header rejected here
+// makes a chain starting in any of those eras undecodable from its first block.
+func TestShelleyBlockHeaderPreviousHashDecoding(t *testing.T) {
+	t.Run("origin null", func(t *testing.T) {
+		headerCbor, bodyCbor := encodeShelleyHeaderWithPrevHash(
+			t,
+			cbor.RawMessage{0xf6},
+		)
+		header, err := shelley.NewShelleyBlockHeaderFromCbor(headerCbor)
+		require.NoError(t, err)
+		assert.Equal(t, common.Blake2b256{}, header.PrevHash())
+		assert.Equal(t, bodyCbor, header.Body.Cbor())
+		assert.Equal(t, headerCbor, header.Cbor())
+		assert.Equal(t, common.Blake2b256Hash(headerCbor), header.Hash())
+	})
+
+	t.Run("exact hash", func(t *testing.T) {
+		expected := common.Blake2b256(bytes.Repeat([]byte{0x42}, 32))
+		prevHash, err := cbor.Encode(expected)
+		require.NoError(t, err)
+		headerCbor, _ := encodeShelleyHeaderWithPrevHash(
+			t,
+			cbor.RawMessage(prevHash),
+		)
+		header, err := shelley.NewShelleyBlockHeaderFromCbor(headerCbor)
+		require.NoError(t, err)
+		assert.Equal(t, expected, header.PrevHash())
+	})
+
+	t.Run("short hash", func(t *testing.T) {
+		prevHash, err := cbor.Encode([]byte{0x42})
+		require.NoError(t, err)
+		headerCbor, _ := encodeShelleyHeaderWithPrevHash(
+			t,
+			cbor.RawMessage(prevHash),
+		)
+		_, err = shelley.NewShelleyBlockHeaderFromCbor(headerCbor)
+		require.ErrorContains(t, err, "expected 32 bytes, got 1")
+	})
+
+	t.Run("non-byte value", func(t *testing.T) {
+		headerCbor, _ := encodeShelleyHeaderWithPrevHash(
+			t,
+			cbor.RawMessage{0x00},
+		)
+		_, err := shelley.NewShelleyBlockHeaderFromCbor(headerCbor)
+		require.ErrorContains(t, err, "expected CBOR byte string")
+	})
+
+	t.Run("global hash remains strict", func(t *testing.T) {
+		var hash common.Blake2b256
+		_, err := cbor.Decode(cbor.RawMessage{0xf6}, &hash)
+		require.ErrorContains(t, err, "expected CBOR byte string")
+	})
 }


### PR DESCRIPTION
`270c74c` accepted a null `prev_hash` in `BabbageBlockHeaderBody` but left `ShelleyBlockHeaderBody` strict. That body serves Shelley, Allegra, Mary, and Alonzo, so a chain whose first block is in any of those eras still fails to decode:

```
decode Alonzo block error: decode blake2b-256 hash: expected CBOR byte string
```

## Cause

The CDDL declares the field as `prev_hash : hash32 / nil` (`ledger/dijkstra/testdata/dijkstra.cddl:55`); an origin header has no predecessor to reference. `a9f0980` gave `Blake2b256` a strict `UnmarshalCBOR` that rejects any non-byte-string input, which is correct for every other `hash32` field — `prev_hash` is the only nullable one in the CDDL. So the tolerance belongs on the field, not on the hash type.

This mirrors the Babbage wire-struct approach exactly rather than relaxing `Blake2b256`.

## Evidence

Decoding 400 real Alonzo blocks taken from Dingo's immutable-DB fixture, unchanged across all runs:

| gouroboros | result |
|:---|:---|
| `v0.197.0` | 400/400 decode |
| `760e96d` (parent of `a9f0980`) | 400/400 decode |
| `a9f0980` | 399/400 — block 0 fails |
| `v0.201.1` | 399/400 |
| `origin/main` (with `270c74c`) | 399/400 |
| this branch | 400/400 |

The one failing block is the chain's first: `block_number=0`, `slot=0`, `prev_hash=null`. `v0.197.0` decoded it to the all-zero hash, which is the value this change restores.

## Scope

Both header body types now handle it; `DijkstraBlockHeader` reuses `BabbageBlockHeaderBody`, and Byron has no `Blake2b256` prev-hash field, so the class is complete.

`TestShelleyBlockHeaderPreviousHashDecoding` mirrors the Babbage cases: origin null, exact hash, short hash, non-byte value, and an assertion that bare `Blake2b256` still rejects null. Reverting the `shelley.go` change fails the `origin null` case.

`go test -race ./...`, `go vet ./...`, `gofmt`, and `golangci-lint run ./ledger/...` all clean.

## Downstream

Dingo's `fix/3376-gouroboros-v0199` (blinklabs-io/dingo#3539) bumps to `v0.201.1` and sees 121 test failures across 5 packages from this single block. It stays blocked until this lands and is released.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts a null `prev_hash` in `ShelleyBlockHeaderBody` so chains whose first block is in the Shelley, Allegra, Mary, or Alonzo eras decode successfully. A previous fix covered only `BabbageBlockHeaderBody`; this extends the same tolerance to the Shelley body.

- Origin headers encode `prev_hash` as null because they have no predecessor; the CDDL declares it `hash32 / nil`.
- Null `prev_hash` decodes to the zero hash, restoring `v0.197.0` behavior.
- Non-null hashes and the global `Blake2b256` decoder stay strict.
- New tests cover origin null, exact hash, short hash, and non-byte values.

<sup>Written for commit 9810eb22673a98946e6effdfa4116130fb211043. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed decoding of Shelley origin block headers when the previous hash is null.
  * Preserved strict validation for valid, malformed, short, and non-byte previous-hash values.

* **Tests**
  * Added coverage for origin headers, valid hash round-trips, invalid hash lengths, and unsupported value types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->