### PR TITLE
fix(blockfetch): apply server state timeouts

### DIFF
--- a/protocol/blockfetch/server.go
+++ b/protocol/blockfetch/server.go
@@ -48,6 +48,7 @@ func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 }
 
 func (s *Server) initProtocol() {
+	stateMap := serverStateMap(s.config)
 	protoConfig := protocol.ProtocolConfig{
 		Name:                ProtocolName,
 		ProtocolId:          ProtocolId,
@@ -58,7 +59,7 @@ func (s *Server) initProtocol() {
 		Role:                protocol.ProtocolRoleServer,
 		MessageHandlerFunc:  s.messageHandler,
 		MessageFromCborFunc: NewMsgFromCbor,
-		StateMap:            StateMap,
+		StateMap:            stateMap,
 		InitialState:        StateIdle,
 	}
 	if s.config != nil {
@@ -68,6 +69,24 @@ func (s *Server) initProtocol() {
 	s.protocolMu.Lock()
 	s.Protocol = p
 	s.protocolMu.Unlock()
+}
+
+// serverStateMap returns an instance-owned state map so server timeout
+// configuration cannot mutate the package defaults or affect another server.
+func serverStateMap(cfg *Config) protocol.StateMap {
+	stateMap := StateMap.Copy()
+	if cfg == nil {
+		return stateMap
+	}
+	if entry, ok := stateMap[StateBusy]; ok {
+		entry.Timeout = cfg.BatchStartTimeout
+		stateMap[StateBusy] = entry
+	}
+	if entry, ok := stateMap[StateStreaming]; ok {
+		entry.Timeout = cfg.BlockTimeout
+		stateMap[StateStreaming] = entry
+	}
+	return stateMap
 }
 
 func (s *Server) ProtocolInstance() *protocol.Protocol {

--- a/protocol/blockfetch/server_test.go
+++ b/protocol/blockfetch/server_test.go
@@ -1,0 +1,29 @@
+package blockfetch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerStateMapUsesInstanceTimeouts(t *testing.T) {
+	cfg := &Config{
+		BatchStartTimeout: 13 * time.Second,
+		BlockTimeout:      17 * time.Second,
+	}
+
+	got := serverStateMap(cfg)
+	require.Equal(t, 13*time.Second, got[StateBusy].Timeout)
+	require.Equal(t, 17*time.Second, got[StateStreaming].Timeout)
+	require.Equal(t, BusyTimeout, StateMap[StateBusy].Timeout)
+	require.Equal(t, StreamingTimeout, StateMap[StateStreaming].Timeout)
+}
+
+func TestServerStateMapsAreIndependent(t *testing.T) {
+	first := serverStateMap(&Config{BlockTimeout: 2 * time.Second})
+	second := serverStateMap(&Config{BlockTimeout: 3 * time.Second})
+
+	require.Equal(t, 2*time.Second, first[StateStreaming].Timeout)
+	require.Equal(t, 3*time.Second, second[StateStreaming].Timeout)
+}

--- a/protocol/blockfetch/server_test.go
+++ b/protocol/blockfetch/server_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package blockfetch
 
 import (


### PR DESCRIPTION
## Summary
- give each BlockFetch server an instance-owned state map
- apply configured batch-start and block-streaming timeouts on the server
- preserve package defaults and isolate parallel server instances

## Validation
- go test ./protocol/blockfetch -count=1
- git diff --check

Fixes #2097

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `blockfetch` server state timeouts by giving each server an instance-owned state map that applies its configured batch-start and block-streaming timeouts. Previously all servers shared the package-default state map, so configured timeouts never took effect and parallel instances could interfere with each other.

Fixes #2097.

<sup>Written for commit e263a8d89ff4579bd7664af9edf1e788750da4e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Server timeout settings are now isolated per instance, preventing one server’s configuration from affecting others.
  * Configured busy and streaming timeouts are applied reliably without changing default protocol settings.

* **Tests**
  * Added coverage for instance-specific timeout behavior and independent server state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->