### PR TITLE
fix(consensus): bound configuration and leadership searches

### DIFF
--- a/consensus/byron/byron.go
+++ b/consensus/byron/byron.go
@@ -161,8 +161,11 @@ func (c *ByronConfig) SlotLeader(slot uint64) (int, []byte) {
 //   - Genesis delegate key hashes (sorted for OBFT slot leader assignment)
 func NewByronConfigFromGenesis(genesis *ledgerbyron.ByronGenesis) (ByronConfig, error) {
 	// Validate security parameter K
-	if genesis.ProtocolConsts.K < 0 {
-		return ByronConfig{}, fmt.Errorf("invalid security parameter K: %d (must be non-negative)", genesis.ProtocolConsts.K)
+	if genesis.ProtocolConsts.K <= 0 {
+		return ByronConfig{}, fmt.Errorf("invalid security parameter K: %d (must be positive)", genesis.ProtocolConsts.K)
+	}
+	if uint64(genesis.ProtocolConsts.K) > math.MaxUint64/10 {
+		return ByronConfig{}, fmt.Errorf("invalid security parameter K: %d overflows slots per epoch", genesis.ProtocolConsts.K)
 	}
 
 	// Validate protocol magic fits in uint32

--- a/consensus/byron/validate_test.go
+++ b/consensus/byron/validate_test.go
@@ -19,6 +19,9 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"fmt"
+	"math"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1843,17 +1846,44 @@ func TestNewByronConfigFromGenesis(t *testing.T) {
 	t.Logf("  NumGenesisKeys: %d", config.NumGenesisKeys)
 }
 
-func TestNewByronConfigFromGenesisRejectsInvalidSecurityParameter(t *testing.T) {
+func parseSecurityParameterGenesis(t *testing.T, k int) byron.ByronGenesis {
+	t.Helper()
+	genesisJSON := fmt.Sprintf(
+		`{"protocolConsts":{"k":%d,"protocolMagic":%d}}`,
+		k,
+		testByronProtocolMagicMainnet,
+	)
 	genesis, err := byron.NewByronGenesisFromReader(
-		strings.NewReader(testByronGenesisJSON),
+		strings.NewReader(genesisJSON),
 	)
 	require.NoError(t, err)
+	return genesis
+}
 
-	for _, k := range []int{0, int(^uint(0) >> 1)} {
-		genesis.ProtocolConsts.K = k
-		_, err = NewByronConfigFromGenesis(&genesis)
-		require.Error(t, err)
+func TestNewByronConfigFromGenesisRejectsZeroSecurityParameter(t *testing.T) {
+	genesis := parseSecurityParameterGenesis(t, 0)
+	_, err := NewByronConfigFromGenesis(&genesis)
+	require.ErrorContains(t, err, "must be positive")
+}
+
+func TestNewByronConfigFromGenesisRejectsSecurityParameterOverflow(
+	t *testing.T,
+) {
+	if strconv.IntSize < 64 {
+		t.Skip("an overflow-producing K cannot be represented by int")
 	}
+	genesis := parseSecurityParameterGenesis(t, math.MaxInt)
+	_, err := NewByronConfigFromGenesis(&genesis)
+	require.ErrorContains(t, err, "overflows slots per epoch")
+}
+
+func TestNewByronConfigFromGenesisAcceptsMaxInt32SecurityParameter(
+	t *testing.T,
+) {
+	genesis := parseSecurityParameterGenesis(t, math.MaxInt32)
+	config, err := NewByronConfigFromGenesis(&genesis)
+	require.NoError(t, err)
+	require.Equal(t, uint64(10)*math.MaxInt32, config.SlotsPerEpoch)
 }
 
 func TestByronTxFeePolicy_CalculateMinFee(t *testing.T) {

--- a/consensus/byron/validate_test.go
+++ b/consensus/byron/validate_test.go
@@ -1843,6 +1843,19 @@ func TestNewByronConfigFromGenesis(t *testing.T) {
 	t.Logf("  NumGenesisKeys: %d", config.NumGenesisKeys)
 }
 
+func TestNewByronConfigFromGenesisRejectsInvalidSecurityParameter(t *testing.T) {
+	genesis, err := byron.NewByronGenesisFromReader(
+		strings.NewReader(testByronGenesisJSON),
+	)
+	require.NoError(t, err)
+
+	for _, k := range []int{0, int(^uint(0) >> 1)} {
+		genesis.ProtocolConsts.K = k
+		_, err = NewByronConfigFromGenesis(&genesis)
+		require.Error(t, err)
+	}
+}
+
 func TestByronTxFeePolicy_CalculateMinFee(t *testing.T) {
 	// Use mainnet-like fee policy values
 	// summand: 155381000000000 (scaled by 10^9)

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -365,7 +365,7 @@ func FindNextSlotLeadershipContext(
 			MaxLeadershipSearchSlots,
 		)
 	}
-	for slot := startSlot; slot <= maxSlot; slot++ {
+	for slot := startSlot; ; slot++ {
 		if err := ctx.Err(); err != nil {
 			return 0, nil, nil, err
 		}
@@ -382,6 +382,9 @@ func FindNextSlotLeadershipContext(
 		}
 		if result.Eligible {
 			return slot, result.Proof, result.Output, nil
+		}
+		if slot == maxSlot {
+			break
 		}
 	}
 	return 0, nil, nil, nil

--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -15,6 +15,7 @@
 package consensus
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -323,12 +324,51 @@ func FindNextSlotLeadership(
 	activeSlotCoeff *big.Rat,
 	vrfSigner VRFSigner,
 ) (uint64, []byte, []byte, error) {
-	if maxSlot == math.MaxUint64 {
-		return 0, nil, nil, errors.New(
-			"maxSlot cannot be math.MaxUint64 to prevent overflow",
+	return FindNextSlotLeadershipContext(
+		context.Background(),
+		startSlot,
+		maxSlot,
+		epochNonce,
+		poolStake,
+		totalStake,
+		activeSlotCoeff,
+		vrfSigner,
+	)
+}
+
+// MaxLeadershipSearchSlots bounds one leadership search so callers cannot
+// accidentally turn a scheduling query into an unbounded VRF workload.
+const MaxLeadershipSearchSlots uint64 = 1_000_000
+
+// FindNextSlotLeadershipContext searches for leadership with cancellation and
+// an explicit maximum range. The legacy function delegates here with a
+// background context.
+func FindNextSlotLeadershipContext(
+	ctx context.Context,
+	startSlot uint64,
+	maxSlot uint64,
+	epochNonce []byte,
+	poolStake uint64,
+	totalStake uint64,
+	activeSlotCoeff *big.Rat,
+	vrfSigner VRFSigner,
+) (uint64, []byte, []byte, error) {
+	if ctx == nil {
+		return 0, nil, nil, errors.New("context is nil")
+	}
+	if maxSlot < startSlot {
+		return 0, nil, nil, errors.New("maxSlot must not precede startSlot")
+	}
+	if maxSlot-startSlot >= MaxLeadershipSearchSlots {
+		return 0, nil, nil, fmt.Errorf(
+			"leadership search range exceeds maximum of %d slots",
+			MaxLeadershipSearchSlots,
 		)
 	}
 	for slot := startSlot; slot <= maxSlot; slot++ {
+		if err := ctx.Err(); err != nil {
+			return 0, nil, nil, err
+		}
 		result, err := IsSlotLeader(
 			slot,
 			epochNonce,

--- a/consensus/leader_test.go
+++ b/consensus/leader_test.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -415,6 +416,28 @@ func TestFindNextSlotLeadershipContextHonorsCancellation(t *testing.T) {
 		signer,
 	)
 	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestFindNextSlotLeadershipContextHandlesMaxUint64Boundary(t *testing.T) {
+	signer, err := NewSimpleVRFSigner(testVRFSeed)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	slot, proof, output, err := FindNextSlotLeadershipContext(
+		ctx,
+		math.MaxUint64,
+		math.MaxUint64,
+		make([]byte, 32),
+		0,
+		1,
+		big.NewRat(1, 2),
+		signer,
+	)
+	require.NoError(t, err)
+	require.Zero(t, slot)
+	require.Nil(t, proof)
+	require.Nil(t, output)
 }
 
 func TestIsSlotLeaderWithModeSlotOverflow(t *testing.T) {

--- a/consensus/leader_test.go
+++ b/consensus/leader_test.go
@@ -15,6 +15,7 @@
 package consensus
 
 import (
+	"context"
 	"math"
 	"math/big"
 	"testing"
@@ -380,6 +381,40 @@ func TestFindNextSlotLeadershipNoEligibility(t *testing.T) {
 	if slot != 0 || proof != nil || output != nil {
 		t.Error("should not find eligibility with zero stake")
 	}
+}
+
+func TestFindNextSlotLeadershipContextRejectsOversizedRange(t *testing.T) {
+	signer, err := NewSimpleVRFSigner(testVRFSeed)
+	require.NoError(t, err)
+	_, _, _, err = FindNextSlotLeadershipContext(
+		context.Background(),
+		0,
+		MaxLeadershipSearchSlots,
+		make([]byte, 32),
+		1,
+		1,
+		big.NewRat(1, 2),
+		signer,
+	)
+	require.Error(t, err)
+}
+
+func TestFindNextSlotLeadershipContextHonorsCancellation(t *testing.T) {
+	signer, err := NewSimpleVRFSigner(testVRFSeed)
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, _, _, err = FindNextSlotLeadershipContext(
+		ctx,
+		0,
+		10,
+		make([]byte, 32),
+		1,
+		1,
+		big.NewRat(1, 2),
+		signer,
+	)
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestIsSlotLeaderWithModeSlotOverflow(t *testing.T) {

--- a/consensus/threshold.go
+++ b/consensus/threshold.go
@@ -856,8 +856,11 @@ func IsVRFOutputBelowThresholdWithMode(
 	if threshold == nil {
 		return false, nil
 	}
-	if len(vrfOutput) == 0 {
-		return false, nil
+	if len(vrfOutput) != 64 {
+		return false, fmt.Errorf(
+			"VRF output: expected 64 bytes, got %d",
+			len(vrfOutput),
+		)
 	}
 
 	var leaderValue []byte

--- a/consensus/threshold_test.go
+++ b/consensus/threshold_test.go
@@ -814,6 +814,19 @@ func TestIsVRFOutputBelowThresholdEmptyOutput(t *testing.T) {
 	}
 }
 
+func TestIsVRFOutputBelowThresholdRejectsMalformedLength(t *testing.T) {
+	threshold := new(big.Int).SetUint64(1)
+	for _, size := range []int{63, 65} {
+		eligible, err := IsVRFOutputBelowThresholdWithMode(
+			make([]byte, size),
+			threshold,
+			ConsensusModeTPraos,
+		)
+		require.False(t, eligible)
+		require.Error(t, err)
+	}
+}
+
 // TestIsVRFOutputBelowThresholdZeroThreshold tests handling of zero threshold.
 func TestIsVRFOutputBelowThresholdZeroThreshold(t *testing.T) {
 	vrfOutput := make([]byte, 64)


### PR DESCRIPTION
## Summary
- reject zero and overflowing Byron security parameters
- reject malformed VRF output lengths
- add a cancellable, bounded leadership-search API while preserving the legacy wrapper

## Validation
- go test ./consensus/... -count=1
- git diff --check

Fixes #2027

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2027 by hardening consensus validation and preventing unbounded leadership searches.

- Rejects Byron security parameter K when zero or large enough to overflow slots per epoch.
- VRF outputs must be exactly 64 bytes; other lengths now return an error instead of being treated as non-leader.
- Adds `FindNextSlotLeadershipContext`, which supports context cancellation, caps each search at 1,000,000 slots, and stops at the requested upper bound.
- `FindNextSlotLeadership` keeps its signature but now delegates with a background context and the same range cap.

<sup>Written for commit d0fc406929615fa6d2798d8449451d13443649e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

