### PR TITLE
fix(byron): domain-separate simple block signatures

### DIFF
--- a/consensus/byron/validate.go
+++ b/consensus/byron/validate.go
@@ -352,10 +352,18 @@ func (v *HeaderValidator) validateSimpleSignature(
 		return nil
 	}
 
-	// Verify Ed25519 signature on ToSign
+	// Byron simple signatures are domain-separated by the main-block tag and
+	// protocol magic. Signing the bare ToSign bytes would allow the same
+	// payload to be replayed across signing domains or networks.
+	signed, err := v.domainSeparateMainBlock(toSign)
+	if err != nil {
+		return fmt.Errorf("failed to domain-separate ToSign: %w", err)
+	}
+
+	// Verify Ed25519 signature on the domain-separated ToSign.
 	valid := ed25519.Verify(
 		input.IssuerPubKey,
-		toSign,
+		signed,
 		input.BlockSignature,
 	)
 	if !valid {
@@ -367,6 +375,20 @@ func (v *HeaderValidator) validateSimpleSignature(
 	}
 
 	return nil
+}
+
+// domainSeparateMainBlock applies Byron's SignMainBlock domain and network
+// magic to a serialized ToSign value.
+func (v *HeaderValidator) domainSeparateMainBlock(toSign []byte) ([]byte, error) {
+	pmBytes, err := cbor.Encode(v.config.ProtocolMagic)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode protocol magic: %w", err)
+	}
+	signed := make([]byte, 0, 1+len(pmBytes)+len(toSign))
+	signed = append(signed, byronSignTagMainBlock)
+	signed = append(signed, pmBytes...)
+	signed = append(signed, toSign...)
+	return signed, nil
 }
 
 // validateBlockSignatureWithProxy handles proxy signatures (types 1 and 2)

--- a/consensus/byron/validate_test.go
+++ b/consensus/byron/validate_test.go
@@ -444,37 +444,50 @@ func TestValidateSimpleSignatureRequiresMainBlockDomain(t *testing.T) {
 	assert.Error(t, validator.validateSimpleSignature(input))
 }
 
-func TestValidateSimpleSignatureGoldenDomainBuffer(t *testing.T) {
-	config := testByronConfig()
-	validator := NewHeaderValidator(config)
-	var seed [ed25519.SeedSize]byte
-	for i := range seed {
-		seed[i] = byte(i)
-	}
-	privKey := ed25519.NewKeyFromSeed(seed[:])
-	pubKey := privKey.Public().(ed25519.PublicKey)
-	header := &byron.ByronMainBlockHeader{}
-	header.ConsensusData.SlotId.Epoch = 7
-	header.ConsensusData.SlotId.Slot = 11
-	header.ConsensusData.Difficulty.Value = 19
-	headerCbor, err := cbor.Encode(header)
+func TestValidateSimpleSignatureReferenceVector(t *testing.T) {
+	// This static type-0 vector follows cardano-sl's Signing/Tag.hs and
+	// Signing/Safe.hs reference layout:
+	// SignMainBlock (0x07) || CBOR(protocol magic) || CBOR(MainToSign).
+	// The fixed buffer, public key, and signature prevent the test from signing
+	// bytes assembled by the implementation under test.
+	headerCbor, err := hex.DecodeString(
+		"8500582000000000000000000000000000000000000000000000000000000000" +
+			"00000000f68482070bf68113f68483000000826000f658200000000000000000" +
+			"000000000000000000000000000000000000000000000000",
+	)
 	require.NoError(t, err)
-	toSign, err := validator.buildToSign(&ValidateHeaderInput{HeaderCbor: headerCbor})
+	signedBuffer, err := hex.DecodeString(
+		"071a2d964a098558200000000000000000000000000000000000000000000000" +
+			"000000000000000000f682070b81138483000000826000f65820000000000000" +
+			"0000000000000000000000000000000000000000000000000000",
+	)
 	require.NoError(t, err)
-	protocolMagic, err := cbor.Encode(config.ProtocolMagic)
+	pubKey, err := hex.DecodeString(
+		"03a107bff3ce10be1d70dd18e74bc09967e4d6309ba50d5f1ddc8664125531b8",
+	)
 	require.NoError(t, err)
-	manual := append([]byte{byronSignTagMainBlock}, protocolMagic...)
-	manual = append(manual, toSign...)
+	signature, err := hex.DecodeString(
+		"905092bd0d1aeceaa69a7bd402545bda19db9cd16a5a6a55a5c0ccc766043d74" +
+			"ee7a6879a6a1df801c85e5691d28a2b61bfc0fbbfeb814e94c1d5e40b5120707",
+	)
+	require.NoError(t, err)
+
+	validator := NewHeaderValidator(testByronConfig())
+	toSign, err := validator.buildToSign(
+		&ValidateHeaderInput{HeaderCbor: headerCbor},
+	)
+	require.NoError(t, err)
 	domain, err := validator.domainSeparateMainBlock(toSign)
 	require.NoError(t, err)
-	require.Equal(t, manual, domain)
+	require.Equal(t, signedBuffer, domain)
+	require.True(t, ed25519.Verify(pubKey, signedBuffer, signature))
 
 	input := &ValidateHeaderInput{
-		IssuerPubKey:   pubKey,
-		BlockSignature: ed25519.Sign(privKey, manual),
-		HeaderCbor:     headerCbor,
+		IssuerPubKey: pubKey,
+		HeaderCbor:   headerCbor,
+		BlockSig:     []any{uint64(byronSigTypeSimple), signature},
 	}
-	require.NoError(t, validator.validateSimpleSignature(input))
+	require.NoError(t, validator.validateBlockSignature(input))
 }
 
 // TestValidateDelegationCertSignature_RealMainnetVector verifies a real

--- a/consensus/byron/validate_test.go
+++ b/consensus/byron/validate_test.go
@@ -409,6 +409,41 @@ func TestValidateBlockSignature(t *testing.T) {
 	}
 }
 
