### PR TITLE
fix(blockfetch): validate streamed block ranges

### DIFF
--- a/protocol/blockfetch/client.go
+++ b/protocol/blockfetch/client.go
@@ -15,6 +15,7 @@
 package blockfetch
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -70,6 +71,8 @@ const (
 // owns the next MsgStartBatch, MsgNoBlocks, MsgBlock, and MsgBatchDone.
 type rangeRequest struct {
 	id             uint64
+	start          pcommon.Point
+	end            pcommon.Point
 	protocol       *protocol.Protocol
 	delivery       requestDelivery
 	pipelined      bool
@@ -720,6 +723,8 @@ func (c *Client) sendRequestRange(
 		c.nextRequestId++
 		req = &rangeRequest{
 			id:            c.nextRequestId,
+			start:         start,
+			end:           end,
 			protocol:      proto,
 			delivery:      delivery,
 			pipelined:     pipelined,
@@ -1030,12 +1035,39 @@ func (c *Client) handleBlock(msgGeneric protocol.Message) error {
 		req.blockDelivered = true
 	}
 	c.queueMutex.Unlock()
-	// Decode only enough to get the block type value
+	// Decode the wrapper and block header before delivering anything. The
+	// response point must be correlated with the requested range; otherwise a
+	// peer can inject an unrelated block into a valid batch.
 	var wrappedBlock WrappedBlock
 	if _, err := cbor.Decode(msg.WrappedBlock, &wrappedBlock); err != nil {
 		return c.failRequest(
 			req,
 			fmt.Errorf("%s: decode error: %w", ProtocolName, err),
+		)
+	}
+	block, err := ledger.NewBlockFromCbor(
+		wrappedBlock.Type,
+		wrappedBlock.RawBlock,
+		lcommon.VerifyConfig{
+			SkipBodyHashValidation: c.config.SkipBlockValidation,
+		},
+	)
+	if err != nil {
+		return c.failRequest(req, err)
+	}
+	blockPoint := pcommon.NewPoint(
+		block.SlotNumber(),
+		block.Hash().Bytes(),
+	)
+	if !pointInRange(blockPoint, req.start, req.end) {
+		return c.failRequest(
+			req,
+			fmt.Errorf(
+				"%s: received block outside requested range: slot=%d hash=%x",
+				ProtocolName,
+				blockPoint.Slot,
+				blockPoint.Hash,
+			),
 		)
 	}
 	// If pipeline is configured, submit to pipeline
@@ -1073,20 +1105,6 @@ func (c *Client) handleBlock(msgGeneric protocol.Message) error {
 		}
 		return nil
 	}
-	var block ledger.Block
-	if req.delivery == deliveryChannel || c.config.BlockFunc != nil {
-		var err error
-		block, err = ledger.NewBlockFromCbor(
-			wrappedBlock.Type,
-			wrappedBlock.RawBlock,
-			lcommon.VerifyConfig{
-				SkipBodyHashValidation: c.config.SkipBlockValidation,
-			},
-		)
-		if err != nil {
-			return c.failRequest(req, err)
-		}
-	}
 	// Check for shutdown
 	select {
 	case <-c.DoneChan():
@@ -1121,6 +1139,26 @@ func (c *Client) handleBlock(msgGeneric protocol.Message) error {
 	default:
 	}
 	return nil
+}
+
+func pointInRange(block, start, end pcommon.Point) bool {
+	if start.Hash != nil {
+		if block.Slot < start.Slot {
+			return false
+		}
+		if block.Slot == start.Slot && !bytes.Equal(block.Hash, start.Hash) {
+			return false
+		}
+	}
+	if end.Hash != nil {
+		if block.Slot > end.Slot {
+			return false
+		}
+		if block.Slot == end.Slot && !bytes.Equal(block.Hash, end.Hash) {
+			return false
+		}
+	}
+	return true
 }
 
 // failRequest retires a request that cannot be completed and returns the

--- a/protocol/blockfetch/client.go
+++ b/protocol/blockfetch/client.go
@@ -73,6 +73,8 @@ type rangeRequest struct {
 	id             uint64
 	start          pcommon.Point
 	end            pcommon.Point
+	lastPoint      pcommon.Point
+	hasLastPoint   bool
 	protocol       *protocol.Protocol
 	delivery       requestDelivery
 	pipelined      bool
@@ -1059,16 +1061,11 @@ func (c *Client) handleBlock(msgGeneric protocol.Message) error {
 		block.SlotNumber(),
 		block.Hash().Bytes(),
 	)
-	if !pointInRange(blockPoint, req.start, req.end) {
-		return c.failRequest(
-			req,
-			fmt.Errorf(
-				"%s: received block outside requested range: slot=%d hash=%x",
-				ProtocolName,
-				blockPoint.Slot,
-				blockPoint.Hash,
-			),
-		)
+	c.queueMutex.Lock()
+	err = req.recordBlock(block, blockPoint)
+	c.queueMutex.Unlock()
+	if err != nil {
+		return c.failRequest(req, err)
 	}
 	// If pipeline is configured, submit to pipeline
 	// Only use pipeline if we are in callback mode (GetBlockRange, RequestRange),
@@ -1161,6 +1158,68 @@ func pointInRange(block, start, end pcommon.Point) bool {
 	return true
 }
 
+func pointsEqual(a, b pcommon.Point) bool {
+	return a.Slot == b.Slot && bytes.Equal(a.Hash, b.Hash)
+}
+
+// recordBlock validates and records the next block in a requested inclusive
+// range. BlockFetch does not carry the expected interior points on the wire,
+// so continuity is established from each decoded block's previous hash. The
+// caller must hold queueMutex.
+func (req *rangeRequest) recordBlock(
+	block ledger.Block,
+	blockPoint pcommon.Point,
+) error {
+	if !pointInRange(blockPoint, req.start, req.end) {
+		return fmt.Errorf(
+			"%s: received block outside requested range: slot=%d hash=%x",
+			ProtocolName,
+			blockPoint.Slot,
+			blockPoint.Hash,
+		)
+	}
+	if !req.hasLastPoint {
+		if req.start.Hash != nil && !pointsEqual(blockPoint, req.start) {
+			return fmt.Errorf(
+				"%s: first received block does not match requested range start: slot=%d hash=%x",
+				ProtocolName,
+				blockPoint.Slot,
+				blockPoint.Hash,
+			)
+		}
+	} else {
+		if pointsEqual(blockPoint, req.lastPoint) {
+			return fmt.Errorf(
+				"%s: received duplicate block in requested range: slot=%d hash=%x",
+				ProtocolName,
+				blockPoint.Slot,
+				blockPoint.Hash,
+			)
+		}
+		if blockPoint.Slot < req.lastPoint.Slot {
+			return fmt.Errorf(
+				"%s: received block before previous range point: slot=%d previous_slot=%d",
+				ProtocolName,
+				blockPoint.Slot,
+				req.lastPoint.Slot,
+			)
+		}
+		prevHash := block.PrevHash()
+		if !bytes.Equal(prevHash[:], req.lastPoint.Hash) {
+			return fmt.Errorf(
+				"%s: received block does not follow previous range point: slot=%d hash=%x previous_hash=%x",
+				ProtocolName,
+				blockPoint.Slot,
+				blockPoint.Hash,
+				req.lastPoint.Hash,
+			)
+		}
+	}
+	req.lastPoint = blockPoint
+	req.hasLastPoint = true
+	return nil
+}
+
 // failRequest retires a request that cannot be completed and returns the
 // error so the protocol is torn down, matching the previous behavior of
 // releasing the busy lock before returning a handler error.
@@ -1193,6 +1252,18 @@ func (c *Client) handleBatchDone() error {
 	if err != nil {
 		c.queueMutex.Unlock()
 		return err
+	}
+	if !req.hasLastPoint || !pointsEqual(req.lastPoint, req.end) {
+		c.queueMutex.Unlock()
+		return c.failRequest(
+			req,
+			fmt.Errorf(
+				"%s: batch completed before requested range end: slot=%d hash=%x",
+				ProtocolName,
+				req.end.Slot,
+				req.end.Hash,
+			),
+		)
 	}
 	c.removeLocked(req)
 	c.queueMutex.Unlock()

--- a/protocol/blockfetch/client_pipelined_test.go
+++ b/protocol/blockfetch/client_pipelined_test.go
@@ -715,9 +715,9 @@ func TestRequestRangeNoBlocksResolvesOnlyItsOwnRequest(t *testing.T) {
 	require.NoError(t, second.err)
 }
 
-// TestGetBlockEmptyBatch verifies GetBlock reports a missing block rather than
-// hanging when a peer completes a batch without sending one.
-func TestGetBlockEmptyBatch(t *testing.T) {
+// TestGetBlockRejectsEmptyBatch verifies GetBlock reports a protocol violation
+// rather than accepting StartBatch followed by BatchDone without its block.
+func TestGetBlockRejectsEmptyBatch(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	_, point1 := testBlock(t, 100)
 	conversation := []ouroboros_mock.ConversationEntry{
@@ -741,13 +741,17 @@ func TestGetBlockEmptyBatch(t *testing.T) {
 		blk, err := h.client.GetBlock(point1)
 		results <- result{block: blk, err: err}
 	}()
-	select {
-	case res := <-results:
-		require.Nil(t, res.block)
-		require.ErrorIs(t, res.err, blockfetch.ErrNoBlocks)
-	case err := <-h.connErrs:
-		t.Fatalf("unexpected connection error: %s", err)
-	case <-time.After(testTimeout):
-		t.Fatal("GetBlock did not return for a batch with no blocks")
+	deadline := time.After(testTimeout)
+	for {
+		select {
+		case res := <-results:
+			require.Nil(t, res.block)
+			require.ErrorContains(t, res.err, "before requested range end")
+			return
+		case err := <-h.connErrs:
+			require.ErrorContains(t, err, "before requested range end")
+		case <-deadline:
+			t.Fatal("GetBlock did not return for a batch with no blocks")
+		}
 	}
 }

--- a/protocol/blockfetch/client_queue_internal_test.go
+++ b/protocol/blockfetch/client_queue_internal_test.go
@@ -34,6 +34,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestPointInRange(t *testing.T) {
+	start := pcommon.NewPoint(100, []byte("start"))
+	end := pcommon.NewPoint(200, []byte("end"))
+	tests := []struct {
+		name  string
+		point pcommon.Point
+		want  bool
+	}{
+		{name: "before", point: pcommon.NewPoint(99, []byte("before"))},
+		{name: "inside", point: pcommon.NewPoint(150, []byte("inside")), want: true},
+		{name: "after", point: pcommon.NewPoint(201, []byte("after"))},
+		{name: "start", point: start, want: true},
+		{name: "end", point: end, want: true},
+		{
+			name:  "same slot wrong hash",
+			point: pcommon.NewPoint(100, []byte("other")),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := pointInRange(test.point, start, end); got != test.want {
+				t.Fatalf("pointInRange() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
 // newQueueTestClient builds a client whose protocol was never started. The
 // outstanding-request queue and the in-flight byte accounting do not touch the
 // network, so they can be exercised directly.

--- a/protocol/blockfetch/client_queue_internal_test.go
+++ b/protocol/blockfetch/client_queue_internal_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/connection"
 	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/muxer"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
@@ -57,6 +58,134 @@ func TestPointInRange(t *testing.T) {
 			if got := pointInRange(test.point, start, end); got != test.want {
 				t.Fatalf("pointInRange() = %v, want %v", got, test.want)
 			}
+		})
+	}
+}
+
+func TestBatchDoneRejectsIncompleteRequestedRange(t *testing.T) {
+	var completionErr error
+	c := newQueueTestClient(&Config{
+		RequestPipelining: true,
+		RangeDoneFunc: func(_ CallbackContext, err error) error {
+			completionErr = err
+			return nil
+		},
+	})
+
+	req := c.appendTestRequest(1024)
+	req.start = pcommon.NewPoint(100, []byte("start"))
+	req.end = pcommon.NewPoint(200, []byte("end"))
+
+	require.NoError(t, c.handleStartBatch())
+
+	err := c.handleBatchDone()
+	require.Error(
+		t,
+		err,
+		"BatchDone must reject a batch that never delivered the requested range",
+	)
+	require.Error(
+		t,
+		completionErr,
+		"RangeDoneFunc must not report an incomplete range as successful",
+	)
+}
+
+func queueTestBlock(
+	t *testing.T,
+	slot uint64,
+	prevHash lcommon.Blake2b256,
+) (*MsgBlock, pcommon.Point) {
+	t.Helper()
+	blk := ledger.BabbageBlock{BlockHeader: &ledger.BabbageBlockHeader{}}
+	blk.BlockHeader.Body.BlockNumber = slot
+	blk.BlockHeader.Body.Slot = slot
+	blk.BlockHeader.Body.PrevHash = prevHash
+	blockCbor, err := cbor.Encode(blk)
+	require.NoError(t, err)
+	_, err = cbor.Decode(blockCbor, &blk)
+	require.NoError(t, err)
+	wrapped, err := cbor.Encode(WrappedBlock{
+		Type:     ledger.BlockTypeBabbage,
+		RawBlock: cbor.RawMessage(blockCbor),
+	})
+	require.NoError(t, err)
+	return NewMsgBlock(wrapped), pcommon.NewPoint(slot, blk.Hash().Bytes())
+}
+
+func TestRangeDeliveryValidation(t *testing.T) {
+	firstMsg, firstPoint := queueTestBlock(t, 100, lcommon.Blake2b256{})
+	firstHash := lcommon.Blake2b256(firstPoint.Hash)
+	middleMsg, middlePoint := queueTestBlock(t, 200, firstHash)
+	middleHash := lcommon.Blake2b256(middlePoint.Hash)
+	lastMsg, lastPoint := queueTestBlock(t, 300, middleHash)
+
+	tests := []struct {
+		name      string
+		messages  []*MsgBlock
+		wantError string
+	}{
+		{
+			name:     "complete linked range",
+			messages: []*MsgBlock{firstMsg, middleMsg, lastMsg},
+		},
+		{
+			name:      "missing range end",
+			messages:  []*MsgBlock{firstMsg, middleMsg},
+			wantError: "before requested range end",
+		},
+		{
+			name:      "missing range start",
+			messages:  []*MsgBlock{middleMsg, lastMsg},
+			wantError: "does not match requested range start",
+		},
+		{
+			name:      "duplicate block",
+			messages:  []*MsgBlock{firstMsg, firstMsg},
+			wantError: "duplicate block",
+		},
+		{
+			name:      "missing interior block",
+			messages:  []*MsgBlock{firstMsg, lastMsg},
+			wantError: "does not follow previous range point",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var completionErr error
+			c := newQueueTestClient(&Config{
+				RequestPipelining:   true,
+				SkipBlockValidation: true,
+				BlockFunc: func(CallbackContext, uint, ledger.Block) error {
+					return nil
+				},
+				RangeDoneFunc: func(_ CallbackContext, err error) error {
+					completionErr = err
+					return nil
+				},
+			})
+			req := c.appendTestRequest(1024)
+			req.start = firstPoint
+			req.end = lastPoint
+
+			require.NoError(t, c.handleStartBatch())
+			var gotErr error
+			for _, msg := range test.messages {
+				gotErr = c.handleBlock(msg)
+				if gotErr != nil {
+					break
+				}
+			}
+			if gotErr == nil {
+				gotErr = c.handleBatchDone()
+			}
+			if test.wantError == "" {
+				require.NoError(t, gotErr)
+				require.NoError(t, completionErr)
+				return
+			}
+			require.ErrorContains(t, gotErr, test.wantError)
+			require.ErrorContains(t, completionErr, test.wantError)
 		})
 	}
 }
@@ -188,6 +317,9 @@ func TestQueueExcessBatchDoneIsNotAppliedToNextRequest(t *testing.T) {
 	})
 	first := c.appendTestRequest(1024)
 	second := c.appendTestRequest(1024)
+	first.end = pcommon.NewPoint(100, []byte("first"))
+	first.lastPoint = first.end
+	first.hasLastPoint = true
 
 	require.NoError(t, c.handleStartBatch())
 	require.True(t, first.started)
@@ -236,7 +368,10 @@ func TestQueueRetiredBytesAreReleased(t *testing.T) {
 			return nil
 		},
 	})
-	c.appendTestRequest(4096)
+	req := c.appendTestRequest(4096)
+	req.end = pcommon.NewPoint(100, []byte("block"))
+	req.lastPoint = req.end
+	req.hasLastPoint = true
 	c.queueMutex.Lock()
 	inFlight := c.inFlightBytes
 	c.queueMutex.Unlock()
@@ -570,17 +705,19 @@ func (p *idlePeer) send(t *testing.T, msg protocol.Message) {
 	}
 }
 
-// completeOneEmptyBatch drives a single pipelined request to completion so the
+// completeOneBatch drives a single pipelined request to completion so the
 // client's state machine returns to Idle through MsgBatchDone, which is the
 // state a peer's next MsgBlock can arrive in.
-func (p *idlePeer) completeOneEmptyBatch(t *testing.T, done chan error) {
+func (p *idlePeer) completeOneBatch(t *testing.T, done chan error) {
 	t.Helper()
+	blockMsg, point := queueTestBlock(t, 100, lcommon.Blake2b256{})
 	_, err := p.client.RequestRange(
 		context.Background(),
-		RangeRequest{ExpectedBytes: 1},
+		RangeRequest{Start: point, End: point, ExpectedBytes: 1},
 	)
 	require.NoError(t, err)
 	p.send(t, NewMsgStartBatch())
+	p.send(t, blockMsg)
 	p.send(t, NewMsgBatchDone())
 	select {
 	case err := <-done:
@@ -615,13 +752,17 @@ func bigBlockMsg(t *testing.T) protocol.Message {
 func TestPipelinedIdleLimitAdmitsMainnetSizedBlock(t *testing.T) {
 	done := make(chan error, 4)
 	p := newIdlePeer(t, &Config{
-		RequestPipelining: true,
+		RequestPipelining:   true,
+		SkipBlockValidation: true,
+		BlockFunc: func(CallbackContext, uint, ledger.Block) error {
+			return nil
+		},
 		RangeDoneFunc: func(_ CallbackContext, err error) error {
 			done <- err
 			return nil
 		},
 	})
-	p.completeOneEmptyBatch(t, done)
+	p.completeOneBatch(t, done)
 
 	// The state machine is back in Idle and the block is larger than the
 	// unpipelined Idle limit. It must be admitted rather than rejected as


### PR DESCRIPTION
## Summary

- correlate every streamed block with the requested inclusive point range
- reject an out-of-range block before pipeline or callback delivery
- add before, inside, after, boundary, and same-slot hash coverage

Fixes #2002

## Validation

- `go test -race ./protocol/blockfetch`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates every streamed block against the requested inclusive point range before pipeline or callback delivery. Out-of-range, duplicate, or non-contiguous blocks, and batches that end before the requested range end, now fail the request and tear down the protocol instead of being delivered. Fixes #2002.

<sup>Written for commit 1977ee6ec5f5f4e6f10e4f05b05abb526d5ba911. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

