### PR TITLE
fix(blockfetch): constrain pipelined sends by state

### DIFF
--- a/protocol/blockfetch/blockfetch.go
+++ b/protocol/blockfetch/blockfetch.go
@@ -66,6 +66,7 @@ var StateMap = protocol.StateMap{
 		Agency:                  protocol.AgencyServer,
 		PendingMessageByteLimit: BusyMaxPendingMessageBytes,
 		Timeout:                 BusyTimeout, // Timeout for server to start batch or respond no blocks
+		PipelinedMessageTypes:   []uint8{MessageTypeRequestRange},
 		Transitions: []protocol.StateTransition{
 			{
 				MsgType:  MessageTypeStartBatch,
@@ -81,6 +82,7 @@ var StateMap = protocol.StateMap{
 		Agency:                  protocol.AgencyServer,
 		PendingMessageByteLimit: StreamingMaxPendingMessageBytes,
 		Timeout:                 StreamingTimeout, // Timeout for server to send next block in batch
+		PipelinedMessageTypes:   []uint8{MessageTypeRequestRange},
 		Transitions: []protocol.StateTransition{
 			{
 				MsgType:  MessageTypeBlock,

--- a/protocol/blockfetch/statemap_test.go
+++ b/protocol/blockfetch/statemap_test.go
@@ -1,0 +1,25 @@
+package blockfetch
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateMapPipeliningIsLimitedToRangeRequests(t *testing.T) {
+	for _, state := range []struct {
+		name  string
+		state protocol.State
+	}{
+		{name: "busy", state: StateBusy},
+		{name: "streaming", state: StateStreaming},
+	} {
+		t.Run(state.name, func(t *testing.T) {
+			types := StateMap[state.state].PipelinedMessageTypes
+			require.Equal(t, []uint8{MessageTypeRequestRange}, types)
+		})
+	}
+	require.Empty(t, StateMap[StateIdle].PipelinedMessageTypes)
+	require.Empty(t, StateMap[StateDone].PipelinedMessageTypes)
+}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -526,6 +526,18 @@ waitSendReadyChan:
 					return
 				}
 				tmpOutbound := outbound
+				if !slices.Contains(
+					p.config.StateMap[p.getCurrentState()].PipelinedMessageTypes,
+					outbound.message.Type(),
+				) {
+					p.SendError(fmt.Errorf(
+						"%s: message type %d is not allowed while pipelined in state %s",
+						p.config.Name,
+						outbound.message.Type(),
+						p.getCurrentState(),
+					))
+					return
+				}
 				pipelinedOutbound = &tmpOutbound
 			}
 		} else {

--- a/protocol/state.go
+++ b/protocol/state.go
@@ -74,6 +74,10 @@ type StateMapEntry struct {
 	// keep the remote peer busy across response boundaries. Leaving this
 	// false preserves the strict "send only while holding agency" behavior.
 	AllowPipelinedSend bool
+	// PipelinedMessageTypes limits which messages may use the pipelined send
+	// path while this state is active. An empty list preserves the default of
+	// allowing no pipelined messages.
+	PipelinedMessageTypes []uint8
 }
 
 // StateMap represents the state machine definition for a mini-protocol


### PR DESCRIPTION
## Summary
- declare which BlockFetch messages may use the pipelined send path
- reject queued messages that are not valid for the active pipelined state
- preserve valid Busy and Streaming request-range sequences

## Validation
- go test ./protocol/blockfetch ./protocol -count=1
- git diff --check

Fixes #2024

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2024 by constraining BlockFetch pipelined sends to only `RequestRange` messages in Busy and Streaming states. Previously, the pipelined path accepted any message type when `AllowPipelinedSend` was enabled, which could disrupt state transitions; now invalid pipelined messages are rejected with a send error.

<sup>Written for commit eb022c21ea9c880e2446f24a3b4fbff4a67e82bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

