### PR TITLE
fix(chainsync): handle at-tip intersection callbacks

### DIFF
--- a/pipeline/apply_stage.go
+++ b/pipeline/apply_stage.go
@@ -226,14 +226,15 @@ func (s *ApplyStage) PendingCount() int {
 
 // ApplyStageRunner runs the apply stage as a single goroutine.
 type ApplyStageRunner struct {
-	stage   *ApplyStage
-	input   <-chan *BlockItem
-	output  chan<- *BlockItem
-	errors  chan<- error
-	metrics *PipelineMetrics
-	done    chan struct{}
-	running bool
-	mu      sync.Mutex
+	stage         *ApplyStage
+	input         <-chan *BlockItem
+	output        chan<- *BlockItem
+	errors        chan<- error
+	metrics       *PipelineMetrics
+	processedFunc func(uint64)
+	done          chan struct{}
+	running       bool
+	mu            sync.Mutex
 }
 
 // NewApplyStageRunner creates a new runner for the apply stage.
@@ -267,6 +268,12 @@ func NewApplyStageRunner(
 // Must be called before Start() to avoid data races.
 func (r *ApplyStageRunner) SetMetrics(metrics *PipelineMetrics) {
 	r.metrics = metrics
+}
+
+// SetProcessedFunc sets a callback invoked after ordered processing completes
+// through the supplied sequence number. It must be called before Start.
+func (r *ApplyStageRunner) SetProcessedFunc(processedFunc func(uint64)) {
+	r.processedFunc = processedFunc
 }
 
 // Start starts the apply stage runner.
@@ -324,6 +331,9 @@ func (r *ApplyStageRunner) run(ctx context.Context) {
 					return
 				}
 				continue
+			}
+			if len(processed) > 0 && r.processedFunc != nil {
+				r.processedFunc(processed[len(processed)-1].SequenceNumber() + 1)
 			}
 
 			// Forward all processed items (includes input item + any buffered items

--- a/pipeline/apply_stage.go
+++ b/pipeline/apply_stage.go
@@ -22,7 +22,9 @@ import (
 )
 
 // ErrPendingLimitExceeded is returned when the apply stage's pending buffer is full.
-var ErrPendingLimitExceeded = errors.New("pipeline: pending block limit exceeded")
+var ErrPendingLimitExceeded = errors.New(
+	"pipeline: pending block limit exceeded",
+)
 
 // ErrBlockNotValidated is returned when the apply stage requires validation
 // but receives a block that was never validated. This guards against blocks
@@ -97,7 +99,10 @@ func (s *ApplyStage) Process(ctx context.Context, item *BlockItem) error {
 //
 // This design eliminates data loss that could occur with callback-based approaches
 // when many buffered items are released at once.
-func (s *ApplyStage) ProcessWithStatus(ctx context.Context, item *BlockItem) ([]*BlockItem, error) {
+func (s *ApplyStage) ProcessWithStatus(
+	ctx context.Context,
+	item *BlockItem,
+) ([]*BlockItem, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -333,7 +338,9 @@ func (r *ApplyStageRunner) run(ctx context.Context) {
 				continue
 			}
 			if len(processed) > 0 && r.processedFunc != nil {
-				r.processedFunc(processed[len(processed)-1].SequenceNumber() + 1)
+				r.processedFunc(
+					processed[len(processed)-1].SequenceNumber() + 1,
+				)
 			}
 
 			// Forward all processed items (includes input item + any buffered items
@@ -351,7 +358,8 @@ func (r *ApplyStageRunner) run(ctx context.Context) {
 func (r *ApplyStageRunner) forwardItem(ctx context.Context, item *BlockItem) {
 	// Record metrics for items that went through the apply stage (both success and failure).
 	// Items with decode/validation errors are not applied and don't have apply metrics.
-	if r.metrics != nil && item.DecodeError() == nil && item.ValidationError() == nil {
+	if r.metrics != nil && item.DecodeError() == nil &&
+		item.ValidationError() == nil {
 		r.metrics.RecordApply(item.ApplyDuration(), item.ApplyError())
 		r.metrics.RecordPipelineLatency(item.TotalDuration())
 	}

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -85,10 +85,14 @@ type BlockPipeline struct {
 	stopped           atomic.Bool
 	wg                sync.WaitGroup
 	mu                sync.Mutex // protects Start/Stop
-	// submitMu serializes successful submissions and Fence boundaries.
-	submitMu       sync.Mutex
+	// submitGate serializes successful submissions and Fence boundaries.
+	// Its channel form lets Fence stop waiting when its context is canceled.
+	submitGate     chan struct{}
 	completionMu   sync.Mutex
 	completionChan chan struct{}
+	// The test hook makes blocked Submit/Fence interleavings deterministic
+	// without changing production behavior.
+	testSubmitLocked func()
 }
 
 // NewBlockPipeline creates a new BlockPipeline using functional options.
@@ -105,10 +109,28 @@ func NewBlockPipeline(opts ...PipelineOption) *BlockPipeline {
 	for _, opt := range opts {
 		opt(&config)
 	}
-	return &BlockPipeline{
-		config:  config,
-		metrics: NewPipelineMetrics(config.MetricsWindowSize),
+	p := &BlockPipeline{
+		config:     config,
+		metrics:    NewPipelineMetrics(config.MetricsWindowSize),
+		submitGate: make(chan struct{}, 1),
 	}
+	p.submitGate <- struct{}{}
+	return p
+}
+
+func (p *BlockPipeline) lockSubmit(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-p.ctx.Done():
+		return ErrPipelineStopped
+	case <-p.submitGate:
+		return nil
+	}
+}
+
+func (p *BlockPipeline) unlockSubmit() {
+	p.submitGate <- struct{}{}
 }
 
 // Start starts the pipeline processing.
@@ -229,11 +251,16 @@ func (p *BlockPipeline) Submit(
 		return ErrPipelineNotStarted
 	}
 
-	// The lock prevents Stop from closing submitChan while a submission is in
+	// The gate prevents Stop from closing submitChan while a submission is in
 	// flight. It also serializes the enqueue and sequence commit, so canceled
 	// submissions cannot leave a sequence gap that would block ordered apply.
-	p.submitMu.Lock()
-	defer p.submitMu.Unlock()
+	if err := p.lockSubmit(ctx); err != nil {
+		return err
+	}
+	defer p.unlockSubmit()
+	if p.testSubmitLocked != nil {
+		p.testSubmitLocked()
+	}
 
 	// Check stopped under lock to ensure we don't race with Stop()
 	if p.stopped.Load() {
@@ -241,7 +268,7 @@ func (p *BlockPipeline) Submit(
 	}
 
 	// Commit a sequence number only after its item was successfully enqueued.
-	// Keeping the provisional ID under submitMu makes successful IDs unique and
+	// Keeping the provisional ID under submitGate makes successful IDs unique and
 	// contiguous in queue order, while canceled or backpressured submissions do
 	// not create positions that Fence must wait for.
 	sequence := p.sequenceCounter.Load()
@@ -268,16 +295,18 @@ func (p *BlockPipeline) Fence(ctx context.Context) error {
 		return ErrPipelineNotStarted
 	}
 
-	// The lock excludes in-flight submissions while we capture the sequence
-	// boundary. Submit commits each sequence number under this lock only after
+	// The gate excludes in-flight submissions while we capture the sequence
+	// boundary. Submit commits each sequence number under this gate only after
 	// enqueue, so every position at or below target is waitable.
-	p.submitMu.Lock()
+	if err := p.lockSubmit(ctx); err != nil {
+		return err
+	}
 	if p.stopped.Load() {
-		p.submitMu.Unlock()
+		p.unlockSubmit()
 		return ErrPipelineStopped
 	}
 	target := p.sequenceCounter.Load()
-	p.submitMu.Unlock()
+	p.unlockSubmit()
 	if target == 0 {
 		return nil
 	}
@@ -340,18 +369,18 @@ func (p *BlockPipeline) Stop() error {
 	}
 
 	// Cancel context FIRST to unblock any Submit() calls waiting on channel send.
-	// This must happen before acquiring submitMu.Lock() to avoid deadlock:
-	// Submit() holds RLock while blocking on channel, and we need it to unblock
-	// via ctx.Done() before we can acquire the write lock.
+	// This must happen before acquiring submitGate to avoid deadlock: Submit()
+	// holds the gate while blocking on the channel, and we need it to unblock
+	// via ctx.Done() before we can acquire the gate.
 	p.cancel()
 
-	// Now acquire write lock to ensure no Submit() calls are in progress.
+	// Now acquire the gate to ensure no Submit() calls are in progress.
 	// Any Submit() blocked on channel send will now return via ctx.Done().
-	p.submitMu.Lock()
+	<-p.submitGate
 	p.stopped.Store(true)
 	// Close input channel to signal shutdown
 	close(p.submitChan)
-	p.submitMu.Unlock()
+	p.unlockSubmit()
 
 	// Wait for decode workers to finish
 	p.decodePool.Stop()

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -82,8 +82,8 @@ type BlockPipeline struct {
 	started           atomic.Bool
 	stopped           atomic.Bool
 	wg                sync.WaitGroup
-	mu                sync.Mutex   // protects Start/Stop
-	submitMu          sync.RWMutex // protects Submit against concurrent Stop
+	mu                sync.Mutex // protects Start/Stop
+	submitMu          sync.Mutex // serializes successful submissions and Fence boundaries
 	completionMu      sync.Mutex
 	completionChan    chan struct{}
 }
@@ -221,30 +221,30 @@ func (p *BlockPipeline) Submit(ctx context.Context, blockType uint, rawCbor []by
 		return ErrPipelineNotStarted
 	}
 
-	// RLock allows concurrent submits while preventing races with Stop().
-	// This is critical: between the stopped check and channel send, Stop() could
-	// close submitChan causing a panic. The RLock ensures Stop() waits until
-	// all in-flight submits complete before closing the channel.
-	p.submitMu.RLock()
-	defer p.submitMu.RUnlock()
+	// The lock prevents Stop from closing submitChan while a submission is in
+	// flight. It also serializes the enqueue and sequence commit, so canceled
+	// submissions cannot leave a sequence gap that would block ordered apply.
+	p.submitMu.Lock()
+	defer p.submitMu.Unlock()
 
 	// Check stopped under lock to ensure we don't race with Stop()
 	if p.stopped.Load() {
 		return ErrPipelineStopped
 	}
 
-	// Allocate sequence number only once, then send.
-	// We use a single blocking select to avoid sequence gaps that would occur
-	// if we allocated in a non-blocking attempt that failed.
-	item := NewBlockItem(blockType, rawCbor, tip, p.sequenceCounter.Add(1)-1)
+	// Commit a sequence number only after its item was successfully enqueued.
+	// Keeping the provisional ID under submitMu makes successful IDs unique and
+	// contiguous in queue order, while canceled or backpressured submissions do
+	// not create positions that Fence must wait for.
+	sequence := p.sequenceCounter.Load()
+	item := NewBlockItem(blockType, rawCbor, tip, sequence)
 
 	select {
 	case p.submitChan <- item:
+		p.sequenceCounter.Add(1)
 		p.metrics.RecordSubmit()
 		return nil
 	case <-ctx.Done():
-		// Context cancelled while waiting - sequence gap is acceptable
-		// because this typically means shutdown.
 		return ctx.Err()
 	case <-p.ctx.Done():
 		return ErrPipelineStopped
@@ -260,9 +260,9 @@ func (p *BlockPipeline) Fence(ctx context.Context) error {
 		return ErrPipelineNotStarted
 	}
 
-	// The write lock excludes in-flight submissions while we capture the
-	// sequence boundary. Submit allocates each sequence number under its read
-	// lock, so every submission that completed before this point is included.
+	// The lock excludes in-flight submissions while we capture the sequence
+	// boundary. Submit commits each sequence number under this lock only after
+	// enqueue, so every position at or below target is waitable.
 	p.submitMu.Lock()
 	if p.stopped.Load() {
 		p.submitMu.Unlock()

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -75,14 +75,17 @@ type BlockPipeline struct {
 	metrics *PipelineMetrics
 
 	// State
-	sequenceCounter atomic.Uint64
-	ctx             context.Context
-	cancel          context.CancelFunc
-	started         atomic.Bool
-	stopped         atomic.Bool
-	wg              sync.WaitGroup
-	mu              sync.Mutex   // protects Start/Stop
-	submitMu        sync.RWMutex // protects Submit against concurrent Stop
+	sequenceCounter   atomic.Uint64
+	completedSequence atomic.Uint64
+	ctx               context.Context
+	cancel            context.CancelFunc
+	started           atomic.Bool
+	stopped           atomic.Bool
+	wg                sync.WaitGroup
+	mu                sync.Mutex   // protects Start/Stop
+	submitMu          sync.RWMutex // protects Submit against concurrent Stop
+	completionMu      sync.Mutex
+	completionChan    chan struct{}
 }
 
 // NewBlockPipeline creates a new BlockPipeline using functional options.
@@ -186,6 +189,11 @@ func (p *BlockPipeline) Start(ctx context.Context) error {
 		bufSize, // Deprecated: pendingQueueSize is no longer used (kept for API compatibility)
 	)
 	p.applyRunner.SetMetrics(p.metrics)
+	p.completionMu.Lock()
+	p.completionChan = make(chan struct{})
+	p.completedSequence.Store(0)
+	p.completionMu.Unlock()
+	p.applyRunner.SetProcessedFunc(p.markProcessed)
 
 	// Start all stages
 	// Note: p.ctx is derived from the passed ctx via context.WithCancel above
@@ -241,6 +249,58 @@ func (p *BlockPipeline) Submit(ctx context.Context, blockType uint, rawCbor []by
 	case <-p.ctx.Done():
 		return ErrPipelineStopped
 	}
+}
+
+// Fence waits until every block submitted before the fence is installed has
+// completed ordered processing. It does not wait for blocks submitted after
+// the fence, allowing callers to establish an exact ordering boundary without
+// draining later work.
+func (p *BlockPipeline) Fence(ctx context.Context) error {
+	if !p.started.Load() {
+		return ErrPipelineNotStarted
+	}
+
+	// The write lock excludes in-flight submissions while we capture the
+	// sequence boundary. Submit allocates each sequence number under its read
+	// lock, so every submission that completed before this point is included.
+	p.submitMu.Lock()
+	if p.stopped.Load() {
+		p.submitMu.Unlock()
+		return ErrPipelineStopped
+	}
+	target := p.sequenceCounter.Load()
+	p.submitMu.Unlock()
+	if target == 0 {
+		return nil
+	}
+
+	for {
+		if p.completedSequence.Load() >= target {
+			return nil
+		}
+		p.completionMu.Lock()
+		if p.completedSequence.Load() >= target {
+			p.completionMu.Unlock()
+			return nil
+		}
+		completionChan := p.completionChan
+		p.completionMu.Unlock()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-p.ctx.Done():
+			return ErrPipelineStopped
+		case <-completionChan:
+		}
+	}
+}
+
+func (p *BlockPipeline) markProcessed(sequence uint64) {
+	p.completedSequence.Store(sequence)
+	p.completionMu.Lock()
+	close(p.completionChan)
+	p.completionChan = make(chan struct{})
+	p.completionMu.Unlock()
 }
 
 // Results returns a channel of successfully processed block items.

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -31,7 +31,9 @@ var ErrPipelineStopped = errors.New("pipeline is stopped")
 var ErrPipelineNotStarted = errors.New("pipeline not started")
 
 // ErrMissingEta0Provider is returned when validation is enabled but no Eta0Provider is configured.
-var ErrMissingEta0Provider = errors.New("pipeline: validation enabled but Eta0Provider not configured")
+var ErrMissingEta0Provider = errors.New(
+	"pipeline: validation enabled but Eta0Provider not configured",
+)
 
 // closedResultsChan is a closed channel returned by Results() before Start() is called.
 // This prevents callers from blocking indefinitely on a nil channel.
@@ -216,7 +218,12 @@ func (p *BlockPipeline) Start(ctx context.Context) error {
 // This method is safe to call concurrently with Stop().
 // The context allows callers to handle timeouts or cancellations when the
 // pipeline is full and applying backpressure.
-func (p *BlockPipeline) Submit(ctx context.Context, blockType uint, rawCbor []byte, tip pcommon.Tip) error {
+func (p *BlockPipeline) Submit(
+	ctx context.Context,
+	blockType uint,
+	rawCbor []byte,
+	tip pcommon.Tip,
+) error {
 	// Early checks for common cases (before acquiring lock)
 	if !p.started.Load() {
 		return ErrPipelineNotStarted
@@ -381,7 +388,13 @@ func (p *BlockPipeline) PendingCount() int {
 	if !p.started.Load() {
 		return 0
 	}
-	channelDepth := len(p.submitChan) + len(p.decodedChan) + len(p.validatedChan)
+	channelDepth := len(
+		p.submitChan,
+	) + len(
+		p.decodedChan,
+	) + len(
+		p.validatedChan,
+	)
 	applyPending := 0
 	if p.applyStage != nil {
 		applyPending = p.applyStage.PendingCount()
@@ -425,7 +438,13 @@ func (p *BlockPipeline) metricsCollector() {
 			return
 		case <-ticker.C:
 			// Update queue depth
-			depth := len(p.submitChan) + len(p.decodedChan) + len(p.validatedChan)
+			depth := len(
+				p.submitChan,
+			) + len(
+				p.decodedChan,
+			) + len(
+				p.validatedChan,
+			)
 			p.metrics.UpdateQueueDepth(depth)
 		}
 	}

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -83,9 +83,10 @@ type BlockPipeline struct {
 	stopped           atomic.Bool
 	wg                sync.WaitGroup
 	mu                sync.Mutex // protects Start/Stop
-	submitMu          sync.Mutex // serializes successful submissions and Fence boundaries
-	completionMu      sync.Mutex
-	completionChan    chan struct{}
+	// submitMu serializes successful submissions and Fence boundaries.
+	submitMu       sync.Mutex
+	completionMu   sync.Mutex
+	completionChan chan struct{}
 }
 
 // NewBlockPipeline creates a new BlockPipeline using functional options.

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -191,7 +191,12 @@ func TestBlockItem_ThreadSafety(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := range numIterations {
-				item.SetValidation(true, "test", nil, time.Duration(j)*time.Millisecond)
+				item.SetValidation(
+					true,
+					"test",
+					nil,
+					time.Duration(j)*time.Millisecond,
+				)
 			}
 		}()
 	}
@@ -304,7 +309,12 @@ func TestDecodeStageWorkerPool_MultipleWorkers(t *testing.T) {
 	// Populate input channel
 	for i := range numItems {
 		tip := createTestTip(uint64(1000+i), uint64(500+i))
-		item := NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, uint64(i))
+		item := NewBlockItem(
+			uint(ledger.BlockTypeConway),
+			rawCbor,
+			tip,
+			uint64(i),
+		)
 		input <- item
 	}
 	close(input)
@@ -329,7 +339,12 @@ func TestDecodeStageWorkerPool_MultipleWorkers(t *testing.T) {
 
 	assert.Len(t, decoded, numItems)
 	for _, item := range decoded {
-		assert.True(t, item.IsDecoded(), "Item seq %d should be decoded", item.SequenceNumber())
+		assert.True(
+			t,
+			item.IsDecoded(),
+			"Item seq %d should be decoded",
+			item.SequenceNumber(),
+		)
 	}
 }
 
@@ -419,7 +434,9 @@ func TestValidateStage_SkipsItemsWithDecodeErrors(t *testing.T) {
 
 	// Create real validate stage
 	config := ValidateStageConfig{
-		Eta0Provider:      StaticEta0Provider("0000000000000000000000000000000000000000000000000000000000000000"),
+		Eta0Provider: StaticEta0Provider(
+			"0000000000000000000000000000000000000000000000000000000000000000",
+		),
 		SlotsPerKesPeriod: 129600,
 	}
 	validateStage := NewValidateStage(config)
@@ -428,7 +445,10 @@ func TestValidateStage_SkipsItemsWithDecodeErrors(t *testing.T) {
 
 	// Should return nil to avoid spurious error - decode stage already reported it
 	assert.NoError(t, err)
-	assert.False(t, item.IsValid()) // Should not be marked valid since decode failed
+	assert.False(
+		t,
+		item.IsValid(),
+	) // Should not be marked valid since decode failed
 }
 
 func TestValidateStage_ValidationResultSetCorrectly(t *testing.T) {
@@ -448,7 +468,9 @@ func TestValidateStage_ValidationResultSetCorrectly(t *testing.T) {
 	// Create real validate stage (validation will fail without proper eta0,
 	// but we can verify the stage processes correctly)
 	config := ValidateStageConfig{
-		Eta0Provider:      StaticEta0Provider("0000000000000000000000000000000000000000000000000000000000000000"),
+		Eta0Provider: StaticEta0Provider(
+			"0000000000000000000000000000000000000000000000000000000000000000",
+		),
 		SlotsPerKesPeriod: 129600,
 		VerifyConfig: common.VerifyConfig{
 			SkipBodyHashValidation:    true,
@@ -508,8 +530,18 @@ func TestValidateStage_Eta0ProviderCalled(t *testing.T) {
 	_ = stage.Process(context.Background(), item)
 
 	// Verify provider was called with the block's slot number
-	assert.Equal(t, block.SlotNumber(), calledSlot, "Provider should be called with block's slot number")
-	assert.Greater(t, item.ValidateDuration(), time.Duration(0), "ValidateDuration should be set")
+	assert.Equal(
+		t,
+		block.SlotNumber(),
+		calledSlot,
+		"Provider should be called with block's slot number",
+	)
+	assert.Greater(
+		t,
+		item.ValidateDuration(),
+		time.Duration(0),
+		"ValidateDuration should be set",
+	)
 }
 
 func TestValidateStage_Eta0ProviderError(t *testing.T) {
@@ -581,7 +613,12 @@ func TestValidateStage_NoProviderReturnsError(t *testing.T) {
 	assert.Error(t, err, "Should fail without Eta0Provider")
 	assert.Contains(t, err.Error(), "eta0 provider not configured")
 	assert.False(t, item.IsValid())
-	assert.Greater(t, item.ValidateDuration(), time.Duration(0), "ValidateDuration should be set")
+	assert.Greater(
+		t,
+		item.ValidateDuration(),
+		time.Duration(0),
+		"ValidateDuration should be set",
+	)
 }
 
 func TestValidateStage_ContextCancellation(t *testing.T) {
@@ -636,7 +673,12 @@ func TestApplyStageOrdering_OutOfOrderReordering(t *testing.T) {
 	items := make([]*BlockItem, 5)
 	for i := range 5 {
 		tip := createTestTip(1000+uint64(i), 500+uint64(i))
-		items[i] = NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, uint64(i))
+		items[i] = NewBlockItem(
+			uint(ledger.BlockTypeConway),
+			rawCbor,
+			tip,
+			uint64(i),
+		)
 		// Decode and validate them
 		block, err := ledger.NewBlockFromCbor(
 			uint(ledger.BlockTypeConway),
@@ -677,7 +719,12 @@ func TestApplyStageOrdering_SkipsInvalidItems(t *testing.T) {
 	items := make([]*BlockItem, 5)
 	for i := range 5 {
 		tip := createTestTip(1000+uint64(i), 500+uint64(i))
-		items[i] = NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, uint64(i))
+		items[i] = NewBlockItem(
+			uint(ledger.BlockTypeConway),
+			rawCbor,
+			tip,
+			uint64(i),
+		)
 
 		block, err := ledger.NewBlockFromCbor(
 			uint(ledger.BlockTypeConway),
@@ -689,7 +736,12 @@ func TestApplyStageOrdering_SkipsInvalidItems(t *testing.T) {
 
 		// Make items 1 and 3 invalid (using validation error)
 		if i == 1 || i == 3 {
-			items[i].SetValidation(false, "", errors.New("validation failed"), time.Millisecond)
+			items[i].SetValidation(
+				false,
+				"",
+				errors.New("validation failed"),
+				time.Millisecond,
+			)
 		} else {
 			items[i].SetValidation(true, "vrf", nil, time.Millisecond)
 		}
@@ -773,7 +825,9 @@ func TestApplyStage_RequireValidation_AppliesValidatedItems(t *testing.T) {
 	assert.NoError(t, item.ApplyError())
 }
 
-func TestApplyStage_RequireValidation_BufferedUnvalidatedItemsSkipped(t *testing.T) {
+func TestApplyStage_RequireValidation_BufferedUnvalidatedItemsSkipped(
+	t *testing.T,
+) {
 	var appliedSeqs []uint64
 	var mu sync.Mutex
 
@@ -935,7 +989,12 @@ func TestBlockPipelineFenceIgnoresCanceledBackpressuredSubmission(
 	for range 3 {
 		require.NoError(
 			t,
-			p.Submit(context.Background(), uint(ledger.BlockTypeConway), rawCbor, tip),
+			p.Submit(
+				context.Background(),
+				uint(ledger.BlockTypeConway),
+				rawCbor,
+				tip,
+			),
 		)
 	}
 	select {
@@ -945,7 +1004,12 @@ func TestBlockPipelineFenceIgnoresCanceledBackpressuredSubmission(
 	}
 	require.NoError(
 		t,
-		p.Submit(context.Background(), uint(ledger.BlockTypeConway), rawCbor, tip),
+		p.Submit(
+			context.Background(),
+			uint(ledger.BlockTypeConway),
+			rawCbor,
+			tip,
+		),
 	)
 
 	backpressuredCtx, cancel := context.WithCancel(context.Background())
@@ -982,7 +1046,10 @@ func TestBlockPipelineFenceIgnoresCanceledBackpressuredSubmission(
 	go func() { fenceDone <- p.Fence(context.Background()) }()
 	select {
 	case err := <-fenceDone:
-		t.Fatalf("fence returned before successful submissions completed: %v", err)
+		t.Fatalf(
+			"fence returned before successful submissions completed: %v",
+			err,
+		)
 	default:
 	}
 
@@ -1015,7 +1082,12 @@ func TestApplyStage_PendingCount(t *testing.T) {
 	// Create items 1 and 2 (but not 0)
 	for i := 1; i <= 2; i++ {
 		tip := createTestTip(1000+uint64(i), 500+uint64(i))
-		item := NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, uint64(i))
+		item := NewBlockItem(
+			uint(ledger.BlockTypeConway),
+			rawCbor,
+			tip,
+			uint64(i),
+		)
 		block, err := ledger.NewBlockFromCbor(
 			uint(ledger.BlockTypeConway),
 			rawCbor,
@@ -1100,7 +1172,12 @@ func TestApplyStage_Reset(t *testing.T) {
 	// Add some pending items
 	for i := 1; i <= 3; i++ {
 		tip := createTestTip(1000+uint64(i), 500+uint64(i))
-		item := NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, uint64(i))
+		item := NewBlockItem(
+			uint(ledger.BlockTypeConway),
+			rawCbor,
+			tip,
+			uint64(i),
+		)
 		block, err := ledger.NewBlockFromCbor(
 			uint(ledger.BlockTypeConway),
 			rawCbor,
@@ -1152,7 +1229,11 @@ func TestBlockPipeline_StartStop(t *testing.T) {
 	p := NewBlockPipeline(
 		WithSkipBodyHashValidation(true),
 		WithValidateWorkers(1),
-		WithEta0Provider(StaticEta0Provider("0000000000000000000000000000000000000000000000000000000000000000")),
+		WithEta0Provider(
+			StaticEta0Provider(
+				"0000000000000000000000000000000000000000000000000000000000000000",
+			),
+		),
 		WithSlotsPerKesPeriod(129600),
 		WithVerifyConfig(common.VerifyConfig{
 			SkipBodyHashValidation:    true,
@@ -1196,7 +1277,12 @@ func TestBlockPipeline_NotStarted(t *testing.T) {
 
 	rawCbor := getValidBlockCbor(t)
 	tip := createTestTip(1000, 500)
-	err := p.Submit(context.Background(), uint(ledger.BlockTypeConway), rawCbor, tip)
+	err := p.Submit(
+		context.Background(),
+		uint(ledger.BlockTypeConway),
+		rawCbor,
+		tip,
+	)
 
 	assert.ErrorIs(t, err, ErrPipelineNotStarted)
 }
@@ -1264,7 +1350,12 @@ func TestBlockPipeline_SubmitAndResults(t *testing.T) {
 	// Submit blocks
 	for i := range numBlocks {
 		tip := createTestTip(uint64(1000+i), uint64(i))
-		item := NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, uint64(i))
+		item := NewBlockItem(
+			uint(ledger.BlockTypeConway),
+			rawCbor,
+			tip,
+			uint64(i),
+		)
 		input <- item
 	}
 	close(input)
@@ -1296,7 +1387,12 @@ func TestBlockPipeline_StatsUpdated(t *testing.T) {
 		submitted.Add(1)
 
 		tip := createTestTip(uint64(1000+i), uint64(i))
-		item := NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, uint64(i))
+		item := NewBlockItem(
+			uint(ledger.BlockTypeConway),
+			rawCbor,
+			tip,
+			uint64(i),
+		)
 
 		stage := NewDecodeStage(true)
 		if err := stage.Process(context.Background(), item); err == nil {
@@ -1332,7 +1428,12 @@ func TestPipelineBackpressure_SlowConsumer(t *testing.T) {
 	go func() {
 		for i := range numBlocks {
 			tip := createTestTip(uint64(i), uint64(i))
-			item := NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, uint64(i))
+			item := NewBlockItem(
+				uint(ledger.BlockTypeConway),
+				rawCbor,
+				tip,
+				uint64(i),
+			)
 			select {
 			case input <- item:
 				itemsProduced.Add(1)
@@ -1390,7 +1491,12 @@ func TestPipelineBackpressure_PrefetchBufferFillsUp(t *testing.T) {
 	// Fill buffer
 	for i := range bufferSize {
 		tip := createTestTip(uint64(i), uint64(i))
-		item := NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, uint64(i))
+		item := NewBlockItem(
+			uint(ledger.BlockTypeConway),
+			rawCbor,
+			tip,
+			uint64(i),
+		)
 		select {
 		case input <- item:
 		default:
@@ -1438,7 +1544,10 @@ func TestPipelineGracefulShutdown_InFlightItemsComplete(t *testing.T) {
 					close(output)
 					return
 				}
-				_ = stage.Process(context.Background(), item) // Use fresh context to complete
+				_ = stage.Process(
+					context.Background(),
+					item,
+				) // Use fresh context to complete
 				output <- item
 				processedCount.Add(1)
 			case <-ctx.Done():
@@ -1457,7 +1566,12 @@ func TestPipelineGracefulShutdown_InFlightItemsComplete(t *testing.T) {
 	// Submit items
 	for i := range numItems {
 		tip := createTestTip(uint64(i), uint64(i))
-		item := NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, uint64(i))
+		item := NewBlockItem(
+			uint(ledger.BlockTypeConway),
+			rawCbor,
+			tip,
+			uint64(i),
+		)
 		input <- item
 	}
 
@@ -1527,10 +1641,13 @@ func TestStageFunc_NameAndProcess(t *testing.T) {
 
 	processedItems := 0
 
-	stage := NewStageFunc("test-stage", func(ctx context.Context, item *BlockItem) error {
-		processedItems++
-		return nil
-	})
+	stage := NewStageFunc(
+		"test-stage",
+		func(ctx context.Context, item *BlockItem) error {
+			processedItems++
+			return nil
+		},
+	)
 
 	assert.Equal(t, "test-stage", stage.Name())
 
@@ -1546,9 +1663,12 @@ func TestStageFunc_ErrorHandling(t *testing.T) {
 
 	expectedErr := errors.New("stage failed")
 
-	stage := NewStageFunc("error-stage", func(ctx context.Context, item *BlockItem) error {
-		return expectedErr
-	})
+	stage := NewStageFunc(
+		"error-stage",
+		func(ctx context.Context, item *BlockItem) error {
+			return expectedErr
+		},
+	)
 
 	err := stage.Process(context.Background(), item)
 	assert.Equal(t, expectedErr, err)
@@ -1580,9 +1700,18 @@ func TestDecodeStageWorkerPool_NumWorkersValidation(t *testing.T) {
 			output := make(chan *BlockItem, 1)
 			errChan := make(chan error, 1)
 
-			pool := NewDecodeStageWorkerPool(stage, tc.numWorkers, input, output, errChan)
+			pool := NewDecodeStageWorkerPool(
+				stage,
+				tc.numWorkers,
+				input,
+				output,
+				errChan,
+			)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(
+				context.Background(),
+				5*time.Second,
+			)
 			defer cancel()
 
 			pool.Start(ctx)
@@ -1613,7 +1742,9 @@ func TestDecodeStageWorkerPool_NumWorkersValidation(t *testing.T) {
 func TestValidateStageWorkerPool_NumWorkersValidation(t *testing.T) {
 	rawCbor := getValidBlockCbor(t)
 	config := ValidateStageConfig{
-		Eta0Provider:      StaticEta0Provider("0000000000000000000000000000000000000000000000000000000000000000"),
+		Eta0Provider: StaticEta0Provider(
+			"0000000000000000000000000000000000000000000000000000000000000000",
+		),
 		SlotsPerKesPeriod: 129600,
 		VerifyConfig: common.VerifyConfig{
 			SkipBodyHashValidation:    true,
@@ -1640,9 +1771,18 @@ func TestValidateStageWorkerPool_NumWorkersValidation(t *testing.T) {
 			output := make(chan *BlockItem, 1)
 			errChan := make(chan error, 1)
 
-			pool := NewValidateStageWorkerPool(stage, tc.numWorkers, input, output, errChan)
+			pool := NewValidateStageWorkerPool(
+				stage,
+				tc.numWorkers,
+				input,
+				output,
+				errChan,
+			)
 
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(
+				context.Background(),
+				5*time.Second,
+			)
 			defer cancel()
 
 			pool.Start(ctx)
@@ -1687,7 +1827,11 @@ func TestBlockPipeline_SubmitStopRaceCondition(t *testing.T) {
 		p := NewBlockPipeline(
 			WithSkipBodyHashValidation(true),
 			WithValidateWorkers(1),
-			WithEta0Provider(StaticEta0Provider("0000000000000000000000000000000000000000000000000000000000000000")),
+			WithEta0Provider(
+				StaticEta0Provider(
+					"0000000000000000000000000000000000000000000000000000000000000000",
+				),
+			),
 			WithSlotsPerKesPeriod(129600),
 			WithVerifyConfig(common.VerifyConfig{
 				SkipBodyHashValidation:    true,
@@ -1715,7 +1859,8 @@ func TestBlockPipeline_SubmitStopRaceCondition(t *testing.T) {
 				// Either no error, ErrPipelineStopped, or context.Canceled is acceptable.
 				// context.Canceled occurs when Stop() cancels the context before Submit
 				// can complete its channel send.
-				if err != nil && !errors.Is(err, ErrPipelineStopped) && !errors.Is(err, context.Canceled) {
+				if err != nil && !errors.Is(err, ErrPipelineStopped) &&
+					!errors.Is(err, context.Canceled) {
 					t.Errorf("Unexpected error: %v", err)
 				}
 			}
@@ -1768,7 +1913,12 @@ func TestApplyStageRunner_OutOfOrderItemsForwarded(t *testing.T) {
 	items := make([]*BlockItem, 5)
 	for i := range 5 {
 		tip := createTestTip(1000+uint64(i), 500+uint64(i))
-		items[i] = NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, uint64(i))
+		items[i] = NewBlockItem(
+			uint(ledger.BlockTypeConway),
+			rawCbor,
+			tip,
+			uint64(i),
+		)
 
 		block, err := ledger.NewBlockFromCbor(
 			uint(ledger.BlockTypeConway),
@@ -1812,7 +1962,12 @@ func TestApplyStageRunner_OutOfOrderItemsForwarded(t *testing.T) {
 
 	// Verify all received items are marked as applied
 	for _, item := range received {
-		assert.True(t, item.IsApplied(), "Item %d should be marked as applied", item.SequenceNumber())
+		assert.True(
+			t,
+			item.IsApplied(),
+			"Item %d should be marked as applied",
+			item.SequenceNumber(),
+		)
 	}
 }
 
@@ -1852,7 +2007,12 @@ func TestApplyStageRunner_OutOfOrderErrorItemsForwardedOnce(t *testing.T) {
 	items := make([]*BlockItem, 5)
 	for i := range 5 {
 		tip := createTestTip(1000+uint64(i), 500+uint64(i))
-		items[i] = NewBlockItem(uint(ledger.BlockTypeConway), rawCbor, tip, uint64(i))
+		items[i] = NewBlockItem(
+			uint(ledger.BlockTypeConway),
+			rawCbor,
+			tip,
+			uint64(i),
+		)
 
 		block, err := ledger.NewBlockFromCbor(
 			uint(ledger.BlockTypeConway),
@@ -1864,7 +2024,12 @@ func TestApplyStageRunner_OutOfOrderErrorItemsForwardedOnce(t *testing.T) {
 
 		// Items 1 and 3 have validation errors
 		if i == 1 || i == 3 {
-			items[i].SetValidation(false, "", fmt.Errorf("validation error for item %d", i), time.Millisecond)
+			items[i].SetValidation(
+				false,
+				"",
+				fmt.Errorf("validation error for item %d", i),
+				time.Millisecond,
+			)
 		} else {
 			items[i].SetValidation(true, "vrf", nil, time.Millisecond)
 		}
@@ -1903,7 +2068,12 @@ collectLoop:
 	runner.Stop()
 
 	// Verify exactly 5 items were forwarded (no duplicates)
-	assert.Len(t, received, 5, "Exactly 5 items should be forwarded (no duplicates)")
+	assert.Len(
+		t,
+		received,
+		5,
+		"Exactly 5 items should be forwarded (no duplicates)",
+	)
 
 	// Count how many times each sequence number appears
 	seqCounts := make(map[uint64]int)
@@ -1913,7 +2083,14 @@ collectLoop:
 
 	// Verify each item was forwarded exactly once
 	for seq, count := range seqCounts {
-		assert.Equal(t, 1, count, "Item %d should be forwarded exactly once, got %d", seq, count)
+		assert.Equal(
+			t,
+			1,
+			count,
+			"Item %d should be forwarded exactly once, got %d",
+			seq,
+			count,
+		)
 	}
 
 	// Verify items with validation errors were NOT applied
@@ -1925,7 +2102,12 @@ collectLoop:
 
 	// Verify valid items (0, 2, 4) were applied in sequence order
 	expectedApplied := []uint64{0, 2, 4}
-	assert.Equal(t, expectedApplied, appliedOrder, "Valid items should be applied in sequence order")
+	assert.Equal(
+		t,
+		expectedApplied,
+		appliedOrder,
+		"Valid items should be applied in sequence order",
+	)
 }
 
 // TestBlockPipeline_StartFailsWithoutEta0Provider verifies that Start() returns
@@ -2029,7 +2211,11 @@ func TestBlockPipeline_MetricsRecorded(t *testing.T) {
 	pipeline := NewBlockPipeline(
 		WithSkipBodyHashValidation(true),
 		WithValidateWorkers(1),
-		WithEta0Provider(StaticEta0Provider("0000000000000000000000000000000000000000000000000000000000000000")),
+		WithEta0Provider(
+			StaticEta0Provider(
+				"0000000000000000000000000000000000000000000000000000000000000000",
+			),
+		),
 		WithSlotsPerKesPeriod(129600),
 		WithVerifyConfig(common.VerifyConfig{
 			SkipBodyHashValidation:    true,
@@ -2072,15 +2258,40 @@ func TestBlockPipeline_MetricsRecorded(t *testing.T) {
 	// Verify metrics
 	stats := pipeline.Stats()
 
-	assert.Equal(t, uint64(numBlocks), stats.BlocksSubmitted, "BlocksSubmitted should match")
-	assert.Equal(t, uint64(numBlocks), stats.BlocksDecoded, "BlocksDecoded should match")
+	assert.Equal(
+		t,
+		uint64(numBlocks),
+		stats.BlocksSubmitted,
+		"BlocksSubmitted should match",
+	)
+	assert.Equal(
+		t,
+		uint64(numBlocks),
+		stats.BlocksDecoded,
+		"BlocksDecoded should match",
+	)
 	assert.Equal(t, uint64(0), stats.DecodeErrors, "DecodeErrors should be 0")
 
 	// Validation will fail due to incorrect Eta0, so we expect validation errors
-	assert.Equal(t, uint64(numBlocks), stats.ValidationErrors, "ValidationErrors should match (validation fails with dummy Eta0)")
-	assert.Equal(t, uint64(0), stats.BlocksValidated, "BlocksValidated should be 0 (validation fails with dummy Eta0)")
+	assert.Equal(
+		t,
+		uint64(numBlocks),
+		stats.ValidationErrors,
+		"ValidationErrors should match (validation fails with dummy Eta0)",
+	)
+	assert.Equal(
+		t,
+		uint64(0),
+		stats.BlocksValidated,
+		"BlocksValidated should be 0 (validation fails with dummy Eta0)",
+	)
 
 	// Apply and pipeline latency won't be recorded for failed validations
 	// (items with validation errors are not applied)
-	assert.Equal(t, uint64(0), stats.BlocksApplied, "BlocksApplied should be 0 (failed validations are not applied)")
+	assert.Equal(
+		t,
+		uint64(0),
+		stats.BlocksApplied,
+		"BlocksApplied should be 0 (failed validations are not applied)",
+	)
 }

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -894,6 +894,115 @@ func TestBlockPipelineFenceWaitsForBlockedApply(t *testing.T) {
 	}
 }
 
+func TestBlockPipelineFenceIgnoresCanceledBackpressuredSubmission(t *testing.T) {
+	applyStarted := make(chan struct{})
+	releaseApply := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseApply) })
+	}
+	config := DefaultPipelineConfig()
+	config.DecodeWorkers = 1
+	config.ValidateWorkers = 0
+	config.PrefetchBufferSize = 1
+	config.SkipBodyHashValidation = true
+	var appliedSequences []uint64
+	var appliedMu sync.Mutex
+	p := NewBlockPipeline(
+		WithConfig(config),
+		WithApplyFunc(func(item *BlockItem) error {
+			appliedMu.Lock()
+			appliedSequences = append(appliedSequences, item.SequenceNumber())
+			first := len(appliedSequences) == 1
+			appliedMu.Unlock()
+			if first {
+				close(applyStarted)
+				<-releaseApply
+			}
+			return nil
+		}),
+	)
+	require.NoError(t, p.Start(context.Background()))
+	defer func() {
+		release()
+		require.NoError(t, p.Stop())
+	}()
+
+	rawCbor := getValidBlockCbor(t)
+	tip := createTestTip(1000, 500)
+	for range 3 {
+		require.NoError(
+			t,
+			p.Submit(context.Background(), uint(ledger.BlockTypeConway), rawCbor, tip),
+		)
+	}
+	select {
+	case <-applyStarted:
+	case <-time.After(time.Second):
+		t.Fatal("pipeline apply did not start")
+	}
+	require.NoError(
+		t,
+		p.Submit(context.Background(), uint(ledger.BlockTypeConway), rawCbor, tip),
+	)
+
+	backpressuredCtx, cancel := context.WithCancel(context.Background())
+	backpressuredSubmit := make(chan error, 1)
+	go func() {
+		backpressuredSubmit <- p.Submit(
+			backpressuredCtx,
+			uint(ledger.BlockTypeConway),
+			rawCbor,
+			tip,
+		)
+	}()
+	select {
+	case err := <-backpressuredSubmit:
+		t.Fatalf("submission escaped backpressure before cancellation: %v", err)
+	default:
+	}
+	cancel()
+	select {
+	case err := <-backpressuredSubmit:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("backpressured submission did not cancel")
+	}
+	processedResults := make(chan struct{}, 4)
+	go func() {
+		for range 4 {
+			<-p.Results()
+			processedResults <- struct{}{}
+		}
+	}()
+
+	fenceDone := make(chan error, 1)
+	go func() { fenceDone <- p.Fence(context.Background()) }()
+	select {
+	case err := <-fenceDone:
+		t.Fatalf("fence returned before successful submissions completed: %v", err)
+	default:
+	}
+
+	release()
+	select {
+	case err := <-fenceDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("fence waited for the canceled submission")
+	}
+	for range 4 {
+		select {
+		case <-processedResults:
+		case <-time.After(time.Second):
+			t.Fatal("pipeline did not forward a successfully processed item")
+		}
+	}
+	appliedMu.Lock()
+	require.Equal(t, []uint64{0, 1, 2, 3}, appliedSequences)
+	appliedMu.Unlock()
+}
+
 func TestApplyStage_PendingCount(t *testing.T) {
 	rawCbor := getValidBlockCbor(t)
 

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -894,7 +894,9 @@ func TestBlockPipelineFenceWaitsForBlockedApply(t *testing.T) {
 	}
 }
 
-func TestBlockPipelineFenceIgnoresCanceledBackpressuredSubmission(t *testing.T) {
+func TestBlockPipelineFenceIgnoresCanceledBackpressuredSubmission(
+	t *testing.T,
+) {
 	applyStarted := make(chan struct{})
 	releaseApply := make(chan struct{})
 	var releaseOnce sync.Once

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -840,6 +840,60 @@ func TestBlockPipeline_Start_WiresRequireValidation(t *testing.T) {
 	assert.False(t, p2.applyStage.requireValidation)
 }
 
+func TestBlockPipelineFenceWaitsForBlockedApply(t *testing.T) {
+	applyStarted := make(chan struct{})
+	releaseApply := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseApply) })
+	}
+	p := NewBlockPipeline(
+		WithDecodeWorkers(1),
+		WithValidateWorkers(0),
+		WithSkipBodyHashValidation(true),
+		WithApplyFunc(func(*BlockItem) error {
+			close(applyStarted)
+			<-releaseApply
+			return nil
+		}),
+	)
+	require.NoError(t, p.Start(context.Background()))
+	defer func() {
+		release()
+		require.NoError(t, p.Stop())
+	}()
+	require.NoError(
+		t,
+		p.Submit(
+			context.Background(),
+			uint(ledger.BlockTypeConway),
+			getValidBlockCbor(t),
+			createTestTip(1000, 500),
+		),
+	)
+	select {
+	case <-applyStarted:
+	case <-time.After(time.Second):
+		t.Fatal("pipeline apply did not start")
+	}
+
+	fenceDone := make(chan error, 1)
+	go func() { fenceDone <- p.Fence(context.Background()) }()
+	select {
+	case <-fenceDone:
+		t.Fatal("pipeline fence returned before the blocked apply completed")
+	default:
+	}
+
+	release()
+	select {
+	case err := <-fenceDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("pipeline fence did not complete after the apply completed")
+	}
+}
+
 func TestApplyStage_PendingCount(t *testing.T) {
 	rawCbor := getValidBlockCbor(t)
 

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -948,6 +948,51 @@ func TestBlockPipelineFenceWaitsForBlockedApply(t *testing.T) {
 	}
 }
 
+func TestBlockPipelineFenceCancelsWhileWaitingForBlockedSubmit(t *testing.T) {
+	p := &BlockPipeline{
+		submitChan: make(chan *BlockItem, 1),
+		submitGate: make(chan struct{}, 1),
+		ctx:        context.Background(),
+	}
+	p.started.Store(true)
+	p.submitGate <- struct{}{}
+	p.submitChan <- nil
+
+	submitLocked := make(chan struct{})
+	p.testSubmitLocked = func() { close(submitLocked) }
+	submitCtx, cancelSubmit := context.WithCancel(context.Background())
+	submitDone := make(chan error, 1)
+	go func() {
+		submitDone <- p.Submit(submitCtx, 0, nil, pcommon.Tip{})
+	}()
+	select {
+	case <-submitLocked:
+	case <-time.After(time.Second):
+		t.Fatal("submission did not acquire the pipeline boundary")
+	}
+	defer func() {
+		cancelSubmit()
+		select {
+		case err := <-submitDone:
+			require.ErrorIs(t, err, context.Canceled)
+		case <-time.After(time.Second):
+			t.Error("blocked submission did not cancel")
+		}
+	}()
+
+	fenceCtx, cancelFence := context.WithCancel(context.Background())
+	defer cancelFence()
+	fenceDone := make(chan error, 1)
+	go func() { fenceDone <- p.Fence(fenceCtx) }()
+	cancelFence()
+	select {
+	case err := <-fenceDone:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("canceled fence did not return while submit held the boundary")
+	}
+}
+
 func TestBlockPipelineFenceIgnoresCanceledBackpressuredSubmission(
 	t *testing.T,
 ) {

--- a/protocol/chainsync/chainsync.go
+++ b/protocol/chainsync/chainsync.go
@@ -167,6 +167,8 @@ type ChainSync struct {
 
 // Config is used to configure the ChainSync protocol instance
 type Config struct {
+	AwaitReplyFunc      AwaitReplyFunc
+	IntersectFoundFunc  IntersectFoundFunc
 	RollBackwardFunc    RollBackwardFunc
 	RollForwardFunc     RollForwardFunc
 	RollForwardRawFunc  RollForwardRawFunc
@@ -221,6 +223,12 @@ type CallbackContext struct {
 
 // Callback function types
 type (
+	// AwaitReplyFunc observes the protocol's at-tip response. It runs on the
+	// ChainSync receive path, ordered after every preceding chain update.
+	AwaitReplyFunc func(CallbackContext) error
+	// IntersectFoundFunc observes the server-accepted local intersection and its
+	// advertised tip before the client asks for the next chain update.
+	IntersectFoundFunc func(CallbackContext, pcommon.Point, Tip) error
 	RollBackwardFunc   func(CallbackContext, pcommon.Point, Tip) error
 	RollForwardFunc    func(CallbackContext, uint, any, Tip) error
 	RollForwardRawFunc func(CallbackContext, uint, []byte, Tip) error
@@ -308,6 +316,22 @@ func (c *Config) validate() error {
 		)
 	}
 	return nil
+}
+
+// WithAwaitReplyFunc specifies the callback invoked for an AwaitReply.
+func WithAwaitReplyFunc(awaitReplyFunc AwaitReplyFunc) ChainSyncOptionFunc {
+	return func(c *Config) {
+		c.AwaitReplyFunc = awaitReplyFunc
+	}
+}
+
+// WithIntersectFoundFunc specifies the callback invoked for IntersectFound.
+func WithIntersectFoundFunc(
+	intersectFoundFunc IntersectFoundFunc,
+) ChainSyncOptionFunc {
+	return func(c *Config) {
+		c.IntersectFoundFunc = intersectFoundFunc
+	}
 }
 
 // WithRollBackwardFunc specifies the RollBackward callback function

--- a/protocol/chainsync/chainsync.go
+++ b/protocol/chainsync/chainsync.go
@@ -97,7 +97,9 @@ var (
 // per Ouroboros Network Specification Table 3.8.
 func MustReplyTimeoutFunc() time.Duration {
 	rangeMs := MustReplyTimeoutMax.Milliseconds() - MustReplyTimeoutMin.Milliseconds()
-	return MustReplyTimeoutMin + time.Duration(rand.Int64N(rangeMs))*time.Millisecond //nolint:gosec
+	return MustReplyTimeoutMin + time.Duration(
+		rand.Int64N(rangeMs),
+	)*time.Millisecond //nolint:gosec
 }
 
 // StateMapNtN is the N2N ChainSync state machine with timeouts per spec Table 3.8.

--- a/protocol/chainsync/chainsync.go
+++ b/protocol/chainsync/chainsync.go
@@ -98,8 +98,9 @@ var (
 func MustReplyTimeoutFunc() time.Duration {
 	rangeMs := MustReplyTimeoutMax.Milliseconds() - MustReplyTimeoutMin.Milliseconds()
 	return MustReplyTimeoutMin + time.Duration(
+		//nolint:gosec // Random timeout is required by the protocol.
 		rand.Int64N(rangeMs),
-	)*time.Millisecond //nolint:gosec
+	)*time.Millisecond
 }
 
 // StateMapNtN is the N2N ChainSync state machine with timeouts per spec Table 3.8.

--- a/protocol/chainsync/client.go
+++ b/protocol/chainsync/client.go
@@ -53,6 +53,11 @@ type Client struct {
 	syncLoopWaitGroup        sync.WaitGroup
 	syncPipelinedRequestNext int
 	protoOptions             protocol.ProtocolOptions
+	// The test hooks make lifecycle interleavings deterministic without changing
+	// production behavior.
+	testStopInitiated          func()
+	testStopWaitingForComplete func()
+	testSyncLoopBeforeBusyLock func()
 
 	// waitingForCurrentTipChan will process all the requests for the current tip until the channel
 	// is empty.
@@ -297,11 +302,14 @@ func (c *Client) Stop() error {
 		if c.lifecycleState == clientStateStopping {
 			ch := c.stoppingDone
 			c.lifecycleMutex.Unlock()
-			if ch != nil {
-				<-ch
-			}
 			if busyLocked {
 				c.busyMutex.Unlock()
+			}
+			if c.testStopWaitingForComplete != nil {
+				c.testStopWaitingForComplete()
+			}
+			if ch != nil {
+				<-ch
 			}
 			return nil
 		}
@@ -322,6 +330,9 @@ func (c *Client) Stop() error {
 	c.lifecycleState = clientStateStopping
 	stoppingDone := make(chan struct{})
 	c.stoppingDone = stoppingDone
+	if c.testStopInitiated != nil {
+		c.testStopInitiated()
+	}
 
 	var sendErr error
 	// Check if protocol is already done before sending Done message
@@ -676,6 +687,9 @@ func (c *Client) syncLoop(
 		case <-doneChan:
 			// Protocol is shutting down
 			return
+		}
+		if c.testSyncLoopBeforeBusyLock != nil {
+			c.testSyncLoopBeforeBusyLock()
 		}
 		c.busyMutex.Lock()
 		c.lifecycleMutex.Lock()

--- a/protocol/chainsync/client.go
+++ b/protocol/chainsync/client.go
@@ -914,6 +914,7 @@ func (c *Client) handleAwaitReply() error {
 		c.lifecycleMutex.Unlock()
 		if err := c.config.Pipeline.Fence(fenceCtx); err != nil {
 			if errors.Is(err, context.Canceled) && fenceCtx.Err() != nil {
+				//nolint:nilerr // A canceled fence is expected while the protocol is stopping.
 				return nil
 			}
 			return err

--- a/protocol/chainsync/client.go
+++ b/protocol/chainsync/client.go
@@ -53,6 +53,8 @@ type Client struct {
 	readyForNextBlockChan    chan bool
 	syncLoopWaitGroup        sync.WaitGroup
 	syncPipelinedRequestNext int
+	awaitReplyCtx            context.Context
+	awaitReplyCancel         context.CancelFunc
 	protoOptions             protocol.ProtocolOptions
 	// The test hooks make lifecycle interleavings deterministic without changing
 	// production behavior.
@@ -115,6 +117,11 @@ func NewClient(
 }
 
 func (c *Client) initProtocol() {
+	if c.awaitReplyCancel != nil {
+		c.awaitReplyCancel()
+	}
+	c.awaitReplyCtx, c.awaitReplyCancel = context.WithCancel(context.Background())
+
 	// Use node-to-client protocol ID
 	ProtocolId := ProtocolIdNtC
 	msgFromCborFunc := NewMsgFromCborNtC
@@ -312,6 +319,7 @@ func (c *Client) Stop() error {
 		// stopped and unblock its waiters without waiting on DoneChan, which an
 		// unstarted protocol never closes.
 		c.lifecycleState = clientStateStopped
+		c.awaitReplyCancel()
 		if c.startingDone != nil {
 			close(c.startingDone)
 			c.startingDone = nil
@@ -330,6 +338,9 @@ func (c *Client) Stop() error {
 		return nil
 	case clientStateRunning:
 		c.lifecycleState = clientStateStopping
+		// AwaitReply runs on the protocol receive loop. Cancel its pipeline fence
+		// before Stop waits for DoneChan, otherwise each waits for the other.
+		c.awaitReplyCancel()
 		stoppingDone := make(chan struct{})
 		c.stoppingDone = stoppingDone
 		proto := c.ProtocolInstance()
@@ -891,22 +902,14 @@ func (c *Client) handleAwaitReply() error {
 		if c.testAwaitReplyBeforeFence != nil {
 			c.testAwaitReplyBeforeFence()
 		}
-		fenceCtx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		go func() {
-			select {
-			case <-c.DoneChan():
-				cancel()
-			case <-fenceCtx.Done():
-			}
-		}()
+		c.lifecycleMutex.Lock()
+		fenceCtx := c.awaitReplyCtx
+		c.lifecycleMutex.Unlock()
 		if err := c.config.Pipeline.Fence(fenceCtx); err != nil {
-			select {
-			case <-c.DoneChan():
+			if errors.Is(err, context.Canceled) && fenceCtx.Err() != nil {
 				return nil
-			default:
-				return err
 			}
+			return err
 		}
 	}
 	if c.config != nil && c.config.AwaitReplyFunc != nil {

--- a/protocol/chainsync/client.go
+++ b/protocol/chainsync/client.go
@@ -944,10 +944,8 @@ func (c *Client) handlePipelineFenceError(
 		//nolint:nilerr // A canceled fence is expected while the protocol is stopping.
 		return nil
 	}
-	if errors.Is(err, pipeline.ErrPipelineStopped) {
-		return nil
-	}
-	if errors.Is(err, pipeline.ErrPipelineNotStarted) {
+	if errors.Is(err, pipeline.ErrPipelineStopped) ||
+		errors.Is(err, pipeline.ErrPipelineNotStarted) {
 		c.lifecycleMutex.Lock()
 		stopping := c.lifecycleState == clientStateStopping ||
 			c.lifecycleState == clientStateStopped

--- a/protocol/chainsync/client.go
+++ b/protocol/chainsync/client.go
@@ -776,20 +776,28 @@ func (c *Client) syncLoop(
 		}
 		// Request the next block(s)
 		msgCount := max(c.config.PipelineLimit, 1)
+		proto := c.ProtocolInstance()
+		c.lifecycleMutex.Unlock()
 		if c.testSyncLoopBeforeRequestNext != nil {
 			c.testSyncLoopBeforeRequestNext()
 		}
 		for range msgCount {
 			msg := NewMsgRequestNext()
-			if err := c.SendMessage(msg); err != nil {
+			if err := proto.SendMessage(msg); err != nil {
 				c.SendError(err)
-				c.lifecycleMutex.Unlock()
 				c.busyMutex.Unlock()
 				return
 			}
 		}
 		if c.testSyncLoopAfterRequestNext != nil {
 			c.testSyncLoopAfterRequestNext()
+		}
+		c.lifecycleMutex.Lock()
+		if c.lifecycleState != clientStateRunning ||
+			c.ProtocolInstance() != proto {
+			c.lifecycleMutex.Unlock()
+			c.busyMutex.Unlock()
+			return
 		}
 		c.syncPipelinedRequestNext = msgCount - 1
 		c.lifecycleMutex.Unlock()

--- a/protocol/chainsync/client.go
+++ b/protocol/chainsync/client.go
@@ -120,7 +120,9 @@ func (c *Client) initProtocol() {
 	if c.awaitReplyCancel != nil {
 		c.awaitReplyCancel()
 	}
-	c.awaitReplyCtx, c.awaitReplyCancel = context.WithCancel(context.Background())
+	c.awaitReplyCtx, c.awaitReplyCancel = context.WithCancel(
+		context.Background(),
+	)
 
 	// Use node-to-client protocol ID
 	ProtocolId := ProtocolIdNtC
@@ -243,7 +245,8 @@ func (c *Client) Start() {
 			oldProto := c.Protocol
 			oldProtoStarted := c.protocolStarted
 			var oldDone <-chan struct{}
-			if prevState == clientStateStopped && oldProto != nil && oldProtoStarted {
+			if prevState == clientStateStopped && oldProto != nil &&
+				oldProtoStarted {
 				oldDone = oldProto.DoneChan()
 			}
 			c.lifecycleMutex.Unlock()
@@ -357,7 +360,10 @@ func (c *Client) Stop() error {
 	}
 }
 
-func (c *Client) stopRunning(proto *protocol.Protocol, stoppingDone chan struct{}) error {
+func (c *Client) stopRunning(
+	proto *protocol.Protocol,
+	stoppingDone chan struct{},
+) error {
 	const busyLockTimeout = 5 * time.Second
 	deadline := time.Now().Add(busyLockTimeout)
 	busyLocked := false
@@ -691,7 +697,8 @@ func (c *Client) Sync(intersectPoints []pcommon.Point) error {
 func (c *Client) sendInitialRequestAndStartSyncLoop() error {
 	c.lifecycleMutex.Lock()
 	defer c.lifecycleMutex.Unlock()
-	if c.lifecycleState != clientStateRunning || c.readyForNextBlockChan == nil {
+	if c.lifecycleState != clientStateRunning ||
+		c.readyForNextBlockChan == nil {
 		return protocol.ErrProtocolShuttingDown
 	}
 	if c.testInitialRequestBeforeEnqueue != nil {
@@ -1143,7 +1150,10 @@ func (c *Client) handleRollBackward(msgGeneric protocol.Message) error {
 		if drainTimeout == 0 {
 			drainTimeout = DefaultPipelineDrainTimeout
 		}
-		drainCtx, drainCancel := context.WithTimeout(context.Background(), drainTimeout)
+		drainCtx, drainCancel := context.WithTimeout(
+			context.Background(),
+			drainTimeout,
+		)
 		defer drainCancel()
 
 		// Create a channel to signal drain completion

--- a/protocol/chainsync/client.go
+++ b/protocol/chainsync/client.go
@@ -34,6 +34,7 @@ const (
 	clientStateNew clientLifecycleState = iota
 	clientStateStarting
 	clientStateRunning
+	clientStateStopping
 	clientStateStopped
 )
 
@@ -47,7 +48,9 @@ type Client struct {
 	lifecycleMutex           sync.Mutex
 	lifecycleState           clientLifecycleState
 	startingDone             chan struct{}
+	stoppingDone             chan struct{}
 	readyForNextBlockChan    chan bool
+	syncLoopWaitGroup        sync.WaitGroup
 	syncPipelinedRequestNext int
 	protoOptions             protocol.ProtocolOptions
 
@@ -199,6 +202,16 @@ func (c *Client) Start() {
 			// Re-check state after the in-flight start completes
 			continue
 
+		case clientStateStopping:
+			// Wait until the running sync loop has stopped before replacing the
+			// protocol and its channels.
+			ch := c.stoppingDone
+			c.lifecycleMutex.Unlock()
+			if ch != nil {
+				<-ch
+			}
+			continue
+
 		case clientStateStopped, clientStateNew:
 			// We will be the goroutine that performs initialization/start.
 			// Save previous state before transitioning to prevent other goroutines from also starting.
@@ -281,6 +294,17 @@ func (c *Client) Stop() error {
 	c.lifecycleMutex.Lock()
 
 	if c.lifecycleState != clientStateRunning {
+		if c.lifecycleState == clientStateStopping {
+			ch := c.stoppingDone
+			c.lifecycleMutex.Unlock()
+			if ch != nil {
+				<-ch
+			}
+			if busyLocked {
+				c.busyMutex.Unlock()
+			}
+			return nil
+		}
 		if busyLocked {
 			c.busyMutex.Unlock()
 		}
@@ -294,6 +318,10 @@ func (c *Client) Stop() error {
 			"protocol", ProtocolName,
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
+
+	c.lifecycleState = clientStateStopping
+	stoppingDone := make(chan struct{})
+	c.stoppingDone = stoppingDone
 
 	var sendErr error
 	// Check if protocol is already done before sending Done message
@@ -315,11 +343,10 @@ func (c *Client) Stop() error {
 		c.readyForNextBlockChan = nil
 	}
 
-	// Stop/unregister the underlying protocol instance, then wait for it to
-	// finish so IsDone reports the completed shutdown when Stop returns.
+	// Stop/unregister the underlying protocol instance, then wait for it and
+	// the sync loop to finish before allowing a restart to replace their state.
 	doneChan := c.DoneChan()
 	c.Protocol.Stop()
-	c.lifecycleState = clientStateStopped
 	// Unblock any goroutine waiting for an in-progress start.
 	if c.startingDone != nil {
 		close(c.startingDone)
@@ -327,6 +354,15 @@ func (c *Client) Stop() error {
 	}
 	c.lifecycleMutex.Unlock()
 	<-doneChan
+	c.syncLoopWaitGroup.Wait()
+
+	c.lifecycleMutex.Lock()
+	c.lifecycleState = clientStateStopped
+	if c.stoppingDone == stoppingDone {
+		close(stoppingDone)
+		c.stoppingDone = nil
+	}
+	c.lifecycleMutex.Unlock()
 	return sendErr
 }
 
@@ -604,16 +640,32 @@ func (c *Client) Sync(intersectPoints []pcommon.Point) error {
 	}
 	// Reset pipelined message counter
 	c.syncPipelinedRequestNext = 0
-	// Start sync loop
-	go c.syncLoop()
+	// Start a sync loop bound to this protocol instance. Stop waits for every
+	// active loop before Start can replace the protocol and its channels.
+	c.lifecycleMutex.Lock()
+	if c.lifecycleState != clientStateRunning || c.readyForNextBlockChan == nil {
+		c.lifecycleMutex.Unlock()
+		return protocol.ErrProtocolShuttingDown
+	}
+	readyForNextBlockChan := c.readyForNextBlockChan
+	doneChan := c.DoneChan()
+	c.syncLoopWaitGroup.Add(1)
+	c.lifecycleMutex.Unlock()
+	go func() {
+		defer c.syncLoopWaitGroup.Done()
+		c.syncLoop(readyForNextBlockChan, doneChan)
+	}()
 	return nil
 }
 
-func (c *Client) syncLoop() {
+func (c *Client) syncLoop(
+	readyForNextBlockChan <-chan bool,
+	doneChan <-chan struct{},
+) {
 	for {
 		// Wait for a block to be received
 		select {
-		case ready, ok := <-c.readyForNextBlockChan:
+		case ready, ok := <-readyForNextBlockChan:
 			if !ok {
 				// Channel is closed, which means we're shutting down
 				return
@@ -621,11 +673,18 @@ func (c *Client) syncLoop() {
 				// Sync was cancelled
 				return
 			}
-		case <-c.DoneChan():
+		case <-doneChan:
 			// Protocol is shutting down
 			return
 		}
 		c.busyMutex.Lock()
+		c.lifecycleMutex.Lock()
+		stopping := c.lifecycleState != clientStateRunning
+		c.lifecycleMutex.Unlock()
+		if stopping {
+			c.busyMutex.Unlock()
+			return
+		}
 		// Wait for next block if we have pipelined messages
 		if c.syncPipelinedRequestNext > 0 {
 			c.syncPipelinedRequestNext--

--- a/protocol/chainsync/client.go
+++ b/protocol/chainsync/client.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/pipeline"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
@@ -696,27 +697,40 @@ func (c *Client) Sync(intersectPoints []pcommon.Point) error {
 
 func (c *Client) sendInitialRequestAndStartSyncLoop() error {
 	c.lifecycleMutex.Lock()
-	defer c.lifecycleMutex.Unlock()
 	if c.lifecycleState != clientStateRunning ||
 		c.readyForNextBlockChan == nil {
+		c.lifecycleMutex.Unlock()
 		return protocol.ErrProtocolShuttingDown
 	}
+	proto := c.ProtocolInstance()
+	readyForNextBlockChan := c.readyForNextBlockChan
+	doneChan := proto.DoneChan()
+	// Reserve the sync-loop wait-group slot before Stop can begin waiting. The
+	// reservation is released below if the request cannot be queued.
+	c.syncLoopWaitGroup.Add(1)
+	c.lifecycleMutex.Unlock()
 	if c.testInitialRequestBeforeEnqueue != nil {
 		c.testInitialRequestBeforeEnqueue()
 	}
-	if err := c.SendMessage(NewMsgRequestNext()); err != nil {
+	if err := proto.SendMessage(NewMsgRequestNext()); err != nil {
+		c.syncLoopWaitGroup.Done()
 		return err
 	}
 	if c.testInitialRequestAfterEnqueue != nil {
 		c.testInitialRequestAfterEnqueue()
 	}
+	c.lifecycleMutex.Lock()
+	defer c.lifecycleMutex.Unlock()
+	if c.lifecycleState != clientStateRunning ||
+		c.readyForNextBlockChan != readyForNextBlockChan ||
+		c.ProtocolInstance() != proto {
+		c.syncLoopWaitGroup.Done()
+		return protocol.ErrProtocolShuttingDown
+	}
 	// Reset pipelined message counter before starting a new loop.
 	c.syncPipelinedRequestNext = 0
 	// Start a sync loop bound to this protocol instance. Stop waits for every
 	// active loop before Start can replace the protocol and its channels.
-	readyForNextBlockChan := c.readyForNextBlockChan
-	doneChan := c.DoneChan()
-	c.syncLoopWaitGroup.Add(1)
 	go func() {
 		defer c.syncLoopWaitGroup.Done()
 		c.syncLoop(readyForNextBlockChan, doneChan)
@@ -916,6 +930,18 @@ func (c *Client) handleAwaitReply() error {
 			if errors.Is(err, context.Canceled) && fenceCtx.Err() != nil {
 				//nolint:nilerr // A canceled fence is expected while the protocol is stopping.
 				return nil
+			}
+			if errors.Is(err, pipeline.ErrPipelineStopped) {
+				return nil
+			}
+			if errors.Is(err, pipeline.ErrPipelineNotStarted) {
+				c.lifecycleMutex.Lock()
+				stopping := c.lifecycleState == clientStateStopping ||
+					c.lifecycleState == clientStateStopped
+				c.lifecycleMutex.Unlock()
+				if stopping {
+					return nil
+				}
 			}
 			return err
 		}

--- a/protocol/chainsync/client.go
+++ b/protocol/chainsync/client.go
@@ -49,15 +49,22 @@ type Client struct {
 	lifecycleState           clientLifecycleState
 	startingDone             chan struct{}
 	stoppingDone             chan struct{}
+	protocolStarted          bool
 	readyForNextBlockChan    chan bool
 	syncLoopWaitGroup        sync.WaitGroup
 	syncPipelinedRequestNext int
 	protoOptions             protocol.ProtocolOptions
 	// The test hooks make lifecycle interleavings deterministic without changing
 	// production behavior.
-	testStopInitiated          func()
-	testStopWaitingForComplete func()
-	testSyncLoopBeforeBusyLock func()
+	testStopInitiated               func()
+	testStopWaitingForComplete      func()
+	testStartBeforeProtocolStart    func()
+	testInitialRequestBeforeEnqueue func()
+	testInitialRequestAfterEnqueue  func()
+	testSyncLoopBeforeBusyLock      func()
+	testSyncLoopBeforeRequestNext   func()
+	testSyncLoopAfterRequestNext    func()
+	testAwaitReplyBeforeFence       func()
 
 	// waitingForCurrentTipChan will process all the requests for the current tip until the channel
 	// is empty.
@@ -179,6 +186,7 @@ func (c *Client) initProtocol() {
 	p := protocol.New(protoConfig)
 	c.protocolMu.Lock()
 	c.Protocol = p
+	c.protocolStarted = false
 	c.protocolMu.Unlock()
 }
 
@@ -226,8 +234,9 @@ func (c *Client) Start() {
 			c.startingDone = ch
 
 			oldProto := c.Protocol
+			oldProtoStarted := c.protocolStarted
 			var oldDone <-chan struct{}
-			if prevState == clientStateStopped && oldProto != nil {
+			if prevState == clientStateStopped && oldProto != nil && oldProtoStarted {
 				oldDone = oldProto.DoneChan()
 			}
 			c.lifecycleMutex.Unlock()
@@ -240,7 +249,7 @@ func (c *Client) Start() {
 
 			c.lifecycleMutex.Lock()
 			// If we were stopped by someone else while waiting, don't continue.
-			if c.lifecycleState != clientStateStarting {
+			if c.lifecycleState != clientStateStarting || c.startingDone != ch {
 				if c.startingDone == ch {
 					close(ch)
 					c.startingDone = nil
@@ -256,13 +265,24 @@ func (c *Client) Start() {
 				c.syncPipelinedRequestNext = 0
 			}
 
-			c.Protocol.Logger().
+			proto := c.ProtocolInstance()
+			proto.Logger().
 				Debug("starting client protocol",
 					"component", "network",
 					"protocol", ProtocolName,
 					"connection_id", c.callbackContext.ConnectionId.String(),
 				)
-			c.Protocol.Start()
+			c.lifecycleMutex.Unlock()
+			if c.testStartBeforeProtocolStart != nil {
+				c.testStartBeforeProtocolStart()
+			}
+			c.lifecycleMutex.Lock()
+			if c.lifecycleState != clientStateStarting || c.startingDone != ch {
+				c.lifecycleMutex.Unlock()
+				return
+			}
+			proto.Start()
+			c.protocolStarted = true
 			c.lifecycleState = clientStateRunning
 			if c.startingDone == ch {
 				close(ch)
@@ -282,6 +302,51 @@ func (c *Client) Start() {
 
 // Stop sends a Done message and transitions the client to the Stopped state.
 func (c *Client) Stop() error {
+	c.lifecycleMutex.Lock()
+	switch c.lifecycleState {
+	case clientStateNew, clientStateStopped:
+		c.lifecycleMutex.Unlock()
+		return nil
+	case clientStateStarting:
+		// Protocol.Start has not been called yet. Mark this start generation as
+		// stopped and unblock its waiters without waiting on DoneChan, which an
+		// unstarted protocol never closes.
+		c.lifecycleState = clientStateStopped
+		if c.startingDone != nil {
+			close(c.startingDone)
+			c.startingDone = nil
+		}
+		c.lifecycleMutex.Unlock()
+		return nil
+	case clientStateStopping:
+		ch := c.stoppingDone
+		c.lifecycleMutex.Unlock()
+		if c.testStopWaitingForComplete != nil {
+			c.testStopWaitingForComplete()
+		}
+		if ch != nil {
+			<-ch
+		}
+		return nil
+	case clientStateRunning:
+		c.lifecycleState = clientStateStopping
+		stoppingDone := make(chan struct{})
+		c.stoppingDone = stoppingDone
+		proto := c.ProtocolInstance()
+		if c.testStopInitiated != nil {
+			c.testStopInitiated()
+		}
+		c.lifecycleMutex.Unlock()
+
+		return c.stopRunning(proto, stoppingDone)
+	default:
+		c.lifecycleState = clientStateStopped
+		c.lifecycleMutex.Unlock()
+		return nil
+	}
+}
+
+func (c *Client) stopRunning(proto *protocol.Protocol, stoppingDone chan struct{}) error {
 	const busyLockTimeout = 5 * time.Second
 	deadline := time.Now().Add(busyLockTimeout)
 	busyLocked := false
@@ -296,74 +361,39 @@ func (c *Client) Stop() error {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	c.lifecycleMutex.Lock()
-
-	if c.lifecycleState != clientStateRunning {
-		if c.lifecycleState == clientStateStopping {
-			ch := c.stoppingDone
-			c.lifecycleMutex.Unlock()
-			if busyLocked {
-				c.busyMutex.Unlock()
-			}
-			if c.testStopWaitingForComplete != nil {
-				c.testStopWaitingForComplete()
-			}
-			if ch != nil {
-				<-ch
-			}
-			return nil
-		}
-		if busyLocked {
-			c.busyMutex.Unlock()
-		}
-		c.lifecycleMutex.Unlock()
-		return nil
-	}
-
-	c.Protocol.Logger().
+	proto.Logger().
 		Debug("stopping client protocol",
 			"component", "network",
 			"protocol", ProtocolName,
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
 
-	c.lifecycleState = clientStateStopping
-	stoppingDone := make(chan struct{})
-	c.stoppingDone = stoppingDone
-	if c.testStopInitiated != nil {
-		c.testStopInitiated()
-	}
-
 	var sendErr error
 	// Check if protocol is already done before sending Done message
-	if !c.IsDone() {
+	if !proto.IsDone() {
 		msg := NewMsgDone()
-		sendErr = c.SendMessage(msg)
+		sendErr = proto.SendMessage(msg)
 		if errors.Is(sendErr, protocol.ErrProtocolShuttingDown) {
 			sendErr = nil
 		}
-		_ = c.WaitSendQueueDrained(250 * time.Millisecond)
+		_ = proto.WaitSendQueueDrained(250 * time.Millisecond)
 	}
 	if busyLocked {
 		c.busyMutex.Unlock()
 	}
 
 	// Close readyForNextBlockChan to signal syncLoop to exit
+	c.lifecycleMutex.Lock()
 	if c.readyForNextBlockChan != nil {
 		close(c.readyForNextBlockChan)
 		c.readyForNextBlockChan = nil
 	}
+	c.lifecycleMutex.Unlock()
 
 	// Stop/unregister the underlying protocol instance, then wait for it and
 	// the sync loop to finish before allowing a restart to replace their state.
-	doneChan := c.DoneChan()
-	c.Protocol.Stop()
-	// Unblock any goroutine waiting for an in-progress start.
-	if c.startingDone != nil {
-		close(c.startingDone)
-		c.startingDone = nil
-	}
-	c.lifecycleMutex.Unlock()
+	doneChan := proto.DoneChan()
+	proto.Stop()
 	<-doneChan
 	c.syncLoopWaitGroup.Wait()
 
@@ -644,24 +674,31 @@ func (c *Client) Sync(intersectPoints []pcommon.Point) error {
 		}
 	}
 
-	// Send initial RequestNext
-	msgRequestNext := NewMsgRequestNext()
-	if err := c.SendMessage(msgRequestNext); err != nil {
+	return c.sendInitialRequestAndStartSyncLoop()
+}
+
+func (c *Client) sendInitialRequestAndStartSyncLoop() error {
+	c.lifecycleMutex.Lock()
+	defer c.lifecycleMutex.Unlock()
+	if c.lifecycleState != clientStateRunning || c.readyForNextBlockChan == nil {
+		return protocol.ErrProtocolShuttingDown
+	}
+	if c.testInitialRequestBeforeEnqueue != nil {
+		c.testInitialRequestBeforeEnqueue()
+	}
+	if err := c.SendMessage(NewMsgRequestNext()); err != nil {
 		return err
 	}
-	// Reset pipelined message counter
+	if c.testInitialRequestAfterEnqueue != nil {
+		c.testInitialRequestAfterEnqueue()
+	}
+	// Reset pipelined message counter before starting a new loop.
 	c.syncPipelinedRequestNext = 0
 	// Start a sync loop bound to this protocol instance. Stop waits for every
 	// active loop before Start can replace the protocol and its channels.
-	c.lifecycleMutex.Lock()
-	if c.lifecycleState != clientStateRunning || c.readyForNextBlockChan == nil {
-		c.lifecycleMutex.Unlock()
-		return protocol.ErrProtocolShuttingDown
-	}
 	readyForNextBlockChan := c.readyForNextBlockChan
 	doneChan := c.DoneChan()
 	c.syncLoopWaitGroup.Add(1)
-	c.lifecycleMutex.Unlock()
 	go func() {
 		defer c.syncLoopWaitGroup.Done()
 		c.syncLoop(readyForNextBlockChan, doneChan)
@@ -693,29 +730,37 @@ func (c *Client) syncLoop(
 		}
 		c.busyMutex.Lock()
 		c.lifecycleMutex.Lock()
-		stopping := c.lifecycleState != clientStateRunning
-		c.lifecycleMutex.Unlock()
-		if stopping {
+		if c.lifecycleState != clientStateRunning {
+			c.lifecycleMutex.Unlock()
 			c.busyMutex.Unlock()
 			return
 		}
 		// Wait for next block if we have pipelined messages
 		if c.syncPipelinedRequestNext > 0 {
 			c.syncPipelinedRequestNext--
+			c.lifecycleMutex.Unlock()
 			c.busyMutex.Unlock()
 			continue
 		}
 		// Request the next block(s)
 		msgCount := max(c.config.PipelineLimit, 1)
+		if c.testSyncLoopBeforeRequestNext != nil {
+			c.testSyncLoopBeforeRequestNext()
+		}
 		for range msgCount {
 			msg := NewMsgRequestNext()
 			if err := c.SendMessage(msg); err != nil {
 				c.SendError(err)
+				c.lifecycleMutex.Unlock()
 				c.busyMutex.Unlock()
 				return
 			}
 		}
+		if c.testSyncLoopAfterRequestNext != nil {
+			c.testSyncLoopAfterRequestNext()
+		}
 		c.syncPipelinedRequestNext = msgCount - 1
+		c.lifecycleMutex.Unlock()
 		c.busyMutex.Unlock()
 	}
 }
@@ -842,6 +887,28 @@ func (c *Client) handleAwaitReply() error {
 			"role", "client",
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
+	if c.config != nil && c.config.Pipeline != nil {
+		if c.testAwaitReplyBeforeFence != nil {
+			c.testAwaitReplyBeforeFence()
+		}
+		fenceCtx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go func() {
+			select {
+			case <-c.DoneChan():
+				cancel()
+			case <-fenceCtx.Done():
+			}
+		}()
+		if err := c.config.Pipeline.Fence(fenceCtx); err != nil {
+			select {
+			case <-c.DoneChan():
+				return nil
+			default:
+				return err
+			}
+		}
+	}
 	if c.config != nil && c.config.AwaitReplyFunc != nil {
 		return c.config.AwaitReplyFunc(c.callbackContext)
 	}

--- a/protocol/chainsync/client.go
+++ b/protocol/chainsync/client.go
@@ -927,29 +927,36 @@ func (c *Client) handleAwaitReply() error {
 		fenceCtx := c.awaitReplyCtx
 		c.lifecycleMutex.Unlock()
 		if err := c.config.Pipeline.Fence(fenceCtx); err != nil {
-			if errors.Is(err, context.Canceled) && fenceCtx.Err() != nil {
-				//nolint:nilerr // A canceled fence is expected while the protocol is stopping.
-				return nil
-			}
-			if errors.Is(err, pipeline.ErrPipelineStopped) {
-				return nil
-			}
-			if errors.Is(err, pipeline.ErrPipelineNotStarted) {
-				c.lifecycleMutex.Lock()
-				stopping := c.lifecycleState == clientStateStopping ||
-					c.lifecycleState == clientStateStopped
-				c.lifecycleMutex.Unlock()
-				if stopping {
-					return nil
-				}
-			}
-			return err
+			return c.handlePipelineFenceError(fenceCtx, err)
 		}
 	}
 	if c.config != nil && c.config.AwaitReplyFunc != nil {
 		return c.config.AwaitReplyFunc(c.callbackContext)
 	}
 	return nil
+}
+
+func (c *Client) handlePipelineFenceError(
+	fenceCtx context.Context,
+	err error,
+) error {
+	if errors.Is(err, context.Canceled) && fenceCtx.Err() != nil {
+		//nolint:nilerr // A canceled fence is expected while the protocol is stopping.
+		return nil
+	}
+	if errors.Is(err, pipeline.ErrPipelineStopped) {
+		return nil
+	}
+	if errors.Is(err, pipeline.ErrPipelineNotStarted) {
+		c.lifecycleMutex.Lock()
+		stopping := c.lifecycleState == clientStateStopping ||
+			c.lifecycleState == clientStateStopped
+		c.lifecycleMutex.Unlock()
+		if stopping {
+			return nil
+		}
+	}
+	return err
 }
 
 func (c *Client) handleRollForward(msgGeneric protocol.Message) error {

--- a/protocol/chainsync/client.go
+++ b/protocol/chainsync/client.go
@@ -742,13 +742,13 @@ func (c *Client) messageHandler(msg protocol.Message) error {
 	var err error
 	switch msg.Type() {
 	case MessageTypeAwaitReply:
-		c.handleAwaitReply()
+		err = c.handleAwaitReply()
 	case MessageTypeRollForward:
 		err = c.handleRollForward(msg)
 	case MessageTypeRollBackward:
 		err = c.handleRollBackward(msg)
 	case MessageTypeIntersectFound:
-		c.handleIntersectFound(msg)
+		err = c.handleIntersectFound(msg)
 	case MessageTypeIntersectNotFound:
 		c.handleIntersectNotFound(msg)
 	default:
@@ -761,7 +761,7 @@ func (c *Client) messageHandler(msg protocol.Message) error {
 	return err
 }
 
-func (c *Client) handleAwaitReply() {
+func (c *Client) handleAwaitReply() error {
 	c.Protocol.Logger().
 		Debug("waiting for next reply",
 			"component", "network",
@@ -769,6 +769,10 @@ func (c *Client) handleAwaitReply() {
 			"role", "client",
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
+	if c.config != nil && c.config.AwaitReplyFunc != nil {
+		return c.config.AwaitReplyFunc(c.callbackContext)
+	}
+	return nil
 }
 
 func (c *Client) handleRollForward(msgGeneric protocol.Message) error {
@@ -1063,7 +1067,7 @@ func (c *Client) handleRollBackward(msgGeneric protocol.Message) error {
 	return nil
 }
 
-func (c *Client) handleIntersectFound(msg protocol.Message) {
+func (c *Client) handleIntersectFound(msg protocol.Message) error {
 	c.Protocol.Logger().
 		Debug("chain intersect found",
 			"component", "network",
@@ -1073,12 +1077,22 @@ func (c *Client) handleIntersectFound(msg protocol.Message) {
 		)
 	msgIntersectFound := msg.(*MsgIntersectFound)
 	c.sendCurrentTip(msgIntersectFound.Tip)
+	if c.config != nil && c.config.IntersectFoundFunc != nil {
+		if err := c.config.IntersectFoundFunc(
+			c.callbackContext,
+			msgIntersectFound.Point,
+			msgIntersectFound.Tip,
+		); err != nil {
+			return err
+		}
+	}
 
 	select {
 	case ch := <-c.wantIntersectFoundChan:
 		ch <- clientPointResult{tip: msgIntersectFound.Tip, point: msgIntersectFound.Point}
 	default:
 	}
+	return nil
 }
 
 func (c *Client) handleIntersectNotFound(msgGeneric protocol.Message) {

--- a/protocol/chainsync/client_callback_test.go
+++ b/protocol/chainsync/client_callback_test.go
@@ -53,7 +53,10 @@ func TestExactTipCallbacksExposeIntersectionBeforeAwaitReply(t *testing.T) {
 		},
 	)
 
-	require.NoError(t, client.handleIntersectFound(NewMsgIntersectFound(intersect, tip)))
+	require.NoError(
+		t,
+		client.handleIntersectFound(NewMsgIntersectFound(intersect, tip)),
+	)
 	require.NoError(t, client.handleAwaitReply())
 	require.Equal(t, []string{"intersect", "await"}, callbacks)
 }
@@ -73,7 +76,11 @@ func TestAtTipCallbackErrorsPropagate(t *testing.T) {
 				},
 			},
 		)
-		require.ErrorIs(t, client.messageHandler(NewMsgAwaitReply()), awaitReplyErr)
+		require.ErrorIs(
+			t,
+			client.messageHandler(NewMsgAwaitReply()),
+			awaitReplyErr,
+		)
 	})
 
 	t.Run("intersect found", func(t *testing.T) {

--- a/protocol/chainsync/client_callback_test.go
+++ b/protocol/chainsync/client_callback_test.go
@@ -105,6 +105,19 @@ func TestAtTipCallbackErrorsPropagate(t *testing.T) {
 }
 
 func TestAwaitReplyHandlesPipelineShutdownState(t *testing.T) {
+	t.Run("unrelated fence error propagates", func(t *testing.T) {
+		client := NewClient(
+			protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+			nil,
+		)
+		expectedErr := errors.New("fence failed")
+		require.ErrorIs(
+			t,
+			client.handlePipelineFenceError(context.Background(), expectedErr),
+			expectedErr,
+		)
+	})
+
 	t.Run("stopped pipeline", func(t *testing.T) {
 		p := pipeline.NewBlockPipeline(
 			pipeline.WithValidateWorkers(0),

--- a/protocol/chainsync/client_callback_test.go
+++ b/protocol/chainsync/client_callback_test.go
@@ -128,7 +128,26 @@ func TestAwaitReplyHandlesPipelineShutdownState(t *testing.T) {
 			protocol.ProtocolOptions{ConnectionId: testConnectionId()},
 			&Config{Pipeline: p},
 		)
+		client.lifecycleState = clientStateStopped
 		require.NoError(t, client.handleAwaitReply())
+	})
+
+	t.Run("stopped pipeline while running", func(t *testing.T) {
+		p := pipeline.NewBlockPipeline(
+			pipeline.WithValidateWorkers(0),
+		)
+		require.NoError(t, p.Start(context.Background()))
+		require.NoError(t, p.Stop())
+		client := NewClient(
+			protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+			&Config{Pipeline: p},
+		)
+		client.lifecycleState = clientStateRunning
+		require.ErrorIs(
+			t,
+			client.handleAwaitReply(),
+			pipeline.ErrPipelineStopped,
+		)
 	})
 
 	t.Run("not-started pipeline while running", func(t *testing.T) {

--- a/protocol/chainsync/client_callback_test.go
+++ b/protocol/chainsync/client_callback_test.go
@@ -118,7 +118,55 @@ func TestAwaitReplyHandlesPipelineShutdownState(t *testing.T) {
 		)
 	})
 
-	t.Run("stopped pipeline", func(t *testing.T) {
+	t.Run("stopped pipeline while running", func(t *testing.T) {
+		p := pipeline.NewBlockPipeline(
+			pipeline.WithValidateWorkers(0),
+		)
+		require.NoError(t, p.Start(context.Background()))
+		require.NoError(t, p.Stop())
+		callbackCalled := false
+		client := NewClient(
+			protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+			&Config{
+				Pipeline: p,
+				AwaitReplyFunc: func(CallbackContext) error {
+					callbackCalled = true
+					return nil
+				},
+			},
+		)
+		client.lifecycleState = clientStateRunning
+		require.ErrorIs(
+			t,
+			client.handleAwaitReply(),
+			pipeline.ErrPipelineStopped,
+		)
+		require.False(t, callbackCalled)
+	})
+
+	t.Run("stopped pipeline while stopping", func(t *testing.T) {
+		p := pipeline.NewBlockPipeline(
+			pipeline.WithValidateWorkers(0),
+		)
+		require.NoError(t, p.Start(context.Background()))
+		require.NoError(t, p.Stop())
+		callbackCalled := false
+		client := NewClient(
+			protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+			&Config{
+				Pipeline: p,
+				AwaitReplyFunc: func(CallbackContext) error {
+					callbackCalled = true
+					return nil
+				},
+			},
+		)
+		client.lifecycleState = clientStateStopping
+		require.NoError(t, client.handleAwaitReply())
+		require.False(t, callbackCalled)
+	})
+
+	t.Run("stopped pipeline while stopped", func(t *testing.T) {
 		p := pipeline.NewBlockPipeline(
 			pipeline.WithValidateWorkers(0),
 		)
@@ -130,24 +178,6 @@ func TestAwaitReplyHandlesPipelineShutdownState(t *testing.T) {
 		)
 		client.lifecycleState = clientStateStopped
 		require.NoError(t, client.handleAwaitReply())
-	})
-
-	t.Run("stopped pipeline while running", func(t *testing.T) {
-		p := pipeline.NewBlockPipeline(
-			pipeline.WithValidateWorkers(0),
-		)
-		require.NoError(t, p.Start(context.Background()))
-		require.NoError(t, p.Stop())
-		client := NewClient(
-			protocol.ProtocolOptions{ConnectionId: testConnectionId()},
-			&Config{Pipeline: p},
-		)
-		client.lifecycleState = clientStateRunning
-		require.ErrorIs(
-			t,
-			client.handleAwaitReply(),
-			pipeline.ErrPipelineStopped,
-		)
 	})
 
 	t.Run("not-started pipeline while running", func(t *testing.T) {

--- a/protocol/chainsync/client_callback_test.go
+++ b/protocol/chainsync/client_callback_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsync
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/protocol"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExactTipCallbacksExposeIntersectionBeforeAwaitReply(t *testing.T) {
+	intersect := pcommon.NewPoint(100, []byte("intersection"))
+	tip := Tip{Point: pcommon.NewPoint(100, []byte("tip")), BlockNumber: 10}
+	var callbacks []string
+	client := NewClient(
+		protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+		&Config{
+			IntersectFoundFunc: func(
+				_ CallbackContext,
+				gotIntersect pcommon.Point,
+				gotTip Tip,
+			) error {
+				require.Equal(t, intersect, gotIntersect)
+				require.Equal(t, tip, gotTip)
+				callbacks = append(callbacks, "intersect")
+				return nil
+			},
+			AwaitReplyFunc: func(CallbackContext) error {
+				callbacks = append(callbacks, "await")
+				return nil
+			},
+		},
+	)
+
+	require.NoError(t, client.handleIntersectFound(NewMsgIntersectFound(intersect, tip)))
+	require.NoError(t, client.handleAwaitReply())
+	require.Equal(t, []string{"intersect", "await"}, callbacks)
+}

--- a/protocol/chainsync/client_callback_test.go
+++ b/protocol/chainsync/client_callback_test.go
@@ -15,6 +15,7 @@
 package chainsync
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/protocol"
@@ -49,4 +50,43 @@ func TestExactTipCallbacksExposeIntersectionBeforeAwaitReply(t *testing.T) {
 	require.NoError(t, client.handleIntersectFound(NewMsgIntersectFound(intersect, tip)))
 	require.NoError(t, client.handleAwaitReply())
 	require.Equal(t, []string{"intersect", "await"}, callbacks)
+}
+
+func TestAtTipCallbackErrorsPropagate(t *testing.T) {
+	awaitReplyErr := errors.New("await reply callback failed")
+	intersectFoundErr := errors.New("intersect found callback failed")
+	intersect := pcommon.NewPoint(100, []byte("intersection"))
+	tip := Tip{Point: pcommon.NewPoint(100, []byte("tip")), BlockNumber: 10}
+
+	t.Run("await reply", func(t *testing.T) {
+		client := NewClient(
+			protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+			&Config{
+				AwaitReplyFunc: func(CallbackContext) error {
+					return awaitReplyErr
+				},
+			},
+		)
+		require.ErrorIs(t, client.messageHandler(NewMsgAwaitReply()), awaitReplyErr)
+	})
+
+	t.Run("intersect found", func(t *testing.T) {
+		client := NewClient(
+			protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+			&Config{
+				IntersectFoundFunc: func(
+					CallbackContext,
+					pcommon.Point,
+					Tip,
+				) error {
+					return intersectFoundErr
+				},
+			},
+		)
+		require.ErrorIs(
+			t,
+			client.messageHandler(NewMsgIntersectFound(intersect, tip)),
+			intersectFoundErr,
+		)
+	})
 }

--- a/protocol/chainsync/client_callback_test.go
+++ b/protocol/chainsync/client_callback_test.go
@@ -104,6 +104,45 @@ func TestAtTipCallbackErrorsPropagate(t *testing.T) {
 	})
 }
 
+func TestAwaitReplyHandlesPipelineShutdownState(t *testing.T) {
+	t.Run("stopped pipeline", func(t *testing.T) {
+		p := pipeline.NewBlockPipeline(
+			pipeline.WithValidateWorkers(0),
+		)
+		require.NoError(t, p.Start(context.Background()))
+		require.NoError(t, p.Stop())
+		client := NewClient(
+			protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+			&Config{Pipeline: p},
+		)
+		require.NoError(t, client.handleAwaitReply())
+	})
+
+	t.Run("not-started pipeline while running", func(t *testing.T) {
+		p := pipeline.NewBlockPipeline()
+		client := NewClient(
+			protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+			&Config{Pipeline: p},
+		)
+		client.lifecycleState = clientStateRunning
+		require.ErrorIs(
+			t,
+			client.handleAwaitReply(),
+			pipeline.ErrPipelineNotStarted,
+		)
+	})
+
+	t.Run("not-started pipeline while stopping", func(t *testing.T) {
+		p := pipeline.NewBlockPipeline()
+		client := NewClient(
+			protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+			&Config{Pipeline: p},
+		)
+		client.lifecycleState = clientStateStopping
+		require.NoError(t, client.handleAwaitReply())
+	})
+}
+
 func TestAwaitReplyWaitsForPipelineFence(t *testing.T) {
 	applyStarted := make(chan struct{})
 	releaseApply := make(chan struct{})

--- a/protocol/chainsync/client_callback_test.go
+++ b/protocol/chainsync/client_callback_test.go
@@ -15,9 +15,15 @@
 package chainsync
 
 import (
+	"context"
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/blinklabs-io/gouroboros/internal/testdata"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/pipeline"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/stretchr/testify/require"
@@ -89,4 +95,84 @@ func TestAtTipCallbackErrorsPropagate(t *testing.T) {
 			intersectFoundErr,
 		)
 	})
+}
+
+func TestAwaitReplyWaitsForPipelineFence(t *testing.T) {
+	applyStarted := make(chan struct{})
+	releaseApply := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseApply) })
+	}
+	p := pipeline.NewBlockPipeline(
+		pipeline.WithDecodeWorkers(1),
+		pipeline.WithValidateWorkers(0),
+		pipeline.WithSkipBodyHashValidation(true),
+		pipeline.WithApplyFunc(func(*pipeline.BlockItem) error {
+			close(applyStarted)
+			<-releaseApply
+			return nil
+		}),
+	)
+	require.NoError(t, p.Start(context.Background()))
+	defer func() {
+		release()
+		require.NoError(t, p.Stop())
+	}()
+
+	fenceStarted := make(chan struct{})
+	callbackCalled := make(chan struct{}, 1)
+	client := NewClient(
+		protocol.ProtocolOptions{ConnectionId: testConnectionId()},
+		&Config{
+			Pipeline: p,
+			RollForwardFunc: func(CallbackContext, uint, any, Tip) error {
+				return nil
+			},
+			AwaitReplyFunc: func(CallbackContext) error {
+				callbackCalled <- struct{}{}
+				return nil
+			},
+		},
+	)
+	client.testAwaitReplyBeforeFence = func() { close(fenceStarted) }
+	blockCbor := testdata.MustDecodeHex(testdata.ConwayBlockHex)
+	rollForward, err := NewMsgRollForwardNtC(
+		ledger.BlockTypeConway,
+		blockCbor,
+		Tip{},
+	)
+	require.NoError(t, err)
+	require.NoError(t, client.handleRollForward(rollForward))
+	select {
+	case <-applyStarted:
+	case <-time.After(time.Second):
+		t.Fatal("pipeline apply did not start")
+	}
+
+	awaitDone := make(chan error, 1)
+	go func() { awaitDone <- client.handleAwaitReply() }()
+	select {
+	case <-fenceStarted:
+	case <-time.After(time.Second):
+		t.Fatal("AwaitReply did not install its pipeline fence")
+	}
+	select {
+	case <-callbackCalled:
+		t.Fatal("AwaitReply callback ran before the blocked apply completed")
+	default:
+	}
+
+	release()
+	select {
+	case err := <-awaitDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("AwaitReply did not finish after the apply completed")
+	}
+	select {
+	case <-callbackCalled:
+	case <-time.After(time.Second):
+		t.Fatal("AwaitReply callback did not run after the pipeline fence")
+	}
 }

--- a/protocol/chainsync/client_stop_test.go
+++ b/protocol/chainsync/client_stop_test.go
@@ -15,14 +15,19 @@
 package chainsync
 
 import (
+	"context"
 	"io"
 	"net"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/internal/testdata"
+	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/muxer"
+	"github.com/blinklabs-io/gouroboros/pipeline"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	"github.com/stretchr/testify/require"
 )
@@ -277,6 +282,100 @@ func TestStopDuringStartAbortsUnstartedProtocol(t *testing.T) {
 	require.Equal(t, clientStateStopped, client.lifecycleState)
 	require.False(t, client.protocolStarted)
 	client.lifecycleMutex.Unlock()
+}
+
+func TestStopCancelsAwaitReplyPipelineFence(t *testing.T) {
+	applyStarted := make(chan struct{})
+	releaseApply := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseApply) })
+	}
+	p := pipeline.NewBlockPipeline(
+		pipeline.WithDecodeWorkers(1),
+		pipeline.WithValidateWorkers(0),
+		pipeline.WithSkipBodyHashValidation(true),
+		pipeline.WithApplyFunc(func(*pipeline.BlockItem) error {
+			close(applyStarted)
+			<-releaseApply
+			return nil
+		}),
+	)
+	require.NoError(t, p.Start(context.Background()))
+	defer func() {
+		release()
+		require.NoError(t, p.Stop())
+	}()
+
+	clientConn, peerConn := net.Pipe()
+	clientMuxer := muxer.New(clientConn)
+	peerMuxer := muxer.New(peerConn)
+	clientMuxer.Start()
+	peerMuxer.Start()
+	defer func() {
+		_ = clientConn.Close()
+		_ = peerConn.Close()
+		clientMuxer.Stop()
+		peerMuxer.Stop()
+	}()
+	peerSendChan, peerRecvChan, _ := peerMuxer.RegisterProtocol(
+		ProtocolIdNtC,
+		muxer.ProtocolRoleResponder,
+	)
+
+	client := NewClient(
+		protocol.ProtocolOptions{
+			ConnectionId: testConnectionId(),
+			Muxer:        clientMuxer,
+			Mode:         protocol.ProtocolModeNodeToClient,
+		},
+		&Config{Pipeline: p},
+	)
+	client.Start()
+	defer func() { require.NoError(t, client.Stop()) }()
+
+	require.NoError(
+		t,
+		p.Submit(
+			context.Background(),
+			uint(ledger.BlockTypeConway),
+			testdata.MustDecodeHex(testdata.ConwayBlockHex),
+			Tip{},
+		),
+	)
+	select {
+	case <-applyStarted:
+	case <-time.After(time.Second):
+		t.Fatal("pipeline apply did not start")
+	}
+
+	fenceStarted := make(chan struct{})
+	client.testAwaitReplyBeforeFence = func() { close(fenceStarted) }
+	require.NoError(t, client.SendMessage(NewMsgRequestNext()))
+	select {
+	case <-peerRecvChan:
+	case <-time.After(time.Second):
+		t.Fatal("client did not send RequestNext")
+	}
+	awaitReplyCbor, err := cbor.Encode(NewMsgAwaitReply())
+	require.NoError(t, err)
+	peerSendChan <- muxer.NewSegment(ProtocolIdNtC, awaitReplyCbor, true)
+	select {
+	case <-fenceStarted:
+	case <-time.After(time.Second):
+		t.Fatal("AwaitReply did not enter the pipeline fence")
+	}
+
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- client.Stop() }()
+	select {
+	case err := <-stopDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Stop waited for the blocked AwaitReply pipeline fence")
+	}
+
+	release()
 }
 
 func newStartedTestClient(t *testing.T, cfg *Config) (*Client, func()) {

--- a/protocol/chainsync/client_stop_test.go
+++ b/protocol/chainsync/client_stop_test.go
@@ -128,25 +128,18 @@ func TestConcurrentStopReleasesBusyMutexDuringActiveSync(t *testing.T) {
 	}
 }
 
-func TestStopWaitsForInitialRequestLifecycleFence(t *testing.T) {
+func TestStopUnblocksInitialRequestEnqueue(t *testing.T) {
 	client, cleanup := newStartedTestClient(t, nil)
 	defer cleanup()
 
 	beforeEnqueue := make(chan struct{})
 	allowEnqueue := make(chan struct{})
-	enqueued := make(chan struct{})
 	stopInitiated := make(chan struct{})
 	client.testInitialRequestBeforeEnqueue = func() {
 		close(beforeEnqueue)
 		<-allowEnqueue
 	}
-	client.testInitialRequestAfterEnqueue = func() { close(enqueued) }
 	client.testStopInitiated = func() {
-		select {
-		case <-enqueued:
-		case <-time.After(time.Second):
-			t.Error("Stop began before Sync queued its initial RequestNext")
-		}
 		close(stopInitiated)
 	}
 
@@ -161,23 +154,16 @@ func TestStopWaitsForInitialRequestLifecycleFence(t *testing.T) {
 	go func() { stopDone <- client.Stop() }()
 	select {
 	case <-stopInitiated:
-		t.Fatal(
-			"Stop began while Sync held the initial request lifecycle fence",
-		)
-	default:
+	case <-time.After(time.Second):
+		t.Fatal("Stop could not begin while Sync was waiting to enqueue")
 	}
 
 	close(allowEnqueue)
 	select {
 	case err := <-syncDone:
-		require.NoError(t, err)
+		require.ErrorIs(t, err, protocol.ErrProtocolShuttingDown)
 	case <-time.After(time.Second):
-		t.Fatal("Sync did not finish queuing its initial RequestNext")
-	}
-	select {
-	case <-stopInitiated:
-	case <-time.After(time.Second):
-		t.Fatal("Stop did not begin after Sync released its lifecycle fence")
+		t.Fatal("Sync did not unblock after Stop began")
 	}
 	select {
 	case err := <-stopDone:

--- a/protocol/chainsync/client_stop_test.go
+++ b/protocol/chainsync/client_stop_test.go
@@ -173,30 +173,24 @@ func TestStopUnblocksInitialRequestEnqueue(t *testing.T) {
 	}
 }
 
-func TestStopWaitsForPipelineRequestBurstLifecycleFence(t *testing.T) {
+func TestStopUnblocksPipelineRequestBurstEnqueue(t *testing.T) {
 	cfg := NewConfig(WithPipelineLimit(3))
 	client, cleanup := newStartedTestClient(t, &cfg)
 	defer cleanup()
 
 	beforeEnqueue := make(chan struct{})
 	allowEnqueue := make(chan struct{})
-	enqueued := make(chan struct{})
 	stopInitiated := make(chan struct{})
+	var releaseEnqueueOnce sync.Once
+	releaseEnqueue := func() {
+		releaseEnqueueOnce.Do(func() { close(allowEnqueue) })
+	}
+	defer releaseEnqueue()
 	client.testSyncLoopBeforeRequestNext = func() {
 		close(beforeEnqueue)
 		<-allowEnqueue
 	}
-	client.testSyncLoopAfterRequestNext = func() { close(enqueued) }
-	client.testStopInitiated = func() {
-		select {
-		case <-enqueued:
-		case <-time.After(time.Second):
-			t.Error(
-				"Stop began before the sync loop queued its RequestNext burst",
-			)
-		}
-		close(stopInitiated)
-	}
+	client.testStopInitiated = func() { close(stopInitiated) }
 
 	readyForNextBlockChan := make(chan bool, 1)
 	client.syncLoopWaitGroup.Add(1)
@@ -214,25 +208,13 @@ func TestStopWaitsForPipelineRequestBurstLifecycleFence(t *testing.T) {
 	go func() { stopDone <- client.Stop() }()
 	select {
 	case <-stopInitiated:
+	case <-time.After(time.Second):
 		t.Fatal(
-			"Stop began while the sync loop held its request lifecycle fence",
+			"Stop could not begin while the sync loop was waiting to enqueue",
 		)
-	default:
 	}
 
-	close(allowEnqueue)
-	select {
-	case <-enqueued:
-	case <-time.After(time.Second):
-		t.Fatal("sync loop did not queue its RequestNext burst")
-	}
-	select {
-	case <-stopInitiated:
-	case <-time.After(time.Second):
-		t.Fatal(
-			"Stop did not begin after the sync loop released its lifecycle fence",
-		)
-	}
+	releaseEnqueue()
 	select {
 	case err := <-stopDone:
 		require.NoError(t, err)

--- a/protocol/chainsync/client_stop_test.go
+++ b/protocol/chainsync/client_stop_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsync
+
+import (
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/muxer"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConcurrentStopReleasesBusyMutexDuringActiveSync(t *testing.T) {
+	clientConn, peerConn := net.Pipe()
+	m := muxer.New(clientConn)
+	m.Start()
+	defer m.Stop()
+	defer clientConn.Close()
+
+	peerDone := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, peerConn)
+		close(peerDone)
+	}()
+	defer func() {
+		_ = peerConn.Close()
+		<-peerDone
+	}()
+
+	client := NewClient(
+		protocol.ProtocolOptions{
+			ConnectionId: connection.ConnectionId{
+				LocalAddr:  &net.TCPAddr{},
+				RemoteAddr: &net.TCPAddr{},
+			},
+			Muxer: m,
+			Mode:  protocol.ProtocolModeNodeToClient,
+		},
+		nil,
+	)
+	client.Start()
+
+	firstStopInitiated := make(chan struct{})
+	secondStopWaiting := make(chan struct{})
+	syncLoopBeforeBusyLock := make(chan struct{})
+	releaseSyncLoop := make(chan struct{})
+	var releaseSyncLoopOnce sync.Once
+	release := func() {
+		releaseSyncLoopOnce.Do(func() { close(releaseSyncLoop) })
+	}
+	defer release()
+
+	client.testStopInitiated = func() { close(firstStopInitiated) }
+	client.testStopWaitingForComplete = func() { close(secondStopWaiting) }
+	client.testSyncLoopBeforeBusyLock = func() {
+		close(syncLoopBeforeBusyLock)
+		<-releaseSyncLoop
+	}
+
+	// Start an active sync loop and stop it immediately before it would acquire
+	// busyMutex. This leaves the lock available for the second Stop call.
+	readyForNextBlockChan := client.readyForNextBlockChan
+	doneChan := client.DoneChan()
+	client.syncLoopWaitGroup.Add(1)
+	go func() {
+		defer client.syncLoopWaitGroup.Done()
+		client.syncLoop(readyForNextBlockChan, doneChan)
+	}()
+	readyForNextBlockChan <- true
+	<-syncLoopBeforeBusyLock
+
+	// Give the first Stop call exclusive access to busyMutex, then wait until it
+	// has transitioned to stopping and released that mutex.
+	client.busyMutex.Lock()
+	firstStopDone := make(chan error, 1)
+	go func() { firstStopDone <- client.Stop() }()
+	client.busyMutex.Unlock()
+	<-firstStopInitiated
+	client.busyMutex.Lock()
+
+	// The active sync loop is still blocked at its test hook, so the second Stop
+	// is the only waiter that can acquire busyMutex.
+	secondStopDone := make(chan error, 1)
+	go func() { secondStopDone <- client.Stop() }()
+	client.busyMutex.Unlock()
+	<-secondStopWaiting
+
+	// The first Stop waits for the sync loop. It can complete only if the second
+	// Stop released busyMutex before waiting for stoppingDone.
+	release()
+	select {
+	case err := <-firstStopDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("first Stop did not complete after the active sync loop was released")
+	}
+	select {
+	case err := <-secondStopDone:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("second Stop did not complete after the active sync loop was released")
+	}
+}

--- a/protocol/chainsync/client_stop_test.go
+++ b/protocol/chainsync/client_stop_test.go
@@ -114,13 +114,17 @@ func TestConcurrentStopReleasesBusyMutexDuringActiveSync(t *testing.T) {
 	case err := <-firstStopDone:
 		require.NoError(t, err)
 	case <-time.After(2 * time.Second):
-		t.Fatal("first Stop did not complete after the active sync loop was released")
+		t.Fatal(
+			"first Stop did not complete after the active sync loop was released",
+		)
 	}
 	select {
 	case err := <-secondStopDone:
 		require.NoError(t, err)
 	case <-time.After(2 * time.Second):
-		t.Fatal("second Stop did not complete after the active sync loop was released")
+		t.Fatal(
+			"second Stop did not complete after the active sync loop was released",
+		)
 	}
 }
 
@@ -157,7 +161,9 @@ func TestStopWaitsForInitialRequestLifecycleFence(t *testing.T) {
 	go func() { stopDone <- client.Stop() }()
 	select {
 	case <-stopInitiated:
-		t.Fatal("Stop began while Sync held the initial request lifecycle fence")
+		t.Fatal(
+			"Stop began while Sync held the initial request lifecycle fence",
+		)
 	default:
 	}
 
@@ -199,7 +205,9 @@ func TestStopWaitsForPipelineRequestBurstLifecycleFence(t *testing.T) {
 		select {
 		case <-enqueued:
 		case <-time.After(time.Second):
-			t.Error("Stop began before the sync loop queued its RequestNext burst")
+			t.Error(
+				"Stop began before the sync loop queued its RequestNext burst",
+			)
 		}
 		close(stopInitiated)
 	}
@@ -220,7 +228,9 @@ func TestStopWaitsForPipelineRequestBurstLifecycleFence(t *testing.T) {
 	go func() { stopDone <- client.Stop() }()
 	select {
 	case <-stopInitiated:
-		t.Fatal("Stop began while the sync loop held its request lifecycle fence")
+		t.Fatal(
+			"Stop began while the sync loop held its request lifecycle fence",
+		)
 	default:
 	}
 
@@ -233,7 +243,9 @@ func TestStopWaitsForPipelineRequestBurstLifecycleFence(t *testing.T) {
 	select {
 	case <-stopInitiated:
 	case <-time.After(time.Second):
-		t.Fatal("Stop did not begin after the sync loop released its lifecycle fence")
+		t.Fatal(
+			"Stop did not begin after the sync loop released its lifecycle fence",
+		)
 	}
 	select {
 	case err := <-stopDone:

--- a/protocol/chainsync/client_stop_test.go
+++ b/protocol/chainsync/client_stop_test.go
@@ -118,3 +118,191 @@ func TestConcurrentStopReleasesBusyMutexDuringActiveSync(t *testing.T) {
 		t.Fatal("second Stop did not complete after the active sync loop was released")
 	}
 }
+
+func TestStopWaitsForInitialRequestLifecycleFence(t *testing.T) {
+	client, cleanup := newStartedTestClient(t, nil)
+	defer cleanup()
+
+	beforeEnqueue := make(chan struct{})
+	allowEnqueue := make(chan struct{})
+	enqueued := make(chan struct{})
+	stopInitiated := make(chan struct{})
+	client.testInitialRequestBeforeEnqueue = func() {
+		close(beforeEnqueue)
+		<-allowEnqueue
+	}
+	client.testInitialRequestAfterEnqueue = func() { close(enqueued) }
+	client.testStopInitiated = func() {
+		select {
+		case <-enqueued:
+		case <-time.After(time.Second):
+			t.Error("Stop began before Sync queued its initial RequestNext")
+		}
+		close(stopInitiated)
+	}
+
+	syncDone := make(chan error, 1)
+	go func() { syncDone <- client.sendInitialRequestAndStartSyncLoop() }()
+	select {
+	case <-beforeEnqueue:
+	case <-time.After(time.Second):
+		t.Fatal("Sync did not reach the initial request fence")
+	}
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- client.Stop() }()
+	select {
+	case <-stopInitiated:
+		t.Fatal("Stop began while Sync held the initial request lifecycle fence")
+	default:
+	}
+
+	close(allowEnqueue)
+	select {
+	case err := <-syncDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Sync did not finish queuing its initial RequestNext")
+	}
+	select {
+	case <-stopInitiated:
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not begin after Sync released its lifecycle fence")
+	}
+	select {
+	case err := <-stopDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not finish")
+	}
+}
+
+func TestStopWaitsForPipelineRequestBurstLifecycleFence(t *testing.T) {
+	cfg := NewConfig(WithPipelineLimit(3))
+	client, cleanup := newStartedTestClient(t, &cfg)
+	defer cleanup()
+
+	beforeEnqueue := make(chan struct{})
+	allowEnqueue := make(chan struct{})
+	enqueued := make(chan struct{})
+	stopInitiated := make(chan struct{})
+	client.testSyncLoopBeforeRequestNext = func() {
+		close(beforeEnqueue)
+		<-allowEnqueue
+	}
+	client.testSyncLoopAfterRequestNext = func() { close(enqueued) }
+	client.testStopInitiated = func() {
+		select {
+		case <-enqueued:
+		case <-time.After(time.Second):
+			t.Error("Stop began before the sync loop queued its RequestNext burst")
+		}
+		close(stopInitiated)
+	}
+
+	readyForNextBlockChan := make(chan bool, 1)
+	client.syncLoopWaitGroup.Add(1)
+	go func() {
+		defer client.syncLoopWaitGroup.Done()
+		client.syncLoop(readyForNextBlockChan, client.DoneChan())
+	}()
+	readyForNextBlockChan <- true
+	select {
+	case <-beforeEnqueue:
+	case <-time.After(time.Second):
+		t.Fatal("sync loop did not reach the pipeline request fence")
+	}
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- client.Stop() }()
+	select {
+	case <-stopInitiated:
+		t.Fatal("Stop began while the sync loop held its request lifecycle fence")
+	default:
+	}
+
+	close(allowEnqueue)
+	select {
+	case <-enqueued:
+	case <-time.After(time.Second):
+		t.Fatal("sync loop did not queue its RequestNext burst")
+	}
+	select {
+	case <-stopInitiated:
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not begin after the sync loop released its lifecycle fence")
+	}
+	select {
+	case err := <-stopDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not finish")
+	}
+}
+
+func TestStopDuringStartAbortsUnstartedProtocol(t *testing.T) {
+	client, cleanup := newStartedTestClient(t, nil)
+	defer cleanup()
+	require.NoError(t, client.Stop())
+
+	beforeProtocolStart := make(chan struct{})
+	allowProtocolStart := make(chan struct{})
+	client.testStartBeforeProtocolStart = func() {
+		close(beforeProtocolStart)
+		<-allowProtocolStart
+	}
+	startDone := make(chan struct{})
+	go func() {
+		client.Start()
+		close(startDone)
+	}()
+	select {
+	case <-beforeProtocolStart:
+	case <-time.After(time.Second):
+		t.Fatal("Start did not reach the protocol-start fence")
+	}
+
+	require.NoError(t, client.Stop())
+	client.lifecycleMutex.Lock()
+	require.Equal(t, clientStateStopped, client.lifecycleState)
+	require.Nil(t, client.startingDone)
+	require.False(t, client.protocolStarted)
+	client.lifecycleMutex.Unlock()
+
+	close(allowProtocolStart)
+	select {
+	case <-startDone:
+	case <-time.After(time.Second):
+		t.Fatal("Start did not abort after Stop returned")
+	}
+	client.lifecycleMutex.Lock()
+	require.Equal(t, clientStateStopped, client.lifecycleState)
+	require.False(t, client.protocolStarted)
+	client.lifecycleMutex.Unlock()
+}
+
+func newStartedTestClient(t *testing.T, cfg *Config) (*Client, func()) {
+	t.Helper()
+	clientConn, peerConn := net.Pipe()
+	m := muxer.New(clientConn)
+	m.Start()
+	peerDone := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, peerConn)
+		close(peerDone)
+	}()
+	client := NewClient(
+		protocol.ProtocolOptions{
+			ConnectionId: testConnectionId(),
+			Muxer:        m,
+			Mode:         protocol.ProtocolModeNodeToClient,
+		},
+		cfg,
+	)
+	client.Start()
+	return client, func() {
+		_ = client.Stop()
+		_ = clientConn.Close()
+		_ = peerConn.Close()
+		m.Stop()
+		<-peerDone
+	}
+}

--- a/protocol/chainsync/client_test.go
+++ b/protocol/chainsync/client_test.go
@@ -614,7 +614,7 @@ func TestSyncPipelining(t *testing.T) {
 	)
 }
 
-func syncCallbacksExposeExactTipIntersection(t *testing.T) {
+func TestSyncCallbacksExposeExactTipIntersection(t *testing.T) {
 	intersect := pcommon.NewPoint(
 		100,
 		test.DecodeHexString("0102030405060708"),
@@ -644,12 +644,13 @@ func syncCallbacksExposeExactTipIntersection(t *testing.T) {
 			IsResponse: true,
 			Messages:   []protocol.Message{chainsync.NewMsgAwaitReply()},
 		},
-		ouroboros_mock.ConversationEntryInput{
-			ProtocolId:  chainsync.ProtocolIdNtC,
-			MessageType: chainsync.MessageTypeDone,
-		},
 	)
-	callbacks := make(chan string, 2)
+	type callback struct {
+		name      string
+		intersect pcommon.Point
+		tip       chainsync.Tip
+	}
+	callbacks := make(chan callback, 2)
 	runTest(
 		t,
 		conversation,
@@ -659,7 +660,11 @@ func syncCallbacksExposeExactTipIntersection(t *testing.T) {
 			for _, want := range []string{"intersect", "await"} {
 				select {
 				case got := <-callbacks:
-					require.Equal(t, want, got)
+					require.Equal(t, want, got.name)
+					if got.name == "intersect" {
+						require.Equal(t, intersect, got.intersect)
+						require.Equal(t, tip, got.tip)
+					}
 				case <-time.After(2 * time.Second):
 					t.Fatalf("timed out waiting for %s callback", want)
 				}
@@ -673,13 +678,15 @@ func syncCallbacksExposeExactTipIntersection(t *testing.T) {
 				gotIntersect pcommon.Point,
 				gotTip chainsync.Tip,
 			) error {
-				require.Equal(t, intersect, gotIntersect)
-				require.Equal(t, tip, gotTip)
-				callbacks <- "intersect"
+				callbacks <- callback{
+					name:      "intersect",
+					intersect: gotIntersect,
+					tip:       gotTip,
+				}
 				return nil
 			},
 			AwaitReplyFunc: func(chainsync.CallbackContext) error {
-				callbacks <- "await"
+				callbacks <- callback{name: "await"}
 				return nil
 			},
 		}),

--- a/protocol/chainsync/client_test.go
+++ b/protocol/chainsync/client_test.go
@@ -614,6 +614,78 @@ func TestSyncPipelining(t *testing.T) {
 	)
 }
 
+func syncCallbacksExposeExactTipIntersection(t *testing.T) {
+	intersect := pcommon.NewPoint(
+		100,
+		test.DecodeHexString("0102030405060708"),
+	)
+	tip := chainsync.Tip{
+		BlockNumber: 10,
+		Point: pcommon.NewPoint(
+			100,
+			test.DecodeHexString("1112131415161718"),
+		),
+	}
+	conversation := append(
+		append([]ouroboros_mock.ConversationEntry{}, conversationHandshakeFindIntersect...),
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: chainsync.ProtocolIdNtC,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				chainsync.NewMsgIntersectFound(intersect, tip),
+			},
+		},
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  chainsync.ProtocolIdNtC,
+			MessageType: chainsync.MessageTypeRequestNext,
+		},
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: chainsync.ProtocolIdNtC,
+			IsResponse: true,
+			Messages:   []protocol.Message{chainsync.NewMsgAwaitReply()},
+		},
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  chainsync.ProtocolIdNtC,
+			MessageType: chainsync.MessageTypeDone,
+		},
+	)
+	callbacks := make(chan string, 2)
+	runTest(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			err := oConn.ChainSync().Client.Sync([]pcommon.Point{intersect})
+			require.NoError(t, err)
+			for _, want := range []string{"intersect", "await"} {
+				select {
+				case got := <-callbacks:
+					require.Equal(t, want, got)
+				case <-time.After(2 * time.Second):
+					t.Fatalf("timed out waiting for %s callback", want)
+				}
+			}
+			require.NoError(t, oConn.ChainSync().Client.Stop())
+		},
+		ouroboros.WithChainSyncConfig(chainsync.Config{
+			SkipBlockValidation: true,
+			IntersectFoundFunc: func(
+				_ chainsync.CallbackContext,
+				gotIntersect pcommon.Point,
+				gotTip chainsync.Tip,
+			) error {
+				require.Equal(t, intersect, gotIntersect)
+				require.Equal(t, tip, gotTip)
+				callbacks <- "intersect"
+				return nil
+			},
+			AwaitReplyFunc: func(chainsync.CallbackContext) error {
+				callbacks <- "await"
+				return nil
+			},
+		}),
+	)
+}
+
 func TestUseCase_MultiCycle_GetCurrentTip_Stop_Start(t *testing.T) {
 	expectedTip1 := chainsync.Tip{
 		BlockNumber: 1,

--- a/protocol/chainsync/client_test.go
+++ b/protocol/chainsync/client_test.go
@@ -464,7 +464,11 @@ func TestSyncPipelining(t *testing.T) {
 			finalTip,
 		)
 		if err != nil {
-			t.Fatalf("failed to create RollForward message for block %d: %s", idx, err)
+			t.Fatalf(
+				"failed to create RollForward message for block %d: %s",
+				idx,
+				err,
+			)
 		}
 		return msg
 	}
@@ -567,7 +571,9 @@ func TestSyncPipelining(t *testing.T) {
 				}
 			}()
 
-			err := oConn.ChainSync().Client.Sync([]pcommon.Point{expectedIntersect})
+			err := oConn.ChainSync().Client.Sync(
+				[]pcommon.Point{expectedIntersect},
+			)
 			if err != nil {
 				t.Fatalf("unexpected error starting sync: %s", err)
 			}
@@ -578,19 +584,32 @@ func TestSyncPipelining(t *testing.T) {
 			case <-time.After(5 * time.Second):
 				receivedMu.Lock()
 				defer receivedMu.Unlock()
-				t.Fatalf("timeout waiting for blocks, received %d of %d", len(receivedBlocks), totalBlocks)
+				t.Fatalf(
+					"timeout waiting for blocks, received %d of %d",
+					len(receivedBlocks),
+					totalBlocks,
+				)
 			}
 
 			// Verify blocks received in order
 			receivedMu.Lock()
 			defer receivedMu.Unlock()
 			if len(receivedBlocks) != totalBlocks {
-				t.Fatalf("expected %d blocks, received %d", totalBlocks, len(receivedBlocks))
+				t.Fatalf(
+					"expected %d blocks, received %d",
+					totalBlocks,
+					len(receivedBlocks),
+				)
 			}
 			for i := range totalBlocks {
 				expectedSlot := uint64(1000 + i)
 				if receivedBlocks[i] != expectedSlot {
-					t.Fatalf("block %d: expected slot %d, got %d", i, expectedSlot, receivedBlocks[i])
+					t.Fatalf(
+						"block %d: expected slot %d, got %d",
+						i,
+						expectedSlot,
+						receivedBlocks[i],
+					)
 				}
 			}
 		},
@@ -627,7 +646,9 @@ func TestSyncCallbacksExposeExactTipIntersection(t *testing.T) {
 		),
 	}
 	conversation := append(
-		append([]ouroboros_mock.ConversationEntry{}, conversationHandshakeFindIntersect...),
+		append(
+			[]ouroboros_mock.ConversationEntry{},
+			conversationHandshakeFindIntersect...),
 		ouroboros_mock.ConversationEntryOutput{
 			ProtocolId: chainsync.ProtocolIdNtC,
 			IsResponse: true,
@@ -860,7 +881,11 @@ func TestStopAfterConnectionClose(t *testing.T) {
 	client.Start()
 
 	// Close the connection first (simulating remote close)
-	require.NoError(t, oConn.Close(), "unexpected error when closing connection")
+	require.NoError(
+		t,
+		oConn.Close(),
+		"unexpected error when closing connection",
+	)
 
 	// Wait for connection to fully close
 	select {
@@ -870,10 +895,18 @@ func TestStopAfterConnectionClose(t *testing.T) {
 	}
 
 	// Now Stop() should not return an error even though connection is closed
-	require.NoError(t, client.Stop(), "Stop() should not return error after connection close")
+	require.NoError(
+		t,
+		client.Stop(),
+		"Stop() should not return error after connection close",
+	)
 
 	// Verify IsDone returns true
-	require.True(t, client.IsDone(), "IsDone() should return true after connection close")
+	require.True(
+		t,
+		client.IsDone(),
+		"IsDone() should return true after connection close",
+	)
 
 	// Wait for mock connection shutdown
 	select {

--- a/protocol/chainsync/client_test.go
+++ b/protocol/chainsync/client_test.go
@@ -665,6 +665,17 @@ func TestSyncCallbacksExposeExactTipIntersection(t *testing.T) {
 			IsResponse: true,
 			Messages:   []protocol.Message{chainsync.NewMsgAwaitReply()},
 		},
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: chainsync.ProtocolIdNtC,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				chainsync.NewMsgRollBackward(pcommon.NewPointOrigin(), tip),
+			},
+		},
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  chainsync.ProtocolIdNtC,
+			MessageType: chainsync.MessageTypeDone,
+		},
 	)
 	type callback struct {
 		name      string
@@ -709,6 +720,13 @@ func TestSyncCallbacksExposeExactTipIntersection(t *testing.T) {
 			AwaitReplyFunc: func(chainsync.CallbackContext) error {
 				callbacks <- callback{name: "await"}
 				return nil
+			},
+			RollBackwardFunc: func(
+				chainsync.CallbackContext,
+				pcommon.Point,
+				chainsync.Tip,
+			) error {
+				return chainsync.ErrStopSyncProcess
 			},
 		}),
 	)


### PR DESCRIPTION
## Summary

Handle callbacks consistently when a chain-sync intersection is already at the
tip of the negotiated chain.

## Validation

- `GOWORK=off go test -race ./protocol/chainsync ./pipeline`
- Full repository lint, vet, NilAway, formatting, and nested-module checks

## Review notes

This PR is limited to callback behavior and regression coverage. No release or
tag is included.

Closes #2114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pipeline fencing to wait until previously submitted work finishes processing.
  - Added ChainSync callbacks for await-reply and intersection-found events.
  - Callbacks now receive accurate intersection and tip information, with errors propagated.

- **Bug Fixes**
  - Improved ChainSync start/stop coordination, including safe concurrent stopping and cancellation.
  - Ensured callbacks run only after relevant pipeline processing completes.
  - Prevented canceled or backpressured submissions from disrupting processing order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->