+func TestValidateSimpleSignatureRequiresMainBlockDomain(t *testing.T) {
+	config := testByronConfig()
+	validator := NewHeaderValidator(config)
+	pubKey, privKey, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	header := &byron.ByronMainBlockHeader{}
+	header.PrevBlock = common.Blake2b256{}
+	header.BodyProof = []any{}
+	header.ConsensusData.SlotId.Epoch = 1
+	header.ConsensusData.SlotId.Slot = 2
+	header.ConsensusData.PubKey = []byte{}
+	header.ConsensusData.Difficulty.Value = 3
+	header.ConsensusData.BlockSig = []any{}
+	header.ExtraData.Attributes = []byte{}
+	header.ExtraData.ExtraProof = common.Blake2b256{}
+	headerCbor, err := cbor.Encode(header)
+	require.NoError(t, err)
+	input := &ValidateHeaderInput{
+		IssuerPubKey: pubKey,
+		HeaderCbor:   headerCbor,
+	}
+	toSign, err := validator.buildToSign(input)
+	require.NoError(t, err)
+	domainSeparated, err := validator.domainSeparateMainBlock(toSign)
+	require.NoError(t, err)
+
+	input.BlockSignature = ed25519.Sign(privKey, domainSeparated)
+	assert.NoError(t, validator.validateSimpleSignature(input))
+
+	// The raw ToSign signature must not verify in the main-block domain.
+	input.BlockSignature = ed25519.Sign(privKey, toSign)
+	assert.Error(t, validator.validateSimpleSignature(input))
+}
+
 // TestValidateDelegationCertSignature_RealMainnetVector verifies a real
 // delegation certificate signature extracted from a mainnet Byron block
 // (slot 4471207), confirming the byte layout reproduced from

--- a/consensus/byron/validate_test.go
+++ b/consensus/byron/validate_test.go
@@ -444,6 +444,39 @@ func TestValidateSimpleSignatureRequiresMainBlockDomain(t *testing.T) {
 	assert.Error(t, validator.validateSimpleSignature(input))
 }
 
+func TestValidateSimpleSignatureGoldenDomainBuffer(t *testing.T) {
+	config := testByronConfig()
+	validator := NewHeaderValidator(config)
+	var seed [ed25519.SeedSize]byte
+	for i := range seed {
+		seed[i] = byte(i)
+	}
+	privKey := ed25519.NewKeyFromSeed(seed[:])
+	pubKey := privKey.Public().(ed25519.PublicKey)
+	header := &byron.ByronMainBlockHeader{}
+	header.ConsensusData.SlotId.Epoch = 7
+	header.ConsensusData.SlotId.Slot = 11
+	header.ConsensusData.Difficulty.Value = 19
+	headerCbor, err := cbor.Encode(header)
+	require.NoError(t, err)
+	toSign, err := validator.buildToSign(&ValidateHeaderInput{HeaderCbor: headerCbor})
+	require.NoError(t, err)
+	protocolMagic, err := cbor.Encode(config.ProtocolMagic)
+	require.NoError(t, err)
+	manual := append([]byte{byronSignTagMainBlock}, protocolMagic...)
+	manual = append(manual, toSign...)
+	domain, err := validator.domainSeparateMainBlock(toSign)
+	require.NoError(t, err)
+	require.Equal(t, manual, domain)
+
+	input := &ValidateHeaderInput{
+		IssuerPubKey:   pubKey,
+		BlockSignature: ed25519.Sign(privKey, manual),
+		HeaderCbor:     headerCbor,
+	}
+	require.NoError(t, validator.validateSimpleSignature(input))
+}
+
 // TestValidateDelegationCertSignature_RealMainnetVector verifies a real
 // delegation certificate signature extracted from a mainnet Byron block
 // (slot 4471207), confirming the byte layout reproduced from


### PR DESCRIPTION
## Summary

- domain-separate Byron simple block signatures with the main-block tag and protocol magic
- reject signatures over the bare `ToSign` payload
- add regression coverage for the signing domain

Refs #2021

## Validation

- `go test -race ./consensus/byron`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2021 by domain-separating Byron simple block signatures with the main-block tag and protocol magic. Signatures over the bare `ToSign` payload are now rejected, preventing the same payload from being replayed across signing domains or networks.

**Bug Fixes**
- Adds a regression test verifying raw `ToSign` signatures fail main-block domain verification.
- Adds a static reference-vector test confirming the domain-separated layout and signature verify against cardano-sl's reference bytes.

<sup>Written for commit 1264cc51b333bc6aef1bea4ca064fd3a7c751e97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Byron main-block signature validation by applying the required signing domain and protocol magic.
  * Signatures created from unqualified raw data are now rejected when domain separation is required.

* **Tests**
  * Added coverage for domain-separated signatures.
  * Added validation against a fixed reference vector to ensure compatibility with established Byron signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->