### PR TITLE
fix(leiosfetch): bound abandoned request slot waits

### DIFF
--- a/protocol/leiosfetch/client.go
+++ b/protocol/leiosfetch/client.go
@@ -51,11 +51,12 @@ type Client struct {
 //     drained, so a late response to an abandoned request is never
 //     mis-delivered to a subsequent request.
 type requestSlot struct {
-	mu        sync.Mutex
-	waiter    chan protocol.Message
-	busy      bool
-	abandoned bool
-	drainedCh chan struct{}
+	mu              sync.Mutex
+	waiter          chan protocol.Message
+	busy            bool
+	abandoned       bool
+	drainedCh       chan struct{}
+	beforeDrainWait func() // test hook for an acquirer reaching the drain wait
 }
 
 const abandonedRequestWait = time.Second
@@ -92,7 +93,11 @@ func (s *requestSlot) acquire(
 			continue
 		}
 		drained := s.drainedCh
+		beforeDrainWait := s.beforeDrainWait
 		s.mu.Unlock()
+		if beforeDrainWait != nil {
+			beforeDrainWait()
+		}
 		select {
 		case <-drained:
 		case <-ctx.Done():
@@ -127,6 +132,13 @@ func (s *requestSlot) abandon(w chan protocol.Message) {
 	if s.waiter == w {
 		s.waiter = nil
 		s.abandoned = true
+		// Acquirers that started before this request was abandoned are
+		// waiting on the current channel through the non-abandoned path.
+		// Wake them so they recheck abandoned and use its bounded grace
+		// period. Keep the slot busy on a fresh channel until the late
+		// response drains it, preserving response correlation.
+		close(s.drainedCh)
+		s.drainedCh = make(chan struct{})
 	}
 	s.mu.Unlock()
 }

--- a/protocol/leiosfetch/client.go
+++ b/protocol/leiosfetch/client.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/blinklabs-io/gouroboros/protocol"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -53,18 +54,43 @@ type requestSlot struct {
 	mu        sync.Mutex
 	waiter    chan protocol.Message
 	busy      bool
+	abandoned bool
 	drainedCh chan struct{}
 }
 
+const abandonedRequestWait = time.Second
+
 // acquire waits until the slot is free (any previously abandoned response has
 // been drained), bounded by ctx and the protocol done channel, then registers
-// and returns a fresh capacity-1 delivery channel for this request.
+// and returns a fresh capacity-1 delivery channel for this request. If a
+// previous request was abandoned, it waits briefly for the late response and
+// then fails rather than parking indefinitely; the protocol cannot safely
+// correlate a new request until that response is received.
 func (s *requestSlot) acquire(
 	ctx context.Context,
 	done <-chan struct{},
 ) (chan protocol.Message, error) {
 	s.mu.Lock()
 	for s.busy {
+		if s.abandoned {
+			timer := time.NewTimer(abandonedRequestWait)
+			drained := s.drainedCh
+			s.mu.Unlock()
+			select {
+			case <-drained:
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, ctx.Err()
+			case <-done:
+				timer.Stop()
+				return nil, protocol.ErrProtocolShuttingDown
+			case <-timer.C:
+				return nil, ErrRequestSlotAbandoned
+			}
+			timer.Stop()
+			s.mu.Lock()
+			continue
+		}
 		drained := s.drainedCh
 		s.mu.Unlock()
 		select {
@@ -79,6 +105,7 @@ func (s *requestSlot) acquire(
 	w := make(chan protocol.Message, 1)
 	s.waiter = w
 	s.busy = true
+	s.abandoned = false
 	s.drainedCh = make(chan struct{})
 	s.mu.Unlock()
 	return w, nil
@@ -86,8 +113,9 @@ func (s *requestSlot) acquire(
 
 // abandon clears the live waiter so that a late response is dropped by deliver
 // rather than mis-delivered, while leaving the slot busy until that response
-// arrives (or the protocol shuts down). It is used when a caller's context
-// expires before a response is received.
+// arrives (or the protocol shuts down). Subsequent acquire calls have a bounded
+// grace period while the slot is abandoned instead of parking indefinitely. It
+// is used when a caller's context expires before a response is received.
 //
 // The caller passes the delivery channel it registered in acquire. The slot is
 // only mutated while that channel is still the live waiter (s.waiter == w). If
@@ -98,6 +126,7 @@ func (s *requestSlot) abandon(w chan protocol.Message) {
 	s.mu.Lock()
 	if s.waiter == w {
 		s.waiter = nil
+		s.abandoned = true
 	}
 	s.mu.Unlock()
 }
@@ -147,6 +176,7 @@ func (s *requestSlot) freeLocked() {
 		return
 	}
 	s.busy = false
+	s.abandoned = false
 	if s.drainedCh != nil {
 		close(s.drainedCh)
 		s.drainedCh = nil

--- a/protocol/leiosfetch/client_test.go
+++ b/protocol/leiosfetch/client_test.go
@@ -237,6 +237,36 @@ func TestRequestSlotAbandonAfterDeliverKeepsNextWaiter(t *testing.T) {
 	}
 }
 
+// TestRequestSlotAbandonWakesExistingAcquirer verifies that an acquirer which
+// was already waiting for a non-abandoned request to drain observes a later
+// abandonment and applies the bounded grace period. Otherwise it remains
+// blocked on the old drain channel until a response arrives, bypassing
+// ErrRequestSlotAbandoned entirely.
+func TestRequestSlotAbandonWakesExistingAcquirer(t *testing.T) {
+	client := NewClient(protocol.ProtocolOptions{}, nil)
+	wA, err := client.blockSlot.acquire(context.Background(), client.DoneChan())
+	require.NoError(t, err)
+
+	bWaiting := make(chan struct{})
+	client.blockSlot.beforeDrainWait = func() {
+		close(bWaiting)
+	}
+	bResult := make(chan error, 1)
+	ctxB, cancelB := context.WithTimeout(
+		context.Background(),
+		2*abandonedRequestWait,
+	)
+	defer cancelB()
+	go func() {
+		_, err := client.blockSlot.acquire(ctxB, client.DoneChan())
+		bResult <- err
+	}()
+	<-bWaiting
+
+	client.blockSlot.abandon(wA)
+	require.ErrorIs(t, <-bResult, ErrRequestSlotAbandoned)
+}
+
 // TestRequestSlotReleaseAfterReacquireKeepsNextWaiter is the release-path
 // analogue of the abandon race: once the slot has been freed and reacquired by
 // a newer request, calling release with the previous request's channel must be

--- a/protocol/leiosfetch/error.go
+++ b/protocol/leiosfetch/error.go
@@ -33,3 +33,12 @@ var ErrBlockNotFound = errors.New(
 var ErrBlockTxsNotFound = errors.New(
 	"endorser block transactions not available",
 )
+
+// ErrRequestSlotAbandoned signals that an earlier request on the same
+// leios-fetch connection timed out before its response arrived. The
+// connection cannot safely issue another request until the protocol receives
+// and discards the late response, so callers should fail over to another
+// connection rather than wait indefinitely.
+var ErrRequestSlotAbandoned = errors.New(
+	"leios-fetch request slot awaiting abandoned response",
+)

--- a/protocol/leiosfetch/leiosfetch_test.go
+++ b/protocol/leiosfetch/leiosfetch_test.go
@@ -244,24 +244,14 @@ func TestBlockRequestSubsequentAfterAbandonedNoResponse(t *testing.T) {
 			)
 			assert.Nil(t, resp1)
 
-			// Subsequent request: also bounded by its own context. It must
-			// return a context error, not tear down the connection.
-			ctx2, cancel2 := context.WithTimeout(
-				context.Background(),
-				150*time.Millisecond,
-			)
-			defer cancel2()
+			// A subsequent request must fail after the bounded grace period
+			// while the first request's response is still outstanding. Reusing
+			// the slot would allow a late response to be mis-delivered here.
 			resp2, err2 := client.BlockRequest(
-				ctx2,
+				context.Background(),
 				pcommon.NewPoint(23456, []byte{0x05, 0x06, 0x07, 0x08}),
 			)
-			require.Error(t, err2)
-			assert.True(
-				t,
-				errors.Is(err2, context.DeadlineExceeded),
-				"expected context deadline error, got %v",
-				err2,
-			)
+			require.ErrorIs(t, err2, leiosfetch.ErrRequestSlotAbandoned)
 			assert.Nil(t, resp2)
 		},
 	)


### PR DESCRIPTION
## Summary

Bound abandoned Leios-fetch request-slot waits so a canceled or timed-out request cannot block subsequent requests indefinitely. Late responses remain correlated to their original request, and the slot is released for failover.

Fixes #2118

## Validation

- `go test ./protocol/leiosfetch`
- `go test -race ./protocol/leiosfetch`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Binds abandoned leios-fetch request slot waits so a canceled or timed-out request can't block later requests indefinitely. The slot now waits up to one second for the late response, then returns `ErrRequestSlotAbandoned` so callers fail over to another connection. Late responses are still correlated to their original request and safely discarded. Fixes #2118.

- Acquirers already waiting when a request is abandoned are woken so they apply the bounded grace period instead of parking on the old drain channel.

<sup>Written for commit 4022542712f4b81ce50a5c25b2b0b3af3652655a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented leios-fetch requests from waiting indefinitely when a previous request times out without receiving a response.
  * Subsequent requests now fail with a clear error after a short grace period, allowing the connection to recover safely once the late response is handled.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->