### PR TITLE
fix: restore 32-bit build compatibility

### DIFF
--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -486,7 +486,7 @@ type txGovProposal struct {
 // uint64 keeps the comparison well-typed on 32-bit targets, where the
 // untyped math.MaxUint32 constant cannot be represented by int.
 func governanceProposalIndexFits(idx int) bool {
-	return uint64(idx) <= uint64(math.MaxUint32)
+	return idx >= 0 && int64(idx) <= int64(math.MaxUint32)
 }
 
 // txProposalActions indexes the governance actions proposed by tx itself by

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -501,7 +501,9 @@ func txProposalActions(
 	txId := tx.Hash()
 	ret := make(map[common.GovActionId]txGovProposal, len(proposals))
 	for idx, proposal := range proposals {
-		if idx > math.MaxUint32 {
+		// Convert through int64 so this comparison also compiles on 32-bit
+		// targets, where math.MaxUint32 does not fit in an int.
+		if int64(idx) > int64(math.MaxUint32) {
 			break
 		}
 		actionId := common.GovActionId{

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -481,6 +481,14 @@ type txGovProposal struct {
 	action common.GovAction
 }
 
+// governanceProposalIndexFits reports whether an int can be represented by
+// the uint32 index carried in a governance action ID. Converting first to
+// uint64 keeps the comparison well-typed on 32-bit targets, where the
+// untyped math.MaxUint32 constant cannot be represented by int.
+func governanceProposalIndexFits(idx int) bool {
+	return uint64(idx) <= uint64(math.MaxUint32)
+}
+
 // txProposalActions indexes the governance actions proposed by tx itself by
 // the governance action id each one receives once the transaction is
 // accepted, (transaction id, proposal index).
@@ -501,9 +509,7 @@ func txProposalActions(
 	txId := tx.Hash()
 	ret := make(map[common.GovActionId]txGovProposal, len(proposals))
 	for idx, proposal := range proposals {
-		// Convert through int64 so this comparison also compiles on 32-bit
-		// targets, where math.MaxUint32 does not fit in an int.
-		if int64(idx) > int64(math.MaxUint32) {
+		if !governanceProposalIndexFits(idx) {
 			break
 		}
 		actionId := common.GovActionId{

--- a/ledger/conway/rules_width_test.go
+++ b/ledger/conway/rules_width_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conway
+
+import (
+	"math"
+	"strconv"
+	"testing"
+)
+
+func TestGovernanceProposalIndexFits(t *testing.T) {
+	tests := []struct {
+		name string
+		idx  int
+		want bool
+	}{
+		{name: "negative", idx: -1, want: false},
+		{name: "zero", idx: 0, want: true},
+		{
+			name: "largest native int",
+			idx:  int(^uint(0) >> 1),
+			want: strconv.IntSize == 32,
+		},
+	}
+
+	// MaxUint32 and MaxUint32+1 are representable as int only on 64-bit
+	// targets. Keep these cases runtime-gated so this test itself compiles on
+	// 32-bit targets while exercising both sides of the production boundary on
+	// 64-bit targets.
+	if strconv.IntSize == 64 {
+		maxUint32 := uint64(math.MaxUint32)
+		tests = append(tests,
+			struct {
+				name string
+				idx  int
+				want bool
+			}{"MaxUint32", int(maxUint32), true},
+			struct {
+				name string
+				idx  int
+				want bool
+			}{"MaxUint32 plus one", int(maxUint32 + 1), false},
+		)
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := governanceProposalIndexFits(test.idx); got != test.want {
+				t.Fatalf("governanceProposalIndexFits(%d) = %t, want %t", test.idx, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Restore 32-bit compilation for the Conway governance proposal index guard.
- Add architecture-aware boundary coverage for the uint32 index limit.

## Validation

- `GOWORK=off GOCACHE=/tmp/gouroboros-2112-cache go test ./ledger/conway -run TestGovernanceProposalIndexFits -count=1`
- `GOWORK=off GOCACHE=/tmp/gouroboros-2112-cache GOARCH=386 GOOS=linux go test ./ledger/conway -run TestGovernanceProposalIndexFits -count=1`
- `GOWORK=off GOCACHE=/tmp/gouroboros-2112-cache GOARCH=386 GOOS=linux go build ./...`
- `git diff --check`

Fixes #2112

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores 32-bit build compatibility for the Conway governance proposal index bound check.

- Converts the index to `uint64` before comparing against `math.MaxUint32`, since the untyped constant can't be represented by `int` on 32-bit targets.
- Adds coverage for the `math.MaxUint32` boundary that runs only on 64-bit targets and exercises negative and zero cases everywhere.

<sup>Written for commit 3331e7f06d287344981889ff0314385cb128ecf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

