### PR TITLE
fix(byron): validate payloads without mutating inputs

### DIFF
--- a/consensus/byron/byron.go
+++ b/consensus/byron/byron.go
@@ -262,11 +262,23 @@ func NewByronConfigFromGenesis(genesis *ledgerbyron.ByronGenesis) (ByronConfig, 
 				err,
 			)
 		}
+		// The genesis file carries omega as a JSON number, so it never had
+		// a wire encoding to preserve; encoding it here is correct.
+		omegaCbor, err := ledgerbyron.EncodeDelegationEpoch(
+			uint64(delegation.Omega),
+		)
+		if err != nil {
+			return ByronConfig{}, fmt.Errorf(
+				"encode delegation omega for genesis key %s: %w",
+				genesisHashHex,
+				err,
+			)
+		}
 		if err := genesisValidator.validateDelegationCertSignature(
 			issuerKey,
 			delegateKey,
 			certificateSignature,
-			uint64(delegation.Omega),
+			omegaCbor,
 		); err != nil {
 			return ByronConfig{}, fmt.Errorf(
 				"validate delegation certificate for genesis key %s: %w",

--- a/consensus/byron/payload_validation_test.go
+++ b/consensus/byron/payload_validation_test.go
@@ -135,6 +135,7 @@ func TestValidateEBBBodyHashMalformedProof(t *testing.T) {
 
 	var validationErr *common.ValidationError
 	require.ErrorAs(t, err, &validationErr)
+	require.NotNil(t, validationErr)
 	require.Equal(
 		t,
 		common.ValidationErrorTypeBodyHash,

--- a/consensus/byron/payload_validation_test.go
+++ b/consensus/byron/payload_validation_test.go
@@ -1,0 +1,144 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package byron
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateBlockSignatureDoesNotMutateInput pins that proxy signature
+// validation treats its ValidateHeaderInput as read-only. The type-0 branch
+// has to fill in BlockSignature from BlockSig before it can verify
+// anything, and used to write that back into the caller's struct.
+func TestValidateBlockSignatureDoesNotMutateInput(t *testing.T) {
+	validator := NewHeaderValidator(testByronConfig())
+	publicKey := bytes.Repeat([]byte{0x11}, ed25519.PublicKeySize)
+	signature := bytes.Repeat([]byte{0x22}, ed25519.SignatureSize)
+	input := &ValidateHeaderInput{
+		Slot:         100,
+		BlockNumber:  10,
+		IssuerPubKey: publicKey,
+		BlockSig:     []any{uint64(byronSigTypeSimple), signature},
+	}
+
+	// The verification itself fails -- the signature is not real -- but
+	// what matters here is what it leaves behind.
+	require.Error(t, validator.validateBlockSignature(input))
+	require.Empty(
+		t,
+		input.BlockSignature,
+		"validation must not write the extracted signature back "+
+			"into the caller's input",
+	)
+	require.Len(t, input.BlockSig, 2)
+}
+
+// TestValidateBlockSignatureInputReuse exercises the consequence of that
+// mutation directly: a caller that reuses one ValidateHeaderInput across
+// blocks must not have the first block's signature carried into the second.
+func TestValidateBlockSignatureInputReuse(t *testing.T) {
+	validator := NewHeaderValidator(testByronConfig())
+	publicKey := bytes.Repeat([]byte{0x11}, ed25519.PublicKeySize)
+	signature := bytes.Repeat([]byte{0x22}, ed25519.SignatureSize)
+	input := &ValidateHeaderInput{
+		Slot:         100,
+		BlockNumber:  10,
+		IssuerPubKey: publicKey,
+		BlockSig:     []any{uint64(byronSigTypeSimple), signature},
+	}
+	require.Error(t, validator.validateBlockSignature(input))
+
+	// Second header through the same struct, this time carrying no
+	// signature at all. It must be rejected for having none, rather than
+	// being checked against the signature left over from the first.
+	input.Slot = 101
+	input.BlockNumber = 11
+	input.BlockSig = nil
+	err := validator.validateBlockSignature(input)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid block signature size: got 0")
+}
+
+// TestValidateBodyHashRealMainnetBlockWithPayloadValidation confirms the
+// opt-in payload check does not reject a real mainnet block.
+func TestValidateBodyHashRealMainnetBlockWithPayloadValidation(t *testing.T) {
+	blockBytes, err := hex.DecodeString(testByronMainBlockHex)
+	require.NoError(t, err)
+	block, err := byron.NewByronMainBlockFromCbor(
+		blockBytes,
+		common.VerifyConfig{SkipBodyHashValidation: true},
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, block.ValidatePayloads())
+	require.NoError(t, ValidateBodyHash(
+		block,
+		common.VerifyConfig{EnableByronPayloadValidation: true},
+	))
+	// The same block must also survive a decode that opts in.
+	_, err = byron.NewByronMainBlockFromCbor(
+		blockBytes,
+		common.VerifyConfig{EnableByronPayloadValidation: true},
+	)
+	require.NoError(t, err)
+}
+
+// TestValidateBodyHashRejectsMalformedPayloadWhenEnabled pins that the
+// opt-in check is what catches a payload the body proof cannot: dlg_proof
+// binds the payload bytes to the header, so a block carrying a malformed
+// certificate still passes the default validation.
+func TestValidateBodyHashRejectsMalformedPayloadWhenEnabled(t *testing.T) {
+	block := &byron.ByronMainBlock{
+		BlockHeader: &byron.ByronMainBlockHeader{ProtocolMagic: 764824073},
+		Body: byron.ByronMainBlockBody{
+			DlgPayload: []any{[]any{uint64(1), uint64(2)}},
+		},
+	}
+	require.ErrorIs(
+		t,
+		block.ValidateDelegationPayload(),
+		byron.ErrInvalidPayload,
+	)
+}
+
+// TestValidateEBBBodyHashMalformedProof pins that an EBB whose body proof
+// is not a hash at all is reported as malformed rather than as a mismatch
+// against the zero hash that used to stand in for it.
+func TestValidateEBBBodyHashMalformedProof(t *testing.T) {
+	block := &byron.ByronEpochBoundaryBlock{
+		BlockHeader: &byron.ByronEpochBoundaryBlockHeader{
+			BodyProof: []any{uint64(0)},
+		},
+	}
+	err := ValidateEBBBodyHash(block)
+	require.Error(t, err)
+	require.ErrorIs(t, err, byron.ErrMalformedBodyProof)
+
+	var validationErr *common.ValidationError
+	require.ErrorAs(t, err, &validationErr)
+	require.Equal(
+		t,
+		common.ValidationErrorTypeBodyHash,
+		validationErr.Type,
+	)
+	require.Contains(t, validationErr.Message, "malformed EBB body proof")
+}

--- a/consensus/byron/pbft_delegation.go
+++ b/consensus/byron/pbft_delegation.go
@@ -179,12 +179,46 @@ func (s PBFTDelegationState) Tick(
 // payload and performs the delegation tick for that block. The update is
 // atomic: malformed or invalid certificates leave the input state unchanged.
 //
+// It takes the payload as the decoder produced it, which means each
+// certificate's epoch is re-encoded before its signature is checked. CBOR
+// admits non-shortest integer encodings that this decoder accepts, so a
+// certificate whose epoch arrived in one of those forms will not verify
+// here -- the issuer signed the bytes on the wire, and a decoded uint64
+// cannot reproduce them. See byron.DelegationCertificate.EpochCbor.
+//
+// Deprecated: use ApplyPayloadCbor, which takes the preserved encodings and
+// does not have that limitation. This method is kept so existing callers
+// holding a ByronMainBlockBody.DlgPayload keep compiling while they
+// migrate; it behaves exactly as it did before ApplyPayloadCbor existed.
+func (s PBFTDelegationState) ApplyPayload(
+	currentEpoch uint64,
+	currentSlot uint64,
+	payload []any,
+) (PBFTDelegationState, error) {
+	raw := make([]cbor.RawMessage, 0, len(payload))
+	for i, certificate := range payload {
+		encoded, err := cbor.Encode(certificate)
+		if err != nil {
+			return PBFTDelegationState{}, fmt.Errorf(
+				"encode Byron PBFT delegation certificate %d: %w", i, err,
+			)
+		}
+		raw = append(raw, encoded)
+	}
+	return s.ApplyPayloadCbor(currentEpoch, currentSlot, raw)
+}
+
+// ApplyPayloadCbor schedules the certificates in a Byron main-block
+// delegation payload and performs the delegation tick for that block. The
+// update is atomic: malformed or invalid certificates leave the input state
+// unchanged.
+//
 // The payload is taken as each certificate's preserved CBOR rather than as
 // decoded values, because a certificate's signature covers its epoch
 // field's wire encoding -- see byron.DelegationCertificate.EpochCbor. Call
 // it with byron.ByronMainBlockBody.DlgPayloadCbor decoded into
 // []cbor.RawMessage.
-func (s PBFTDelegationState) ApplyPayload(
+func (s PBFTDelegationState) ApplyPayloadCbor(
 	currentEpoch uint64,
 	currentSlot uint64,
 	payload []cbor.RawMessage,

--- a/consensus/byron/pbft_delegation.go
+++ b/consensus/byron/pbft_delegation.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
@@ -176,10 +178,16 @@ func (s PBFTDelegationState) Tick(
 // ApplyPayload schedules the certificates in a Byron main-block delegation
 // payload and performs the delegation tick for that block. The update is
 // atomic: malformed or invalid certificates leave the input state unchanged.
+//
+// The payload is taken as each certificate's preserved CBOR rather than as
+// decoded values, because a certificate's signature covers its epoch
+// field's wire encoding -- see byron.DelegationCertificate.EpochCbor. Call
+// it with byron.ByronMainBlockBody.DlgPayloadCbor decoded into
+// []cbor.RawMessage.
 func (s PBFTDelegationState) ApplyPayload(
 	currentEpoch uint64,
 	currentSlot uint64,
-	payload []any,
+	payload []cbor.RawMessage,
 ) (PBFTDelegationState, error) {
 	next := s.clone()
 	for i, rawCertificate := range payload {
@@ -241,20 +249,13 @@ func (s PBFTDelegationState) clone() PBFTDelegationState {
 func (s *PBFTDelegationState) scheduleCertificate(
 	currentEpoch uint64,
 	currentSlot uint64,
-	rawCertificate any,
+	rawCertificate cbor.RawMessage,
 ) error {
-	certificate, ok := rawCertificate.([]any)
-	if !ok || len(certificate) != 4 {
-		return fmt.Errorf(
-			"invalid certificate shape: got %T with %d elements",
-			rawCertificate,
-			len(certificate),
-		)
-	}
-	delegationEpoch, err := extractUint64(certificate[0])
+	certificate, err := byron.ParseDelegationCertificate(rawCertificate)
 	if err != nil {
-		return fmt.Errorf("decode delegation epoch: %w", err)
+		return err
 	}
+	delegationEpoch := certificate.Epoch
 	if delegationEpoch < currentEpoch ||
 		delegationEpoch-currentEpoch > 1 {
 		return fmt.Errorf(
@@ -263,31 +264,7 @@ func (s *PBFTDelegationState) scheduleCertificate(
 			currentEpoch,
 		)
 	}
-	issuerKey, ok := certificate[1].([]byte)
-	if !ok || len(issuerKey) != 64 {
-		return fmt.Errorf(
-			"invalid issuer verification key: got %T with length %d",
-			certificate[1],
-			len(issuerKey),
-		)
-	}
-	delegateKey, ok := certificate[2].([]byte)
-	if !ok || len(delegateKey) != 64 {
-		return fmt.Errorf(
-			"invalid delegate verification key: got %T with length %d",
-			certificate[2],
-			len(delegateKey),
-		)
-	}
-	certificateSignature, ok := certificate[3].([]byte)
-	if !ok || len(certificateSignature) != 64 {
-		return fmt.Errorf(
-			"invalid certificate signature: got %T with length %d",
-			certificate[3],
-			len(certificateSignature),
-		)
-	}
-	delegator, err := PBFTVerificationKeyHash(issuerKey)
+	delegator, err := PBFTVerificationKeyHash(certificate.IssuerVK)
 	if err != nil {
 		return fmt.Errorf("derive delegation issuer: %w", err)
 	}
@@ -323,18 +300,10 @@ func (s *PBFTDelegationState) scheduleCertificate(
 			)
 		}
 	}
-	validator := NewHeaderValidator(ByronConfig{
-		ProtocolMagic: s.protocolMagic,
-	})
-	if err := validator.validateDelegationCertSignature(
-		issuerKey,
-		delegateKey,
-		certificateSignature,
-		delegationEpoch,
-	); err != nil {
+	if err := certificate.Verify(s.protocolMagic); err != nil {
 		return fmt.Errorf("validate delegation certificate: %w", err)
 	}
-	delegate, err := PBFTVerificationKeyHash(delegateKey)
+	delegate, err := PBFTVerificationKeyHash(certificate.DelegateVK)
 	if err != nil {
 		return fmt.Errorf("derive delegation delegate: %w", err)
 	}

--- a/consensus/byron/pbft_delegation_test.go
+++ b/consensus/byron/pbft_delegation_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/stretchr/testify/require"
 )
@@ -56,7 +57,7 @@ func signedPBFTDelegationCertificate(
 	require.NoError(t, err)
 	protocolMagicCbor, err := cbor.Encode(protocolMagic)
 	require.NoError(t, err)
-	signed := []byte{byronSignTagCertificate}
+	signed := []byte{byron.SignTagCertificate}
 	signed = append(signed, protocolMagicCbor...)
 	signed = append(signed, innerCbor...)
 	return []any{

--- a/consensus/byron/pbft_delegation_test.go
+++ b/consensus/byron/pbft_delegation_test.go
@@ -105,7 +105,7 @@ func TestPBFTDelegationStateActivationAndRevocation(t *testing.T) {
 		issuerPrivateKey,
 		replacementDelegateKey,
 	)
-	state, err = state.ApplyPayload(
+	state, err = state.ApplyPayloadCbor(
 		1, 101, []cbor.RawMessage{activationCertificate},
 	)
 	require.NoError(t, err)
@@ -132,7 +132,7 @@ func TestPBFTDelegationStateActivationAndRevocation(t *testing.T) {
 		issuerPrivateKey,
 		issuerKey,
 	)
-	state, err = state.ApplyPayload(
+	state, err = state.ApplyPayloadCbor(
 		2, 201, []cbor.RawMessage{revocationCertificate},
 	)
 	require.NoError(t, err)
@@ -229,7 +229,7 @@ func TestPBFTDelegationStateRejectsInvalidPayloadAtomically(t *testing.T) {
 	)
 	malformed, err := cbor.Encode([]any{})
 	require.NoError(t, err)
-	_, err = state.ApplyPayload(
+	_, err = state.ApplyPayloadCbor(
 		1, 101, []cbor.RawMessage{certificate, malformed},
 	)
 	require.ErrorContains(
@@ -270,8 +270,62 @@ func TestPBFTDelegationStateRejectsDuplicateEpoch(t *testing.T) {
 		issuerPrivateKey,
 		replacementDelegateKey,
 	)
-	state, err = state.ApplyPayload(1, 101, []cbor.RawMessage{certificate})
+	state, err = state.ApplyPayloadCbor(1, 101, []cbor.RawMessage{certificate})
 	require.NoError(t, err)
-	_, err = state.ApplyPayload(1, 102, []cbor.RawMessage{certificate})
+	_, err = state.ApplyPayloadCbor(1, 102, []cbor.RawMessage{certificate})
 	require.ErrorContains(t, err, "already delegated for epoch 1")
+}
+
+// TestPBFTDelegationStateApplyPayloadDecodedCompat pins the deprecated
+// ApplyPayload entry point, which downstream callers reach with a decoded
+// ByronMainBlockBody.DlgPayload ([]any) rather than preserved CBOR.
+func TestPBFTDelegationStateApplyPayloadDecodedCompat(t *testing.T) {
+	const protocolMagic = uint32(42)
+	issuerKey, issuerPrivateKey := deterministicPBFTVerificationKey(0x61)
+	initialDelegateKey, _ := deterministicPBFTVerificationKey(0x62)
+	replacementDelegateKey, _ := deterministicPBFTVerificationKey(0x63)
+	issuerHash, err := PBFTVerificationKeyHash(issuerKey)
+	require.NoError(t, err)
+	initialDelegateHash, err := PBFTVerificationKeyHash(initialDelegateKey)
+	require.NoError(t, err)
+	replacementHash, err := PBFTVerificationKeyHash(replacementDelegateKey)
+	require.NoError(t, err)
+	state, err := NewPBFTDelegationState(ByronConfig{
+		ProtocolMagic:    protocolMagic,
+		SecurityParam:    10,
+		GenesisKeyHashes: [][]byte{issuerHash.Bytes()},
+		GenesisDelegations: map[common.Blake2b224]common.Blake2b224{
+			issuerHash: initialDelegateHash,
+		},
+	})
+	require.NoError(t, err)
+
+	certificate := signedPBFTDelegationCertificate(
+		t,
+		protocolMagic,
+		1,
+		issuerKey,
+		issuerPrivateKey,
+		replacementDelegateKey,
+	)
+	// Decode the certificate the way a block body would present it, so the
+	// payload has the []any shape the deprecated entry point takes.
+	var decoded []any
+	_, err = cbor.Decode(certificate, &decoded)
+	require.NoError(t, err)
+
+	state, err = state.ApplyPayload(1, 101, []any{decoded})
+	require.NoError(t, err)
+	state = state.Tick(1, 121)
+	require.Equal(
+		t,
+		replacementHash,
+		state.ActiveDelegations()[issuerHash],
+		"the decoded payload path must still schedule and activate",
+	)
+
+	_, err = state.ApplyPayload(1, 101, []any{"not a certificate"})
+	require.ErrorContains(
+		t, err, "delegation certificate is not a 4-element array",
+	)
 }

--- a/consensus/byron/pbft_delegation_test.go
+++ b/consensus/byron/pbft_delegation_test.go
@@ -45,7 +45,7 @@ func signedPBFTDelegationCertificate(
 	issuerKey []byte,
 	issuerPrivateKey ed25519.PrivateKey,
 	delegateKey []byte,
-) []any {
+) cbor.RawMessage {
 	t.Helper()
 	epochCbor, err := cbor.Encode(epoch)
 	require.NoError(t, err)
@@ -60,12 +60,14 @@ func signedPBFTDelegationCertificate(
 	signed := []byte{byron.SignTagCertificate}
 	signed = append(signed, protocolMagicCbor...)
 	signed = append(signed, innerCbor...)
-	return []any{
+	encoded, err := cbor.Encode([]any{
 		epoch,
 		append([]byte(nil), issuerKey...),
 		append([]byte(nil), delegateKey...),
 		ed25519.Sign(issuerPrivateKey, signed),
-	}
+	})
+	require.NoError(t, err)
+	return encoded
 }
 
 func TestPBFTDelegationStateActivationAndRevocation(t *testing.T) {
@@ -103,7 +105,9 @@ func TestPBFTDelegationStateActivationAndRevocation(t *testing.T) {
 		issuerPrivateKey,
 		replacementDelegateKey,
 	)
-	state, err = state.ApplyPayload(1, 101, []any{activationCertificate})
+	state, err = state.ApplyPayload(
+		1, 101, []cbor.RawMessage{activationCertificate},
+	)
 	require.NoError(t, err)
 	require.Equal(
 		t,
@@ -128,7 +132,9 @@ func TestPBFTDelegationStateActivationAndRevocation(t *testing.T) {
 		issuerPrivateKey,
 		issuerKey,
 	)
-	state, err = state.ApplyPayload(2, 201, []any{revocationCertificate})
+	state, err = state.ApplyPayload(
+		2, 201, []cbor.RawMessage{revocationCertificate},
+	)
 	require.NoError(t, err)
 	state = state.Tick(2, 220)
 	require.Equal(
@@ -221,8 +227,14 @@ func TestPBFTDelegationStateRejectsInvalidPayloadAtomically(t *testing.T) {
 		issuerPrivateKey,
 		replacementDelegateKey,
 	)
-	_, err = state.ApplyPayload(1, 101, []any{certificate, []any{}})
-	require.ErrorContains(t, err, "invalid certificate shape")
+	malformed, err := cbor.Encode([]any{})
+	require.NoError(t, err)
+	_, err = state.ApplyPayload(
+		1, 101, []cbor.RawMessage{certificate, malformed},
+	)
+	require.ErrorContains(
+		t, err, "delegation certificate is not a 4-element array",
+	)
 	require.Equal(
 		t,
 		initialDelegateHash,
@@ -258,8 +270,8 @@ func TestPBFTDelegationStateRejectsDuplicateEpoch(t *testing.T) {
 		issuerPrivateKey,
 		replacementDelegateKey,
 	)
-	state, err = state.ApplyPayload(1, 101, []any{certificate})
+	state, err = state.ApplyPayload(1, 101, []cbor.RawMessage{certificate})
 	require.NoError(t, err)
-	_, err = state.ApplyPayload(1, 102, []any{certificate})
+	_, err = state.ApplyPayload(1, 102, []cbor.RawMessage{certificate})
 	require.ErrorContains(t, err, "already delegated for epoch 1")
 }

--- a/consensus/byron/validate.go
+++ b/consensus/byron/validate.go
@@ -445,12 +445,36 @@ func (v *HeaderValidator) validateProxySignature(
 		)
 	}
 
-	// Extract certificate components
+	// Extract certificate components. The epoch is taken twice: as a value
+	// for the checks below, and as its preserved wire encoding, which is
+	// what the certificate signature actually covers.
 	epochOrOmega, err := extractUint64(
 		cert[0],
 	) // epochOrOmega - used for replay protection
 	if err != nil {
 		return fmt.Errorf("failed to extract epoch/omega from cert: %w", err)
+	}
+	epochCbor, err := proxyCertEpochCbor(input.HeaderCbor)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to recover delegation certificate epoch encoding: %w",
+			err,
+		)
+	}
+	// Confirm the walk through the raw header landed on the same field the
+	// decoded BlockSig holds, so a header whose shape differs from what
+	// proxyCertEpochCbor assumes is rejected rather than verified against
+	// some other field's bytes.
+	var recoveredEpoch uint64
+	if _, err := cbor.Decode(epochCbor, &recoveredEpoch); err != nil {
+		return fmt.Errorf("decode delegation certificate epoch: %w", err)
+	}
+	if recoveredEpoch != epochOrOmega {
+		return fmt.Errorf(
+			"delegation certificate epoch encoding %x decodes to %d, "+
+				"but the header's decoded certificate says %d",
+			epochCbor, recoveredEpoch, epochOrOmega,
+		)
 	}
 
 	issuerVK, ok := cert[1].([]byte)
@@ -528,7 +552,7 @@ func (v *HeaderValidator) validateProxySignature(
 	// from cardano-ledger-byron's Delegation/Certificate.hs and
 	// cardano-crypto's Signing/{Tag,Signature}.hs.
 	if err := v.validateDelegationCertSignature(
-		issuerVK, delegateVK, certSig, epochOrOmega,
+		issuerVK, delegateVK, certSig, epochCbor,
 	); err != nil {
 		return fmt.Errorf(
 			"delegation certificate signature verification failed: %w",
@@ -592,6 +616,56 @@ func (v *HeaderValidator) validateProxySignature(
 	}
 
 	return nil
+}
+
+// proxyCertEpochCbor recovers the preserved wire encoding of the epoch
+// field inside a header's proxy delegation certificate, by walking the
+// header's own CBOR:
+//
+//	header[3]         -> consensus_data
+//	consensus_data[3] -> block_sig
+//	block_sig[1]      -> [certificate, block_signature]
+//	certificate[0]    -> epoch
+//
+// The decoded BlockSig cannot supply this. CBOR admits non-shortest integer
+// encodings and this decoder accepts them, so an epoch that arrived as
+// 0x1807 decodes to 7 and re-encodes to 0x07 -- and the issuer signed the
+// bytes on the wire, not the round trip.
+func proxyCertEpochCbor(headerCbor []byte) ([]byte, error) {
+	if len(headerCbor) == 0 {
+		return nil, errors.New(
+			"header CBOR is required to recover the certificate epoch",
+		)
+	}
+	path := []struct {
+		label string
+		index int
+		count int
+	}{
+		{label: "header", index: 3, count: 5},
+		{label: "consensus data", index: 3, count: 4},
+		{label: "block signature", index: 1, count: 2},
+		{label: "delegation signature", index: 0, count: 2},
+		{label: "delegation certificate", index: 0, count: 4},
+	}
+	current := cbor.RawMessage(headerCbor)
+	for _, step := range path {
+		var elements []cbor.RawMessage
+		if _, err := cbor.Decode(current, &elements); err != nil {
+			return nil, fmt.Errorf("decode %s: %w", step.label, err)
+		}
+		if len(elements) != step.count {
+			return nil, fmt.Errorf(
+				"%s is not a %d-element array, got %d elements",
+				step.label, step.count, len(elements),
+			)
+		}
+		current = elements[step.index]
+	}
+	if len(current) == 0 {
+		return nil, errors.New("delegation certificate epoch encoding is empty")
+	}
+	return current, nil
 }
 
 // Byron signing tags used by header validation. The full set, and the
@@ -721,9 +795,12 @@ func extractUint64(v any) (uint64, error) {
 // in byron.VerifyDelegationCertificateSignature, so that header validation
 // here and delegation payload validation in ledger/byron cannot drift
 // apart.
+//
+// epochCbor is the epoch field's preserved wire encoding, not a re-encoding
+// of its decoded value -- see that function's doc comment.
 func (v *HeaderValidator) validateDelegationCertSignature(
 	issuerVK, delegateVK, certSig []byte,
-	epochOrOmega uint64,
+	epochCbor []byte,
 ) error {
 	// Check if verification should be skipped
 	if v.SkipDelegationCertVerification {
@@ -738,7 +815,7 @@ func (v *HeaderValidator) validateDelegationCertSignature(
 		issuerVK,
 		delegateVK,
 		certSig,
-		epochOrOmega,
+		epochCbor,
 	)
 }
 

--- a/consensus/byron/validate.go
+++ b/consensus/byron/validate.go
@@ -372,7 +372,13 @@ func (v *HeaderValidator) validateBlockSignatureWithProxy(
 	switch sigType {
 	case byronSigTypeSimple:
 		// Simple signature: [0, signature]
-		// If BlockSignature is empty but BlockSig contains the signature, extract it
+		// If BlockSignature is empty but BlockSig contains the signature,
+		// extract it. The extracted signature is written to a copy of the
+		// input, never to the caller's: ValidateHeaderInput is caller-owned
+		// and callers reuse one across blocks, so filling in BlockSignature
+		// here would leave this block's signature behind for the next
+		// header validated with the same struct -- one that may carry no
+		// signature of its own, and would then be checked against this one.
 		if len(input.BlockSignature) == 0 && len(input.BlockSig) > 1 {
 			sigBytes, ok := input.BlockSig[1].([]byte)
 			if !ok {
@@ -381,7 +387,9 @@ func (v *HeaderValidator) validateBlockSignatureWithProxy(
 					input.BlockSig[1],
 				)
 			}
-			input.BlockSignature = sigBytes
+			withSig := *input
+			withSig.BlockSignature = sigBytes
+			return v.validateSimpleSignature(&withSig)
 		}
 		return v.validateSimpleSignature(input)
 
@@ -586,21 +594,13 @@ func (v *HeaderValidator) validateProxySignature(
 	return nil
 }
 
-// Byron signing tags (from cardano-sl)
+// Byron signing tags used by header validation. The full set, and the
+// signed-buffer construction they domain-separate, lives in ledger/byron
+// (sign.go) so that package's payload validation and this package's header
+// validation cannot drift apart.
 const (
-	byronSignTagTx             = 0x01
-	byronSignTagRedeemTx       = 0x02
-	byronSignTagVssCert        = 0x03
-	byronSignTagUSProposal     = 0x04
-	byronSignTagCommitment     = 0x05
-	byronSignTagUSVote         = 0x06
-	byronSignTagMainBlock      = 0x07
-	byronSignTagMainBlockLight = 0x08
-	byronSignTagMainBlockHeavy = 0x09
-	// byronSignTagCertificate is SignCertificate from cardano-crypto's
-	// Cardano.Crypto.Signing.Tag: used to sign/verify delegation
-	// certificates (see validateDelegationCertSignature).
-	byronSignTagCertificate = 0x0a
+	byronSignTagMainBlockLight = byron.SignTagMainBlockLight
+	byronSignTagMainBlockHeavy = byron.SignTagMainBlockHeavy
 )
 
 // buildToSign constructs the ToSign data that is actually signed in Byron blocks.
@@ -710,29 +710,17 @@ func extractUint64(v any) (uint64, error) {
 	}
 }
 
-// validateDelegationCertSignature verifies the delegation certificate signature.
-// The issuer signs the certificate to authorize the delegate to produce blocks.
+// validateDelegationCertSignature verifies the delegation certificate
+// signature that authorizes a delegate to produce blocks on the issuer's
+// behalf, honoring this validator's SkipDelegationCertVerification escape
+// hatch.
 //
-// This reproduces cardano-ledger-byron's Cardano.Chain.Delegation.Certificate
-// signing/verification exactly (verified against a real mainnet delegation
-// certificate, see TestValidateDelegationCertSignature):
-//
-//	inner = "00" || CC.unXPub(delegateVK) || CBOR(epochOrOmega)
-//	  -- "00" is the two ASCII bytes 0x30 0x30, delegateVK is the raw
-//	  -- 64-byte extended verification key, and the epoch is CBOR-encoded.
-//
-// signCertificate calls `safeSign protocolMagicId SignCertificate safeSigner
-// inner`, and safeSign (Cardano.Crypto.Signing.Signature) is defined as
-// `coerce . safeSignRaw pm (Just tag) ss . serialize'`, i.e. it CBOR-encodes
-// its ByteString argument (wrapping it in a CBOR byte-string header) before
-// prepending the sign tag and signing:
-//
-//	signed = signTag(pm, SignCertificate) || CBOR_bytestring(inner)
-//	signTag(pm, SignCertificate) = 0x0a || CBOR(protocolMagic)
-//
-// The certificate's own signature (certSig) is then a standard Ed25519
-// signature over `signed`, verifiable with the issuer's 32-byte Ed25519
-// public key (the first 32 bytes of the 64-byte extended issuerVK).
+// The signing format itself -- reproduced from cardano-ledger-byron's
+// Cardano.Chain.Delegation.Certificate and verified against a real mainnet
+// delegation certificate (see TestValidateDelegationCertSignature) -- lives
+// in byron.VerifyDelegationCertificateSignature, so that header validation
+// here and delegation payload validation in ledger/byron cannot drift
+// apart.
 func (v *HeaderValidator) validateDelegationCertSignature(
 	issuerVK, delegateVK, certSig []byte,
 	epochOrOmega uint64,
@@ -745,67 +733,13 @@ func (v *HeaderValidator) validateDelegationCertSignature(
 		// validator verifies delegation certificate signatures fail-closed.
 		return nil
 	}
-
-	if len(issuerVK) != 64 {
-		return fmt.Errorf(
-			"invalid issuerVK size: got %d, expected 64",
-			len(issuerVK),
-		)
-	}
-	if len(delegateVK) != 64 {
-		return fmt.Errorf(
-			"invalid delegateVK size: got %d, expected 64",
-			len(delegateVK),
-		)
-	}
-	if len(certSig) != ed25519.SignatureSize {
-		return fmt.Errorf(
-			"invalid certSig size: got %d, expected %d",
-			len(certSig),
-			ed25519.SignatureSize,
-		)
-	}
-
-	// CBOR-encode the epoch/omega value
-	epochBytes, err := cbor.Encode(epochOrOmega)
-	if err != nil {
-		return fmt.Errorf("failed to encode epoch/omega: %w", err)
-	}
-
-	// inner = "00" || delegateVK || CBOR(epoch)
-	inner := make([]byte, 0, 2+len(delegateVK)+len(epochBytes))
-	inner = append(inner, '0', '0') // ASCII "00"
-	inner = append(inner, delegateVK...)
-	inner = append(inner, epochBytes...)
-
-	// safeSign CBOR-encodes its ByteString argument (wraps it as a CBOR
-	// byte string) before signing.
-	innerCbor, err := cbor.Encode(inner)
-	if err != nil {
-		return fmt.Errorf("failed to encode certificate payload: %w", err)
-	}
-
-	// Encode protocol magic for the SignCertificate tag
-	pmBytes, err := cbor.Encode(v.config.ProtocolMagic)
-	if err != nil {
-		return fmt.Errorf("failed to encode protocol magic: %w", err)
-	}
-
-	// signed = 0x0a || CBOR(protocolMagic) || CBOR_bytestring(inner)
-	signed := make([]byte, 0, 1+len(pmBytes)+len(innerCbor))
-	signed = append(signed, byronSignTagCertificate)
-	signed = append(signed, pmBytes...)
-	signed = append(signed, innerCbor...)
-
-	issuerPubKey := issuerVK[:32]
-	if !ed25519.Verify(issuerPubKey, signed, certSig) {
-		return fmt.Errorf(
-			"delegation certificate signature verification failed for epoch/omega %d",
-			epochOrOmega,
-		)
-	}
-
-	return nil
+	return byron.VerifyDelegationCertificateSignature(
+		v.config.ProtocolMagic,
+		issuerVK,
+		delegateVK,
+		certSig,
+		epochOrOmega,
+	)
 }
 
 // validateGenesisDelegate checks if the issuer is a valid genesis delegate
@@ -1137,6 +1071,22 @@ func ValidateBodyHash(
 		}
 	}
 
+	// Validate the delegation and update payloads themselves -- opt-in
+	// only (EnableByronPayloadValidation). The dlg_proof/upd_proof checks
+	// above bind those payloads' bytes to the header but say nothing about
+	// whether they decode to well-formed certificates, proposals, and
+	// votes, or whether the signatures inside them verify. See that flag's
+	// doc comment for why the check is not on by default.
+	if cfg.EnableByronPayloadValidation {
+		if err := block.ValidatePayloads(); err != nil {
+			return &common.ValidationError{
+				Type:    common.ValidationErrorTypeBodyHash,
+				Message: "byron payload validation failed",
+				Cause:   err,
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -1324,8 +1274,18 @@ func ValidateEBBBodyHash(block *byron.ByronEpochBoundaryBlock) error {
 		}
 	}
 
-	// Get the expected body hash from the header
-	expectedHash := block.BlockHeader.BlockBodyHash()
+	// Get the expected body hash from the header. The checked accessor is
+	// used so a body proof that is not a hash at all is reported as
+	// malformed, rather than yielding a zero hash that the comparison
+	// below would report as an ordinary mismatch.
+	expectedHash, err := block.BlockHeader.BlockBodyHashChecked()
+	if err != nil {
+		return &common.ValidationError{
+			Type:    common.ValidationErrorTypeBodyHash,
+			Message: "malformed EBB body proof in header",
+			Cause:   err,
+		}
+	}
 
 	// Compute the actual body hash
 	// EBB body is a list of stakeholder IDs ([]Blake2b224)

--- a/consensus/byron/validate_test.go
+++ b/consensus/byron/validate_test.go
@@ -413,6 +413,17 @@ func TestValidateBlockSignature(t *testing.T) {
 // (slot 4471207), confirming the byte layout reproduced from
 // cardano-ledger-byron's Delegation/Certificate.hs and cardano-crypto's
 // Signing/{Tag,Signature}.hs.
+// testEpochCbor encodes a delegation certificate epoch the way it would
+// appear on the wire. validateDelegationCertSignature takes the epoch
+// field's preserved encoding rather than its decoded value, so tests that
+// build a certificate from scratch have to produce that encoding too.
+func testEpochCbor(t *testing.T, epoch uint64) []byte {
+	t.Helper()
+	encoded, err := cbor.Encode(epoch)
+	require.NoError(t, err)
+	return encoded
+}
+
 func TestValidateDelegationCertSignature_RealMainnetVector(t *testing.T) {
 	issuerVK, err := hex.DecodeString(
 		"1bc97a2fe02c297880ce8ecfd997fe4c1ec09ee10feeee9f686760166b05281d" +
@@ -434,7 +445,7 @@ func TestValidateDelegationCertSignature_RealMainnetVector(t *testing.T) {
 	validator := NewHeaderValidator(config)
 
 	err = validator.validateDelegationCertSignature(
-		issuerVK, delegateVK, certSig, 0,
+		issuerVK, delegateVK, certSig, testEpochCbor(t, 0),
 	)
 	require.NoError(
 		t,
@@ -446,19 +457,19 @@ func TestValidateDelegationCertSignature_RealMainnetVector(t *testing.T) {
 	tamperedSig := append([]byte{}, certSig...)
 	tamperedSig[0] ^= 0xFF
 	err = validator.validateDelegationCertSignature(
-		issuerVK, delegateVK, tamperedSig, 0,
+		issuerVK, delegateVK, tamperedSig, testEpochCbor(t, 0),
 	)
 	require.Error(t, err, "tampered certificate signature must fail")
 
 	err = validator.validateDelegationCertSignature(
-		issuerVK, delegateVK, certSig, 1, // wrong epoch
+		issuerVK, delegateVK, certSig, testEpochCbor(t, 1), // wrong epoch
 	)
 	require.Error(t, err, "wrong epoch must fail signature verification")
 
 	tamperedDelegateVK := append([]byte{}, delegateVK...)
 	tamperedDelegateVK[0] ^= 0xFF
 	err = validator.validateDelegationCertSignature(
-		issuerVK, tamperedDelegateVK, certSig, 0,
+		issuerVK, tamperedDelegateVK, certSig, testEpochCbor(t, 0),
 	)
 	require.Error(
 		t,
@@ -508,7 +519,7 @@ func TestValidateDelegationCertSignature_Deterministic(t *testing.T) {
 	certSig := ed25519.Sign(issuerPriv, signed)
 
 	err = validator.validateDelegationCertSignature(
-		issuerVK, delegateVK, certSig, epoch,
+		issuerVK, delegateVK, certSig, epochBytes,
 	)
 	require.NoError(
 		t,
@@ -521,7 +532,7 @@ func TestValidateDelegationCertSignature_Deterministic(t *testing.T) {
 	skipValidator := NewHeaderValidator(config)
 	skipValidator.SkipDelegationCertVerification = true
 	err = skipValidator.validateDelegationCertSignature(
-		issuerVK, delegateVK, make([]byte, ed25519.SignatureSize), epoch,
+		issuerVK, delegateVK, make([]byte, ed25519.SignatureSize), epochBytes,
 	)
 	require.NoError(
 		t,
@@ -533,23 +544,23 @@ func TestValidateDelegationCertSignature_Deterministic(t *testing.T) {
 	tamperedSig := append([]byte{}, certSig...)
 	tamperedSig[0] ^= 0xFF
 	err = validator.validateDelegationCertSignature(
-		issuerVK, delegateVK, tamperedSig, epoch,
+		issuerVK, delegateVK, tamperedSig, epochBytes,
 	)
 	require.Error(t, err, "tampered signature must be rejected by default")
 
 	// Malformed key sizes must be rejected before attempting verification.
 	err = validator.validateDelegationCertSignature(
-		issuerVK[:32], delegateVK, certSig, epoch,
+		issuerVK[:32], delegateVK, certSig, epochBytes,
 	)
 	require.Error(t, err, "short issuerVK must be rejected")
 
 	err = validator.validateDelegationCertSignature(
-		issuerVK, delegateVK[:32], certSig, epoch,
+		issuerVK, delegateVK[:32], certSig, epochBytes,
 	)
 	require.Error(t, err, "short delegateVK must be rejected")
 
 	err = validator.validateDelegationCertSignature(
-		issuerVK, delegateVK, certSig[:32], epoch,
+		issuerVK, delegateVK, certSig[:32], epochBytes,
 	)
 	require.Error(t, err, "short certSig must be rejected")
 }

--- a/ledger/byron/bodyhash_test.go
+++ b/ledger/byron/bodyhash_test.go
@@ -86,6 +86,39 @@ func TestMainBlockBodyHashCheckedMalformed(t *testing.T) {
 			name:      "raw bytes of the wrong length",
 			bodyProof: bytes.Repeat([]byte{0x01}, 16),
 		},
+		{
+			// A bare hash is the epoch boundary block's body proof format.
+			// A main block header carrying one has no transaction proof at
+			// all, so it must not be accepted here.
+			name: "bare 32-byte hash",
+			bodyProof: bytes.Repeat(
+				[]byte{0x01}, common.Blake2b256Size,
+			),
+		},
+		{
+			name: "oversized outer array",
+			bodyProof: []any{
+				[]any{
+					uint64(0),
+					bytes.Repeat([]byte{0x01}, common.Blake2b256Size),
+					bytes.Repeat([]byte{0x02}, common.Blake2b256Size),
+				},
+				nil, nil, nil,
+				"trailing junk",
+			},
+		},
+		{
+			name: "oversized tx proof",
+			bodyProof: []any{
+				[]any{
+					uint64(0),
+					bytes.Repeat([]byte{0x01}, common.Blake2b256Size),
+					bytes.Repeat([]byte{0x02}, common.Blake2b256Size),
+					"trailing junk",
+				},
+				nil, nil, nil,
+			},
+		},
 	}
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -163,4 +196,52 @@ func TestBlockBodyHashCheckedNilReceivers(t *testing.T) {
 
 	_, err = (&byron.ByronMainBlock{}).BlockBodyHashChecked()
 	require.ErrorIs(t, err, byron.ErrMalformedBodyProof)
+}
+
+// TestMainBlockValidateBodyProofRejectsOversizedShapes pins that the
+// decode-time path rejects an over-long body proof on shape, rather than
+// letting it through to a content check that happens to fail for an
+// unrelated reason.
+func TestMainBlockValidateBodyProofRejectsOversizedShapes(t *testing.T) {
+	hash := bytes.Repeat([]byte{0x01}, common.Blake2b256Size)
+	txProof := []any{uint64(0), hash, hash}
+
+	testCases := []struct {
+		name      string
+		bodyProof any
+	}{
+		{
+			name: "oversized outer array",
+			bodyProof: []any{
+				txProof, nil, hash, hash, "trailing junk",
+			},
+		},
+		{
+			name:      "undersized outer array",
+			bodyProof: []any{txProof, nil, hash},
+		},
+		{
+			name: "oversized tx proof",
+			bodyProof: []any{
+				[]any{uint64(0), hash, hash, "trailing junk"},
+				nil, hash, hash,
+			},
+		},
+		{
+			name:      "bare hash",
+			bodyProof: hash,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			block := &byron.ByronMainBlock{
+				BlockHeader: &byron.ByronMainBlockHeader{
+					BodyProof: testCase.bodyProof,
+				},
+			}
+			err := block.ValidateBodyProof()
+			require.ErrorIs(t, err, byron.ErrBodyProofMismatch)
+			require.ErrorContains(t, err, "element array")
+		})
+	}
 }

--- a/ledger/byron/bodyhash_test.go
+++ b/ledger/byron/bodyhash_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package byron_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMainBlockBodyHashCheckedValid(t *testing.T) {
+	merkleRoot := bytes.Repeat([]byte{0x3c}, common.Blake2b256Size)
+	header := &byron.ByronMainBlockHeader{
+		BodyProof: []any{
+			[]any{
+				uint64(2),
+				merkleRoot,
+				bytes.Repeat([]byte{0x4d}, common.Blake2b256Size),
+			},
+			[]any{uint64(3), bytes.Repeat([]byte{0x00}, 32)},
+			bytes.Repeat([]byte{0x01}, common.Blake2b256Size),
+			bytes.Repeat([]byte{0x02}, common.Blake2b256Size),
+		},
+	}
+
+	hash, err := header.BlockBodyHashChecked()
+	require.NoError(t, err)
+	require.Equal(t, merkleRoot, hash.Bytes())
+	require.Equal(t, hash, header.BlockBodyHash())
+}
+
+func TestMainBlockBodyHashCheckedMalformed(t *testing.T) {
+	testCases := []struct {
+		name      string
+		bodyProof any
+	}{
+		{
+			name:      "nil proof",
+			bodyProof: nil,
+		},
+		{
+			name:      "proof is not an array",
+			bodyProof: uint64(7),
+		},
+		{
+			name:      "empty array",
+			bodyProof: []any{},
+		},
+		{
+			name:      "tx proof is not an array",
+			bodyProof: []any{uint64(0), nil, nil, nil},
+		},
+		{
+			name:      "tx proof too short",
+			bodyProof: []any{[]any{uint64(0)}, nil, nil, nil},
+		},
+		{
+			name: "merkle root is not bytes",
+			bodyProof: []any{
+				[]any{uint64(0), "root", nil}, nil, nil, nil,
+			},
+		},
+		{
+			name: "merkle root truncated",
+			bodyProof: []any{
+				[]any{uint64(0), bytes.Repeat([]byte{0x01}, 16), nil},
+				nil, nil, nil,
+			},
+		},
+		{
+			name:      "raw bytes of the wrong length",
+			bodyProof: bytes.Repeat([]byte{0x01}, 16),
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			header := &byron.ByronMainBlockHeader{
+				BodyProof: testCase.bodyProof,
+			}
+			hash, err := header.BlockBodyHashChecked()
+			require.ErrorIs(t, err, byron.ErrMalformedBodyProof)
+			require.Equal(t, common.Blake2b256{}, hash)
+			// BlockBodyHash still stands in a zero hash for the
+			// common.BlockHeader interface, which has no way to report this.
+			require.Equal(t, common.Blake2b256{}, header.BlockBodyHash())
+		})
+	}
+}
+
+func TestEBBBodyHashCheckedValid(t *testing.T) {
+	bodyHash := bytes.Repeat([]byte{0x7e}, common.Blake2b256Size)
+	header := &byron.ByronEpochBoundaryBlockHeader{BodyProof: bodyHash}
+
+	hash, err := header.BlockBodyHashChecked()
+	require.NoError(t, err)
+	require.Equal(t, bodyHash, hash.Bytes())
+	require.Equal(t, hash, header.BlockBodyHash())
+}
+
+func TestEBBBodyHashCheckedMalformed(t *testing.T) {
+	testCases := []struct {
+		name      string
+		bodyProof any
+	}{
+		{name: "nil proof", bodyProof: nil},
+		{name: "proof is an array", bodyProof: []any{uint64(0)}},
+		{
+			name:      "proof truncated",
+			bodyProof: bytes.Repeat([]byte{0x01}, 31),
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			header := &byron.ByronEpochBoundaryBlockHeader{
+				BodyProof: testCase.bodyProof,
+			}
+			hash, err := header.BlockBodyHashChecked()
+			require.ErrorIs(t, err, byron.ErrMalformedBodyProof)
+			require.Equal(t, common.Blake2b256{}, hash)
+			require.Equal(t, common.Blake2b256{}, header.BlockBodyHash())
+		})
+	}
+}
+
+// TestEBBValidateBodyProofMalformed pins the distinction the checked
+// accessor exists for: a body proof that cannot be parsed is reported as
+// malformed, not as a mismatch against the zero hash that standing one in
+// would otherwise produce.
+func TestEBBValidateBodyProofMalformed(t *testing.T) {
+	block := &byron.ByronEpochBoundaryBlock{
+		BlockHeader: &byron.ByronEpochBoundaryBlockHeader{
+			BodyProof: []any{uint64(0)},
+		},
+	}
+	err := block.ValidateBodyProof()
+	require.ErrorIs(t, err, byron.ErrMalformedBodyProof)
+	require.NotErrorIs(t, err, byron.ErrBodyProofMismatch)
+}
+
+func TestBlockBodyHashCheckedNilReceivers(t *testing.T) {
+	var mainBlock *byron.ByronMainBlock
+	_, err := mainBlock.BlockBodyHashChecked()
+	require.ErrorIs(t, err, byron.ErrMalformedBodyProof)
+
+	var ebb *byron.ByronEpochBoundaryBlock
+	_, err = ebb.BlockBodyHashChecked()
+	require.ErrorIs(t, err, byron.ErrMalformedBodyProof)
+
+	_, err = (&byron.ByronMainBlock{}).BlockBodyHashChecked()
+	require.ErrorIs(t, err, byron.ErrMalformedBodyProof)
+}

--- a/ledger/byron/bodyproof.go
+++ b/ledger/byron/bodyproof.go
@@ -28,6 +28,12 @@ import (
 // that binds the two together.
 var ErrBodyProofMismatch = errors.New("byron block body proof mismatch")
 
+// ErrMalformedBodyProof reports a Byron header whose body proof does not
+// have the wire shape the format requires, so no body hash can be read out
+// of it at all. This is distinct from ErrBodyProofMismatch, which reports a
+// well-formed proof that disagrees with the body.
+var ErrMalformedBodyProof = errors.New("byron block body proof is malformed")
+
 // Indices into the Byron header's body proof, which is
 // [tx_proof, ssc_proof, dlg_proof, upd_proof].
 const (
@@ -69,6 +75,13 @@ const (
 // this call; NewByronMainBlockFromCbor forwards whatever VerifyConfig it
 // was given here, so that same flag controls decode-time behavior too.
 //
+// The dlg_proof and upd_proof comparisons bind the delegation and update
+// payload bytes to the header but say nothing about what those bytes
+// decode to. Pass a common.VerifyConfig with EnableByronPayloadValidation
+// set to true to additionally validate those payloads structurally and
+// verify the signatures they carry, via ValidatePayloads; see that flag's
+// doc comment for why it is opt-in.
+//
 // This was not always the default: an earlier version of this function
 // unconditionally ran the full ssc_proof hash comparison, after an even
 // earlier version had deliberately skipped ssc_proof's hashes entirely,
@@ -106,9 +119,15 @@ func (b *ByronMainBlock) ValidateBodyProof(
 	); err != nil {
 		return err
 	}
-	return checkPayloadHash(
+	if err := checkPayloadHash(
 		"update", proof[bodyProofUpdIndex], b.Body.UpdPayloadCbor(),
-	)
+	); err != nil {
+		return err
+	}
+	if cfg.EnableByronPayloadValidation {
+		return b.ValidatePayloads()
+	}
+	return nil
 }
 
 // ValidateSscProof validates only a Byron main block's ssc_proof, entirely
@@ -265,6 +284,14 @@ func encodeWitnessList(witnesses [][]byte) []byte {
 // its header. EBBs have no transactions, so the whole body is covered by a
 // single hash.
 func (b *ByronEpochBoundaryBlock) ValidateBodyProof() error {
+	// Read the header hash through the checked accessor so a body proof
+	// that is not a hash at all is reported as malformed, rather than
+	// reaching checkHash's comparison and being reported as a mismatch
+	// against a value the header never carried.
+	expected, err := b.BlockBodyHashChecked()
+	if err != nil {
+		return err
+	}
 	bodyCbor := b.BodyCbor()
 	if len(bodyCbor) == 0 {
 		return fmt.Errorf(
@@ -274,7 +301,7 @@ func (b *ByronEpochBoundaryBlock) ValidateBodyProof() error {
 	}
 	return checkHash(
 		"body hash",
-		b.BlockHeader.BodyProof,
+		expected[:],
 		common.Blake2b256Hash(bodyCbor),
 	)
 }

--- a/ledger/byron/bodyproof.go
+++ b/ledger/byron/bodyproof.go
@@ -190,10 +190,12 @@ func (b *ByronMainBlock) bodyProofArray() ([]any, error) {
 		)
 	}
 	proof, ok := b.BlockHeader.BodyProof.([]any)
-	if !ok || len(proof) < bodyProofLength {
+	if !ok || len(proof) != bodyProofLength {
 		return nil, fmt.Errorf(
-			"%w: header body proof is not a %d-element array",
+			"%w: header body proof is not a %d-element array, "+
+				"got %T with %d elements",
 			ErrBodyProofMismatch, bodyProofLength,
+			b.BlockHeader.BodyProof, len(proof),
 		)
 	}
 	return proof, nil
@@ -201,10 +203,10 @@ func (b *ByronMainBlock) bodyProofArray() ([]any, error) {
 
 func (b *ByronMainBlock) validateTxProof(rawProof any) error {
 	txProof, ok := rawProof.([]any)
-	if !ok || len(txProof) < txProofLength {
+	if !ok || len(txProof) != txProofLength {
 		return fmt.Errorf(
-			"%w: tx proof is not a %d-element array",
-			ErrBodyProofMismatch, txProofLength,
+			"%w: tx proof is not a %d-element array, got %T with %d elements",
+			ErrBodyProofMismatch, txProofLength, rawProof, len(txProof),
 		)
 	}
 

--- a/ledger/byron/byron.go
+++ b/ledger/byron/byron.go
@@ -140,7 +140,20 @@ func (h *ByronMainBlockHeader) Era() common.Era {
 	return EraByron
 }
 
-func (h *ByronMainBlockHeader) BlockBodyHash() common.Blake2b256 {
+// BlockBodyHashChecked returns the header's representative body hash, or an
+// error wrapping ErrMalformedBodyProof when the body proof does not have
+// the wire shape a hash can be read out of.
+//
+// Prefer this over BlockBodyHash anywhere the result is compared against a
+// computed hash: BlockBodyHash has to satisfy common.BlockHeader, which
+// gives it no way to report a malformed proof, so it stands in a zero hash
+// instead. A caller that then compares that zero hash reports a hash
+// mismatch, naming a value the block never carried, when the real fault is
+// that the proof could not be parsed at all.
+func (h *ByronMainBlockHeader) BlockBodyHashChecked() (
+	common.Blake2b256,
+	error,
+) {
 	// Byron BodyProof is an array: [tx_proof, ssc_proof, dlg_proof, upd_proof]
 	// tx_proof is: [txCount, txBodyMerkleRoot, txWitnessMerkleRoot]
 	// We return the txBodyMerkleRoot as the representative body hash
@@ -152,7 +165,7 @@ func (h *ByronMainBlockHeader) BlockBodyHash() common.Blake2b256 {
 				len(txBodyRoot) == common.Blake2b256Size {
 				var hash common.Blake2b256
 				copy(hash[:], txBodyRoot)
-				return hash
+				return hash, nil
 			}
 		}
 	}
@@ -161,11 +174,26 @@ func (h *ByronMainBlockHeader) BlockBodyHash() common.Blake2b256 {
 		len(bodyProofBytes) == common.Blake2b256Size {
 		var hash common.Blake2b256
 		copy(hash[:], bodyProofBytes)
-		return hash
+		return hash, nil
 	}
-	// Return zero hash instead of panicking to prevent DoS in verification path
-	// This will cause validation to fail gracefully rather than crash
-	return common.Blake2b256{}
+	return common.Blake2b256{}, fmt.Errorf(
+		"%w: main block header body proof is %T, expected a "+
+			"[tx_proof, ssc_proof, dlg_proof, upd_proof] array whose "+
+			"tx_proof carries a %d-byte merkle root",
+		ErrMalformedBodyProof, h.BodyProof, common.Blake2b256Size,
+	)
+}
+
+// BlockBodyHash satisfies common.BlockHeader. It returns a zero hash for a
+// malformed body proof rather than panicking, so a hostile block cannot
+// take down the verification path; callers that act on the result should
+// use BlockBodyHashChecked, which reports why instead.
+func (h *ByronMainBlockHeader) BlockBodyHash() common.Blake2b256 {
+	hash, err := h.BlockBodyHashChecked()
+	if err != nil {
+		return common.Blake2b256{}
+	}
+	return hash
 }
 
 type ByronTransactionBody struct {
@@ -1106,17 +1134,37 @@ func (h *ByronEpochBoundaryBlockHeader) Era() common.Era {
 	return EraByron
 }
 
-func (h *ByronEpochBoundaryBlockHeader) BlockBodyHash() common.Blake2b256 {
+// BlockBodyHashChecked returns the EBB header's body hash, or an error
+// wrapping ErrMalformedBodyProof when the body proof is not a 32-byte hash.
+// See ByronMainBlockHeader.BlockBodyHashChecked for why this exists
+// alongside BlockBodyHash.
+func (h *ByronEpochBoundaryBlockHeader) BlockBodyHashChecked() (
+	common.Blake2b256,
+	error,
+) {
 	// BodyProof is the hash of the block body, encoded as bytes in CBOR
 	if bodyProofBytes, ok := h.BodyProof.([]byte); ok &&
 		len(bodyProofBytes) == common.Blake2b256Size {
 		var hash common.Blake2b256
 		copy(hash[:], bodyProofBytes)
-		return hash
+		return hash, nil
 	}
-	// Return zero hash instead of panicking to prevent DoS in verification path
-	// This will cause validation to fail gracefully rather than crash
-	return common.Blake2b256{}
+	return common.Blake2b256{}, fmt.Errorf(
+		"%w: epoch boundary block header body proof is %T, expected a "+
+			"%d-byte hash",
+		ErrMalformedBodyProof, h.BodyProof, common.Blake2b256Size,
+	)
+}
+
+// BlockBodyHash satisfies common.BlockHeader. See
+// ByronMainBlockHeader.BlockBodyHash for why a malformed proof yields a
+// zero hash here rather than an error.
+func (h *ByronEpochBoundaryBlockHeader) BlockBodyHash() common.Blake2b256 {
+	hash, err := h.BlockBodyHashChecked()
+	if err != nil {
+		return common.Blake2b256{}
+	}
+	return hash
 }
 
 type ByronMainBlock struct {
@@ -1188,6 +1236,17 @@ func (b *ByronMainBlock) Utxorpc() (*utxorpc.Block, error) {
 
 func (b *ByronMainBlock) BlockBodyHash() common.Blake2b256 {
 	return b.Header().BlockBodyHash()
+}
+
+// BlockBodyHashChecked reports a malformed body proof instead of standing in
+// a zero hash. See ByronMainBlockHeader.BlockBodyHashChecked.
+func (b *ByronMainBlock) BlockBodyHashChecked() (common.Blake2b256, error) {
+	if b == nil || b.BlockHeader == nil {
+		return common.Blake2b256{}, fmt.Errorf(
+			"%w: block or block header is nil", ErrMalformedBodyProof,
+		)
+	}
+	return b.BlockHeader.BlockBodyHashChecked()
 }
 
 type ByronEpochBoundaryBlock struct {
@@ -1275,6 +1334,20 @@ func (b *ByronEpochBoundaryBlock) Utxorpc() (*utxorpc.Block, error) {
 
 func (b *ByronEpochBoundaryBlock) BlockBodyHash() common.Blake2b256 {
 	return b.Header().BlockBodyHash()
+}
+
+// BlockBodyHashChecked reports a malformed body proof instead of standing in
+// a zero hash. See ByronMainBlockHeader.BlockBodyHashChecked.
+func (b *ByronEpochBoundaryBlock) BlockBodyHashChecked() (
+	common.Blake2b256,
+	error,
+) {
+	if b == nil || b.BlockHeader == nil {
+		return common.Blake2b256{}, fmt.Errorf(
+			"%w: block or block header is nil", ErrMalformedBodyProof,
+		)
+	}
+	return b.BlockHeader.BlockBodyHashChecked()
 }
 
 func NewByronEpochBoundaryBlockFromCbor(

--- a/ledger/byron/byron.go
+++ b/ledger/byron/byron.go
@@ -156,32 +156,43 @@ func (h *ByronMainBlockHeader) BlockBodyHashChecked() (
 ) {
 	// Byron BodyProof is an array: [tx_proof, ssc_proof, dlg_proof, upd_proof]
 	// tx_proof is: [txCount, txBodyMerkleRoot, txWitnessMerkleRoot]
-	// We return the txBodyMerkleRoot as the representative body hash
-	if proofSlice, ok := h.BodyProof.([]any); ok && len(proofSlice) >= 1 {
-		// Extract tx_proof which is the first element
-		if txProof, ok := proofSlice[0].([]any); ok && len(txProof) >= 2 {
-			// txProof[1] is the txBodyMerkleRoot
-			if txBodyRoot, ok := txProof[1].([]byte); ok &&
-				len(txBodyRoot) == common.Blake2b256Size {
-				var hash common.Blake2b256
-				copy(hash[:], txBodyRoot)
-				return hash, nil
-			}
-		}
+	// We return the txBodyMerkleRoot as the representative body hash.
+	//
+	// Both shapes are required exactly, not as minimums: the CDDL fixes
+	// them, cardano-ledger reads them with enforceSize, and accepting a
+	// longer array would let a header carry trailing junk that no other
+	// check looks at. There is deliberately no fallback for a body proof
+	// that is a bare hash -- that is the epoch boundary block's format, and
+	// accepting it here would mean a main block header could pass this
+	// while carrying no transaction proof at all.
+	proof, ok := h.BodyProof.([]any)
+	if !ok || len(proof) != bodyProofLength {
+		return common.Blake2b256{}, fmt.Errorf(
+			"%w: main block header body proof is not a %d-element array, "+
+				"got %T with %d elements",
+			ErrMalformedBodyProof, bodyProofLength, h.BodyProof, len(proof),
+		)
 	}
-	// Fallback: check if BodyProof is raw bytes (shouldn't happen for main blocks)
-	if bodyProofBytes, ok := h.BodyProof.([]byte); ok &&
-		len(bodyProofBytes) == common.Blake2b256Size {
-		var hash common.Blake2b256
-		copy(hash[:], bodyProofBytes)
-		return hash, nil
+	txProof, ok := proof[bodyProofTxIndex].([]any)
+	if !ok || len(txProof) != txProofLength {
+		return common.Blake2b256{}, fmt.Errorf(
+			"%w: main block tx proof is not a %d-element array, "+
+				"got %T with %d elements",
+			ErrMalformedBodyProof, txProofLength,
+			proof[bodyProofTxIndex], len(txProof),
+		)
 	}
-	return common.Blake2b256{}, fmt.Errorf(
-		"%w: main block header body proof is %T, expected a "+
-			"[tx_proof, ssc_proof, dlg_proof, upd_proof] array whose "+
-			"tx_proof carries a %d-byte merkle root",
-		ErrMalformedBodyProof, h.BodyProof, common.Blake2b256Size,
-	)
+	merkleRoot, ok := txProof[txProofMerkleIndex].([]byte)
+	if !ok || len(merkleRoot) != common.Blake2b256Size {
+		return common.Blake2b256{}, fmt.Errorf(
+			"%w: main block tx merkle root is not a %d-byte hash, got %T",
+			ErrMalformedBodyProof, common.Blake2b256Size,
+			txProof[txProofMerkleIndex],
+		)
+	}
+	var hash common.Blake2b256
+	copy(hash[:], merkleRoot)
+	return hash, nil
 }
 
 // BlockBodyHash satisfies common.BlockHeader. It returns a zero hash for a

--- a/ledger/byron/payload.go
+++ b/ledger/byron/payload.go
@@ -51,7 +51,8 @@ const (
 	updatePayloadElementCount     = 2
 	updateProposalMetadataIndex   = 3
 	updateProposalAttributesIndex = 4
-	installerHashElementCount     = 1
+	installerHashElementCount     = 4
+	installerHashHashIndex        = 1
 	// systemTagMaxLength is cardano-ledger-byron's systemTagMaxLength.
 	systemTagMaxLength = 10
 )
@@ -377,13 +378,9 @@ func (p *ByronUpdateProposal) Validate(protocolMagic uint32) error {
 //   - the field is a CBOR map;
 //   - each key is a text string of at most systemTagMaxLength characters,
 //     all ASCII -- SystemTag's checkSystemTag;
-//   - each value is a one-element array holding a 32-byte hash --
-//     InstallerHash's enforceSize "InstallerHash" 1.
-//
-// NOTE: the InstallerHash framing above is transcribed from the reference
-// decoder, not confirmed against a real mainnet proposal -- this repository
-// has no such vector. It is the reason
-// common.VerifyConfig.EnableByronPayloadValidation stays opt-in.
+//   - each value is a four-element array whose element 1 is a 32-byte hash
+//     -- InstallerHash's enforceSize "InstallerHash" 4, which drops
+//     elements 0, 2, and 3 and reads the hash out of element 1.
 func validateProposalMetadata(raw cbor.RawMessage) error {
 	var metadata map[string]cbor.RawMessage
 	if _, err := cbor.Decode(raw, &metadata); err != nil {
@@ -426,20 +423,24 @@ func validateSystemTag(tag string) error {
 }
 
 // validateInstallerHash reproduces cardano-ledger-byron's InstallerHash
-// decoder: a one-element array wrapping a blake2b-256 hash.
+// decoder, which enforces a four-element array, drops elements 0, 2, and 3,
+// and reads the Hash Raw out of element 1. The four elements are the
+// remains of cardano-sl's UpdateData record, of which only one hash
+// survived into cardano-ledger-byron.
+//
+// Elements 0, 2, and 3 are deliberately left unchecked: the reference
+// discards them without interpreting them, so constraining them here could
+// only reject something the reference accepts.
 func validateInstallerHash(tag string, raw cbor.RawMessage) error {
-	fields, err := payloadFields(
-		fmt.Sprintf("update proposal installer hash for system tag %q", tag),
-		raw,
-		installerHashElementCount,
+	label := fmt.Sprintf(
+		"update proposal installer hash for system tag %q", tag,
 	)
+	fields, err := payloadFields(label, raw, installerHashElementCount)
 	if err != nil {
 		return err
 	}
 	_, err = payloadBytes(
-		fmt.Sprintf("update proposal installer hash for system tag %q", tag),
-		fields[0],
-		common.Blake2b256Size,
+		label, fields[installerHashHashIndex], common.Blake2b256Size,
 	)
 	return err
 }

--- a/ledger/byron/payload.go
+++ b/ledger/byron/payload.go
@@ -18,6 +18,7 @@ import (
 	"crypto/ed25519"
 	"errors"
 	"fmt"
+	"unicode"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
@@ -46,6 +47,13 @@ const (
 	updateVoteElementCount        = 4
 	updateProposalElementCount    = 7
 	updateProposalSignedBodyCount = 5
+	updatePayloadVotesIndex       = 1
+	updatePayloadElementCount     = 2
+	updateProposalMetadataIndex   = 3
+	updateProposalAttributesIndex = 4
+	installerHashElementCount     = 1
+	// systemTagMaxLength is cardano-ledger-byron's systemTagMaxLength.
+	systemTagMaxLength = 10
 )
 
 // DelegationCertificate is a decoded Byron heavyweight delegation
@@ -53,7 +61,14 @@ const (
 // are the full 64-byte extended form the wire format carries; see
 // VerificationKeySize.
 type DelegationCertificate struct {
-	Epoch      uint64
+	Epoch uint64
+	// EpochCbor is the epoch field's original wire encoding, which is what
+	// the certificate's signature covers. It is kept because CBOR admits
+	// non-shortest integer encodings that this decoder accepts: an epoch
+	// that arrived as 0x1807 decodes to 7 and re-encodes to 0x07, and
+	// verifying against the re-encoding would reject a certificate its
+	// issuer signed correctly.
+	EpochCbor  []byte
 	IssuerVK   []byte
 	DelegateVK []byte
 	Signature  []byte
@@ -62,31 +77,41 @@ type DelegationCertificate struct {
 // UpdateVote is a decoded Byron update-proposal vote from a main block's
 // update payload.
 type UpdateVote struct {
-	VoterVK    []byte
-	ProposalId []byte
-	Decision   bool
-	Signature  []byte
+	VoterVK []byte
+	// ProposalIdCbor is the proposal id field's original wire encoding,
+	// which is what the vote's signature covers. See
+	// DelegationCertificate.EpochCbor: a 32-byte id that arrived as
+	// 0x590020... re-encodes to 0x5820..., and the voter signed the former.
+	ProposalId     []byte
+	ProposalIdCbor []byte
+	Decision       bool
+	Signature      []byte
 }
 
 // ParseDelegationCertificate decodes and structurally validates one entry
-// of a Byron main block's delegation payload, which the decoder hands back
-// untyped because the payload as a whole is stored as []any.
+// of a Byron main block's delegation payload, from that entry's original
+// CBOR.
+//
+// It takes raw CBOR rather than a decoded value because the certificate's
+// signature covers the epoch field's wire encoding, which a decoded uint64
+// cannot reproduce -- see DelegationCertificate.EpochCbor.
 //
 // The returned certificate's byte slices are copies: callers routinely hold
 // these past the lifetime of the block they came from, and a certificate
 // that aliased the decoded block would let a later mutation of one change
 // the other.
-func ParseDelegationCertificate(raw any) (*DelegationCertificate, error) {
-	fields, ok := raw.([]any)
-	if !ok || len(fields) != delegationCertElementCount {
-		return nil, fmt.Errorf(
-			"%w: delegation certificate is not a %d-element array, "+
-				"got %T with %d elements",
-			ErrInvalidPayload, delegationCertElementCount, raw, len(fields),
-		)
-	}
-	epoch, err := asUint(fields[delegationCertEpochIndex])
+func ParseDelegationCertificate(
+	raw cbor.RawMessage,
+) (*DelegationCertificate, error) {
+	fields, err := payloadFields(
+		"delegation certificate", raw, delegationCertElementCount,
+	)
 	if err != nil {
+		return nil, err
+	}
+	epochCbor := fields[delegationCertEpochIndex]
+	var epoch uint64
+	if _, err := cbor.Decode(epochCbor, &epoch); err != nil {
 		return nil, fmt.Errorf(
 			"%w: delegation certificate epoch: %w", ErrInvalidPayload, err,
 		)
@@ -117,6 +142,7 @@ func ParseDelegationCertificate(raw any) (*DelegationCertificate, error) {
 	}
 	return &DelegationCertificate{
 		Epoch:      epoch,
+		EpochCbor:  append([]byte(nil), epochCbor...),
 		IssuerVK:   issuerVK,
 		DelegateVK: delegateVK,
 		Signature:  signature,
@@ -132,25 +158,26 @@ func (c *DelegationCertificate) Verify(protocolMagic uint32) error {
 		)
 	}
 	return VerifyDelegationCertificateSignature(
-		protocolMagic, c.IssuerVK, c.DelegateVK, c.Signature, c.Epoch,
+		protocolMagic, c.IssuerVK, c.DelegateVK, c.Signature, c.EpochCbor,
 	)
 }
 
 // ParseUpdateVote decodes and structurally validates one entry of a Byron
-// main block's update-payload vote list.
+// main block's update-payload vote list, from that entry's original CBOR.
 //
 // The wire format is [voterVK, proposalId, decision, signature]. Byron only
 // ever recorded positive votes -- cardano-ledger-byron drops the decision
 // bit on decode and re-encodes a hardcoded True -- so a false decision is
 // something no real block carries, and is rejected here rather than
 // silently accepted as a vote whose signature covers the opposite value.
-func ParseUpdateVote(raw any) (*UpdateVote, error) {
-	fields, ok := raw.([]any)
-	if !ok || len(fields) != updateVoteElementCount {
-		return nil, fmt.Errorf(
-			"%w: update vote is not a %d-element array, got %T with %d elements",
-			ErrInvalidPayload, updateVoteElementCount, raw, len(fields),
-		)
+//
+// Like ParseDelegationCertificate this takes raw CBOR, because the vote's
+// signature covers the proposal id field's wire encoding -- see
+// UpdateVote.ProposalIdCbor.
+func ParseUpdateVote(raw cbor.RawMessage) (*UpdateVote, error) {
+	fields, err := payloadFields("update vote", raw, updateVoteElementCount)
+	if err != nil {
+		return nil, err
 	}
 	voterVK, err := payloadBytes(
 		"update vote voter verification key",
@@ -160,19 +187,20 @@ func ParseUpdateVote(raw any) (*UpdateVote, error) {
 	if err != nil {
 		return nil, err
 	}
+	proposalIdCbor := fields[updateVoteProposalIdIndex]
 	proposalId, err := payloadBytes(
-		"update vote proposal id",
-		fields[updateVoteProposalIdIndex],
-		common.Blake2b256Size,
+		"update vote proposal id", proposalIdCbor, common.Blake2b256Size,
 	)
 	if err != nil {
 		return nil, err
 	}
-	decision, ok := fields[updateVoteDecisionIndex].(bool)
-	if !ok {
+	var decision bool
+	if _, err := cbor.Decode(
+		fields[updateVoteDecisionIndex], &decision,
+	); err != nil {
 		return nil, fmt.Errorf(
-			"%w: update vote decision is not a boolean, got %T",
-			ErrInvalidPayload, fields[updateVoteDecisionIndex],
+			"%w: update vote decision is not a boolean: %w",
+			ErrInvalidPayload, err,
 		)
 	}
 	if !decision {
@@ -190,39 +218,43 @@ func ParseUpdateVote(raw any) (*UpdateVote, error) {
 		return nil, err
 	}
 	return &UpdateVote{
-		VoterVK:    voterVK,
-		ProposalId: proposalId,
-		Decision:   decision,
-		Signature:  signature,
+		VoterVK:        voterVK,
+		ProposalId:     proposalId,
+		ProposalIdCbor: append([]byte(nil), proposalIdCbor...),
+		Decision:       decision,
+		Signature:      signature,
 	}, nil
 }
 
 // Verify checks the vote's signature, reproducing
 // cardano-ledger-byron's Cardano.Chain.Update.Vote signing format:
 //
-//	inner  = 0x82 || CBOR(proposalId) || 0xf5
+//	inner  = 0x82 || proposalIdCbor || 0xf5
 //	signed = 0x06 || CBOR(protocolMagic) || inner
 //
 // 0x82 is a two-element definite-length array header and 0xf5 is CBOR true,
 // together the encoding of the (UpId, Bool) pair signatureForVote signs.
 // This mirrors recoverSignedBytes, which reassembles the same two bytes
 // around the proposal id's preserved encoding rather than re-encoding the
-// pair.
+// pair -- and preserved is what it has to be, since a non-shortest id
+// encoding would not survive a round trip.
 func (v *UpdateVote) Verify(protocolMagic uint32) error {
 	if v == nil {
 		return fmt.Errorf("%w: update vote is nil", ErrInvalidPayload)
+	}
+	if len(v.ProposalIdCbor) == 0 {
+		return fmt.Errorf(
+			"%w: update vote has no preserved proposal id encoding",
+			ErrInvalidPayload,
+		)
 	}
 	const (
 		cborArrayLen2 byte = 0x82
 		cborTrue      byte = 0xf5
 	)
-	proposalIdCbor, err := cbor.Encode(v.ProposalId)
-	if err != nil {
-		return fmt.Errorf("encode update vote proposal id: %w", err)
-	}
-	inner := make([]byte, 0, 2+len(proposalIdCbor))
+	inner := make([]byte, 0, 2+len(v.ProposalIdCbor))
 	inner = append(inner, cborArrayLen2)
-	inner = append(inner, proposalIdCbor...)
+	inner = append(inner, v.ProposalIdCbor...)
 	inner = append(inner, cborTrue)
 	signed, err := signedBytes(SignTagUSVote, protocolMagic, inner)
 	if err != nil {
@@ -237,6 +269,20 @@ func (v *UpdateVote) Verify(protocolMagic uint32) error {
 	return nil
 }
 
+// proposalFields returns an update proposal's seven fields as their
+// original wire encodings.
+func (p *ByronUpdateProposal) proposalFields() ([]cbor.RawMessage, error) {
+	proposalCbor := p.Cbor()
+	if len(proposalCbor) == 0 {
+		return nil, fmt.Errorf(
+			"%w: update proposal has no preserved CBOR", ErrInvalidPayload,
+		)
+	}
+	return payloadFields(
+		"update proposal", proposalCbor, updateProposalElementCount,
+	)
+}
+
 // signedBody returns the exact bytes an update proposal's signature covers:
 // a five-element array header followed by the proposal's first five fields
 // as they appeared on the wire.
@@ -248,26 +294,8 @@ func (v *UpdateVote) Verify(protocolMagic uint32) error {
 // five fields re-framed as a five-element array, and two of those fields
 // decode into `any`, so re-encoding them is not guaranteed to reproduce the
 // issuer's bytes.
-func (p *ByronUpdateProposal) signedBody() ([]byte, error) {
+func signedBody(fields []cbor.RawMessage) []byte {
 	const cborArrayLen5 byte = 0x85
-	proposalCbor := p.Cbor()
-	if len(proposalCbor) == 0 {
-		return nil, fmt.Errorf(
-			"%w: update proposal has no preserved CBOR", ErrInvalidPayload,
-		)
-	}
-	var fields []cbor.RawMessage
-	if _, err := cbor.Decode(proposalCbor, &fields); err != nil {
-		return nil, fmt.Errorf(
-			"%w: decode update proposal fields: %w", ErrInvalidPayload, err,
-		)
-	}
-	if len(fields) != updateProposalElementCount {
-		return nil, fmt.Errorf(
-			"%w: update proposal is not a %d-element array, got %d elements",
-			ErrInvalidPayload, updateProposalElementCount, len(fields),
-		)
-	}
 	size := 1
 	for _, field := range fields[:updateProposalSignedBodyCount] {
 		size += len(field)
@@ -277,7 +305,7 @@ func (p *ByronUpdateProposal) signedBody() ([]byte, error) {
 	for _, field := range fields[:updateProposalSignedBodyCount] {
 		body = append(body, field...)
 	}
-	return body, nil
+	return body
 }
 
 // Validate structurally validates an update proposal and verifies its
@@ -287,6 +315,16 @@ func (p *ByronUpdateProposal) signedBody() ([]byte, error) {
 //	signed = 0x04 || CBOR(protocolMagic) || signedBody()
 //
 // See signedBody for how the signed body is recovered.
+//
+// Authenticating the signed bytes is not on its own enough to accept a
+// proposal: the signature covers whatever the issuer put in the metadata
+// and attributes fields, so a correctly signed proposal can still carry
+// values the reference decoder rejects outright -- a bare integer in place
+// of the metadata map, say. validateProposalMetadata and
+// validateProposalAttributes reproduce what
+// cardano-ledger-byron's ProposalBody decoder enforces for those two
+// fields, so this cannot accept a proposal cardano-ledger would refuse to
+// decode.
 func (p *ByronUpdateProposal) Validate(protocolMagic uint32) error {
 	if p == nil {
 		return fmt.Errorf("%w: update proposal is nil", ErrInvalidPayload)
@@ -303,11 +341,23 @@ func (p *ByronUpdateProposal) Validate(protocolMagic uint32) error {
 			ErrInvalidPayload, len(p.Signature), ed25519.SignatureSize,
 		)
 	}
-	body, err := p.signedBody()
+	fields, err := p.proposalFields()
 	if err != nil {
 		return err
 	}
-	signed, err := signedBytes(SignTagUSProposal, protocolMagic, body)
+	if err := validateProposalMetadata(
+		fields[updateProposalMetadataIndex],
+	); err != nil {
+		return err
+	}
+	if err := validateProposalAttributes(
+		fields[updateProposalAttributesIndex],
+	); err != nil {
+		return err
+	}
+	signed, err := signedBytes(
+		SignTagUSProposal, protocolMagic, signedBody(fields),
+	)
 	if err != nil {
 		return err
 	}
@@ -319,20 +369,205 @@ func (p *ByronUpdateProposal) Validate(protocolMagic uint32) error {
 	return nil
 }
 
+// validateProposalMetadata enforces the shape of an update proposal's
+// metadata field, which cardano-ledger-byron types as
+// Map SystemTag InstallerHash (Cardano.Chain.Update.Proposal's ProposalBody,
+// via Cardano.Chain.Update.SystemTag and .InstallerHash):
+//
+//   - the field is a CBOR map;
+//   - each key is a text string of at most systemTagMaxLength characters,
+//     all ASCII -- SystemTag's checkSystemTag;
+//   - each value is a one-element array holding a 32-byte hash --
+//     InstallerHash's enforceSize "InstallerHash" 1.
+//
+// NOTE: the InstallerHash framing above is transcribed from the reference
+// decoder, not confirmed against a real mainnet proposal -- this repository
+// has no such vector. It is the reason
+// common.VerifyConfig.EnableByronPayloadValidation stays opt-in.
+func validateProposalMetadata(raw cbor.RawMessage) error {
+	var metadata map[string]cbor.RawMessage
+	if _, err := cbor.Decode(raw, &metadata); err != nil {
+		return fmt.Errorf(
+			"%w: update proposal metadata is not a map of system tags to "+
+				"installer hashes: %w",
+			ErrInvalidPayload, err,
+		)
+	}
+	for tag, installerHash := range metadata {
+		if err := validateSystemTag(tag); err != nil {
+			return err
+		}
+		if err := validateInstallerHash(tag, installerHash); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateSystemTag reproduces cardano-ledger-byron's checkSystemTag.
+func validateSystemTag(tag string) error {
+	for i := range len(tag) {
+		if tag[i] > unicode.MaxASCII {
+			return fmt.Errorf(
+				"%w: update proposal system tag %q is not ASCII",
+				ErrInvalidPayload, tag,
+			)
+		}
+	}
+	// Every byte is ASCII by this point, so byte length is character
+	// length, which is what checkSystemTag bounds.
+	if len(tag) > systemTagMaxLength {
+		return fmt.Errorf(
+			"%w: update proposal system tag %q is %d characters, at most %d allowed",
+			ErrInvalidPayload, tag, len(tag), systemTagMaxLength,
+		)
+	}
+	return nil
+}
+
+// validateInstallerHash reproduces cardano-ledger-byron's InstallerHash
+// decoder: a one-element array wrapping a blake2b-256 hash.
+func validateInstallerHash(tag string, raw cbor.RawMessage) error {
+	fields, err := payloadFields(
+		fmt.Sprintf("update proposal installer hash for system tag %q", tag),
+		raw,
+		installerHashElementCount,
+	)
+	if err != nil {
+		return err
+	}
+	_, err = payloadBytes(
+		fmt.Sprintf("update proposal installer hash for system tag %q", tag),
+		fields[0],
+		common.Blake2b256Size,
+	)
+	return err
+}
+
+// validateProposalAttributes enforces that an update proposal's attributes
+// field is an empty map, which is what cardano-ledger-byron's
+// dropEmptyAttributes requires: it reads a definite map length and errors
+// with "Found unexpected attributes!" on anything other than zero.
+//
+// The check reads the map header directly rather than decoding into a Go
+// map, because the field's key type is not fixed -- the reference drops it
+// without ever decoding the keys -- and a decode would have to guess one.
+//
+// The reference reads the length with decodeMapLenCanonical, so a
+// non-shortest length header is rejected too. That is safe to reproduce:
+// Byron's decoders are canonical throughout (enforceSize is
+// decodeListLenCanonical), so every attributes map a node ever accepted on
+// mainnet is canonically encoded.
+func validateProposalAttributes(raw cbor.RawMessage) error {
+	length, err := cborMapLen(raw)
+	if err != nil {
+		return fmt.Errorf(
+			"%w: update proposal attributes: %w", ErrInvalidPayload, err,
+		)
+	}
+	if length != 0 {
+		return fmt.Errorf(
+			"%w: update proposal carries %d attributes, expected none",
+			ErrInvalidPayload, length,
+		)
+	}
+	return nil
+}
+
+// cborMapLen reads the entry count out of a definite-length CBOR map
+// header, requiring the shortest encoding of that count and rejecting
+// indefinite-length maps -- matching the reference's decodeMapLenCanonical.
+func cborMapLen(raw []byte) (uint64, error) {
+	const (
+		majorTypeMap       = 5
+		majorTypeShift     = 5
+		inlineArgumentMax  = 23
+		argumentOneByte    = 24
+		argumentEightByte  = 27
+		argumentIndefinite = 31
+		argumentMask       = 0x1f
+	)
+	if len(raw) == 0 {
+		return 0, errors.New("empty encoding")
+	}
+	if raw[0]>>majorTypeShift != majorTypeMap {
+		return 0, fmt.Errorf("not a CBOR map, initial byte is 0x%02x", raw[0])
+	}
+	argument := raw[0] & argumentMask
+	if argument <= inlineArgumentMax {
+		return uint64(argument), nil
+	}
+	if argument == argumentIndefinite {
+		return 0, errors.New("indefinite-length map is not permitted")
+	}
+	if argument < argumentOneByte || argument > argumentEightByte {
+		return 0, fmt.Errorf("reserved map header argument %d", argument)
+	}
+	width := 1 << (argument - argumentOneByte)
+	if len(raw) < 1+width {
+		return 0, fmt.Errorf(
+			"truncated map header: need %d bytes, have %d", 1+width, len(raw),
+		)
+	}
+	var length uint64
+	for _, b := range raw[1 : 1+width] {
+		length = length<<8 | uint64(b)
+	}
+	if shortestMapArgumentWidth(length) != width {
+		return 0, fmt.Errorf(
+			"map length %d is not encoded in its shortest form", length,
+		)
+	}
+	return length, nil
+}
+
+// shortestMapArgumentWidth returns how many argument bytes the canonical
+// encoding of a map length uses. Lengths up to 23 are carried in the
+// initial byte itself, so they use none -- which is what makes an empty
+// attributes map written as 0xb8 0x00 non-canonical.
+func shortestMapArgumentWidth(length uint64) int {
+	switch {
+	case length <= 23:
+		return 0
+	case length <= 0xff:
+		return 1
+	case length <= 0xffff:
+		return 2
+	case length <= 0xffffffff:
+		return 4
+	default:
+		return 8
+	}
+}
+
 // ValidateDelegationPayload structurally validates every heavyweight
 // delegation certificate in a Byron main block's delegation payload and
 // verifies each certificate's signature.
 //
 // The block's own header protocol magic is used for domain separation, so a
 // certificate signed for another network fails here.
+//
+// Validation walks the payload's preserved CBOR rather than its decoded
+// []any, because each certificate's signature covers its epoch field's wire
+// encoding. A block whose delegation payload was not decoded from CBOR --
+// one assembled in Go -- therefore cannot be checked, and is rejected
+// rather than verified against re-encoded bytes.
 func (b *ByronMainBlock) ValidateDelegationPayload() error {
 	if b == nil || b.BlockHeader == nil {
 		return fmt.Errorf(
 			"%w: block or block header is nil", ErrInvalidPayload,
 		)
 	}
+	certificates, err := payloadEntries(
+		"delegation payload",
+		b.Body.DlgPayloadCbor(),
+		len(b.Body.DlgPayload),
+	)
+	if err != nil {
+		return err
+	}
 	protocolMagic := b.BlockHeader.ProtocolMagic
-	for i, rawCertificate := range b.Body.DlgPayload {
+	for i, rawCertificate := range certificates {
 		certificate, err := ParseDelegationCertificate(rawCertificate)
 		if err != nil {
 			return fmt.Errorf("delegation certificate %d: %w", i, err)
@@ -348,6 +583,10 @@ func (b *ByronMainBlock) ValidateDelegationPayload() error {
 // vote in a Byron main block's update payload and verifies their
 // signatures, using the block's own header protocol magic for domain
 // separation.
+//
+// Like ValidateDelegationPayload, the votes are read out of the payload's
+// preserved CBOR: a vote's signature covers its proposal id field's wire
+// encoding. Proposals carry their own preserved CBOR already.
 func (b *ByronMainBlock) ValidateUpdatePayload() error {
 	if b == nil || b.BlockHeader == nil {
 		return fmt.Errorf(
@@ -362,7 +601,11 @@ func (b *ByronMainBlock) ValidateUpdatePayload() error {
 			return fmt.Errorf("update proposal %d: %w", i, err)
 		}
 	}
-	for i, rawVote := range b.Body.UpdPayload.Votes {
+	votes, err := b.updateVotesCbor()
+	if err != nil {
+		return err
+	}
+	for i, rawVote := range votes {
 		vote, err := ParseUpdateVote(rawVote)
 		if err != nil {
 			return fmt.Errorf("update vote %d: %w", i, err)
@@ -372,6 +615,40 @@ func (b *ByronMainBlock) ValidateUpdatePayload() error {
 		}
 	}
 	return nil
+}
+
+// updateVotesCbor returns the preserved CBOR of each vote in the block's
+// update payload, which is the second element of the payload's
+// [proposals, votes] array.
+func (b *ByronMainBlock) updateVotesCbor() ([]cbor.RawMessage, error) {
+	voteCount := len(b.Body.UpdPayload.Votes)
+	updCbor := b.Body.UpdPayloadCbor()
+	if len(updCbor) == 0 {
+		if voteCount == 0 {
+			return nil, nil
+		}
+		return nil, fmt.Errorf(
+			"%w: update payload carries %d votes but has no preserved CBOR",
+			ErrInvalidPayload, voteCount,
+		)
+	}
+	var parts []cbor.RawMessage
+	if _, err := cbor.Decode(updCbor, &parts); err != nil {
+		return nil, fmt.Errorf(
+			"%w: decode update payload: %w", ErrInvalidPayload, err,
+		)
+	}
+	if len(parts) != updatePayloadElementCount {
+		return nil, fmt.Errorf(
+			"%w: update payload is not a %d-element array, got %d elements",
+			ErrInvalidPayload, updatePayloadElementCount, len(parts),
+		)
+	}
+	return payloadEntries(
+		"update payload votes",
+		parts[updatePayloadVotesIndex],
+		voteCount,
+	)
 }
 
 // ValidatePayloads runs ValidateDelegationPayload and
@@ -384,16 +661,86 @@ func (b *ByronMainBlock) ValidatePayloads() error {
 	return b.ValidateUpdatePayload()
 }
 
-// payloadBytes asserts that a decoded payload field is a byte string of an
-// exact length, returning a copy so the result does not alias the block it
-// was decoded from.
-func payloadBytes(label string, value any, size int) ([]byte, error) {
-	raw, ok := value.([]byte)
-	if !ok || len(raw) != size {
+// payloadEntries decodes a payload list into its per-entry preserved CBOR,
+// cross-checking the count against what the typed decode produced so the
+// two views of the same bytes cannot silently diverge.
+func payloadEntries(
+	label string,
+	raw []byte,
+	decodedCount int,
+) ([]cbor.RawMessage, error) {
+	if len(raw) == 0 {
+		if decodedCount == 0 {
+			return nil, nil
+		}
 		return nil, fmt.Errorf(
-			"%w: %s is not %d bytes, got %T with length %d",
-			ErrInvalidPayload, label, size, value, len(raw),
+			"%w: %s carries %d entries but has no preserved CBOR",
+			ErrInvalidPayload, label, decodedCount,
 		)
 	}
-	return append([]byte(nil), raw...), nil
+	var entries []cbor.RawMessage
+	if _, err := cbor.Decode(raw, &entries); err != nil {
+		return nil, fmt.Errorf(
+			"%w: decode %s: %w", ErrInvalidPayload, label, err,
+		)
+	}
+	if len(entries) != decodedCount {
+		return nil, fmt.Errorf(
+			"%w: %s decodes to %d entries, preserved CBOR holds %d",
+			ErrInvalidPayload, label, decodedCount, len(entries),
+		)
+	}
+	return entries, nil
+}
+
+// payloadFields decodes one payload entry into its per-field preserved
+// CBOR, asserting the entry is an array of exactly count elements.
+func payloadFields(
+	label string,
+	raw cbor.RawMessage,
+	count int,
+) ([]cbor.RawMessage, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf(
+			"%w: %s has no preserved CBOR", ErrInvalidPayload, label,
+		)
+	}
+	var fields []cbor.RawMessage
+	if _, err := cbor.Decode(raw, &fields); err != nil {
+		return nil, fmt.Errorf(
+			"%w: %s is not a %d-element array: %w",
+			ErrInvalidPayload, label, count, err,
+		)
+	}
+	if len(fields) != count {
+		return nil, fmt.Errorf(
+			"%w: %s is not a %d-element array, got %d elements",
+			ErrInvalidPayload, label, count, len(fields),
+		)
+	}
+	return fields, nil
+}
+
+// payloadBytes decodes one preserved payload field as a byte string of an
+// exact length. The result is a fresh slice, so it does not alias the block
+// it was decoded from.
+func payloadBytes(
+	label string,
+	raw cbor.RawMessage,
+	size int,
+) ([]byte, error) {
+	var value []byte
+	if _, err := cbor.Decode(raw, &value); err != nil {
+		return nil, fmt.Errorf(
+			"%w: %s is not a %d-byte string: %w",
+			ErrInvalidPayload, label, size, err,
+		)
+	}
+	if len(value) != size {
+		return nil, fmt.Errorf(
+			"%w: %s is not %d bytes, got %d",
+			ErrInvalidPayload, label, size, len(value),
+		)
+	}
+	return value, nil
 }

--- a/ledger/byron/payload.go
+++ b/ledger/byron/payload.go
@@ -1,0 +1,399 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package byron
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// ErrInvalidPayload reports a Byron main block whose delegation or update
+// payload is malformed: the body proof binds the payload bytes to the
+// header, but says nothing about whether those bytes decode to anything
+// meaningful, so a block can pass ValidateBodyProof while carrying a
+// delegation certificate with a truncated key or a vote that is not even
+// an array.
+var ErrInvalidPayload = errors.New("byron block payload is invalid")
+
+// Element counts and indices for the delegation certificate wire format,
+// which is [epoch, issuerVK, delegateVK, certSig].
+const (
+	delegationCertEpochIndex      = 0
+	delegationCertIssuerIndex     = 1
+	delegationCertDelegateIndex   = 2
+	delegationCertSignatureIndex  = 3
+	delegationCertElementCount    = 4
+	updateVoteVoterIndex          = 0
+	updateVoteProposalIdIndex     = 1
+	updateVoteDecisionIndex       = 2
+	updateVoteSignatureIndex      = 3
+	updateVoteElementCount        = 4
+	updateProposalElementCount    = 7
+	updateProposalSignedBodyCount = 5
+)
+
+// DelegationCertificate is a decoded Byron heavyweight delegation
+// certificate from a main block's delegation payload. The verification keys
+// are the full 64-byte extended form the wire format carries; see
+// VerificationKeySize.
+type DelegationCertificate struct {
+	Epoch      uint64
+	IssuerVK   []byte
+	DelegateVK []byte
+	Signature  []byte
+}
+
+// UpdateVote is a decoded Byron update-proposal vote from a main block's
+// update payload.
+type UpdateVote struct {
+	VoterVK    []byte
+	ProposalId []byte
+	Decision   bool
+	Signature  []byte
+}
+
+// ParseDelegationCertificate decodes and structurally validates one entry
+// of a Byron main block's delegation payload, which the decoder hands back
+// untyped because the payload as a whole is stored as []any.
+//
+// The returned certificate's byte slices are copies: callers routinely hold
+// these past the lifetime of the block they came from, and a certificate
+// that aliased the decoded block would let a later mutation of one change
+// the other.
+func ParseDelegationCertificate(raw any) (*DelegationCertificate, error) {
+	fields, ok := raw.([]any)
+	if !ok || len(fields) != delegationCertElementCount {
+		return nil, fmt.Errorf(
+			"%w: delegation certificate is not a %d-element array, "+
+				"got %T with %d elements",
+			ErrInvalidPayload, delegationCertElementCount, raw, len(fields),
+		)
+	}
+	epoch, err := asUint(fields[delegationCertEpochIndex])
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: delegation certificate epoch: %w", ErrInvalidPayload, err,
+		)
+	}
+	issuerVK, err := payloadBytes(
+		"delegation certificate issuer verification key",
+		fields[delegationCertIssuerIndex],
+		VerificationKeySize,
+	)
+	if err != nil {
+		return nil, err
+	}
+	delegateVK, err := payloadBytes(
+		"delegation certificate delegate verification key",
+		fields[delegationCertDelegateIndex],
+		VerificationKeySize,
+	)
+	if err != nil {
+		return nil, err
+	}
+	signature, err := payloadBytes(
+		"delegation certificate signature",
+		fields[delegationCertSignatureIndex],
+		ed25519.SignatureSize,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &DelegationCertificate{
+		Epoch:      epoch,
+		IssuerVK:   issuerVK,
+		DelegateVK: delegateVK,
+		Signature:  signature,
+	}, nil
+}
+
+// Verify checks the certificate's own signature against the protocol magic
+// of the network it claims to belong to.
+func (c *DelegationCertificate) Verify(protocolMagic uint32) error {
+	if c == nil {
+		return fmt.Errorf(
+			"%w: delegation certificate is nil", ErrInvalidPayload,
+		)
+	}
+	return VerifyDelegationCertificateSignature(
+		protocolMagic, c.IssuerVK, c.DelegateVK, c.Signature, c.Epoch,
+	)
+}
+
+// ParseUpdateVote decodes and structurally validates one entry of a Byron
+// main block's update-payload vote list.
+//
+// The wire format is [voterVK, proposalId, decision, signature]. Byron only
+// ever recorded positive votes -- cardano-ledger-byron drops the decision
+// bit on decode and re-encodes a hardcoded True -- so a false decision is
+// something no real block carries, and is rejected here rather than
+// silently accepted as a vote whose signature covers the opposite value.
+func ParseUpdateVote(raw any) (*UpdateVote, error) {
+	fields, ok := raw.([]any)
+	if !ok || len(fields) != updateVoteElementCount {
+		return nil, fmt.Errorf(
+			"%w: update vote is not a %d-element array, got %T with %d elements",
+			ErrInvalidPayload, updateVoteElementCount, raw, len(fields),
+		)
+	}
+	voterVK, err := payloadBytes(
+		"update vote voter verification key",
+		fields[updateVoteVoterIndex],
+		VerificationKeySize,
+	)
+	if err != nil {
+		return nil, err
+	}
+	proposalId, err := payloadBytes(
+		"update vote proposal id",
+		fields[updateVoteProposalIdIndex],
+		common.Blake2b256Size,
+	)
+	if err != nil {
+		return nil, err
+	}
+	decision, ok := fields[updateVoteDecisionIndex].(bool)
+	if !ok {
+		return nil, fmt.Errorf(
+			"%w: update vote decision is not a boolean, got %T",
+			ErrInvalidPayload, fields[updateVoteDecisionIndex],
+		)
+	}
+	if !decision {
+		return nil, fmt.Errorf(
+			"%w: update vote decision is false, which Byron never records",
+			ErrInvalidPayload,
+		)
+	}
+	signature, err := payloadBytes(
+		"update vote signature",
+		fields[updateVoteSignatureIndex],
+		ed25519.SignatureSize,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &UpdateVote{
+		VoterVK:    voterVK,
+		ProposalId: proposalId,
+		Decision:   decision,
+		Signature:  signature,
+	}, nil
+}
+
+// Verify checks the vote's signature, reproducing
+// cardano-ledger-byron's Cardano.Chain.Update.Vote signing format:
+//
+//	inner  = 0x82 || CBOR(proposalId) || 0xf5
+//	signed = 0x06 || CBOR(protocolMagic) || inner
+//
+// 0x82 is a two-element definite-length array header and 0xf5 is CBOR true,
+// together the encoding of the (UpId, Bool) pair signatureForVote signs.
+// This mirrors recoverSignedBytes, which reassembles the same two bytes
+// around the proposal id's preserved encoding rather than re-encoding the
+// pair.
+func (v *UpdateVote) Verify(protocolMagic uint32) error {
+	if v == nil {
+		return fmt.Errorf("%w: update vote is nil", ErrInvalidPayload)
+	}
+	const (
+		cborArrayLen2 byte = 0x82
+		cborTrue      byte = 0xf5
+	)
+	proposalIdCbor, err := cbor.Encode(v.ProposalId)
+	if err != nil {
+		return fmt.Errorf("encode update vote proposal id: %w", err)
+	}
+	inner := make([]byte, 0, 2+len(proposalIdCbor))
+	inner = append(inner, cborArrayLen2)
+	inner = append(inner, proposalIdCbor...)
+	inner = append(inner, cborTrue)
+	signed, err := signedBytes(SignTagUSVote, protocolMagic, inner)
+	if err != nil {
+		return err
+	}
+	if !verifyEd25519(v.VoterVK, signed, v.Signature) {
+		return fmt.Errorf(
+			"%w: update vote for proposal %x", ErrInvalidSignature,
+			v.ProposalId,
+		)
+	}
+	return nil
+}
+
+// signedBody returns the exact bytes an update proposal's signature covers:
+// a five-element array header followed by the proposal's first five fields
+// as they appeared on the wire.
+//
+// The bytes are recovered from the proposal's preserved CBOR rather than
+// re-encoded. cardano-ledger-byron does the same thing for the same reason
+// (recoverProposalSignedBytes prepends "\133" -- 0x85 -- to the decoded
+// body's byte span): the signature covers a seven-element proposal's first
+// five fields re-framed as a five-element array, and two of those fields
+// decode into `any`, so re-encoding them is not guaranteed to reproduce the
+// issuer's bytes.
+func (p *ByronUpdateProposal) signedBody() ([]byte, error) {
+	const cborArrayLen5 byte = 0x85
+	proposalCbor := p.Cbor()
+	if len(proposalCbor) == 0 {
+		return nil, fmt.Errorf(
+			"%w: update proposal has no preserved CBOR", ErrInvalidPayload,
+		)
+	}
+	var fields []cbor.RawMessage
+	if _, err := cbor.Decode(proposalCbor, &fields); err != nil {
+		return nil, fmt.Errorf(
+			"%w: decode update proposal fields: %w", ErrInvalidPayload, err,
+		)
+	}
+	if len(fields) != updateProposalElementCount {
+		return nil, fmt.Errorf(
+			"%w: update proposal is not a %d-element array, got %d elements",
+			ErrInvalidPayload, updateProposalElementCount, len(fields),
+		)
+	}
+	size := 1
+	for _, field := range fields[:updateProposalSignedBodyCount] {
+		size += len(field)
+	}
+	body := make([]byte, 0, size)
+	body = append(body, cborArrayLen5)
+	for _, field := range fields[:updateProposalSignedBodyCount] {
+		body = append(body, field...)
+	}
+	return body, nil
+}
+
+// Validate structurally validates an update proposal and verifies its
+// issuer signature, reproducing cardano-ledger-byron's
+// Cardano.Chain.Update.Proposal signing format:
+//
+//	signed = 0x04 || CBOR(protocolMagic) || signedBody()
+//
+// See signedBody for how the signed body is recovered.
+func (p *ByronUpdateProposal) Validate(protocolMagic uint32) error {
+	if p == nil {
+		return fmt.Errorf("%w: update proposal is nil", ErrInvalidPayload)
+	}
+	if len(p.From) != VerificationKeySize {
+		return fmt.Errorf(
+			"%w: update proposal issuer key is %d bytes, expected %d",
+			ErrInvalidPayload, len(p.From), VerificationKeySize,
+		)
+	}
+	if len(p.Signature) != ed25519.SignatureSize {
+		return fmt.Errorf(
+			"%w: update proposal signature is %d bytes, expected %d",
+			ErrInvalidPayload, len(p.Signature), ed25519.SignatureSize,
+		)
+	}
+	body, err := p.signedBody()
+	if err != nil {
+		return err
+	}
+	signed, err := signedBytes(SignTagUSProposal, protocolMagic, body)
+	if err != nil {
+		return err
+	}
+	if !verifyEd25519(p.From, signed, p.Signature) {
+		return fmt.Errorf(
+			"%w: update proposal from %x", ErrInvalidSignature, p.From[:32],
+		)
+	}
+	return nil
+}
+
+// ValidateDelegationPayload structurally validates every heavyweight
+// delegation certificate in a Byron main block's delegation payload and
+// verifies each certificate's signature.
+//
+// The block's own header protocol magic is used for domain separation, so a
+// certificate signed for another network fails here.
+func (b *ByronMainBlock) ValidateDelegationPayload() error {
+	if b == nil || b.BlockHeader == nil {
+		return fmt.Errorf(
+			"%w: block or block header is nil", ErrInvalidPayload,
+		)
+	}
+	protocolMagic := b.BlockHeader.ProtocolMagic
+	for i, rawCertificate := range b.Body.DlgPayload {
+		certificate, err := ParseDelegationCertificate(rawCertificate)
+		if err != nil {
+			return fmt.Errorf("delegation certificate %d: %w", i, err)
+		}
+		if err := certificate.Verify(protocolMagic); err != nil {
+			return fmt.Errorf("delegation certificate %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// ValidateUpdatePayload structurally validates every update proposal and
+// vote in a Byron main block's update payload and verifies their
+// signatures, using the block's own header protocol magic for domain
+// separation.
+func (b *ByronMainBlock) ValidateUpdatePayload() error {
+	if b == nil || b.BlockHeader == nil {
+		return fmt.Errorf(
+			"%w: block or block header is nil", ErrInvalidPayload,
+		)
+	}
+	protocolMagic := b.BlockHeader.ProtocolMagic
+	for i := range b.Body.UpdPayload.Proposals {
+		if err := b.Body.UpdPayload.Proposals[i].Validate(
+			protocolMagic,
+		); err != nil {
+			return fmt.Errorf("update proposal %d: %w", i, err)
+		}
+	}
+	for i, rawVote := range b.Body.UpdPayload.Votes {
+		vote, err := ParseUpdateVote(rawVote)
+		if err != nil {
+			return fmt.Errorf("update vote %d: %w", i, err)
+		}
+		if err := vote.Verify(protocolMagic); err != nil {
+			return fmt.Errorf("update vote %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// ValidatePayloads runs ValidateDelegationPayload and
+// ValidateUpdatePayload. This is what ValidateBodyProof calls when a caller
+// opts in via common.VerifyConfig.EnableByronPayloadValidation.
+func (b *ByronMainBlock) ValidatePayloads() error {
+	if err := b.ValidateDelegationPayload(); err != nil {
+		return err
+	}
+	return b.ValidateUpdatePayload()
+}
+
+// payloadBytes asserts that a decoded payload field is a byte string of an
+// exact length, returning a copy so the result does not alias the block it
+// was decoded from.
+func payloadBytes(label string, value any, size int) ([]byte, error) {
+	raw, ok := value.([]byte)
+	if !ok || len(raw) != size {
+		return nil, fmt.Errorf(
+			"%w: %s is not %d bytes, got %T with length %d",
+			ErrInvalidPayload, label, size, value, len(raw),
+		)
+	}
+	return append([]byte(nil), raw...), nil
+}

--- a/ledger/byron/payload_test.go
+++ b/ledger/byron/payload_test.go
@@ -190,18 +190,36 @@ func nonCanonicalEmptyMap() []byte {
 	return []byte{0xb8, 0x00}
 }
 
-// installerMetadata builds a metadata map of one system tag to one
-// installer hash, in the shape cardano-ledger-byron's ProposalBody decoder
-// requires: Map SystemTag InstallerHash, where InstallerHash is a
-// one-element array around a blake2b-256 hash.
-func installerMetadata(t *testing.T, tag string) []byte {
+// installerHashField builds an InstallerHash in the shape
+// cardano-ledger-byron's decoder requires: a four-element array whose
+// element 1 carries the blake2b-256 hash. Elements 0, 2, and 3 are the
+// remains of cardano-sl's UpdateData record and are dropped by the
+// reference, so their content is arbitrary here.
+func installerHashField(t *testing.T) []byte {
 	t.Helper()
-	installerHash := rawArray(
+	filler := mustEncode(t, bytes.Repeat([]byte{0x00}, common.Blake2b256Size))
+	return rawArray(
+		filler,
 		mustEncode(t, bytes.Repeat([]byte{0x7c}, common.Blake2b256Size)),
+		filler,
+		filler,
 	)
+}
+
+// metadataMap builds a one-entry metadata map from a system tag to an
+// already-encoded installer hash.
+func metadataMap(t *testing.T, tag string, installerHash []byte) []byte {
+	t.Helper()
 	out := []byte{0xa1}
 	out = append(out, mustEncode(t, tag)...)
 	return append(out, installerHash...)
+}
+
+// installerMetadata builds a metadata map of one system tag to one
+// reference-shaped installer hash.
+func installerMetadata(t *testing.T, tag string) []byte {
+	t.Helper()
+	return metadataMap(t, tag, installerHashField(t))
 }
 
 func decodeProposal(
@@ -699,6 +717,18 @@ func TestUpdateProposalShapes(t *testing.T) {
 			metadata:   installerMetadata(t, "0123456789"),
 			attributes: emptyMap(),
 		},
+		{
+			// Elements 0, 2 and 3 are dropped by the reference without
+			// being interpreted, so their content must not be constrained.
+			name: "installer hash with arbitrary dropped elements",
+			metadata: metadataMap(t, "linux", rawArray(
+				mustEncode(t, uint64(1)),
+				mustEncode(t, bytes.Repeat([]byte{0x7c}, 32)),
+				mustEncode(t, "anything"),
+				mustEncode(t, []any{}),
+			)),
+			attributes: emptyMap(),
+		},
 	}
 	for _, testCase := range accepted {
 		t.Run("accepts "+testCase.name, func(t *testing.T) {
@@ -760,24 +790,39 @@ func TestUpdateProposalShapes(t *testing.T) {
 		},
 		{
 			name: "installer hash not wrapped in an array",
-			metadata: func() []byte {
-				out := []byte{0xa1}
-				out = append(out, mustEncode(t, "linux")...)
-				return append(out, mustEncode(
-					t, bytes.Repeat([]byte{0x7c}, common.Blake2b256Size),
-				)...)
-			}(),
+			metadata: metadataMap(t, "linux", mustEncode(
+				t, bytes.Repeat([]byte{0x7c}, common.Blake2b256Size),
+			)),
+			attributes: emptyMap(),
+		},
+		{
+			// The pre-cardano-ledger shape: a one-element array. The
+			// reference enforces four.
+			name: "installer hash with one element",
+			metadata: metadataMap(t, "linux", rawArray(
+				mustEncode(t, bytes.Repeat([]byte{0x7c}, common.Blake2b256Size)),
+			)),
+			attributes: emptyMap(),
+		},
+		{
+			name: "installer hash with five elements",
+			metadata: metadataMap(t, "linux", rawArray(
+				mustEncode(t, bytes.Repeat([]byte{0x00}, 32)),
+				mustEncode(t, bytes.Repeat([]byte{0x7c}, 32)),
+				mustEncode(t, bytes.Repeat([]byte{0x00}, 32)),
+				mustEncode(t, bytes.Repeat([]byte{0x00}, 32)),
+				mustEncode(t, bytes.Repeat([]byte{0x00}, 32)),
+			)),
 			attributes: emptyMap(),
 		},
 		{
 			name: "installer hash wrong length",
-			metadata: func() []byte {
-				out := []byte{0xa1}
-				out = append(out, mustEncode(t, "linux")...)
-				return append(out, rawArray(
-					mustEncode(t, bytes.Repeat([]byte{0x7c}, 16)),
-				)...)
-			}(),
+			metadata: metadataMap(t, "linux", rawArray(
+				mustEncode(t, bytes.Repeat([]byte{0x00}, 32)),
+				mustEncode(t, bytes.Repeat([]byte{0x7c}, 16)),
+				mustEncode(t, bytes.Repeat([]byte{0x00}, 32)),
+				mustEncode(t, bytes.Repeat([]byte{0x00}, 32)),
+			)),
 			attributes: emptyMap(),
 		},
 	}

--- a/ledger/byron/payload_test.go
+++ b/ledger/byron/payload_test.go
@@ -614,7 +614,7 @@ func TestValidatePayloadsReportsOffendingIndex(t *testing.T) {
 	)
 	err := block.ValidateDelegationPayload()
 	require.ErrorIs(t, err, byron.ErrInvalidPayload)
-	require.Contains(t, err.Error(), "delegation certificate 1")
+	require.ErrorContains(t, err, "delegation certificate 1")
 }
 
 func TestValidatePayloadsWrongNetwork(t *testing.T) {

--- a/ledger/byron/payload_test.go
+++ b/ledger/byron/payload_test.go
@@ -27,6 +27,23 @@ import (
 
 const testPayloadProtocolMagic = uint32(764824073)
 
+// rawArray frames already-encoded fields as a definite-length CBOR array,
+// leaving each field's bytes untouched. Tests assemble payload entries this
+// way, rather than encoding a Go value, so they can control the exact wire
+// encoding of individual fields -- which is the whole point of the
+// non-shortest vectors below.
+func rawArray(fields ...[]byte) cbor.RawMessage {
+	count := len(fields)
+	if count > 23 {
+		panic("rawArray only handles arrays short enough for a 1-byte header")
+	}
+	out := []byte{byte(0x80 + count)}
+	for _, field := range fields {
+		out = append(out, field...)
+	}
+	return out
+}
+
 // testKeyPair returns a deterministic Byron extended verification key (the
 // 32-byte Ed25519 public key followed by 32 chain-code bytes) and the
 // Ed25519 private key that signs for it.
@@ -40,219 +57,348 @@ func testKeyPair(seedByte byte) ([]byte, ed25519.PrivateKey) {
 	return verificationKey, private
 }
 
-// signedDelegationCertificate builds a delegation certificate in the wire
-// shape the decoder produces, signed by issuerPrivate.
+// shortestEpoch and nonShortestEpoch encode the same epoch two ways. CBOR
+// permits both and this decoder accepts both, but only one is what a given
+// certificate's issuer signed over.
+func shortestEpoch(t *testing.T, epoch uint64) []byte {
+	t.Helper()
+	return mustEncode(t, epoch)
+}
+
+func nonShortestEpoch(epoch byte) []byte {
+	// Major type 0 with a 1-byte argument, where the shortest form would
+	// have inlined the value in the initial byte.
+	return []byte{0x18, epoch}
+}
+
+// shortestProposalId and nonShortestProposalId likewise encode the same
+// 32-byte proposal id with a 1-byte and a 2-byte length header.
+func shortestProposalId(t *testing.T, id []byte) []byte {
+	t.Helper()
+	return mustEncode(t, id)
+}
+
+func nonShortestProposalId(id []byte) []byte {
+	out := []byte{0x59, 0x00, byte(len(id))}
+	return append(out, id...)
+}
+
+// signedDelegationCertificate builds a delegation certificate over the
+// caller's chosen epoch encoding, signing exactly those bytes.
 func signedDelegationCertificate(
 	t *testing.T,
 	protocolMagic uint32,
-	epoch uint64,
+	epochField []byte,
 	issuerVK []byte,
 	issuerPrivate ed25519.PrivateKey,
 	delegateVK []byte,
-) []any {
+) cbor.RawMessage {
 	t.Helper()
-	epochCbor, err := cbor.Encode(epoch)
-	require.NoError(t, err)
-	inner := make([]byte, 0, 2+len(delegateVK)+len(epochCbor))
+	inner := make([]byte, 0, 2+len(delegateVK)+len(epochField))
 	inner = append(inner, '0', '0')
 	inner = append(inner, delegateVK...)
-	inner = append(inner, epochCbor...)
-	innerCbor, err := cbor.Encode(inner)
-	require.NoError(t, err)
-	magicCbor, err := cbor.Encode(protocolMagic)
-	require.NoError(t, err)
+	inner = append(inner, epochField...)
 	signed := []byte{byron.SignTagCertificate}
-	signed = append(signed, magicCbor...)
-	signed = append(signed, innerCbor...)
-	return []any{
-		epoch,
-		append([]byte(nil), issuerVK...),
-		append([]byte(nil), delegateVK...),
-		ed25519.Sign(issuerPrivate, signed),
-	}
+	signed = append(signed, mustEncode(t, protocolMagic)...)
+	signed = append(signed, mustEncode(t, inner)...)
+	return rawArray(
+		epochField,
+		mustEncode(t, issuerVK),
+		mustEncode(t, delegateVK),
+		mustEncode(t, ed25519.Sign(issuerPrivate, signed)),
+	)
 }
 
-// signedUpdateVote builds an update vote in the wire shape the decoder
-// produces, signed by voterPrivate.
+// signedUpdateVote builds a vote over the caller's chosen proposal id
+// encoding, signing exactly those bytes.
 func signedUpdateVote(
 	t *testing.T,
 	protocolMagic uint32,
 	voterVK []byte,
 	voterPrivate ed25519.PrivateKey,
-	proposalId []byte,
-) []any {
+	proposalIdField []byte,
+) cbor.RawMessage {
 	t.Helper()
-	proposalIdCbor, err := cbor.Encode(proposalId)
-	require.NoError(t, err)
-	magicCbor, err := cbor.Encode(protocolMagic)
-	require.NoError(t, err)
+	inner := []byte{0x82}
+	inner = append(inner, proposalIdField...)
+	inner = append(inner, 0xf5)
 	signed := []byte{byron.SignTagUSVote}
-	signed = append(signed, magicCbor...)
-	signed = append(signed, 0x82)
-	signed = append(signed, proposalIdCbor...)
-	signed = append(signed, 0xf5)
-	return []any{
-		append([]byte(nil), voterVK...),
-		append([]byte(nil), proposalId...),
-		true,
-		ed25519.Sign(voterPrivate, signed),
-	}
-}
-
-// roundTripProposal encodes a proposal and decodes it back so the result
-// carries preserved CBOR, which is what the signature check reads its
-// signed body out of.
-func roundTripProposal(
-	t *testing.T,
-	proposal byron.ByronUpdateProposal,
-) byron.ByronUpdateProposal {
-	t.Helper()
-	encoded, err := cbor.Encode(&proposal)
-	require.NoError(t, err)
-	var decoded byron.ByronUpdateProposal
-	_, err = cbor.Decode(encoded, &decoded)
-	require.NoError(t, err)
-	require.NotEmpty(t, decoded.Cbor())
-	return decoded
+	signed = append(signed, mustEncode(t, protocolMagic)...)
+	signed = append(signed, inner...)
+	return rawArray(
+		mustEncode(t, voterVK),
+		proposalIdField,
+		mustEncode(t, true),
+		mustEncode(t, ed25519.Sign(voterPrivate, signed)),
+	)
 }
 
 // signedUpdateProposal builds a proposal whose signature covers its own
-// first five fields, by round-tripping it once with a placeholder signature
-// to recover the exact signed bytes, then again with the real one.
+// first five fields, framed as a five-element array. attributesField lets a
+// caller substitute a non-shortest encoding for one of those fields.
 func signedUpdateProposal(
 	t *testing.T,
 	protocolMagic uint32,
 	issuerVK []byte,
 	issuerPrivate ed25519.PrivateKey,
-) byron.ByronUpdateProposal {
+	metadataField []byte,
+	attributesField []byte,
+) cbor.RawMessage {
 	t.Helper()
-	base := byron.ByronUpdateProposal{
-		BlockVersion: byron.ByronBlockVersion{
-			Major: 1,
-			Minor: 0,
-		},
-		BlockVersionMod: byron.ByronUpdateProposalBlockVersionMod{
-			MaxTxSize: []uint64{4096},
-		},
-		SoftwareVersion: byron.ByronSoftwareVersion{
-			Name:    "cardano-sl",
-			Version: 1,
-		},
-		Data:       map[string]any{},
-		Attributes: map[string]any{},
-		From:       append([]byte(nil), issuerVK...),
-		Signature:  make([]byte, ed25519.SignatureSize),
-	}
-	// Recover the signed body from a placeholder round trip: the signature
-	// sits outside the five fields it covers, so signing does not disturb
-	// them.
-	placeholder := roundTripProposal(t, base)
-	var fields []cbor.RawMessage
-	_, err := cbor.Decode(placeholder.Cbor(), &fields)
-	require.NoError(t, err)
-	require.Len(t, fields, 7)
+	blockVersion := mustEncode(t, byron.ByronBlockVersion{Major: 1, Minor: 0})
+	blockVersionMod := mustEncode(
+		t,
+		byron.ByronUpdateProposalBlockVersionMod{MaxTxSize: []uint64{4096}},
+	)
+	softwareVersion := mustEncode(
+		t,
+		byron.ByronSoftwareVersion{Name: "cardano-sl", Version: 1},
+	)
+	data := metadataField
+
 	body := []byte{0x85}
-	for _, field := range fields[:5] {
+	for _, field := range [][]byte{
+		blockVersion, blockVersionMod, softwareVersion, data, attributesField,
+	} {
 		body = append(body, field...)
 	}
-	magicCbor, err := cbor.Encode(protocolMagic)
-	require.NoError(t, err)
 	signed := []byte{byron.SignTagUSProposal}
-	signed = append(signed, magicCbor...)
+	signed = append(signed, mustEncode(t, protocolMagic)...)
 	signed = append(signed, body...)
-	base.Signature = ed25519.Sign(issuerPrivate, signed)
-	return roundTripProposal(t, base)
+	return rawArray(
+		blockVersion,
+		blockVersionMod,
+		softwareVersion,
+		data,
+		attributesField,
+		mustEncode(t, issuerVK),
+		mustEncode(t, ed25519.Sign(issuerPrivate, signed)),
+	)
 }
 
+// emptyMap is the canonical encoding of a map with no entries, which is
+// what both an absent metadata map and the always-empty attributes field
+// look like on the wire.
+func emptyMap() []byte {
+	return []byte{0xa0}
+}
+
+// nonCanonicalEmptyMap encodes the same empty map with a 1-byte count
+// header. cardano-ledger-byron reads attributes with decodeMapLenCanonical
+// and rejects this.
+func nonCanonicalEmptyMap() []byte {
+	return []byte{0xb8, 0x00}
+}
+
+// installerMetadata builds a metadata map of one system tag to one
+// installer hash, in the shape cardano-ledger-byron's ProposalBody decoder
+// requires: Map SystemTag InstallerHash, where InstallerHash is a
+// one-element array around a blake2b-256 hash.
+func installerMetadata(t *testing.T, tag string) []byte {
+	t.Helper()
+	installerHash := rawArray(
+		mustEncode(t, bytes.Repeat([]byte{0x7c}, common.Blake2b256Size)),
+	)
+	out := []byte{0xa1}
+	out = append(out, mustEncode(t, tag)...)
+	return append(out, installerHash...)
+}
+
+func decodeProposal(
+	t *testing.T,
+	raw cbor.RawMessage,
+) byron.ByronUpdateProposal {
+	t.Helper()
+	var proposal byron.ByronUpdateProposal
+	_, err := cbor.Decode(raw, &proposal)
+	require.NoError(t, err)
+	require.NotEmpty(t, proposal.Cbor())
+	return proposal
+}
+
+// testMainBlock assembles a Byron main block body as CBOR and decodes it,
+// so the block carries the preserved payload bytes that validation reads.
 func testMainBlock(
+	t *testing.T,
 	protocolMagic uint32,
-	dlgPayload []any,
-	updPayload byron.ByronUpdatePayload,
+	certificates []cbor.RawMessage,
+	proposals []cbor.RawMessage,
+	votes []cbor.RawMessage,
 ) *byron.ByronMainBlock {
+	t.Helper()
+	rawList := func(entries []cbor.RawMessage) []byte {
+		out := []byte{}
+		for _, entry := range entries {
+			out = append(out, entry...)
+		}
+		return append(
+			[]byte{byte(0x80 + len(entries))}, out...,
+		)
+	}
+	body := rawArray(
+		[]byte{0x80},                             // empty tx payload
+		mustEncode(t, []any{uint64(3), []any{}}), // certificates ssc payload
+		rawList(certificates),
+		rawArray(rawList(proposals), rawList(votes)),
+	)
+	var decoded byron.ByronMainBlockBody
+	_, err := cbor.Decode(body, &decoded)
+	require.NoError(t, err)
 	return &byron.ByronMainBlock{
 		BlockHeader: &byron.ByronMainBlockHeader{
 			ProtocolMagic: protocolMagic,
 		},
-		Body: byron.ByronMainBlockBody{
-			DlgPayload: dlgPayload,
-			UpdPayload: updPayload,
-		},
+		Body: decoded,
 	}
 }
 
 func TestParseDelegationCertificateValid(t *testing.T) {
 	issuerVK, issuerPrivate := testKeyPair(0x11)
 	delegateVK, _ := testKeyPair(0x22)
+	epochField := shortestEpoch(t, 7)
 	raw := signedDelegationCertificate(
-		t, testPayloadProtocolMagic, 7, issuerVK, issuerPrivate, delegateVK,
+		t, testPayloadProtocolMagic, epochField, issuerVK, issuerPrivate,
+		delegateVK,
 	)
 
 	certificate, err := byron.ParseDelegationCertificate(raw)
 	require.NoError(t, err)
 	require.Equal(t, uint64(7), certificate.Epoch)
+	require.Equal(t, epochField, certificate.EpochCbor)
 	require.Equal(t, issuerVK, certificate.IssuerVK)
 	require.Equal(t, delegateVK, certificate.DelegateVK)
 	require.NoError(t, certificate.Verify(testPayloadProtocolMagic))
 }
 
+// TestDelegationCertificateNonShortestEpoch is the regression vector for
+// re-encoding the epoch instead of preserving it. CBOR admits a non-shortest
+// integer encoding, this decoder accepts it, and the issuer signed the bytes
+// that were actually on the wire -- so verification has to use those.
+func TestDelegationCertificateNonShortestEpoch(t *testing.T) {
+	issuerVK, issuerPrivate := testKeyPair(0x11)
+	delegateVK, _ := testKeyPair(0x22)
+	epochField := nonShortestEpoch(7)
+	require.NotEqual(t, shortestEpoch(t, 7), epochField)
+
+	raw := signedDelegationCertificate(
+		t, testPayloadProtocolMagic, epochField, issuerVK, issuerPrivate,
+		delegateVK,
+	)
+	certificate, err := byron.ParseDelegationCertificate(raw)
+	require.NoError(t, err)
+	// The decoded value is the same epoch either way...
+	require.Equal(t, uint64(7), certificate.Epoch)
+	// ...but the preserved encoding is what the signature covers.
+	require.Equal(t, epochField, certificate.EpochCbor)
+	require.NoError(
+		t,
+		certificate.Verify(testPayloadProtocolMagic),
+		"a certificate signed over a non-shortest epoch encoding must verify",
+	)
+}
+
+// TestDelegationCertificateEpochEncodingIsLoadBearing is the converse: a
+// certificate signed over the shortest encoding must NOT verify when the
+// wire carries the non-shortest one, which proves the wire bytes are what
+// gets used.
+func TestDelegationCertificateEpochEncodingIsLoadBearing(t *testing.T) {
+	issuerVK, issuerPrivate := testKeyPair(0x11)
+	delegateVK, _ := testKeyPair(0x22)
+	signedOverShortest := signedDelegationCertificate(
+		t, testPayloadProtocolMagic, shortestEpoch(t, 7), issuerVK,
+		issuerPrivate, delegateVK,
+	)
+	fields := decodeFields(t, signedOverShortest, 4)
+	// Swap in the other encoding of the same epoch, keeping the signature.
+	swapped := rawArray(
+		nonShortestEpoch(7), fields[1], fields[2], fields[3],
+	)
+	certificate, err := byron.ParseDelegationCertificate(swapped)
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), certificate.Epoch)
+	require.ErrorIs(
+		t,
+		certificate.Verify(testPayloadProtocolMagic),
+		byron.ErrInvalidSignature,
+	)
+}
+
+func decodeFields(
+	t *testing.T,
+	raw cbor.RawMessage,
+	count int,
+) []cbor.RawMessage {
+	t.Helper()
+	var decoded []cbor.RawMessage
+	_, err := cbor.Decode(raw, &decoded)
+	require.NoError(t, err)
+	require.Len(t, decoded, count)
+	fields := make([]cbor.RawMessage, count)
+	copy(fields, decoded)
+	return fields
+}
+
 func TestParseDelegationCertificateMalformed(t *testing.T) {
 	issuerVK, issuerPrivate := testKeyPair(0x11)
 	delegateVK, _ := testKeyPair(0x22)
-	valid := signedDelegationCertificate(
-		t, testPayloadProtocolMagic, 7, issuerVK, issuerPrivate, delegateVK,
-	)
+	valid := decodeFields(t, signedDelegationCertificate(
+		t, testPayloadProtocolMagic, shortestEpoch(t, 7), issuerVK,
+		issuerPrivate, delegateVK,
+	), 4)
 
 	testCases := []struct {
 		name string
-		raw  any
+		raw  cbor.RawMessage
 	}{
 		{
+			name: "empty",
+			raw:  nil,
+		},
+		{
 			name: "not an array",
-			raw:  []byte{0x01, 0x02},
+			raw:  mustEncode(t, []byte{0x01, 0x02}),
 		},
 		{
 			name: "too few elements",
-			raw:  valid[:3],
+			raw:  rawArray(valid[0], valid[1], valid[2]),
 		},
 		{
 			name: "too many elements",
-			raw:  append(append([]any{}, valid...), uint64(0)),
+			raw: rawArray(
+				valid[0], valid[1], valid[2], valid[3],
+				mustEncode(t, uint64(0)),
+			),
 		},
 		{
 			name: "negative epoch",
-			raw: []any{
-				int64(-1), valid[1], valid[2], valid[3],
-			},
+			raw: rawArray(
+				mustEncode(t, int64(-1)), valid[1], valid[2], valid[3],
+			),
 		},
 		{
 			name: "issuer key not bytes",
-			raw: []any{
-				valid[0], "not-a-key", valid[2], valid[3],
-			},
+			raw: rawArray(
+				valid[0], mustEncode(t, "not-a-key"), valid[2], valid[3],
+			),
 		},
 		{
 			name: "issuer key truncated",
-			raw: []any{
-				valid[0],
-				issuerVK[:32],
-				valid[2],
-				valid[3],
-			},
+			raw: rawArray(
+				valid[0], mustEncode(t, issuerVK[:32]), valid[2], valid[3],
+			),
 		},
 		{
 			name: "delegate key truncated",
-			raw: []any{
-				valid[0], valid[1], delegateVK[:16], valid[3],
-			},
+			raw: rawArray(
+				valid[0], valid[1], mustEncode(t, delegateVK[:16]), valid[3],
+			),
 		},
 		{
 			name: "signature truncated",
-			raw: []any{
-				valid[0],
-				valid[1],
-				valid[2],
-				make([]byte, ed25519.SignatureSize-1),
-			},
+			raw: rawArray(
+				valid[0], valid[1], valid[2],
+				mustEncode(t, make([]byte, ed25519.SignatureSize-1)),
+			),
 		},
 	}
 	for _, testCase := range testCases {
@@ -267,87 +413,72 @@ func TestDelegationCertificateSignatureMismatch(t *testing.T) {
 	issuerVK, issuerPrivate := testKeyPair(0x11)
 	delegateVK, _ := testKeyPair(0x22)
 	impostorVK, _ := testKeyPair(0x33)
+	valid := decodeFields(t, signedDelegationCertificate(
+		t, testPayloadProtocolMagic, shortestEpoch(t, 7), issuerVK,
+		issuerPrivate, delegateVK,
+	), 4)
 
-	t.Run("signed by another key", func(t *testing.T) {
-		raw := signedDelegationCertificate(
-			t, testPayloadProtocolMagic, 7, issuerVK, issuerPrivate,
-			delegateVK,
-		)
-		// Keep the signature, swap the key it claims to come from.
-		raw[1] = impostorVK
-		certificate, err := byron.ParseDelegationCertificate(raw)
-		require.NoError(t, err)
-		require.ErrorIs(
-			t,
-			certificate.Verify(testPayloadProtocolMagic),
-			byron.ErrInvalidSignature,
-		)
-	})
-
-	t.Run("delegate substituted", func(t *testing.T) {
-		raw := signedDelegationCertificate(
-			t, testPayloadProtocolMagic, 7, issuerVK, issuerPrivate,
-			delegateVK,
-		)
-		raw[2] = impostorVK
-		certificate, err := byron.ParseDelegationCertificate(raw)
-		require.NoError(t, err)
-		require.ErrorIs(
-			t,
-			certificate.Verify(testPayloadProtocolMagic),
-			byron.ErrInvalidSignature,
-		)
-	})
-
-	t.Run("epoch substituted", func(t *testing.T) {
-		raw := signedDelegationCertificate(
-			t, testPayloadProtocolMagic, 7, issuerVK, issuerPrivate,
-			delegateVK,
-		)
-		raw[0] = uint64(8)
-		certificate, err := byron.ParseDelegationCertificate(raw)
-		require.NoError(t, err)
-		require.ErrorIs(
-			t,
-			certificate.Verify(testPayloadProtocolMagic),
-			byron.ErrInvalidSignature,
-		)
-	})
-
-	t.Run("wrong network", func(t *testing.T) {
-		raw := signedDelegationCertificate(
-			t, testPayloadProtocolMagic, 7, issuerVK, issuerPrivate,
-			delegateVK,
-		)
-		certificate, err := byron.ParseDelegationCertificate(raw)
-		require.NoError(t, err)
-		require.ErrorIs(
-			t,
-			certificate.Verify(testPayloadProtocolMagic+1),
-			byron.ErrInvalidSignature,
-		)
-	})
+	testCases := []struct {
+		name  string
+		raw   cbor.RawMessage
+		magic uint32
+	}{
+		{
+			name: "signed by another key",
+			raw: rawArray(
+				valid[0], mustEncode(t, impostorVK), valid[2], valid[3],
+			),
+			magic: testPayloadProtocolMagic,
+		},
+		{
+			name: "delegate substituted",
+			raw: rawArray(
+				valid[0], valid[1], mustEncode(t, impostorVK), valid[3],
+			),
+			magic: testPayloadProtocolMagic,
+		},
+		{
+			name: "epoch substituted",
+			raw: rawArray(
+				shortestEpoch(t, 8), valid[1], valid[2], valid[3],
+			),
+			magic: testPayloadProtocolMagic,
+		},
+		{
+			name:  "wrong network",
+			raw:   rawArray(valid[0], valid[1], valid[2], valid[3]),
+			magic: testPayloadProtocolMagic + 1,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			certificate, err := byron.ParseDelegationCertificate(testCase.raw)
+			require.NoError(t, err)
+			require.ErrorIs(
+				t,
+				certificate.Verify(testCase.magic),
+				byron.ErrInvalidSignature,
+			)
+		})
+	}
 }
 
 func TestParseDelegationCertificateDoesNotAliasInput(t *testing.T) {
 	issuerVK, issuerPrivate := testKeyPair(0x11)
 	delegateVK, _ := testKeyPair(0x22)
 	raw := signedDelegationCertificate(
-		t, testPayloadProtocolMagic, 7, issuerVK, issuerPrivate, delegateVK,
+		t, testPayloadProtocolMagic, shortestEpoch(t, 7), issuerVK,
+		issuerPrivate, delegateVK,
 	)
 
 	certificate, err := byron.ParseDelegationCertificate(raw)
 	require.NoError(t, err)
 
-	// Scribble over the decoded payload the certificate came from. A
-	// certificate that aliased it would start verifying against bytes its
-	// issuer never signed.
-	for _, index := range []int{1, 2, 3} {
-		field, ok := raw[index].([]byte)
-		require.True(t, ok)
-		for i := range field {
-			field[i] = 0xff
-		}
+	// Scribble over the buffer the certificate came from. A certificate
+	// that aliased it would start verifying against bytes its issuer never
+	// signed.
+	for i := range raw {
+		raw[i] = 0xff
 	}
 	require.NoError(t, certificate.Verify(testPayloadProtocolMagic))
 }
@@ -355,58 +486,121 @@ func TestParseDelegationCertificateDoesNotAliasInput(t *testing.T) {
 func TestParseUpdateVoteValid(t *testing.T) {
 	voterVK, voterPrivate := testKeyPair(0x44)
 	proposalId := bytes.Repeat([]byte{0x5a}, common.Blake2b256Size)
+	idField := shortestProposalId(t, proposalId)
 	raw := signedUpdateVote(
-		t, testPayloadProtocolMagic, voterVK, voterPrivate, proposalId,
+		t, testPayloadProtocolMagic, voterVK, voterPrivate, idField,
 	)
 
 	vote, err := byron.ParseUpdateVote(raw)
 	require.NoError(t, err)
 	require.Equal(t, voterVK, vote.VoterVK)
 	require.Equal(t, proposalId, vote.ProposalId)
+	require.Equal(t, idField, vote.ProposalIdCbor)
 	require.True(t, vote.Decision)
 	require.NoError(t, vote.Verify(testPayloadProtocolMagic))
+}
+
+// TestUpdateVoteNonShortestProposalId is the regression vector the reviewer
+// called out: a 32-byte proposal id encoded with a 2-byte length header
+// (0x59 0x00 0x20) re-encodes to 0x58 0x20, so verifying against the
+// re-encoding would reject a vote its voter signed correctly.
+func TestUpdateVoteNonShortestProposalId(t *testing.T) {
+	voterVK, voterPrivate := testKeyPair(0x44)
+	proposalId := bytes.Repeat([]byte{0x5a}, common.Blake2b256Size)
+	idField := nonShortestProposalId(proposalId)
+	require.NotEqual(t, shortestProposalId(t, proposalId), idField)
+	require.Equal(t, []byte{0x59, 0x00, 0x20}, idField[:3])
+
+	raw := signedUpdateVote(
+		t, testPayloadProtocolMagic, voterVK, voterPrivate, idField,
+	)
+	vote, err := byron.ParseUpdateVote(raw)
+	require.NoError(t, err)
+	require.Equal(t, proposalId, vote.ProposalId)
+	require.Equal(t, idField, vote.ProposalIdCbor)
+	require.NoError(
+		t,
+		vote.Verify(testPayloadProtocolMagic),
+		"a vote signed over a non-shortest proposal id must verify",
+	)
+}
+
+// TestUpdateVoteProposalIdEncodingIsLoadBearing is the converse of the
+// above: swapping the wire encoding while keeping the signature must fail.
+func TestUpdateVoteProposalIdEncodingIsLoadBearing(t *testing.T) {
+	voterVK, voterPrivate := testKeyPair(0x44)
+	proposalId := bytes.Repeat([]byte{0x5a}, common.Blake2b256Size)
+	signedOverShortest := signedUpdateVote(
+		t, testPayloadProtocolMagic, voterVK, voterPrivate,
+		shortestProposalId(t, proposalId),
+	)
+	fields := decodeFields(t, signedOverShortest, 4)
+	swapped := rawArray(
+		fields[0], nonShortestProposalId(proposalId), fields[2], fields[3],
+	)
+	vote, err := byron.ParseUpdateVote(swapped)
+	require.NoError(t, err)
+	require.Equal(t, proposalId, vote.ProposalId)
+	require.ErrorIs(
+		t,
+		vote.Verify(testPayloadProtocolMagic),
+		byron.ErrInvalidSignature,
+	)
 }
 
 func TestParseUpdateVoteMalformed(t *testing.T) {
 	voterVK, voterPrivate := testKeyPair(0x44)
 	proposalId := bytes.Repeat([]byte{0x5a}, common.Blake2b256Size)
-	valid := signedUpdateVote(
-		t, testPayloadProtocolMagic, voterVK, voterPrivate, proposalId,
-	)
+	valid := decodeFields(t, signedUpdateVote(
+		t, testPayloadProtocolMagic, voterVK, voterPrivate,
+		shortestProposalId(t, proposalId),
+	), 4)
 
 	testCases := []struct {
 		name string
-		raw  any
+		raw  cbor.RawMessage
 	}{
 		{
+			name: "empty",
+			raw:  nil,
+		},
+		{
 			name: "not an array",
-			raw:  uint64(3),
+			raw:  mustEncode(t, uint64(3)),
 		},
 		{
 			name: "too few elements",
-			raw:  valid[:3],
+			raw:  rawArray(valid[0], valid[1], valid[2]),
 		},
 		{
 			name: "voter key truncated",
-			raw:  []any{voterVK[:32], valid[1], valid[2], valid[3]},
+			raw: rawArray(
+				mustEncode(t, voterVK[:32]), valid[1], valid[2], valid[3],
+			),
 		},
 		{
 			name: "proposal id wrong length",
-			raw:  []any{valid[0], proposalId[:16], valid[2], valid[3]},
+			raw: rawArray(
+				valid[0], mustEncode(t, proposalId[:16]), valid[2], valid[3],
+			),
 		},
 		{
 			name: "decision not a boolean",
-			raw:  []any{valid[0], valid[1], uint64(1), valid[3]},
+			raw: rawArray(
+				valid[0], valid[1], mustEncode(t, uint64(1)), valid[3],
+			),
 		},
 		{
 			name: "decision false",
-			raw:  []any{valid[0], valid[1], false, valid[3]},
+			raw: rawArray(
+				valid[0], valid[1], mustEncode(t, false), valid[3],
+			),
 		},
 		{
 			name: "signature truncated",
-			raw: []any{
-				valid[0], valid[1], valid[2], make([]byte, 8),
-			},
+			raw: rawArray(
+				valid[0], valid[1], valid[2], mustEncode(t, make([]byte, 8)),
+			),
 		},
 	}
 	for _, testCase := range testCases {
@@ -421,62 +615,195 @@ func TestUpdateVoteSignatureMismatch(t *testing.T) {
 	voterVK, voterPrivate := testKeyPair(0x44)
 	impostorVK, _ := testKeyPair(0x55)
 	proposalId := bytes.Repeat([]byte{0x5a}, common.Blake2b256Size)
+	valid := decodeFields(t, signedUpdateVote(
+		t, testPayloadProtocolMagic, voterVK, voterPrivate,
+		shortestProposalId(t, proposalId),
+	), 4)
 
-	t.Run("voter substituted", func(t *testing.T) {
-		raw := signedUpdateVote(
-			t, testPayloadProtocolMagic, voterVK, voterPrivate, proposalId,
-		)
-		raw[0] = impostorVK
-		vote, err := byron.ParseUpdateVote(raw)
-		require.NoError(t, err)
-		require.ErrorIs(
-			t,
-			vote.Verify(testPayloadProtocolMagic),
-			byron.ErrInvalidSignature,
-		)
-	})
-
-	t.Run("proposal id substituted", func(t *testing.T) {
-		raw := signedUpdateVote(
-			t, testPayloadProtocolMagic, voterVK, voterPrivate, proposalId,
-		)
-		raw[1] = bytes.Repeat([]byte{0x01}, common.Blake2b256Size)
-		vote, err := byron.ParseUpdateVote(raw)
-		require.NoError(t, err)
-		require.ErrorIs(
-			t,
-			vote.Verify(testPayloadProtocolMagic),
-			byron.ErrInvalidSignature,
-		)
-	})
-
-	t.Run("wrong network", func(t *testing.T) {
-		raw := signedUpdateVote(
-			t, testPayloadProtocolMagic, voterVK, voterPrivate, proposalId,
-		)
-		vote, err := byron.ParseUpdateVote(raw)
-		require.NoError(t, err)
-		require.ErrorIs(
-			t,
-			vote.Verify(testPayloadProtocolMagic+1),
-			byron.ErrInvalidSignature,
-		)
-	})
+	testCases := []struct {
+		name  string
+		raw   cbor.RawMessage
+		magic uint32
+	}{
+		{
+			name: "voter substituted",
+			raw: rawArray(
+				mustEncode(t, impostorVK), valid[1], valid[2], valid[3],
+			),
+			magic: testPayloadProtocolMagic,
+		},
+		{
+			name: "proposal id substituted",
+			raw: rawArray(
+				valid[0],
+				mustEncode(
+					t, bytes.Repeat([]byte{0x01}, common.Blake2b256Size),
+				),
+				valid[2],
+				valid[3],
+			),
+			magic: testPayloadProtocolMagic,
+		},
+		{
+			name:  "wrong network",
+			raw:   rawArray(valid[0], valid[1], valid[2], valid[3]),
+			magic: testPayloadProtocolMagic + 1,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			vote, err := byron.ParseUpdateVote(testCase.raw)
+			require.NoError(t, err)
+			require.ErrorIs(
+				t,
+				vote.Verify(testCase.magic),
+				byron.ErrInvalidSignature,
+			)
+		})
+	}
 }
 
 func TestUpdateProposalValid(t *testing.T) {
 	issuerVK, issuerPrivate := testKeyPair(0x66)
-	proposal := signedUpdateProposal(
+	proposal := decodeProposal(t, signedUpdateProposal(
 		t, testPayloadProtocolMagic, issuerVK, issuerPrivate,
-	)
+		emptyMap(), emptyMap(),
+	))
 	require.NoError(t, proposal.Validate(testPayloadProtocolMagic))
+}
+
+// TestUpdateProposalShapes covers the metadata and attributes fields, which
+// the signature covers but does not constrain: a correctly signed proposal
+// can still carry values cardano-ledger-byron's ProposalBody decoder
+// refuses, and Validate has to refuse them too.
+func TestUpdateProposalShapes(t *testing.T) {
+	issuerVK, issuerPrivate := testKeyPair(0x66)
+
+	accepted := []struct {
+		name       string
+		metadata   []byte
+		attributes []byte
+	}{
+		{
+			name:       "empty metadata and attributes",
+			metadata:   emptyMap(),
+			attributes: emptyMap(),
+		},
+		{
+			name:       "one installer",
+			metadata:   installerMetadata(t, "linux"),
+			attributes: emptyMap(),
+		},
+		{
+			name:       "system tag at the length limit",
+			metadata:   installerMetadata(t, "0123456789"),
+			attributes: emptyMap(),
+		},
+	}
+	for _, testCase := range accepted {
+		t.Run("accepts "+testCase.name, func(t *testing.T) {
+			proposal := decodeProposal(t, signedUpdateProposal(
+				t, testPayloadProtocolMagic, issuerVK, issuerPrivate,
+				testCase.metadata, testCase.attributes,
+			))
+			require.NoError(t, proposal.Validate(testPayloadProtocolMagic))
+		})
+	}
+
+	rejected := []struct {
+		name       string
+		metadata   []byte
+		attributes []byte
+	}{
+		{
+			// The case from review: both fields decode into `any`, so an
+			// integer in either one used to sail through on a good
+			// signature.
+			name:       "integer metadata and attributes",
+			metadata:   mustEncode(t, uint64(99)),
+			attributes: mustEncode(t, uint64(99)),
+		},
+		{
+			name:       "integer metadata",
+			metadata:   mustEncode(t, uint64(99)),
+			attributes: emptyMap(),
+		},
+		{
+			name:       "integer attributes",
+			metadata:   emptyMap(),
+			attributes: mustEncode(t, uint64(99)),
+		},
+		{
+			name:       "array metadata",
+			metadata:   rawArray(mustEncode(t, uint64(1))),
+			attributes: emptyMap(),
+		},
+		{
+			name:       "non-empty attributes",
+			metadata:   emptyMap(),
+			attributes: installerMetadata(t, "linux"),
+		},
+		{
+			name:       "non-canonical empty attributes",
+			metadata:   emptyMap(),
+			attributes: nonCanonicalEmptyMap(),
+		},
+		{
+			name:       "system tag over the length limit",
+			metadata:   installerMetadata(t, "01234567890"),
+			attributes: emptyMap(),
+		},
+		{
+			name:       "non-ascii system tag",
+			metadata:   installerMetadata(t, "linu\u00fe"),
+			attributes: emptyMap(),
+		},
+		{
+			name: "installer hash not wrapped in an array",
+			metadata: func() []byte {
+				out := []byte{0xa1}
+				out = append(out, mustEncode(t, "linux")...)
+				return append(out, mustEncode(
+					t, bytes.Repeat([]byte{0x7c}, common.Blake2b256Size),
+				)...)
+			}(),
+			attributes: emptyMap(),
+		},
+		{
+			name: "installer hash wrong length",
+			metadata: func() []byte {
+				out := []byte{0xa1}
+				out = append(out, mustEncode(t, "linux")...)
+				return append(out, rawArray(
+					mustEncode(t, bytes.Repeat([]byte{0x7c}, 16)),
+				)...)
+			}(),
+			attributes: emptyMap(),
+		},
+	}
+	for _, testCase := range rejected {
+		t.Run("rejects "+testCase.name, func(t *testing.T) {
+			raw := signedUpdateProposal(
+				t, testPayloadProtocolMagic, issuerVK, issuerPrivate,
+				testCase.metadata, testCase.attributes,
+			)
+			proposal := decodeProposal(t, raw)
+			// The signature is genuine; only the shape is wrong.
+			require.ErrorIs(
+				t,
+				proposal.Validate(testPayloadProtocolMagic),
+				byron.ErrInvalidPayload,
+			)
+		})
+	}
 }
 
 func TestUpdateProposalMalformed(t *testing.T) {
 	issuerVK, issuerPrivate := testKeyPair(0x66)
-	valid := signedUpdateProposal(
+	valid := decodeProposal(t, signedUpdateProposal(
 		t, testPayloadProtocolMagic, issuerVK, issuerPrivate,
-	)
+		emptyMap(), emptyMap(),
+	))
 
 	t.Run("issuer key truncated", func(t *testing.T) {
 		proposal := valid
@@ -523,9 +850,10 @@ func TestUpdateProposalMalformed(t *testing.T) {
 func TestUpdateProposalSignatureMismatch(t *testing.T) {
 	issuerVK, issuerPrivate := testKeyPair(0x66)
 	impostorVK, _ := testKeyPair(0x77)
-	valid := signedUpdateProposal(
+	valid := decodeProposal(t, signedUpdateProposal(
 		t, testPayloadProtocolMagic, issuerVK, issuerPrivate,
-	)
+		emptyMap(), emptyMap(),
+	))
 
 	t.Run("issuer substituted", func(t *testing.T) {
 		proposal := valid
@@ -538,9 +866,10 @@ func TestUpdateProposalSignatureMismatch(t *testing.T) {
 	})
 
 	t.Run("signature from another proposal", func(t *testing.T) {
-		other := signedUpdateProposal(
+		other := decodeProposal(t, signedUpdateProposal(
 			t, testPayloadProtocolMagic+1, issuerVK, issuerPrivate,
-		)
+			emptyMap(), emptyMap(),
+		))
 		proposal := valid
 		proposal.Signature = append([]byte(nil), other.Signature...)
 		require.ErrorIs(
@@ -560,9 +889,7 @@ func TestUpdateProposalSignatureMismatch(t *testing.T) {
 }
 
 func TestValidatePayloadsEmpty(t *testing.T) {
-	block := testMainBlock(
-		testPayloadProtocolMagic, nil, byron.ByronUpdatePayload{},
-	)
+	block := testMainBlock(t, testPayloadProtocolMagic, nil, nil, nil)
 	require.NoError(t, block.ValidatePayloads())
 }
 
@@ -573,28 +900,64 @@ func TestValidatePayloadsValid(t *testing.T) {
 	proposerVK, proposerPrivate := testKeyPair(0x66)
 
 	block := testMainBlock(
+		t,
 		testPayloadProtocolMagic,
-		[]any{
+		[]cbor.RawMessage{
 			signedDelegationCertificate(
-				t, testPayloadProtocolMagic, 7, issuerVK, issuerPrivate,
-				delegateVK,
+				t, testPayloadProtocolMagic, shortestEpoch(t, 7), issuerVK,
+				issuerPrivate, delegateVK,
 			),
 		},
-		byron.ByronUpdatePayload{
-			Proposals: []byron.ByronUpdateProposal{
-				signedUpdateProposal(
-					t, testPayloadProtocolMagic, proposerVK, proposerPrivate,
+		[]cbor.RawMessage{
+			signedUpdateProposal(
+				t, testPayloadProtocolMagic, proposerVK, proposerPrivate,
+				emptyMap(), emptyMap(),
+			),
+		},
+		[]cbor.RawMessage{
+			signedUpdateVote(
+				t, testPayloadProtocolMagic, voterVK, voterPrivate,
+				shortestProposalId(
+					t, bytes.Repeat([]byte{0x5a}, common.Blake2b256Size),
 				),
-			},
-			Votes: []any{
-				signedUpdateVote(
-					t,
-					testPayloadProtocolMagic,
-					voterVK,
-					voterPrivate,
+			),
+		},
+	)
+	require.NoError(t, block.ValidatePayloads())
+}
+
+// TestValidatePayloadsNonShortestEncodings runs a whole block whose
+// delegation certificate, vote, and proposal all use non-shortest field
+// encodings. This is the end-to-end form of the regression: before
+// preserving the wire bytes, every one of these would have been rejected.
+func TestValidatePayloadsNonShortestEncodings(t *testing.T) {
+	issuerVK, issuerPrivate := testKeyPair(0x11)
+	delegateVK, _ := testKeyPair(0x22)
+	voterVK, voterPrivate := testKeyPair(0x44)
+	proposerVK, proposerPrivate := testKeyPair(0x66)
+
+	block := testMainBlock(
+		t,
+		testPayloadProtocolMagic,
+		[]cbor.RawMessage{
+			signedDelegationCertificate(
+				t, testPayloadProtocolMagic, nonShortestEpoch(7), issuerVK,
+				issuerPrivate, delegateVK,
+			),
+		},
+		[]cbor.RawMessage{
+			signedUpdateProposal(
+				t, testPayloadProtocolMagic, proposerVK, proposerPrivate,
+				emptyMap(), emptyMap(),
+			),
+		},
+		[]cbor.RawMessage{
+			signedUpdateVote(
+				t, testPayloadProtocolMagic, voterVK, voterPrivate,
+				nonShortestProposalId(
 					bytes.Repeat([]byte{0x5a}, common.Blake2b256Size),
 				),
-			},
+			),
 		},
 	)
 	require.NoError(t, block.ValidatePayloads())
@@ -604,13 +967,16 @@ func TestValidatePayloadsReportsOffendingIndex(t *testing.T) {
 	issuerVK, issuerPrivate := testKeyPair(0x11)
 	delegateVK, _ := testKeyPair(0x22)
 	good := signedDelegationCertificate(
-		t, testPayloadProtocolMagic, 7, issuerVK, issuerPrivate, delegateVK,
+		t, testPayloadProtocolMagic, shortestEpoch(t, 7), issuerVK,
+		issuerPrivate, delegateVK,
 	)
 
 	block := testMainBlock(
+		t,
 		testPayloadProtocolMagic,
-		[]any{good, []any{uint64(1)}},
-		byron.ByronUpdatePayload{},
+		[]cbor.RawMessage{good, rawArray(mustEncode(t, uint64(1)))},
+		nil,
+		nil,
 	)
 	err := block.ValidateDelegationPayload()
 	require.ErrorIs(t, err, byron.ErrInvalidPayload)
@@ -622,20 +988,51 @@ func TestValidatePayloadsWrongNetwork(t *testing.T) {
 	delegateVK, _ := testKeyPair(0x22)
 	// The certificate is signed for one network; the block claims another.
 	block := testMainBlock(
+		t,
 		testPayloadProtocolMagic+1,
-		[]any{
+		[]cbor.RawMessage{
 			signedDelegationCertificate(
-				t, testPayloadProtocolMagic, 7, issuerVK, issuerPrivate,
-				delegateVK,
+				t, testPayloadProtocolMagic, shortestEpoch(t, 7), issuerVK,
+				issuerPrivate, delegateVK,
 			),
 		},
-		byron.ByronUpdatePayload{},
+		nil,
+		nil,
 	)
 	require.ErrorIs(
 		t,
 		block.ValidateDelegationPayload(),
 		byron.ErrInvalidSignature,
 	)
+}
+
+// TestValidatePayloadsRequiresPreservedCbor pins that a block assembled in
+// Go, with no preserved payload bytes, is rejected rather than verified
+// against re-encoded ones.
+func TestValidatePayloadsRequiresPreservedCbor(t *testing.T) {
+	block := &byron.ByronMainBlock{
+		BlockHeader: &byron.ByronMainBlockHeader{
+			ProtocolMagic: testPayloadProtocolMagic,
+		},
+		Body: byron.ByronMainBlockBody{
+			DlgPayload: []any{[]any{uint64(7)}},
+		},
+	}
+	err := block.ValidateDelegationPayload()
+	require.ErrorIs(t, err, byron.ErrInvalidPayload)
+	require.ErrorContains(t, err, "no preserved CBOR")
+
+	votes := &byron.ByronMainBlock{
+		BlockHeader: &byron.ByronMainBlockHeader{
+			ProtocolMagic: testPayloadProtocolMagic,
+		},
+		Body: byron.ByronMainBlockBody{
+			UpdPayload: byron.ByronUpdatePayload{Votes: []any{[]any{}}},
+		},
+	}
+	err = votes.ValidateUpdatePayload()
+	require.ErrorIs(t, err, byron.ErrInvalidPayload)
+	require.ErrorContains(t, err, "no preserved CBOR")
 }
 
 func TestValidatePayloadsNilBlock(t *testing.T) {

--- a/ledger/byron/payload_test.go
+++ b/ledger/byron/payload_test.go
@@ -1,0 +1,661 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package byron_test
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/require"
+)
+
+const testPayloadProtocolMagic = uint32(764824073)
+
+// testKeyPair returns a deterministic Byron extended verification key (the
+// 32-byte Ed25519 public key followed by 32 chain-code bytes) and the
+// Ed25519 private key that signs for it.
+func testKeyPair(seedByte byte) ([]byte, ed25519.PrivateKey) {
+	private := ed25519.NewKeyFromSeed(
+		bytes.Repeat([]byte{seedByte}, ed25519.SeedSize),
+	)
+	verificationKey := make([]byte, byron.VerificationKeySize)
+	copy(verificationKey, private.Public().(ed25519.PublicKey))
+	copy(verificationKey[32:], bytes.Repeat([]byte{seedByte ^ 0xff}, 32))
+	return verificationKey, private
+}
+
+// signedDelegationCertificate builds a delegation certificate in the wire
+// shape the decoder produces, signed by issuerPrivate.
+func signedDelegationCertificate(
+	t *testing.T,
+	protocolMagic uint32,
+	epoch uint64,
+	issuerVK []byte,
+	issuerPrivate ed25519.PrivateKey,
+	delegateVK []byte,
+) []any {
+	t.Helper()
+	epochCbor, err := cbor.Encode(epoch)
+	require.NoError(t, err)
+	inner := make([]byte, 0, 2+len(delegateVK)+len(epochCbor))
+	inner = append(inner, '0', '0')
+	inner = append(inner, delegateVK...)
+	inner = append(inner, epochCbor...)
+	innerCbor, err := cbor.Encode(inner)
+	require.NoError(t, err)
+	magicCbor, err := cbor.Encode(protocolMagic)
+	require.NoError(t, err)
+	signed := []byte{byron.SignTagCertificate}
+	signed = append(signed, magicCbor...)
+	signed = append(signed, innerCbor...)
+	return []any{
+		epoch,
+		append([]byte(nil), issuerVK...),
+		append([]byte(nil), delegateVK...),
+		ed25519.Sign(issuerPrivate, signed),
+	}
+}
+
+// signedUpdateVote builds an update vote in the wire shape the decoder
+// produces, signed by voterPrivate.
+func signedUpdateVote(
+	t *testing.T,
+	protocolMagic uint32,
+	voterVK []byte,
+	voterPrivate ed25519.PrivateKey,
+	proposalId []byte,
+) []any {
+	t.Helper()
+	proposalIdCbor, err := cbor.Encode(proposalId)
+	require.NoError(t, err)
+	magicCbor, err := cbor.Encode(protocolMagic)
+	require.NoError(t, err)
+	signed := []byte{byron.SignTagUSVote}
+	signed = append(signed, magicCbor...)
+	signed = append(signed, 0x82)
+	signed = append(signed, proposalIdCbor...)
+	signed = append(signed, 0xf5)
+	return []any{
+		append([]byte(nil), voterVK...),
+		append([]byte(nil), proposalId...),
+		true,
+		ed25519.Sign(voterPrivate, signed),
+	}
+}
+
+// roundTripProposal encodes a proposal and decodes it back so the result
+// carries preserved CBOR, which is what the signature check reads its
+// signed body out of.
+func roundTripProposal(
+	t *testing.T,
+	proposal byron.ByronUpdateProposal,
+) byron.ByronUpdateProposal {
+	t.Helper()
+	encoded, err := cbor.Encode(&proposal)
+	require.NoError(t, err)
+	var decoded byron.ByronUpdateProposal
+	_, err = cbor.Decode(encoded, &decoded)
+	require.NoError(t, err)
+	require.NotEmpty(t, decoded.Cbor())
+	return decoded
+}
+
+// signedUpdateProposal builds a proposal whose signature covers its own
+// first five fields, by round-tripping it once with a placeholder signature
+// to recover the exact signed bytes, then again with the real one.
+func signedUpdateProposal(
+	t *testing.T,
+	protocolMagic uint32,
+	issuerVK []byte,
+	issuerPrivate ed25519.PrivateKey,
+) byron.ByronUpdateProposal {
+	t.Helper()
+	base := byron.ByronUpdateProposal{
+		BlockVersion: byron.ByronBlockVersion{
+			Major: 1,
+			Minor: 0,
+		},
+		BlockVersionMod: byron.ByronUpdateProposalBlockVersionMod{
+			MaxTxSize: []uint64{4096},
+		},
+		SoftwareVersion: byron.ByronSoftwareVersion{
+			Name:    "cardano-sl",
+			Version: 1,
+		},
+		Data:       map[string]any{},
+		Attributes: map[string]any{},
+		From:       append([]byte(nil), issuerVK...),
+		Signature:  make([]byte, ed25519.SignatureSize),
+	}
+	// Recover the signed body from a placeholder round trip: the signature
+	// sits outside the five fields it covers, so signing does not disturb
+	// them.
+	placeholder := roundTripProposal(t, base)
+	var fields []cbor.RawMessage
+	_, err := cbor.Decode(placeholder.Cbor(), &fields)
+	require.NoError(t, err)
+	require.Len(t, fields, 7)
+	body := []byte{0x85}
+	for _, field := range fields[:5] {
+		body = append(body, field...)
+	}
+	magicCbor, err := cbor.Encode(protocolMagic)
+	require.NoError(t, err)
+	signed := []byte{byron.SignTagUSProposal}
+	signed = append(signed, magicCbor...)
+	signed = append(signed, body...)
+	base.Signature = ed25519.Sign(issuerPrivate, signed)
+	return roundTripProposal(t, base)
+}
+
+func testMainBlock(
+	protocolMagic uint32,
+	dlgPayload []any,
+	updPayload byron.ByronUpdatePayload,
+) *byron.ByronMainBlock {
+	return &byron.ByronMainBlock{
+		BlockHeader: &byron.ByronMainBlockHeader{
+			ProtocolMagic: protocolMagic,
+		},
+		Body: byron.ByronMainBlockBody{
+			DlgPayload: dlgPayload,
+			UpdPayload: updPayload,
+		},
+	}
+}
+
+func TestParseDelegationCertificateValid(t *testing.T) {
+	issuerVK, issuerPrivate := testKeyPair(0x11)
+	delegateVK, _ := testKeyPair(0x22)
+	raw := signedDelegationCertificate(
+		t, testPayloadProtocolMagic, 7, issuerVK, issuerPrivate, delegateVK,
+	)
+
+	certificate, err := byron.ParseDelegationCertificate(raw)
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), certificate.Epoch)
+	require.Equal(t, issuerVK, certificate.IssuerVK)
+	require.Equal(t, delegateVK, certificate.DelegateVK)
+	require.NoError(t, certificate.Verify(testPayloadProtocolMagic))
+}
+
+func TestParseDelegationCertificateMalformed(t *testing.T) {
+	issuerVK, issuerPrivate := testKeyPair(0x11)
+	delegateVK, _ := testKeyPair(0x22)
+	valid := signedDelegationCertificate(
+		t, testPayloadProtocolMagic, 7, issuerVK, issuerPrivate, delegateVK,
+	)
+
+	testCases := []struct {
+		name string
+		raw  any
+	}{
+		{
+			name: "not an array",
+			raw:  []byte{0x01, 0x02},
+		},
+		{
+			name: "too few elements",
+			raw:  valid[:3],
+		},
+		{
+			name: "too many elements",
+			raw:  append(append([]any{}, valid...), uint64(0)),
+		},
+		{
+			name: "negative epoch",
+			raw: []any{
+				int64(-1), valid[1], valid[2], valid[3],
+			},
+		},
+		{
+			name: "issuer key not bytes",
+			raw: []any{
+				valid[0], "not-a-key", valid[2], valid[3],
+			},
+		},
+		{
+			name: "issuer key truncated",
+			raw: []any{
+				valid[0],
+				issuerVK[:32],
+				valid[2],
+				valid[3],
+			},
+		},
+		{
+			name: "delegate key truncated",
+			raw: []any{
+				valid[0], valid[1], delegateVK[:16], valid[3],
+			},
+		},
+		{
+			name: "signature truncated",
+			raw: []any{
+				valid[0],
+				valid[1],
+				valid[2],
+				make([]byte, ed25519.SignatureSize-1),
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := byron.ParseDelegationCertificate(testCase.raw)
+			require.ErrorIs(t, err, byron.ErrInvalidPayload)
+		})
+	}
+}
+
+func TestDelegationCertificateSignatureMismatch(t *testing.T) {
+	issuerVK, issuerPrivate := testKeyPair(0x11)
+	delegateVK, _ := testKeyPair(0x22)
+	impostorVK, _ := testKeyPair(0x33)
+
+	t.Run("signed by another key", func(t *testing.T) {
+		raw := signedDelegationCertificate(
+			t, testPayloadProtocolMagic, 7, issuerVK, issuerPrivate,
+			delegateVK,
+		)
+		// Keep the signature, swap the key it claims to come from.
+		raw[1] = impostorVK
+		certificate, err := byron.ParseDelegationCertificate(raw)
+		require.NoError(t, err)
+		require.ErrorIs(
+			t,
+			certificate.Verify(testPayloadProtocolMagic),
+			byron.ErrInvalidSignature,
+		)
+	})
+
+	t.Run("delegate substituted", func(t *testing.T) {
+		raw := signedDelegationCertificate(
+			t, testPayloadProtocolMagic, 7, issuerVK, issuerPrivate,
+			delegateVK,
+		)
+		raw[2] = impostorVK
+		certificate, err := byron.ParseDelegationCertificate(raw)
+		require.NoError(t, err)
+		require.ErrorIs(
+			t,
+			certificate.Verify(testPayloadProtocolMagic),
+			byron.ErrInvalidSignature,
+		)
+	})
+
+	t.Run("epoch substituted", func(t *testing.T) {
+		raw := signedDelegationCertificate(
+			t, testPayloadProtocolMagic, 7, issuerVK, issuerPrivate,
+			delegateVK,
+		)
+		raw[0] = uint64(8)
+		certificate, err := byron.ParseDelegationCertificate(raw)
+		require.NoError(t, err)
+		require.ErrorIs(
+			t,
+			certificate.Verify(testPayloadProtocolMagic),
+			byron.ErrInvalidSignature,
+		)
+	})
+
+	t.Run("wrong network", func(t *testing.T) {
+		raw := signedDelegationCertificate(
+			t, testPayloadProtocolMagic, 7, issuerVK, issuerPrivate,
+			delegateVK,
+		)
+		certificate, err := byron.ParseDelegationCertificate(raw)
+		require.NoError(t, err)
+		require.ErrorIs(
+			t,
+			certificate.Verify(testPayloadProtocolMagic+1),
+			byron.ErrInvalidSignature,
+		)
+	})
+}
+
+func TestParseDelegationCertificateDoesNotAliasInput(t *testing.T) {
+	issuerVK, issuerPrivate := testKeyPair(0x11)
+	delegateVK, _ := testKeyPair(0x22)
+	raw := signedDelegationCertificate(
+		t, testPayloadProtocolMagic, 7, issuerVK, issuerPrivate, delegateVK,
+	)
+
+	certificate, err := byron.ParseDelegationCertificate(raw)
+	require.NoError(t, err)
+
+	// Scribble over the decoded payload the certificate came from. A
+	// certificate that aliased it would start verifying against bytes its
+	// issuer never signed.
+	for _, index := range []int{1, 2, 3} {
+		field, ok := raw[index].([]byte)
+		require.True(t, ok)
+		for i := range field {
+			field[i] = 0xff
+		}
+	}
+	require.NoError(t, certificate.Verify(testPayloadProtocolMagic))
+}
+
+func TestParseUpdateVoteValid(t *testing.T) {
+	voterVK, voterPrivate := testKeyPair(0x44)
+	proposalId := bytes.Repeat([]byte{0x5a}, common.Blake2b256Size)
+	raw := signedUpdateVote(
+		t, testPayloadProtocolMagic, voterVK, voterPrivate, proposalId,
+	)
+
+	vote, err := byron.ParseUpdateVote(raw)
+	require.NoError(t, err)
+	require.Equal(t, voterVK, vote.VoterVK)
+	require.Equal(t, proposalId, vote.ProposalId)
+	require.True(t, vote.Decision)
+	require.NoError(t, vote.Verify(testPayloadProtocolMagic))
+}
+
+func TestParseUpdateVoteMalformed(t *testing.T) {
+	voterVK, voterPrivate := testKeyPair(0x44)
+	proposalId := bytes.Repeat([]byte{0x5a}, common.Blake2b256Size)
+	valid := signedUpdateVote(
+		t, testPayloadProtocolMagic, voterVK, voterPrivate, proposalId,
+	)
+
+	testCases := []struct {
+		name string
+		raw  any
+	}{
+		{
+			name: "not an array",
+			raw:  uint64(3),
+		},
+		{
+			name: "too few elements",
+			raw:  valid[:3],
+		},
+		{
+			name: "voter key truncated",
+			raw:  []any{voterVK[:32], valid[1], valid[2], valid[3]},
+		},
+		{
+			name: "proposal id wrong length",
+			raw:  []any{valid[0], proposalId[:16], valid[2], valid[3]},
+		},
+		{
+			name: "decision not a boolean",
+			raw:  []any{valid[0], valid[1], uint64(1), valid[3]},
+		},
+		{
+			name: "decision false",
+			raw:  []any{valid[0], valid[1], false, valid[3]},
+		},
+		{
+			name: "signature truncated",
+			raw: []any{
+				valid[0], valid[1], valid[2], make([]byte, 8),
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := byron.ParseUpdateVote(testCase.raw)
+			require.ErrorIs(t, err, byron.ErrInvalidPayload)
+		})
+	}
+}
+
+func TestUpdateVoteSignatureMismatch(t *testing.T) {
+	voterVK, voterPrivate := testKeyPair(0x44)
+	impostorVK, _ := testKeyPair(0x55)
+	proposalId := bytes.Repeat([]byte{0x5a}, common.Blake2b256Size)
+
+	t.Run("voter substituted", func(t *testing.T) {
+		raw := signedUpdateVote(
+			t, testPayloadProtocolMagic, voterVK, voterPrivate, proposalId,
+		)
+		raw[0] = impostorVK
+		vote, err := byron.ParseUpdateVote(raw)
+		require.NoError(t, err)
+		require.ErrorIs(
+			t,
+			vote.Verify(testPayloadProtocolMagic),
+			byron.ErrInvalidSignature,
+		)
+	})
+
+	t.Run("proposal id substituted", func(t *testing.T) {
+		raw := signedUpdateVote(
+			t, testPayloadProtocolMagic, voterVK, voterPrivate, proposalId,
+		)
+		raw[1] = bytes.Repeat([]byte{0x01}, common.Blake2b256Size)
+		vote, err := byron.ParseUpdateVote(raw)
+		require.NoError(t, err)
+		require.ErrorIs(
+			t,
+			vote.Verify(testPayloadProtocolMagic),
+			byron.ErrInvalidSignature,
+		)
+	})
+
+	t.Run("wrong network", func(t *testing.T) {
+		raw := signedUpdateVote(
+			t, testPayloadProtocolMagic, voterVK, voterPrivate, proposalId,
+		)
+		vote, err := byron.ParseUpdateVote(raw)
+		require.NoError(t, err)
+		require.ErrorIs(
+			t,
+			vote.Verify(testPayloadProtocolMagic+1),
+			byron.ErrInvalidSignature,
+		)
+	})
+}
+
+func TestUpdateProposalValid(t *testing.T) {
+	issuerVK, issuerPrivate := testKeyPair(0x66)
+	proposal := signedUpdateProposal(
+		t, testPayloadProtocolMagic, issuerVK, issuerPrivate,
+	)
+	require.NoError(t, proposal.Validate(testPayloadProtocolMagic))
+}
+
+func TestUpdateProposalMalformed(t *testing.T) {
+	issuerVK, issuerPrivate := testKeyPair(0x66)
+	valid := signedUpdateProposal(
+		t, testPayloadProtocolMagic, issuerVK, issuerPrivate,
+	)
+
+	t.Run("issuer key truncated", func(t *testing.T) {
+		proposal := valid
+		proposal.From = issuerVK[:32]
+		require.ErrorIs(
+			t,
+			proposal.Validate(testPayloadProtocolMagic),
+			byron.ErrInvalidPayload,
+		)
+	})
+
+	t.Run("signature truncated", func(t *testing.T) {
+		proposal := valid
+		proposal.Signature = make([]byte, 16)
+		require.ErrorIs(
+			t,
+			proposal.Validate(testPayloadProtocolMagic),
+			byron.ErrInvalidPayload,
+		)
+	})
+
+	t.Run("no preserved cbor", func(t *testing.T) {
+		proposal := byron.ByronUpdateProposal{
+			From:      append([]byte(nil), issuerVK...),
+			Signature: make([]byte, ed25519.SignatureSize),
+		}
+		require.ErrorIs(
+			t,
+			proposal.Validate(testPayloadProtocolMagic),
+			byron.ErrInvalidPayload,
+		)
+	})
+
+	t.Run("nil proposal", func(t *testing.T) {
+		var proposal *byron.ByronUpdateProposal
+		require.ErrorIs(
+			t,
+			proposal.Validate(testPayloadProtocolMagic),
+			byron.ErrInvalidPayload,
+		)
+	})
+}
+
+func TestUpdateProposalSignatureMismatch(t *testing.T) {
+	issuerVK, issuerPrivate := testKeyPair(0x66)
+	impostorVK, _ := testKeyPair(0x77)
+	valid := signedUpdateProposal(
+		t, testPayloadProtocolMagic, issuerVK, issuerPrivate,
+	)
+
+	t.Run("issuer substituted", func(t *testing.T) {
+		proposal := valid
+		proposal.From = append([]byte(nil), impostorVK...)
+		require.ErrorIs(
+			t,
+			proposal.Validate(testPayloadProtocolMagic),
+			byron.ErrInvalidSignature,
+		)
+	})
+
+	t.Run("signature from another proposal", func(t *testing.T) {
+		other := signedUpdateProposal(
+			t, testPayloadProtocolMagic+1, issuerVK, issuerPrivate,
+		)
+		proposal := valid
+		proposal.Signature = append([]byte(nil), other.Signature...)
+		require.ErrorIs(
+			t,
+			proposal.Validate(testPayloadProtocolMagic),
+			byron.ErrInvalidSignature,
+		)
+	})
+
+	t.Run("wrong network", func(t *testing.T) {
+		require.ErrorIs(
+			t,
+			valid.Validate(testPayloadProtocolMagic+1),
+			byron.ErrInvalidSignature,
+		)
+	})
+}
+
+func TestValidatePayloadsEmpty(t *testing.T) {
+	block := testMainBlock(
+		testPayloadProtocolMagic, nil, byron.ByronUpdatePayload{},
+	)
+	require.NoError(t, block.ValidatePayloads())
+}
+
+func TestValidatePayloadsValid(t *testing.T) {
+	issuerVK, issuerPrivate := testKeyPair(0x11)
+	delegateVK, _ := testKeyPair(0x22)
+	voterVK, voterPrivate := testKeyPair(0x44)
+	proposerVK, proposerPrivate := testKeyPair(0x66)
+
+	block := testMainBlock(
+		testPayloadProtocolMagic,
+		[]any{
+			signedDelegationCertificate(
+				t, testPayloadProtocolMagic, 7, issuerVK, issuerPrivate,
+				delegateVK,
+			),
+		},
+		byron.ByronUpdatePayload{
+			Proposals: []byron.ByronUpdateProposal{
+				signedUpdateProposal(
+					t, testPayloadProtocolMagic, proposerVK, proposerPrivate,
+				),
+			},
+			Votes: []any{
+				signedUpdateVote(
+					t,
+					testPayloadProtocolMagic,
+					voterVK,
+					voterPrivate,
+					bytes.Repeat([]byte{0x5a}, common.Blake2b256Size),
+				),
+			},
+		},
+	)
+	require.NoError(t, block.ValidatePayloads())
+}
+
+func TestValidatePayloadsReportsOffendingIndex(t *testing.T) {
+	issuerVK, issuerPrivate := testKeyPair(0x11)
+	delegateVK, _ := testKeyPair(0x22)
+	good := signedDelegationCertificate(
+		t, testPayloadProtocolMagic, 7, issuerVK, issuerPrivate, delegateVK,
+	)
+
+	block := testMainBlock(
+		testPayloadProtocolMagic,
+		[]any{good, []any{uint64(1)}},
+		byron.ByronUpdatePayload{},
+	)
+	err := block.ValidateDelegationPayload()
+	require.ErrorIs(t, err, byron.ErrInvalidPayload)
+	require.Contains(t, err.Error(), "delegation certificate 1")
+}
+
+func TestValidatePayloadsWrongNetwork(t *testing.T) {
+	issuerVK, issuerPrivate := testKeyPair(0x11)
+	delegateVK, _ := testKeyPair(0x22)
+	// The certificate is signed for one network; the block claims another.
+	block := testMainBlock(
+		testPayloadProtocolMagic+1,
+		[]any{
+			signedDelegationCertificate(
+				t, testPayloadProtocolMagic, 7, issuerVK, issuerPrivate,
+				delegateVK,
+			),
+		},
+		byron.ByronUpdatePayload{},
+	)
+	require.ErrorIs(
+		t,
+		block.ValidateDelegationPayload(),
+		byron.ErrInvalidSignature,
+	)
+}
+
+func TestValidatePayloadsNilBlock(t *testing.T) {
+	var block *byron.ByronMainBlock
+	require.ErrorIs(
+		t,
+		block.ValidateDelegationPayload(),
+		byron.ErrInvalidPayload,
+	)
+	require.ErrorIs(t, block.ValidateUpdatePayload(), byron.ErrInvalidPayload)
+
+	headerless := &byron.ByronMainBlock{}
+	require.ErrorIs(
+		t,
+		headerless.ValidateDelegationPayload(),
+		byron.ErrInvalidPayload,
+	)
+	require.ErrorIs(
+		t,
+		headerless.ValidateUpdatePayload(),
+		byron.ErrInvalidPayload,
+	)
+}

--- a/ledger/byron/sign.go
+++ b/ledger/byron/sign.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package byron
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+)
+
+// Byron sign tags, from cardano-crypto's Cardano.Crypto.Signing.Tag. Every
+// Byron signature is domain-separated by prefixing the signed buffer with
+// its tag byte followed by the CBOR-encoded protocol magic, so a signature
+// made for one purpose (or one network) can never be replayed as another.
+const (
+	SignTagTx             byte = 0x01
+	SignTagRedeemTx       byte = 0x02
+	SignTagVssCert        byte = 0x03
+	SignTagUSProposal     byte = 0x04
+	SignTagCommitment     byte = 0x05
+	SignTagUSVote         byte = 0x06
+	SignTagMainBlock      byte = 0x07
+	SignTagMainBlockLight byte = 0x08
+	SignTagMainBlockHeavy byte = 0x09
+	SignTagCertificate    byte = 0x0a
+)
+
+// VerificationKeySize is the size of a Byron extended Ed25519 verification
+// key: a 32-byte Ed25519 public key followed by a 32-byte chain code. Only
+// the leading 32 bytes take part in signature verification, but the full 64
+// bytes are what the wire format carries and what gets hashed and signed
+// over, so the distinction matters.
+const VerificationKeySize = 64
+
+// ErrInvalidSignature reports a Byron signature that is structurally
+// well-formed but does not verify against the key it claims to come from.
+var ErrInvalidSignature = errors.New("byron signature verification failed")
+
+// signTag builds the domain-separation prefix for a Byron signature:
+// the tag byte followed by the CBOR-encoded protocol magic. This is
+// cardano-crypto's `signTag pm tag`.
+func signTag(tag byte, protocolMagic uint32) ([]byte, error) {
+	magicCbor, err := cbor.Encode(protocolMagic)
+	if err != nil {
+		return nil, fmt.Errorf("encode protocol magic: %w", err)
+	}
+	prefix := make([]byte, 0, 1+len(magicCbor))
+	prefix = append(prefix, tag)
+	return append(prefix, magicCbor...), nil
+}
+
+// signedBytes assembles the exact buffer a Byron signature is made over:
+// the domain-separation tag, then the already-serialized payload.
+//
+// Callers pass payload already in its signed-over serialized form, because
+// what that form is differs per tag: `safeSign pm tag ss` is
+// `safeSignRaw pm (Just tag) ss . serialize'`, so the payload is the CBOR
+// encoding of whatever Haskell value was signed. For a ByteString argument
+// (delegation certificates) that means the value wrapped in a CBOR
+// byte-string header; for a structured record (update proposals, votes)
+// it means that record's own CBOR encoding, which must be reproduced from
+// preserved bytes rather than re-encoded.
+func signedBytes(
+	tag byte,
+	protocolMagic uint32,
+	payload []byte,
+) ([]byte, error) {
+	prefix, err := signTag(tag, protocolMagic)
+	if err != nil {
+		return nil, err
+	}
+	signed := make([]byte, 0, len(prefix)+len(payload))
+	signed = append(signed, prefix...)
+	return append(signed, payload...), nil
+}
+
+// verifyEd25519 checks sig over signed using the Ed25519 half of a Byron
+// extended verification key.
+func verifyEd25519(verificationKey, signed, sig []byte) bool {
+	if len(verificationKey) != VerificationKeySize ||
+		len(sig) != ed25519.SignatureSize {
+		return false
+	}
+	return ed25519.Verify(verificationKey[:32], signed, sig)
+}
+
+// VerifyDelegationCertificateSignature verifies a Byron heavyweight
+// delegation certificate signature, reproducing cardano-ledger-byron's
+// Cardano.Chain.Delegation.Certificate signing format exactly:
+//
+//	inner  = "00" || delegateVK || CBOR(epoch)
+//	signed = 0x0a || CBOR(protocolMagic) || CBOR_bytestring(inner)
+//
+// "00" is the two ASCII bytes 0x30 0x30, delegateVK is the raw 64-byte
+// extended verification key, and the CBOR byte-string wrapping of inner
+// comes from safeSign applying serialize' to its ByteString argument.
+// certSig is then a plain Ed25519 signature over signed, verifiable with
+// the leading 32 bytes of the 64-byte extended issuerVK.
+func VerifyDelegationCertificateSignature(
+	protocolMagic uint32,
+	issuerVK []byte,
+	delegateVK []byte,
+	certSig []byte,
+	epoch uint64,
+) error {
+	if len(issuerVK) != VerificationKeySize {
+		return fmt.Errorf(
+			"invalid issuer verification key size: got %d, expected %d",
+			len(issuerVK), VerificationKeySize,
+		)
+	}
+	if len(delegateVK) != VerificationKeySize {
+		return fmt.Errorf(
+			"invalid delegate verification key size: got %d, expected %d",
+			len(delegateVK), VerificationKeySize,
+		)
+	}
+	if len(certSig) != ed25519.SignatureSize {
+		return fmt.Errorf(
+			"invalid certificate signature size: got %d, expected %d",
+			len(certSig), ed25519.SignatureSize,
+		)
+	}
+	epochCbor, err := cbor.Encode(epoch)
+	if err != nil {
+		return fmt.Errorf("encode delegation epoch: %w", err)
+	}
+	inner := make([]byte, 0, 2+len(delegateVK)+len(epochCbor))
+	inner = append(inner, '0', '0')
+	inner = append(inner, delegateVK...)
+	inner = append(inner, epochCbor...)
+	innerCbor, err := cbor.Encode(inner)
+	if err != nil {
+		return fmt.Errorf("encode delegation certificate payload: %w", err)
+	}
+	signed, err := signedBytes(SignTagCertificate, protocolMagic, innerCbor)
+	if err != nil {
+		return err
+	}
+	if !verifyEd25519(issuerVK, signed, certSig) {
+		return fmt.Errorf(
+			"%w: delegation certificate for epoch %d",
+			ErrInvalidSignature, epoch,
+		)
+	}
+	return nil
+}

--- a/ledger/byron/sign.go
+++ b/ledger/byron/sign.go
@@ -98,11 +98,31 @@ func verifyEd25519(verificationKey, signed, sig []byte) bool {
 	return ed25519.Verify(verificationKey[:32], signed, sig)
 }
 
+// EncodeDelegationEpoch returns the CBOR encoding of a delegation
+// certificate's epoch for callers whose epoch did not arrive as CBOR in the
+// first place -- notably the genesis file's heavyweight delegations, which
+// carry it as a JSON number.
+//
+// Do NOT use this to reconstruct the epoch of a certificate that was
+// decoded from CBOR. CBOR admits non-shortest integer encodings and this
+// decoder accepts them, so a certificate whose epoch arrived as 0x1807
+// decodes to 7 and re-encodes to 0x07 -- different bytes, and the issuer
+// signed the ones on the wire. Pass the preserved field encoding to
+// VerifyDelegationCertificateSignature instead; ParseDelegationCertificate
+// keeps it in DelegationCertificate.EpochCbor for exactly this reason.
+func EncodeDelegationEpoch(epoch uint64) ([]byte, error) {
+	encoded, err := cbor.Encode(epoch)
+	if err != nil {
+		return nil, fmt.Errorf("encode delegation epoch: %w", err)
+	}
+	return encoded, nil
+}
+
 // VerifyDelegationCertificateSignature verifies a Byron heavyweight
 // delegation certificate signature, reproducing cardano-ledger-byron's
 // Cardano.Chain.Delegation.Certificate signing format exactly:
 //
-//	inner  = "00" || delegateVK || CBOR(epoch)
+//	inner  = "00" || delegateVK || epochCbor
 //	signed = 0x0a || CBOR(protocolMagic) || CBOR_bytestring(inner)
 //
 // "00" is the two ASCII bytes 0x30 0x30, delegateVK is the raw 64-byte
@@ -110,12 +130,18 @@ func verifyEd25519(verificationKey, signed, sig []byte) bool {
 // comes from safeSign applying serialize' to its ByteString argument.
 // certSig is then a plain Ed25519 signature over signed, verifiable with
 // the leading 32 bytes of the 64-byte extended issuerVK.
+//
+// epochCbor must be the epoch field's ORIGINAL wire encoding, not a
+// re-encoding of its decoded value: cardano-ledger verifies against the
+// annotated bytes, and this decoder accepts non-shortest integer encodings
+// that would not survive a round trip. ParseDelegationCertificate preserves
+// it; callers whose epoch never was CBOR use EncodeDelegationEpoch.
 func VerifyDelegationCertificateSignature(
 	protocolMagic uint32,
 	issuerVK []byte,
 	delegateVK []byte,
 	certSig []byte,
-	epoch uint64,
+	epochCbor []byte,
 ) error {
 	if len(issuerVK) != VerificationKeySize {
 		return fmt.Errorf(
@@ -135,9 +161,10 @@ func VerifyDelegationCertificateSignature(
 			len(certSig), ed25519.SignatureSize,
 		)
 	}
-	epochCbor, err := cbor.Encode(epoch)
-	if err != nil {
-		return fmt.Errorf("encode delegation epoch: %w", err)
+	if len(epochCbor) == 0 {
+		return errors.New(
+			"delegation certificate epoch encoding is empty",
+		)
 	}
 	inner := make([]byte, 0, 2+len(delegateVK)+len(epochCbor))
 	inner = append(inner, '0', '0')
@@ -153,8 +180,8 @@ func VerifyDelegationCertificateSignature(
 	}
 	if !verifyEd25519(issuerVK, signed, certSig) {
 		return fmt.Errorf(
-			"%w: delegation certificate for epoch %d",
-			ErrInvalidSignature, epoch,
+			"%w: delegation certificate for epoch %x",
+			ErrInvalidSignature, epochCbor,
 		)
 	}
 	return nil

--- a/ledger/common/verify_config.go
+++ b/ledger/common/verify_config.go
@@ -158,6 +158,38 @@ type VerifyConfig struct {
 	// (e.g. NewByronMainBlockFromCbor) leave it off and rely on the
 	// structural check alone.
 	EnableByronSscProofHashValidation bool
+	// EnableByronPayloadValidation opts into structurally validating a
+	// Byron main block's delegation and update payloads and verifying the
+	// signatures they carry -- heavyweight delegation certificates, update
+	// proposals, and update votes -- in addition to the always-on check
+	// that those payloads' bytes hash to the dlg_proof/upd_proof in the
+	// header.
+	//
+	// Those two checks answer different questions. dlg_proof and upd_proof
+	// bind the payload bytes to the header, so a block cannot carry a
+	// payload its issuer did not commit to; they say nothing about whether
+	// those bytes decode to a well-formed certificate, or whether the
+	// signature inside one verifies. A block whose delegation payload holds
+	// a certificate with a truncated verification key, or a vote signed by
+	// a key that did not sign it, passes the proof check unchanged.
+	//
+	// Default false, for the same reason as
+	// EnableByronSscProofHashValidation: the update proposal and vote
+	// signing formats reproduced here (see ledger/byron's
+	// ByronUpdateProposal.Validate and UpdateVote.Verify) are taken from
+	// cardano-ledger-byron's Cardano.Chain.Update sources rather than
+	// confirmed against real mainnet blocks carrying those payloads, which
+	// are rare enough that this repository has no such vector. Making them
+	// decode-gating by default would risk an undiscovered edge case turning
+	// into a real mainnet block that fails to decode. The delegation
+	// certificate half is on firmer ground -- its signing format is the
+	// same one consensus/byron already verifies against a real mainnet
+	// certificate on every proxy-signed header -- but the flag covers both
+	// so that opting in is a single, coherent decision.
+	//
+	// Callers who want only the delegation half without the update half can
+	// call byron.ByronMainBlock.ValidateDelegationPayload directly.
+	EnableByronPayloadValidation bool
 	// LedgerState provides the current ledger state for transaction validation.
 	// Required if SkipTransactionValidation or SkipStakePoolValidation is false.
 	LedgerState LedgerState


### PR DESCRIPTION
<img width="1787" height="516" alt="image" src="https://github.com/user-attachments/assets/cb82db0d-ab04-42c7-84b9-a4018af15221" />

https://github.com/user-attachments/assets/1dcf2697-6eea-473e-a4e4-1feb554a26b7

Fixes: #2100

This PR fixes three bugs in the Byron-era block code:

First, blocks carry delegation certificates, update proposals, and votes that were never actually inspected, the code checked that their bytes hadn't been tampered with, but never opened them up to confirm they were well-formed or that their signatures were genuine, so a certificate with a broken key or a vote signed by the wrong person slipped straight through. This PR adds that checking (off by default, behind a flag, since the update-proposal format hasn't been confirmed against a real mainnet block yet). 

Second, when a block header was too malformed to read a hash out of, the code quietly substituted all zeros and then reported a "hash mismatch"  sending anyone debugging it after a problem that didn't exist, so it now says the header is malformed instead. 

Third, a validation function was writing data back into the caller's own struct, meaning if you reused that struct for the next block, it arrived carrying the previous block's signature; it now writes to a copy.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three Byron validation bugs: payloads now get structural and signature checks (opt-in via `EnableByronPayloadValidation`), malformed body proofs are reported as malformed instead of as hash mismatches, and proxy signature validation no longer mutates the caller's input.

**Bug Fixes**
- Delegation certificates, update proposals, and votes are now validated for well-formedness and genuine signatures; previously only their bytes were compared against the header proof.
- Body proofs that don't parse as a hash now return a "malformed" error instead of silently substituting a zero hash and reporting a mismatch; nil blocks and headers report the same error.
- `validateBlockSignature` extracts the signature into a copy of `ValidateHeaderInput`, preventing a reused struct from carrying the previous block's signature into the next validation.
- Payload decoding preserves each certificate's CBOR wire encoding (`[]cbor.RawMessage`) since signatures cover it; `ApplyPayloadCbor` replaces the deprecated `ApplyPayload` at the consensus layer.

The new payload validation is off by default because the update-proposal/vote signing format hasn't been confirmed against a real mainnet block; delegation certificate verification uses the same format already trusted in header validation.

<sup>Written for commit f9fc9f6573e308fb439a821331553b5cf5f77988. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added optional validation for Byron delegation certificates, update proposals, and update votes, including signature verification.
- Added checked body-hash validation to identify malformed proof formats distinctly.

## Bug Fixes
- Prevented validation from modifying caller-provided data.
- Prevented reused validation inputs from retaining stale signatures or hashes.

## Tests
- Expanded coverage for valid, malformed, and signature-invalid Byron payloads and body proofs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->