### PR TITLE
fix(localstatequery): bound client query inputs

### DIFF
--- a/protocol/localstatequery/bounds_test.go
+++ b/protocol/localstatequery/bounds_test.go
@@ -1,8 +1,13 @@
 package localstatequery
 
 import (
+	"net"
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/protocol"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,4 +22,96 @@ func TestValidateLocalStateQuerySetRejectsDuplicateInput(t *testing.T) {
 
 func TestValidateLocalStateQuerySetPreservesDistinctInput(t *testing.T) {
 	require.NoError(t, validateLocalStateQuerySet([]int{1, 2, 3}, "items"))
+}
+
+func TestSetQueryInputsAreBoundedBeforeProtocolUse(t *testing.T) {
+	client := NewClient(protocol.ProtocolOptions{
+		ConnectionId: connection.ConnectionId{
+			LocalAddr:  &net.TCPAddr{},
+			RemoteAddr: &net.TCPAddr{},
+		},
+	}, nil)
+	overflowCredentials := make([]lcommon.Credential, maxLocalStateQuerySetItems+1)
+	overflowDreps := make([]lcommon.Drep, maxLocalStateQuerySetItems+1)
+	overflowPoolIDs := make([]ledger.PoolId, maxLocalStateQuerySetItems+1)
+	overflowStatuses := make([]int, maxLocalStateQuerySetItems+1)
+
+	tests := []struct {
+		name  string
+		query func() error
+	}{
+		{
+			name: "pool distribution v2",
+			query: func() error {
+				_, err := client.GetPoolDistr2(overflowPoolIDs)
+				return err
+			},
+		},
+		{
+			name: "DRep state",
+			query: func() error {
+				_, err := client.GetDRepState(overflowCredentials)
+				return err
+			},
+		},
+		{
+			name: "DRep stake distribution",
+			query: func() error {
+				_, err := client.GetDRepStakeDistr(overflowDreps)
+				return err
+			},
+		},
+		{
+			name: "committee cold credentials",
+			query: func() error {
+				_, err := client.GetCommitteeMembersState(
+					overflowCredentials,
+					nil,
+					nil,
+				)
+				return err
+			},
+		},
+		{
+			name: "committee hot credentials",
+			query: func() error {
+				_, err := client.GetCommitteeMembersState(
+					nil,
+					overflowCredentials,
+					nil,
+				)
+				return err
+			},
+		},
+		{
+			name: "committee statuses",
+			query: func() error {
+				_, err := client.GetCommitteeMembersState(
+					nil,
+					nil,
+					overflowStatuses,
+				)
+				return err
+			},
+		},
+		{
+			name: "filtered vote delegatees",
+			query: func() error {
+				_, err := client.GetFilteredVoteDelegatees(overflowCredentials)
+				return err
+			},
+		},
+		{
+			name: "SPO stake distribution",
+			query: func() error {
+				_, err := client.GetSPOStakeDistr(overflowPoolIDs)
+				return err
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Error(t, test.query())
+		})
+	}
 }

--- a/protocol/localstatequery/bounds_test.go
+++ b/protocol/localstatequery/bounds_test.go
@@ -1,0 +1,20 @@
+package localstatequery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateLocalStateQuerySetRejectsOversizedInput(t *testing.T) {
+	items := make([]int, maxLocalStateQuerySetItems+1)
+	require.Error(t, validateLocalStateQuerySet(items, "items"))
+}
+
+func TestValidateLocalStateQuerySetRejectsDuplicateInput(t *testing.T) {
+	require.Error(t, validateLocalStateQuerySet([]int{1, 2, 1}, "items"))
+}
+
+func TestValidateLocalStateQuerySetPreservesDistinctInput(t *testing.T) {
+	require.NoError(t, validateLocalStateQuerySet([]int{1, 2, 3}, "items"))
+}

--- a/protocol/localstatequery/client.go
+++ b/protocol/localstatequery/client.go
@@ -1084,6 +1084,9 @@ func (c *Client) GetPoolDistr2(
 		)
 	c.busyMutex.Lock()
 	defer c.busyMutex.Unlock()
+	if err := validateLocalStateQuerySet(poolIds, "pool IDs"); err != nil {
+		return nil, err
+	}
 	currentEra, err := c.getCurrentEra()
 	if err != nil {
 		return nil, err
@@ -1220,6 +1223,9 @@ func (c *Client) GetDRepState(
 		)
 	c.busyMutex.Lock()
 	defer c.busyMutex.Unlock()
+	if err := validateLocalStateQuerySet(credentials, "credentials"); err != nil {
+		return nil, err
+	}
 	currentEra, err := c.getCurrentEra()
 	if err != nil {
 		return nil, err
@@ -1276,6 +1282,9 @@ func (c *Client) GetDRepStakeDistr(
 		)
 	c.busyMutex.Lock()
 	defer c.busyMutex.Unlock()
+	if err := validateLocalStateQuerySet(dreps, "DReps"); err != nil {
+		return nil, err
+	}
 	currentEra, err := c.getCurrentEra()
 	if err != nil {
 		return nil, err
@@ -1341,6 +1350,15 @@ func (c *Client) GetCommitteeMembersState(
 		)
 	c.busyMutex.Lock()
 	defer c.busyMutex.Unlock()
+	if err := validateLocalStateQuerySet(coldCreds, "cold credentials"); err != nil {
+		return nil, err
+	}
+	if err := validateLocalStateQuerySet(hotCreds, "hot credentials"); err != nil {
+		return nil, err
+	}
+	if err := validateLocalStateQuerySet(statuses, "statuses"); err != nil {
+		return nil, err
+	}
 	currentEra, err := c.getCurrentEra()
 	if err != nil {
 		return nil, err
@@ -1414,6 +1432,9 @@ func (c *Client) GetFilteredVoteDelegatees(
 		)
 	c.busyMutex.Lock()
 	defer c.busyMutex.Unlock()
+	if err := validateLocalStateQuerySet(credentials, "credentials"); err != nil {
+		return nil, err
+	}
 	currentEra, err := c.getCurrentEra()
 	if err != nil {
 		return nil, err
@@ -1470,6 +1491,9 @@ func (c *Client) GetSPOStakeDistr(
 		)
 	c.busyMutex.Lock()
 	defer c.busyMutex.Unlock()
+	if err := validateLocalStateQuerySet(poolIds, "pool IDs"); err != nil {
+		return nil, err
+	}
 	currentEra, err := c.getCurrentEra()
 	if err != nil {
 		return nil, err

--- a/protocol/localstatequery/client.go
+++ b/protocol/localstatequery/client.go
@@ -26,6 +26,27 @@ import (
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
 
+const maxLocalStateQuerySetItems = 10_000
+
+func validateLocalStateQuerySet[T any](items []T, name string) error {
+	if len(items) > maxLocalStateQuerySetItems {
+		return fmt.Errorf("%s contains %d items; maximum is %d", name, len(items), maxLocalStateQuerySetItems)
+	}
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		encoded, err := cbor.Encode(item)
+		if err != nil {
+			return fmt.Errorf("encode %s item: %w", name, err)
+		}
+		key := string(encoded)
+		if _, exists := seen[key]; exists {
+			return fmt.Errorf("%s contains duplicate item", name)
+		}
+		seen[key] = struct{}{}
+	}
+	return nil
+}
+
 // Client implements the LocalStateQuery client
 type Client struct {
 	*protocol.Protocol
@@ -240,6 +261,9 @@ func (c *Client) GetChainBlockNo() (int64, error) {
 	if err := c.runQuery(query, &result); err != nil {
 		return 0, err
 	}
+	if len(result) < 2 {
+		return 0, errors.New("malformed chain block number result")
+	}
 	return result[1], nil
 }
 
@@ -306,6 +330,9 @@ func (c *Client) GetEpochNo() (int, error) {
 	if err := c.runQuery(query, &result); err != nil {
 		return 0, err
 	}
+	if len(result) == 0 {
+		return 0, errors.New("empty epoch number result")
+	}
 	return result[0], nil
 }
 
@@ -322,6 +349,9 @@ func (c *Client) GetNonMyopicMemberRewards(stakes []any) (*NonMyopicMemberReward
 		)
 	c.busyMutex.Lock()
 	defer c.busyMutex.Unlock()
+	if err := validateLocalStateQuerySet(stakes, "stakes"); err != nil {
+		return nil, err
+	}
 	currentEra, err := c.getCurrentEra()
 	if err != nil {
 		return nil, err
@@ -380,11 +410,17 @@ func (c *Client) GetCurrentProtocolParams() (lcommon.ProtocolParameters, error) 
 		if err := c.runQuery(query, &result); err != nil {
 			return nil, err
 		}
+		if len(result) == 0 {
+			return nil, errors.New("empty result from Conway protocol parameters query")
+		}
 		return &result[0], nil
 	case ledger.EraIdBabbage:
 		result := []ledger.BabbageProtocolParameters{}
 		if err := c.runQuery(query, &result); err != nil {
 			return nil, err
+		}
+		if len(result) == 0 {
+			return nil, errors.New("empty result from Babbage protocol parameters query")
 		}
 		return &result[0], nil
 	case ledger.EraIdAlonzo:
@@ -392,11 +428,17 @@ func (c *Client) GetCurrentProtocolParams() (lcommon.ProtocolParameters, error) 
 		if err := c.runQuery(query, &result); err != nil {
 			return nil, err
 		}
+		if len(result) == 0 {
+			return nil, errors.New("empty result from Alonzo protocol parameters query")
+		}
 		return &result[0], nil
 	case ledger.EraIdMary:
 		result := []ledger.MaryProtocolParameters{}
 		if err := c.runQuery(query, &result); err != nil {
 			return nil, err
+		}
+		if len(result) == 0 {
+			return nil, errors.New("empty result from Mary protocol parameters query")
 		}
 		return &result[0], nil
 	case ledger.EraIdAllegra:
@@ -404,11 +446,17 @@ func (c *Client) GetCurrentProtocolParams() (lcommon.ProtocolParameters, error) 
 		if err := c.runQuery(query, &result); err != nil {
 			return nil, err
 		}
+		if len(result) == 0 {
+			return nil, errors.New("empty result from Allegra protocol parameters query")
+		}
 		return &result[0], nil
 	case ledger.EraIdShelley:
 		result := []ledger.ShelleyProtocolParameters{}
 		if err := c.runQuery(query, &result); err != nil {
 			return nil, err
+		}
+		if len(result) == 0 {
+			return nil, errors.New("empty result from Shelley protocol parameters query")
 		}
 		return &result[0], nil
 	default:
@@ -560,6 +608,9 @@ func (c *Client) GetFilteredDelegationsAndRewardAccounts(
 		)
 	c.busyMutex.Lock()
 	defer c.busyMutex.Unlock()
+	if err := validateLocalStateQuerySet(creds, "credentials"); err != nil {
+		return nil, err
+	}
 	currentEra, err := c.getCurrentEra()
 	if err != nil {
 		return nil, err
@@ -590,6 +641,9 @@ func (c *Client) GetStakeDelegDeposits(
 		)
 	c.busyMutex.Lock()
 	defer c.busyMutex.Unlock()
+	if err := validateLocalStateQuerySet(creds, "credentials"); err != nil {
+		return nil, err
+	}
 	currentEra, err := c.getCurrentEra()
 	if err != nil {
 		return nil, err
@@ -627,6 +681,9 @@ func (c *Client) GetGenesisConfig() (*GenesisConfigResult, error) {
 	result := []GenesisConfigResult{}
 	if err := c.runQuery(query, &result); err != nil {
 		return nil, err
+	}
+	if len(result) == 0 {
+		return nil, errors.New("empty result from genesis config query")
 	}
 	return &result[0], nil
 }
@@ -898,6 +955,9 @@ func (c *Client) GetPoolState(poolIds []any) (*PoolStateResult, error) {
 		)
 	c.busyMutex.Lock()
 	defer c.busyMutex.Unlock()
+	if err := validateLocalStateQuerySet(poolIds, "pool IDs"); err != nil {
+		return nil, err
+	}
 	currentEra, err := c.getCurrentEra()
 	if err != nil {
 		return nil, err
@@ -937,6 +997,9 @@ func (c *Client) GetStakeSnapshots(
 		)
 	c.busyMutex.Lock()
 	defer c.busyMutex.Unlock()
+	if err := validateLocalStateQuerySet(poolIds, "pool IDs"); err != nil {
+		return nil, err
+	}
 	currentEra, err := c.getCurrentEra()
 	if err != nil {
 		return nil, err
@@ -975,6 +1038,9 @@ func (c *Client) GetPoolDistr(poolIds []any) (*PoolDistrResult, error) {
 		)
 	c.busyMutex.Lock()
 	defer c.busyMutex.Unlock()
+	if err := validateLocalStateQuerySet(poolIds, "pool IDs"); err != nil {
+		return nil, err
+	}
 	currentEra, err := c.getCurrentEra()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- reject oversized and duplicate LocalStateQuery set inputs before encoding
- validate indexed response shapes before returning elements
- preserve existing query ordering and semantics

## Validation
- go test ./protocol/localstatequery -count=1
- git diff --check

Fixes #2091

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds `localstatequery` client query inputs so oversized or duplicate sets are rejected before encoding, and validates indexed responses so malformed results error out instead of being returned. Fixes #2091.

- Rejects set inputs over 10,000 items and duplicate items for stakes, credentials, pool IDs, DReps, and committee statuses.
- Returns an error for empty or truncated responses from chain block number, epoch, protocol parameters, genesis config, and related queries.
- Preserves existing query ordering and semantics.
- Adds unit tests for input validation.

<sup>Written for commit d11928ffccd08356f59fb0bd00c656e1a8e45ca3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

