### PR TITLE
fix(ledger): validate certificate deposits and refunds

### DIFF
--- a/ledger/common/state.go
+++ b/ledger/common/state.go
@@ -40,6 +40,14 @@ type CertState interface {
 	IsStakeCredentialRegistered(Credential) bool
 }
 
+// StakeCredentialDepositState is the optional ledger-state capability used by
+// Conway certificate validation to retrieve the deposit held for a registered
+// stake credential. The returned pointer is nil when the credential is not
+// registered.
+type StakeCredentialDepositState interface {
+	StakeCredentialDeposit(Credential) (*uint64, error)
+}
+
 // PoolState defines the interface for querying the current pool state
 type PoolState interface {
 	// PoolCurrentState returns the latest active registration certificate for the given pool key hash.

--- a/ledger/conway/certificate_deposits_test.go
+++ b/ledger/conway/certificate_deposits_test.go
@@ -315,7 +315,7 @@ func TestCertificateRegistrationDepositsProductionPath(t *testing.T) {
 	}
 	for _, credType := range credentialTypes {
 		fixture := newCertificateDepositCredentialFixture(t, credType)
-			t.Run(
+		t.Run(
 			"legacy stake registration/credential-"+string(rune('0'+credType)),
 			func(t *testing.T) {
 				certificateCbor, err := cbor.Encode([]any{

--- a/ledger/conway/certificate_deposits_test.go
+++ b/ledger/conway/certificate_deposits_test.go
@@ -456,7 +456,7 @@ func TestCertificateDeregistrationStateProductionPath(t *testing.T) {
 					withdrawal,
 				)
 			}
-			buildLegacyDeregistration := func() *conway.ConwayTransaction {
+			buildLegacyDeregistration := func(refund uint64) *conway.ConwayTransaction {
 				certificateCbor, err := cbor.Encode([]any{
 					uint64(1),
 					credentialCbor,
@@ -466,7 +466,7 @@ func TestCertificateDeregistrationStateProductionPath(t *testing.T) {
 					t,
 					fixture,
 					[][]byte{certificateCbor},
-					int64(pp.KeyDeposit),
+					int64(refund),
 					0,
 				)
 			}
@@ -497,7 +497,7 @@ func TestCertificateDeregistrationStateProductionPath(t *testing.T) {
 				)
 			})
 			t.Run("legacy recorded refund", func(t *testing.T) {
-				tx := buildLegacyDeregistration()
+				tx := buildLegacyDeregistration(uint64(pp.KeyDeposit))
 				require.NoError(t, runCertificateDepositProductionRules(
 					t,
 					tx,
@@ -505,15 +505,31 @@ func TestCertificateDeregistrationStateProductionPath(t *testing.T) {
 					pp,
 				))
 			})
-			t.Run("legacy incorrect recorded refund", func(t *testing.T) {
-				tx := buildLegacyDeregistration()
+			// A credential may have registered before KeyDeposit changed. Its
+			// legacy deregistration refunds the deposit recorded in ledger
+			// state rather than the current protocol parameter.
+			t.Run("legacy refund follows recorded deposit", func(t *testing.T) {
+				recorded := uint64(pp.KeyDeposit) + 1
+				tx := buildLegacyDeregistration(recorded)
+				require.NoError(t, runCertificateDepositProductionRules(
+					t,
+					tx,
+					buildState(true, 0, recorded),
+					pp,
+				))
+			})
+			t.Run("legacy refund of the parameter is not conserved", func(t *testing.T) {
+				// Balancing against the current parameter while state records a
+				// larger deposit must fail value conservation, which proves the
+				// refund is taken from ledger state.
+				tx := buildLegacyDeregistration(uint64(pp.KeyDeposit))
 				err := runCertificateDepositProductionRules(
 					t,
 					tx,
 					buildState(true, 0, uint64(pp.KeyDeposit)+1),
 					pp,
 				)
-				var target conway.CertificateRefundIncorrectError
+				var target shelley.ValueNotConservedUtxoError
 				require.True(
 					t,
 					errors.As(err, &target),

--- a/ledger/conway/certificate_deposits_test.go
+++ b/ledger/conway/certificate_deposits_test.go
@@ -315,7 +315,7 @@ func TestCertificateRegistrationDepositsProductionPath(t *testing.T) {
 	}
 	for _, credType := range credentialTypes {
 		fixture := newCertificateDepositCredentialFixture(t, credType)
-		t.Run(
+			t.Run(
 			"legacy stake registration/credential-"+string(rune('0'+credType)),
 			func(t *testing.T) {
 				certificateCbor, err := cbor.Encode([]any{
@@ -326,9 +326,15 @@ func TestCertificateRegistrationDepositsProductionPath(t *testing.T) {
 					},
 				})
 				require.NoError(t, err)
+				// Legacy stake-registration certificates do not carry a
+				// credential-auth purpose.  In particular, an explicit native
+				// script witness is extraneous; script credentials become
+				// authorized by the later operation that uses them.
+				legacyFixture := fixture
+				legacyFixture.nativeCbor = nil
 				tx := certificateDepositTransaction(
 					t,
-					fixture,
+					legacyFixture,
 					[][]byte{certificateCbor},
 					-int64(pp.KeyDeposit),
 					0,

--- a/ledger/conway/certificate_deposits_test.go
+++ b/ledger/conway/certificate_deposits_test.go
@@ -1,0 +1,503 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conway_test
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	certificateDepositInputAmount = uint64(2_000_000_000_000)
+	certificateDepositFee         = uint64(200_000)
+	certificateDepositTxId        = "d228b482a1aae768e4a796380f49e021d9c21f70d3c12cb186b188dedfc0ee22"
+)
+
+type certificateDepositCredentialKey struct {
+	credType uint
+	hash     common.Blake2b224
+}
+
+type certificateDepositLedgerState struct {
+	common.LedgerState
+	deposits map[certificateDepositCredentialKey]uint64
+}
+
+func (s certificateDepositLedgerState) StakeCredentialDeposit(
+	cred common.Credential,
+) (*uint64, error) {
+	deposit, found := s.deposits[certificateDepositCredentialKey{
+		credType: cred.CredType,
+		hash:     cred.Credential,
+	}]
+	if !found {
+		return nil, nil
+	}
+	return &deposit, nil
+}
+
+type certificateDepositCredentialFixture struct {
+	credential common.Credential
+	privateKey ed25519.PrivateKey
+	nativeCbor []byte
+}
+
+func newCertificateDepositCredentialFixture(
+	t *testing.T,
+	credType uint,
+) certificateDepositCredentialFixture {
+	t.Helper()
+	switch credType {
+	case common.CredentialTypeAddrKeyHash:
+		privateKey := ed25519.NewKeyFromSeed(make([]byte, ed25519.SeedSize))
+		publicKey := privateKey.Public().(ed25519.PublicKey)
+		return certificateDepositCredentialFixture{
+			credential: common.Credential{
+				CredType:   credType,
+				Credential: common.Blake2b224Hash(publicKey),
+			},
+			privateKey: privateKey,
+		}
+	case common.CredentialTypeScriptHash:
+		nativeCbor, err := cbor.Encode([]any{uint64(1), []any{}})
+		require.NoError(t, err)
+		var nativeScript common.NativeScript
+		_, err = cbor.Decode(nativeCbor, &nativeScript)
+		require.NoError(t, err)
+		return certificateDepositCredentialFixture{
+			credential: common.Credential{
+				CredType:   credType,
+				Credential: common.Blake2b224(nativeScript.Hash()),
+			},
+			nativeCbor: nativeCbor,
+		}
+	default:
+		t.Fatalf("unsupported credential type %d", credType)
+		return certificateDepositCredentialFixture{}
+	}
+}
+
+func certificateDepositPparams() *conway.ConwayProtocolParameters {
+	return &conway.ConwayProtocolParameters{
+		KeyDeposit:   2_000_000,
+		DRepDeposit:  500_000_000,
+		MaxTxSize:    16_384,
+		MaxValueSize: 5_000,
+		ProtocolVersion: common.ProtocolParametersProtocolVersion{
+			Major: common.ProtocolVersionVanRossem,
+		},
+	}
+}
+
+func certificateDepositOutput(t *testing.T, amount uint64) cbor.RawMessage {
+	t.Helper()
+	encoded, err := cbor.Encode([]any{
+		append([]byte{0x61}, make([]byte, 28)...),
+		amount,
+	})
+	require.NoError(t, err)
+	return cbor.RawMessage(encoded)
+}
+
+func certificateDepositTransaction(
+	t *testing.T,
+	fixture certificateDepositCredentialFixture,
+	certificateCbor []byte,
+	certificateValueDelta int64,
+	withdrawalAmount uint64,
+) *conway.ConwayTransaction {
+	t.Helper()
+	inputCbor, err := cbor.Encode(
+		shelley.NewShelleyTransactionInput(certificateDepositTxId, 0),
+	)
+	require.NoError(t, err)
+	outputAmount := int64(certificateDepositInputAmount) +
+		certificateValueDelta + int64(withdrawalAmount) -
+		int64(certificateDepositFee)
+	require.Positive(t, outputAmount)
+	bodyFields := map[int]any{
+		0: cbor.Tag{
+			Number:  258,
+			Content: []cbor.RawMessage{cbor.RawMessage(inputCbor)},
+		},
+		1: []cbor.RawMessage{
+			certificateDepositOutput(t, uint64(outputAmount)),
+		},
+		2: certificateDepositFee,
+		4: []cbor.RawMessage{cbor.RawMessage(certificateCbor)},
+	}
+	if withdrawalAmount > 0 {
+		header := byte(0xe1)
+		if fixture.credential.CredType == common.CredentialTypeScriptHash {
+			header = 0xf1
+		}
+		rewardAddress := append(
+			[]byte{header},
+			fixture.credential.Credential.Bytes()...,
+		)
+		keyCbor, err := cbor.Encode(rewardAddress)
+		require.NoError(t, err)
+		valueCbor, err := cbor.Encode(withdrawalAmount)
+		require.NoError(t, err)
+		withdrawalsCbor := []byte{0xa1}
+		withdrawalsCbor = append(withdrawalsCbor, keyCbor...)
+		withdrawalsCbor = append(withdrawalsCbor, valueCbor...)
+		bodyFields[5] = cbor.RawMessage(withdrawalsCbor)
+	}
+	bodyCbor, err := cbor.Encode(bodyFields)
+	require.NoError(t, err)
+	var body conway.ConwayTransactionBody
+	_, err = cbor.Decode(bodyCbor, &body)
+	require.NoError(t, err)
+
+	probe := &conway.ConwayTransaction{Body: body, TxIsValid: true}
+	witnessFields := map[int]any{}
+	if fixture.privateKey != nil {
+		publicKey := fixture.privateKey.Public().(ed25519.PublicKey)
+		hash := probe.Hash()
+		witnessFields[0] = []any{
+			[]any{[]byte(publicKey), ed25519.Sign(fixture.privateKey, hash[:])},
+		}
+	}
+	if fixture.nativeCbor != nil {
+		witnessFields[1] = []cbor.RawMessage{
+			cbor.RawMessage(fixture.nativeCbor),
+		}
+	}
+	witnessCbor, err := cbor.Encode(witnessFields)
+	require.NoError(t, err)
+	txCbor, err := cbor.Encode([]any{
+		cbor.RawMessage(bodyCbor),
+		cbor.RawMessage(witnessCbor),
+		true,
+		nil,
+	})
+	require.NoError(t, err)
+	var tx conway.ConwayTransaction
+	_, err = cbor.Decode(txCbor, &tx)
+	require.NoError(t, err)
+	return &tx
+}
+
+func runCertificateDepositProductionRules(
+	t *testing.T,
+	tx *conway.ConwayTransaction,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	t.Helper()
+	for _, rule := range conway.UtxoValidationRules {
+		if err := rule(tx, 0, ls, pp); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func certificateDepositBaseState(
+	pool common.PoolKeyHash,
+) *mockledger.MockLedgerState {
+	return mockledger.NewLedgerStateBuilder().
+		WithUtxos([]common.Utxo{{
+			Id: shelley.NewShelleyTransactionInput(
+				certificateDepositTxId,
+				0,
+			),
+			Output: shelley.ShelleyTransactionOutput{
+				OutputAmount: certificateDepositInputAmount,
+			},
+		}}).
+		WithNetworkId(1).
+		WithPoolRegistrations([]common.PoolRegistrationCertificate{{
+			Operator: pool,
+		}}).
+		Build()
+}
+
+func TestCertificateRegistrationDepositsProductionPath(t *testing.T) {
+	pp := certificateDepositPparams()
+	pool := common.PoolKeyHash(common.Blake2b224Hash([]byte("pool")))
+	drepAbstain := []any{uint64(common.DrepTypeAbstain)}
+	credentialTypes := []uint{
+		common.CredentialTypeAddrKeyHash,
+		common.CredentialTypeScriptHash,
+	}
+	type certificateCase struct {
+		name     string
+		expected uint64
+		build    func(common.Credential, int64) []any
+	}
+	cases := []certificateCase{
+		{
+			name:     "stake registration",
+			expected: uint64(pp.KeyDeposit),
+			build: func(cred common.Credential, amount int64) []any {
+				return []any{uint64(7), []any{cred.CredType, cred.Credential.Bytes()}, amount}
+			},
+		},
+		{
+			name:     "stake registration delegation",
+			expected: uint64(pp.KeyDeposit),
+			build: func(cred common.Credential, amount int64) []any {
+				return []any{uint64(11), []any{cred.CredType, cred.Credential.Bytes()}, pool.Bytes(), amount}
+			},
+		},
+		{
+			name:     "vote registration delegation",
+			expected: uint64(pp.KeyDeposit),
+			build: func(cred common.Credential, amount int64) []any {
+				return []any{uint64(12), []any{cred.CredType, cred.Credential.Bytes()}, drepAbstain, amount}
+			},
+		},
+		{
+			name:     "stake vote registration delegation",
+			expected: uint64(pp.KeyDeposit),
+			build: func(cred common.Credential, amount int64) []any {
+				return []any{uint64(13), []any{cred.CredType, cred.Credential.Bytes()}, pool.Bytes(), drepAbstain, amount}
+			},
+		},
+		{
+			name:     "DRep registration",
+			expected: pp.DRepDeposit,
+			build: func(cred common.Credential, amount int64) []any {
+				return []any{uint64(16), []any{cred.CredType, cred.Credential.Bytes()}, amount, nil}
+			},
+		},
+	}
+	for _, credType := range credentialTypes {
+		for _, testCase := range cases {
+			t.Run(testCase.name+"/credential-"+string(rune('0'+credType)), func(t *testing.T) {
+				fixture := newCertificateDepositCredentialFixture(t, credType)
+				for _, valid := range []bool{true, false} {
+					t.Run(map[bool]string{true: "valid", false: "invalid"}[valid], func(t *testing.T) {
+						amount := int64(testCase.expected)
+						if !valid {
+							amount--
+						}
+						certificateCbor, err := cbor.Encode(
+							testCase.build(fixture.credential, amount),
+						)
+						require.NoError(t, err)
+						tx := certificateDepositTransaction(
+							t,
+							fixture,
+							certificateCbor,
+							-amount,
+							0,
+						)
+						ls := certificateDepositLedgerState{
+							LedgerState: certificateDepositBaseState(pool),
+							deposits:    map[certificateDepositCredentialKey]uint64{},
+						}
+						err = runCertificateDepositProductionRules(t, tx, ls, pp)
+						if valid {
+							require.NoError(t, err)
+							return
+						}
+						var target conway.CertificateDepositIncorrectError
+						require.True(t, errors.As(err, &target), "unexpected error: %v", err)
+					})
+				}
+			})
+		}
+	}
+}
+
+func TestCertificateDeregistrationStateProductionPath(t *testing.T) {
+	pp := certificateDepositPparams()
+	pool := common.PoolKeyHash(common.Blake2b224Hash([]byte("pool")))
+	for _, credType := range []uint{
+		common.CredentialTypeAddrKeyHash,
+		common.CredentialTypeScriptHash,
+	} {
+		t.Run("credential-"+string(rune('0'+credType)), func(t *testing.T) {
+			fixture := newCertificateDepositCredentialFixture(t, credType)
+			credentialCbor := []any{
+				fixture.credential.CredType,
+				fixture.credential.Credential.Bytes(),
+			}
+			buildState := func(registered bool, balance, deposit uint64) common.LedgerState {
+				builder := mockledger.NewLedgerStateBuilder().
+					WithUtxos([]common.Utxo{{
+						Id: shelley.NewShelleyTransactionInput(certificateDepositTxId, 0),
+						Output: shelley.ShelleyTransactionOutput{
+							OutputAmount: certificateDepositInputAmount,
+						},
+					}}).
+					WithNetworkId(1).
+					WithPoolRegistrations([]common.PoolRegistrationCertificate{{Operator: pool}})
+				deposits := map[certificateDepositCredentialKey]uint64{}
+				if registered {
+					builder.WithRewardAccountCredentialBalance(fixture.credential, balance)
+					deposits[certificateDepositCredentialKey{
+						credType: fixture.credential.CredType,
+						hash:     fixture.credential.Credential,
+					}] = deposit
+				}
+				return certificateDepositLedgerState{
+					LedgerState: builder.Build(),
+					deposits:    deposits,
+				}
+			}
+			buildDeregistration := func(refund int64, withdrawal uint64) *conway.ConwayTransaction {
+				certificateCbor, err := cbor.Encode([]any{uint64(8), credentialCbor, refund})
+				require.NoError(t, err)
+				return certificateDepositTransaction(t, fixture, certificateCbor, refund, withdrawal)
+			}
+
+			t.Run("valid recorded refund", func(t *testing.T) {
+				tx := buildDeregistration(int64(pp.KeyDeposit), 0)
+				require.NoError(t, runCertificateDepositProductionRules(
+					t,
+					tx,
+					buildState(true, 0, uint64(pp.KeyDeposit)),
+					pp,
+				))
+			})
+			t.Run("incorrect refund", func(t *testing.T) {
+				tx := buildDeregistration(int64(pp.KeyDeposit)+1, 0)
+				err := runCertificateDepositProductionRules(
+					t,
+					tx,
+					buildState(true, 0, uint64(pp.KeyDeposit)),
+					pp,
+				)
+				var target conway.CertificateRefundIncorrectError
+				require.True(t, errors.As(err, &target), "unexpected error: %v", err)
+			})
+			t.Run("unregistered", func(t *testing.T) {
+				tx := buildDeregistration(int64(pp.KeyDeposit), 0)
+				err := runCertificateDepositProductionRules(
+					t,
+					tx,
+					buildState(false, 0, 0),
+					pp,
+				)
+				var target conway.StakeCredentialNotRegisteredError
+				require.True(t, errors.As(err, &target), "unexpected error: %v", err)
+			})
+			t.Run("nonzero reward balance", func(t *testing.T) {
+				tx := buildDeregistration(int64(pp.KeyDeposit), 0)
+				err := runCertificateDepositProductionRules(
+					t,
+					tx,
+					buildState(true, 5_000_000, uint64(pp.KeyDeposit)),
+					pp,
+				)
+				var target conway.StakeCredentialNonZeroRewardBalanceError
+				require.True(t, errors.As(err, &target), "unexpected error: %v", err)
+			})
+			t.Run("withdraw all before deregistration", func(t *testing.T) {
+				const balance = uint64(5_000_000)
+				tx := buildDeregistration(int64(pp.KeyDeposit), balance)
+				withdrawalPparams := *pp
+				withdrawalPparams.ProtocolVersion.Major = common.ProtocolVersionDijkstra
+				require.NoError(t, runCertificateDepositProductionRules(
+					t,
+					tx,
+					buildState(true, balance, uint64(pp.KeyDeposit)),
+					&withdrawalPparams,
+				))
+			})
+		})
+	}
+}
+
+func TestDRepDeregistrationRefundProductionPath(t *testing.T) {
+	pp := certificateDepositPparams()
+	for _, credType := range []uint{
+		common.CredentialTypeAddrKeyHash,
+		common.CredentialTypeScriptHash,
+	} {
+		fixture := newCertificateDepositCredentialFixture(t, credType)
+		credentialCbor := []any{
+			fixture.credential.CredType,
+			fixture.credential.Credential.Bytes(),
+		}
+		for _, refund := range []int64{
+			int64(pp.DRepDeposit),
+			int64(pp.DRepDeposit) + 1,
+		} {
+			certificateCbor, err := cbor.Encode([]any{uint64(17), credentialCbor, refund})
+			require.NoError(t, err)
+			tx := certificateDepositTransaction(t, fixture, certificateCbor, refund, 0)
+			baseState := mockledger.NewLedgerStateBuilder().
+				WithUtxos([]common.Utxo{{
+					Id: shelley.NewShelleyTransactionInput(certificateDepositTxId, 0),
+					Output: shelley.ShelleyTransactionOutput{
+						OutputAmount: certificateDepositInputAmount,
+					},
+				}}).
+				WithNetworkId(1).
+				WithDRepRegistrations([]common.DRepRegistration{{
+					Credential: fixture.credential.Credential,
+					Deposit:    pp.DRepDeposit,
+				}}).
+				Build()
+			ls := certificateDepositLedgerState{
+				LedgerState: baseState,
+				deposits:    map[certificateDepositCredentialKey]uint64{},
+			}
+			err = runCertificateDepositProductionRules(t, tx, ls, pp)
+			if refund == int64(pp.DRepDeposit) {
+				require.NoError(t, err)
+				continue
+			}
+			var target conway.CertificateRefundIncorrectError
+			require.True(t, errors.As(err, &target), "unexpected error: %v", err)
+		}
+		certificateCbor, err := cbor.Encode([]any{
+			uint64(17),
+			credentialCbor,
+			int64(pp.DRepDeposit),
+		})
+		require.NoError(t, err)
+		tx := certificateDepositTransaction(
+			t,
+			fixture,
+			certificateCbor,
+			int64(pp.DRepDeposit),
+			0,
+		)
+		ls := certificateDepositLedgerState{
+			LedgerState: mockledger.NewLedgerStateBuilder().
+				WithUtxos([]common.Utxo{{
+					Id: shelley.NewShelleyTransactionInput(
+						certificateDepositTxId,
+						0,
+					),
+					Output: shelley.ShelleyTransactionOutput{
+						OutputAmount: certificateDepositInputAmount,
+					},
+				}}).
+				WithNetworkId(1).
+				Build(),
+			deposits: map[certificateDepositCredentialKey]uint64{},
+		}
+		err = runCertificateDepositProductionRules(t, tx, ls, pp)
+		var target conway.DRepNotRegisteredError
+		require.True(t, errors.As(err, &target), "unexpected error: %v", err)
+	}
+}
+
+var _ common.StakeCredentialDepositState = certificateDepositLedgerState{}

--- a/ledger/conway/certificate_deposits_test.go
+++ b/ledger/conway/certificate_deposits_test.go
@@ -122,7 +122,7 @@ func certificateDepositOutput(t *testing.T, amount uint64) cbor.RawMessage {
 func certificateDepositTransaction(
 	t *testing.T,
 	fixture certificateDepositCredentialFixture,
-	certificateCbor []byte,
+	certificateCbors [][]byte,
 	certificateValueDelta int64,
 	withdrawalAmount uint64,
 ) *conway.ConwayTransaction {
@@ -135,6 +135,10 @@ func certificateDepositTransaction(
 		certificateValueDelta + int64(withdrawalAmount) -
 		int64(certificateDepositFee)
 	require.Positive(t, outputAmount)
+	certificates := make([]cbor.RawMessage, len(certificateCbors))
+	for idx, certificateCbor := range certificateCbors {
+		certificates[idx] = cbor.RawMessage(certificateCbor)
+	}
 	bodyFields := map[int]any{
 		0: cbor.Tag{
 			Number:  258,
@@ -144,7 +148,7 @@ func certificateDepositTransaction(
 			certificateDepositOutput(t, uint64(outputAmount)),
 		},
 		2: certificateDepositFee,
-		4: []cbor.RawMessage{cbor.RawMessage(certificateCbor)},
+		4: certificates,
 	}
 	if withdrawalAmount > 0 {
 		header := byte(0xe1)
@@ -252,73 +256,144 @@ func TestCertificateRegistrationDepositsProductionPath(t *testing.T) {
 			name:     "stake registration",
 			expected: uint64(pp.KeyDeposit),
 			build: func(cred common.Credential, amount int64) []any {
-				return []any{uint64(7), []any{cred.CredType, cred.Credential.Bytes()}, amount}
+				return []any{
+					uint64(7),
+					[]any{cred.CredType, cred.Credential.Bytes()},
+					amount,
+				}
 			},
 		},
 		{
 			name:     "stake registration delegation",
 			expected: uint64(pp.KeyDeposit),
 			build: func(cred common.Credential, amount int64) []any {
-				return []any{uint64(11), []any{cred.CredType, cred.Credential.Bytes()}, pool.Bytes(), amount}
+				return []any{
+					uint64(11),
+					[]any{cred.CredType, cred.Credential.Bytes()},
+					pool.Bytes(),
+					amount,
+				}
 			},
 		},
 		{
 			name:     "vote registration delegation",
 			expected: uint64(pp.KeyDeposit),
 			build: func(cred common.Credential, amount int64) []any {
-				return []any{uint64(12), []any{cred.CredType, cred.Credential.Bytes()}, drepAbstain, amount}
+				return []any{
+					uint64(12),
+					[]any{cred.CredType, cred.Credential.Bytes()},
+					drepAbstain,
+					amount,
+				}
 			},
 		},
 		{
 			name:     "stake vote registration delegation",
 			expected: uint64(pp.KeyDeposit),
 			build: func(cred common.Credential, amount int64) []any {
-				return []any{uint64(13), []any{cred.CredType, cred.Credential.Bytes()}, pool.Bytes(), drepAbstain, amount}
+				return []any{
+					uint64(13),
+					[]any{cred.CredType, cred.Credential.Bytes()},
+					pool.Bytes(),
+					drepAbstain,
+					amount,
+				}
 			},
 		},
 		{
 			name:     "DRep registration",
 			expected: pp.DRepDeposit,
 			build: func(cred common.Credential, amount int64) []any {
-				return []any{uint64(16), []any{cred.CredType, cred.Credential.Bytes()}, amount, nil}
+				return []any{
+					uint64(16),
+					[]any{cred.CredType, cred.Credential.Bytes()},
+					amount,
+					nil,
+				}
 			},
 		},
 	}
 	for _, credType := range credentialTypes {
-		for _, testCase := range cases {
-			t.Run(testCase.name+"/credential-"+string(rune('0'+credType)), func(t *testing.T) {
-				fixture := newCertificateDepositCredentialFixture(t, credType)
-				for _, valid := range []bool{true, false} {
-					t.Run(map[bool]string{true: "valid", false: "invalid"}[valid], func(t *testing.T) {
-						amount := int64(testCase.expected)
-						if !valid {
-							amount--
-						}
-						certificateCbor, err := cbor.Encode(
-							testCase.build(fixture.credential, amount),
-						)
-						require.NoError(t, err)
-						tx := certificateDepositTransaction(
-							t,
-							fixture,
-							certificateCbor,
-							-amount,
-							0,
-						)
-						ls := certificateDepositLedgerState{
-							LedgerState: certificateDepositBaseState(pool),
-							deposits:    map[certificateDepositCredentialKey]uint64{},
-						}
-						err = runCertificateDepositProductionRules(t, tx, ls, pp)
-						if valid {
-							require.NoError(t, err)
-							return
-						}
-						var target conway.CertificateDepositIncorrectError
-						require.True(t, errors.As(err, &target), "unexpected error: %v", err)
-					})
+		fixture := newCertificateDepositCredentialFixture(t, credType)
+		t.Run(
+			"legacy stake registration/credential-"+string(rune('0'+credType)),
+			func(t *testing.T) {
+				certificateCbor, err := cbor.Encode([]any{
+					uint64(0),
+					[]any{
+						fixture.credential.CredType,
+						fixture.credential.Credential.Bytes(),
+					},
+				})
+				require.NoError(t, err)
+				tx := certificateDepositTransaction(
+					t,
+					fixture,
+					[][]byte{certificateCbor},
+					-int64(pp.KeyDeposit),
+					0,
+				)
+				ls := certificateDepositLedgerState{
+					LedgerState: certificateDepositBaseState(pool),
+					deposits:    map[certificateDepositCredentialKey]uint64{},
 				}
-			})
+				require.NoError(
+					t,
+					runCertificateDepositProductionRules(t, tx, ls, pp),
+				)
+			},
+		)
+		for _, testCase := range cases {
+			t.Run(
+				testCase.name+"/credential-"+string(rune('0'+credType)),
+				func(t *testing.T) {
+					for _, valid := range []bool{true, false} {
+						t.Run(
+							map[bool]string{true: "valid", false: "invalid"}[valid],
+							func(t *testing.T) {
+								amount := int64(testCase.expected)
+								if !valid {
+									amount--
+								}
+								certificateCbor, err := cbor.Encode(
+									testCase.build(fixture.credential, amount),
+								)
+								require.NoError(t, err)
+								tx := certificateDepositTransaction(
+									t,
+									fixture,
+									[][]byte{certificateCbor},
+									-amount,
+									0,
+								)
+								ls := certificateDepositLedgerState{
+									LedgerState: certificateDepositBaseState(
+										pool,
+									),
+									deposits: map[certificateDepositCredentialKey]uint64{},
+								}
+								err = runCertificateDepositProductionRules(
+									t,
+									tx,
+									ls,
+									pp,
+								)
+								if valid {
+									require.NoError(t, err)
+									return
+								}
+								var target conway.CertificateDepositIncorrectError
+								require.True(
+									t,
+									errors.As(err, &target),
+									"unexpected error: %v",
+									err,
+								)
+							},
+						)
+					}
+				},
+			)
 		}
 	}
 }
@@ -348,7 +423,10 @@ func TestCertificateDeregistrationStateProductionPath(t *testing.T) {
 					WithPoolRegistrations([]common.PoolRegistrationCertificate{{Operator: pool}})
 				deposits := map[certificateDepositCredentialKey]uint64{}
 				if registered {
-					builder.WithRewardAccountCredentialBalance(fixture.credential, balance)
+					builder.WithRewardAccountCredentialBalance(
+						fixture.credential,
+						balance,
+					)
 					deposits[certificateDepositCredentialKey{
 						credType: fixture.credential.CredType,
 						hash:     fixture.credential.Credential,
@@ -360,9 +438,31 @@ func TestCertificateDeregistrationStateProductionPath(t *testing.T) {
 				}
 			}
 			buildDeregistration := func(refund int64, withdrawal uint64) *conway.ConwayTransaction {
-				certificateCbor, err := cbor.Encode([]any{uint64(8), credentialCbor, refund})
+				certificateCbor, err := cbor.Encode(
+					[]any{uint64(8), credentialCbor, refund},
+				)
 				require.NoError(t, err)
-				return certificateDepositTransaction(t, fixture, certificateCbor, refund, withdrawal)
+				return certificateDepositTransaction(
+					t,
+					fixture,
+					[][]byte{certificateCbor},
+					refund,
+					withdrawal,
+				)
+			}
+			buildLegacyDeregistration := func() *conway.ConwayTransaction {
+				certificateCbor, err := cbor.Encode([]any{
+					uint64(1),
+					credentialCbor,
+				})
+				require.NoError(t, err)
+				return certificateDepositTransaction(
+					t,
+					fixture,
+					[][]byte{certificateCbor},
+					int64(pp.KeyDeposit),
+					0,
+				)
 			}
 
 			t.Run("valid recorded refund", func(t *testing.T) {
@@ -383,7 +483,37 @@ func TestCertificateDeregistrationStateProductionPath(t *testing.T) {
 					pp,
 				)
 				var target conway.CertificateRefundIncorrectError
-				require.True(t, errors.As(err, &target), "unexpected error: %v", err)
+				require.True(
+					t,
+					errors.As(err, &target),
+					"unexpected error: %v",
+					err,
+				)
+			})
+			t.Run("legacy recorded refund", func(t *testing.T) {
+				tx := buildLegacyDeregistration()
+				require.NoError(t, runCertificateDepositProductionRules(
+					t,
+					tx,
+					buildState(true, 0, uint64(pp.KeyDeposit)),
+					pp,
+				))
+			})
+			t.Run("legacy incorrect recorded refund", func(t *testing.T) {
+				tx := buildLegacyDeregistration()
+				err := runCertificateDepositProductionRules(
+					t,
+					tx,
+					buildState(true, 0, uint64(pp.KeyDeposit)+1),
+					pp,
+				)
+				var target conway.CertificateRefundIncorrectError
+				require.True(
+					t,
+					errors.As(err, &target),
+					"unexpected error: %v",
+					err,
+				)
 			})
 			t.Run("unregistered", func(t *testing.T) {
 				tx := buildDeregistration(int64(pp.KeyDeposit), 0)
@@ -394,7 +524,12 @@ func TestCertificateDeregistrationStateProductionPath(t *testing.T) {
 					pp,
 				)
 				var target conway.StakeCredentialNotRegisteredError
-				require.True(t, errors.As(err, &target), "unexpected error: %v", err)
+				require.True(
+					t,
+					errors.As(err, &target),
+					"unexpected error: %v",
+					err,
+				)
 			})
 			t.Run("nonzero reward balance", func(t *testing.T) {
 				tx := buildDeregistration(int64(pp.KeyDeposit), 0)
@@ -405,7 +540,12 @@ func TestCertificateDeregistrationStateProductionPath(t *testing.T) {
 					pp,
 				)
 				var target conway.StakeCredentialNonZeroRewardBalanceError
-				require.True(t, errors.As(err, &target), "unexpected error: %v", err)
+				require.True(
+					t,
+					errors.As(err, &target),
+					"unexpected error: %v",
+					err,
+				)
 			})
 			t.Run("withdraw all before deregistration", func(t *testing.T) {
 				const balance = uint64(5_000_000)
@@ -438,12 +578,23 @@ func TestDRepDeregistrationRefundProductionPath(t *testing.T) {
 			int64(pp.DRepDeposit),
 			int64(pp.DRepDeposit) + 1,
 		} {
-			certificateCbor, err := cbor.Encode([]any{uint64(17), credentialCbor, refund})
+			certificateCbor, err := cbor.Encode(
+				[]any{uint64(17), credentialCbor, refund},
+			)
 			require.NoError(t, err)
-			tx := certificateDepositTransaction(t, fixture, certificateCbor, refund, 0)
+			tx := certificateDepositTransaction(
+				t,
+				fixture,
+				[][]byte{certificateCbor},
+				refund,
+				0,
+			)
 			baseState := mockledger.NewLedgerStateBuilder().
 				WithUtxos([]common.Utxo{{
-					Id: shelley.NewShelleyTransactionInput(certificateDepositTxId, 0),
+					Id: shelley.NewShelleyTransactionInput(
+						certificateDepositTxId,
+						0,
+					),
 					Output: shelley.ShelleyTransactionOutput{
 						OutputAmount: certificateDepositInputAmount,
 					},
@@ -464,7 +615,12 @@ func TestDRepDeregistrationRefundProductionPath(t *testing.T) {
 				continue
 			}
 			var target conway.CertificateRefundIncorrectError
-			require.True(t, errors.As(err, &target), "unexpected error: %v", err)
+			require.True(
+				t,
+				errors.As(err, &target),
+				"unexpected error: %v",
+				err,
+			)
 		}
 		certificateCbor, err := cbor.Encode([]any{
 			uint64(17),
@@ -475,7 +631,7 @@ func TestDRepDeregistrationRefundProductionPath(t *testing.T) {
 		tx := certificateDepositTransaction(
 			t,
 			fixture,
-			certificateCbor,
+			[][]byte{certificateCbor},
 			int64(pp.DRepDeposit),
 			0,
 		)
@@ -497,6 +653,45 @@ func TestDRepDeregistrationRefundProductionPath(t *testing.T) {
 		err = runCertificateDepositProductionRules(t, tx, ls, pp)
 		var target conway.DRepNotRegisteredError
 		require.True(t, errors.As(err, &target), "unexpected error: %v", err)
+	}
+}
+
+func TestCertificateDepositStateFoldProductionPath(t *testing.T) {
+	pp := certificateDepositPparams()
+	pool := common.PoolKeyHash(common.Blake2b224Hash([]byte("pool")))
+	for _, credType := range []uint{
+		common.CredentialTypeAddrKeyHash,
+		common.CredentialTypeScriptHash,
+	} {
+		fixture := newCertificateDepositCredentialFixture(t, credType)
+		credentialCbor := []any{
+			fixture.credential.CredType,
+			fixture.credential.Credential.Bytes(),
+		}
+		registrationCbor, err := cbor.Encode([]any{
+			uint64(7),
+			credentialCbor,
+			int64(pp.KeyDeposit),
+		})
+		require.NoError(t, err)
+		deregistrationCbor, err := cbor.Encode([]any{
+			uint64(8),
+			credentialCbor,
+			int64(pp.KeyDeposit),
+		})
+		require.NoError(t, err)
+		tx := certificateDepositTransaction(
+			t,
+			fixture,
+			[][]byte{registrationCbor, deregistrationCbor},
+			0,
+			0,
+		)
+		ls := certificateDepositLedgerState{
+			LedgerState: certificateDepositBaseState(pool),
+			deposits:    map[certificateDepositCredentialKey]uint64{},
+		}
+		require.NoError(t, runCertificateDepositProductionRules(t, tx, ls, pp))
 	}
 }
 

--- a/ledger/conway/errors.go
+++ b/ledger/conway/errors.go
@@ -376,13 +376,13 @@ func (e CertificateDepositIncorrectError) Error() string {
 // does not refund the deposit recorded for the credential.
 type CertificateRefundIncorrectError struct {
 	CertificateType common.CertificateType
-	Supplied        any
+	Supplied        int64
 	Expected        uint64
 }
 
 func (e CertificateRefundIncorrectError) Error() string {
 	return fmt.Sprintf(
-		"incorrect refund for certificate type %d: supplied %v, expected %d",
+		"incorrect refund for certificate type %d: supplied %d, expected %d",
 		e.CertificateType,
 		e.Supplied,
 		e.Expected,

--- a/ledger/conway/errors.go
+++ b/ledger/conway/errors.go
@@ -355,6 +355,102 @@ func (DRepDelegationStateUnavailableError) Error() string {
 	return "ledger state does not support DRep delegation lookups"
 }
 
+// CertificateDepositIncorrectError indicates that a registration certificate
+// does not carry the active protocol-parameter deposit.
+type CertificateDepositIncorrectError struct {
+	CertificateType common.CertificateType
+	Supplied        int64
+	Expected        uint64
+}
+
+func (e CertificateDepositIncorrectError) Error() string {
+	return fmt.Sprintf(
+		"incorrect deposit for certificate type %d: supplied %d, expected %d",
+		e.CertificateType,
+		e.Supplied,
+		e.Expected,
+	)
+}
+
+// CertificateRefundIncorrectError indicates that a deregistration certificate
+// does not refund the deposit recorded for the credential.
+type CertificateRefundIncorrectError struct {
+	CertificateType common.CertificateType
+	Supplied        int64
+	Expected        uint64
+}
+
+func (e CertificateRefundIncorrectError) Error() string {
+	return fmt.Sprintf(
+		"incorrect refund for certificate type %d: supplied %d, expected %d",
+		e.CertificateType,
+		e.Supplied,
+		e.Expected,
+	)
+}
+
+// CertificateDepositStateUnavailableError indicates that ledger state cannot
+// provide the held stake-credential deposits needed for refund validation.
+type CertificateDepositStateUnavailableError struct{}
+
+func (CertificateDepositStateUnavailableError) Error() string {
+	return "ledger state does not support stake credential deposit lookups"
+}
+
+// CertificateDepositStateInconsistentError indicates that a registered stake
+// credential has no corresponding deposit or reward-account state.
+type CertificateDepositStateInconsistentError struct {
+	Credential common.Credential
+}
+
+func (e CertificateDepositStateInconsistentError) Error() string {
+	return fmt.Sprintf(
+		"registered stake credential has incomplete deposit state: %x",
+		e.Credential.Credential[:],
+	)
+}
+
+// StakeCredentialNotRegisteredError indicates a deregistration certificate
+// for a credential absent from the left-folded certificate state.
+type StakeCredentialNotRegisteredError struct {
+	Credential common.Credential
+}
+
+func (e StakeCredentialNotRegisteredError) Error() string {
+	return fmt.Sprintf(
+		"stake credential is not registered: %x",
+		e.Credential.Credential[:],
+	)
+}
+
+// StakeCredentialNonZeroRewardBalanceError indicates a deregistration whose
+// post-withdrawal reward balance is not zero.
+type StakeCredentialNonZeroRewardBalanceError struct {
+	Credential common.Credential
+	Balance    uint64
+}
+
+func (e StakeCredentialNonZeroRewardBalanceError) Error() string {
+	return fmt.Sprintf(
+		"stake credential has nonzero reward balance: %x (%d)",
+		e.Credential.Credential[:],
+		e.Balance,
+	)
+}
+
+// DRepNotRegisteredError indicates a DRep deregistration certificate for a
+// credential absent from the left-folded DRep state.
+type DRepNotRegisteredError struct {
+	Credential common.Credential
+}
+
+func (e DRepNotRegisteredError) Error() string {
+	return fmt.Sprintf(
+		"DRep is not registered: %x",
+		e.Credential.Credential[:],
+	)
+}
+
 // StakeCredentialAlreadyRegisteredError indicates attempting to register an already registered stake credential
 type StakeCredentialAlreadyRegisteredError struct {
 	Credential common.Credential

--- a/ledger/conway/errors.go
+++ b/ledger/conway/errors.go
@@ -376,13 +376,13 @@ func (e CertificateDepositIncorrectError) Error() string {
 // does not refund the deposit recorded for the credential.
 type CertificateRefundIncorrectError struct {
 	CertificateType common.CertificateType
-	Supplied        int64
+	Supplied        any
 	Expected        uint64
 }
 
 func (e CertificateRefundIncorrectError) Error() string {
 	return fmt.Sprintf(
-		"incorrect refund for certificate type %d: supplied %d, expected %d",
+		"incorrect refund for certificate type %d: supplied %v, expected %d",
 		e.CertificateType,
 		e.Supplied,
 		e.Expected,

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -1880,29 +1880,26 @@ func UtxoValidateValueNotConservedUtxo(
 		case *common.StakeDeregistrationCertificate:
 			// A legacy deregistration refunds the deposit recorded when the
 			// credential registered, which may predate a KeyDeposit change.
-			// UtxoValidateCertificateDeposits requires the same capability for
-			// the same certificate, so falling back to the current parameter
-			// here would leave the two rules disagreeing about what a state
-			// without it may do. Both fail closed.
-			depositState, ok := ls.(common.StakeCredentialDepositState)
-			if !ok {
-				return CertificateDepositStateUnavailableError{}
-			}
-			deposit, err := depositState.StakeCredentialDeposit(
-				tmpCert.StakeCredential,
-			)
-			if err != nil {
-				return err
-			}
-			if deposit == nil {
-				return CertificateDepositStateInconsistentError{
-					Credential: tmpCert.StakeCredential,
+			//
+			// The current parameter remains the fallback for a state that
+			// cannot report the recorded deposit. Failing closed here instead
+			// rejects six Amaru conformance vectors, because value
+			// conservation runs for every legacy deregistration while
+			// UtxoValidateCertificateDeposits only needs the capability once a
+			// credential resolves as registered.
+			refund := new(big.Int).SetUint64(uint64(tmpPparams.KeyDeposit))
+			if depositState, ok := ls.(common.StakeCredentialDepositState); ok {
+				deposit, err := depositState.StakeCredentialDeposit(
+					tmpCert.StakeCredential,
+				)
+				if err != nil {
+					return err
+				}
+				if deposit != nil {
+					refund = new(big.Int).SetUint64(*deposit)
 				}
 			}
-			consumedValue.Add(
-				consumedValue,
-				new(big.Int).SetUint64(*deposit),
-			)
+			consumedValue.Add(consumedValue, refund)
 			// Note: PoolRetirementCertificate does NOT refund the deposit as part of the transaction.
 			// Pool deposits are refunded at epoch boundary after the retirement epoch has passed.
 		}

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -3469,7 +3469,7 @@ func UtxoValidateCertificateDeposits(
 		if supplied == nil && state.deposit != keyDeposit {
 			return CertificateRefundIncorrectError{
 				CertificateType: certificateType,
-				Supplied:        int64(keyDeposit),
+				Supplied:        keyDeposit,
 				Expected:        state.deposit,
 			}
 		}

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -1878,8 +1878,24 @@ func UtxoValidateValueNotConservedUtxo(
 			}
 			consumedValue.Add(consumedValue, big.NewInt(tmpCert.Amount))
 		case *common.StakeDeregistrationCertificate:
-			// Traditional stake deregistration uses protocol KeyDeposit parameter
-			consumedValue.Add(consumedValue, new(big.Int).SetUint64(uint64(tmpPparams.KeyDeposit)))
+			// A legacy deregistration refunds the deposit recorded when the
+			// credential registered, which may predate a KeyDeposit change.
+			// The current parameter is only a fallback for a ledger state that
+			// cannot report the recorded deposit, and such a state is already
+			// rejected by UtxoValidateCertificateDeposits.
+			refund := new(big.Int).SetUint64(uint64(tmpPparams.KeyDeposit))
+			if depositState, ok := ls.(common.StakeCredentialDepositState); ok {
+				deposit, err := depositState.StakeCredentialDeposit(
+					tmpCert.StakeCredential,
+				)
+				if err != nil {
+					return err
+				}
+				if deposit != nil {
+					refund = new(big.Int).SetUint64(*deposit)
+				}
+			}
+			consumedValue.Add(consumedValue, refund)
 			// Note: PoolRetirementCertificate does NOT refund the deposit as part of the transaction.
 			// Pool deposits are refunded at epoch boundary after the retirement epoch has passed.
 		}
@@ -3463,13 +3479,6 @@ func UtxoValidateCertificateDeposits(
 			return CertificateRefundIncorrectError{
 				CertificateType: certificateType,
 				Supplied:        *supplied,
-				Expected:        state.deposit,
-			}
-		}
-		if supplied == nil && state.deposit != keyDeposit {
-			return CertificateRefundIncorrectError{
-				CertificateType: certificateType,
-				Supplied:        keyDeposit,
 				Expected:        state.deposit,
 			}
 		}

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -85,6 +85,7 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateNativeScripts,
 	UtxoValidateDelegation,
 	UtxoValidateWithdrawals,
+	UtxoValidateCertificateDeposits,
 	UtxoValidateCommitteeCertificates,
 	UtxoValidateUnknownVoters,
 	UtxoValidateUnknownGovActionIds,
@@ -3291,6 +3292,315 @@ func UtxoValidateWithdrawals(
 			return WithdrawalNotDelegatedToDRepError{
 				RewardAddress: *addr,
 			}
+		}
+	}
+	return nil
+}
+
+type certificateStakeCredentialKey struct {
+	credType uint
+	hash     common.Blake2b224
+}
+
+type certificateStakeState struct {
+	registered bool
+	deposit    uint64
+	balance    uint64
+}
+
+// UtxoValidateCertificateDeposits validates Conway certificate deposits and
+// refunds against the protocol parameters and the certificate state produced
+// by the certificates that precede them in the transaction. Withdrawals are
+// applied to the temporary reward-account state before certificates, matching
+// the Conway LEDGER/CERTS transition ordering.
+func UtxoValidateCertificateDeposits(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	if !tx.IsValid() {
+		return nil
+	}
+	depositPparams, ok := pp.(interface {
+		KeyDepositAmount() *big.Int
+		DRepDepositAmount() *big.Int
+	})
+	if !ok {
+		return errors.New("pparams do not expose Conway certificate deposits")
+	}
+	keyDepositAmount := depositPparams.KeyDepositAmount()
+	if keyDepositAmount == nil || !keyDepositAmount.IsUint64() {
+		return errors.New("key deposit does not fit uint64")
+	}
+	keyDeposit := keyDepositAmount.Uint64()
+	drepDepositAmount := depositPparams.DRepDepositAmount()
+	if drepDepositAmount == nil || !drepDepositAmount.IsUint64() {
+		return errors.New("DRep deposit does not fit uint64")
+	}
+	drepDeposit := drepDepositAmount.Uint64()
+	stakeStates := make(map[certificateStakeCredentialKey]certificateStakeState)
+	stakeKey := func(cred common.Credential) certificateStakeCredentialKey {
+		return certificateStakeCredentialKey{
+			credType: cred.CredType,
+			hash:     cred.Credential,
+		}
+	}
+	loadStakeState := func(cred common.Credential) (certificateStakeState, error) {
+		key := stakeKey(cred)
+		if state, found := stakeStates[key]; found {
+			return state, nil
+		}
+		state := certificateStakeState{
+			registered: ls.IsStakeCredentialRegistered(cred),
+		}
+		if state.registered {
+			depositState, ok := ls.(common.StakeCredentialDepositState)
+			if !ok {
+				return state, CertificateDepositStateUnavailableError{}
+			}
+			deposit, err := depositState.StakeCredentialDeposit(cred)
+			if err != nil {
+				return state, err
+			}
+			if deposit == nil {
+				return state, CertificateDepositStateInconsistentError{
+					Credential: cred,
+				}
+			}
+			state.deposit = *deposit
+			balance, err := ls.RewardAccountBalance(cred)
+			if err != nil {
+				return state, err
+			}
+			if balance == nil {
+				return state, CertificateDepositStateInconsistentError{
+					Credential: cred,
+				}
+			}
+			state.balance = *balance
+		}
+		stakeStates[key] = state
+		return state, nil
+	}
+	storeStakeState := func(cred common.Credential, state certificateStakeState) {
+		stakeStates[stakeKey(cred)] = state
+	}
+
+	deregisteredStakeCredentials := make(
+		map[certificateStakeCredentialKey]struct{},
+	)
+	for _, cert := range tx.Certificates() {
+		switch c := cert.(type) {
+		case *common.StakeDeregistrationCertificate:
+			deregisteredStakeCredentials[stakeKey(c.StakeCredential)] = struct{}{}
+		case *common.DeregistrationCertificate:
+			deregisteredStakeCredentials[stakeKey(c.StakeCredential)] = struct{}{}
+		}
+	}
+
+	// The reference drains withdrawals before running CERTS. Withdrawal
+	// validation runs immediately before this rule, so only valid withdrawal
+	// amounts reach this transition.
+	for addr, amount := range tx.Withdrawals() {
+		cred, found := addr.StakeCredential()
+		if !found || amount == nil || !amount.IsUint64() {
+			continue
+		}
+		if _, found := deregisteredStakeCredentials[stakeKey(cred)]; !found {
+			continue
+		}
+		state, err := loadStakeState(cred)
+		if err != nil {
+			return err
+		}
+		withdrawal := amount.Uint64()
+		if withdrawal <= state.balance {
+			state.balance -= withdrawal
+			storeStakeState(cred, state)
+		}
+	}
+
+	registerStake := func(
+		cred common.Credential,
+		certificateType common.CertificateType,
+		supplied int64,
+	) error {
+		if supplied < 0 || uint64(supplied) != keyDeposit {
+			return CertificateDepositIncorrectError{
+				CertificateType: certificateType,
+				Supplied:        supplied,
+				Expected:        keyDeposit,
+			}
+		}
+		key := stakeKey(cred)
+		state, found := stakeStates[key]
+		if !found {
+			state.registered = ls.IsStakeCredentialRegistered(cred)
+		}
+		if state.registered {
+			return StakeCredentialAlreadyRegisteredError{Credential: cred}
+		}
+		state.registered = true
+		state.deposit = keyDeposit
+		state.balance = 0
+		storeStakeState(cred, state)
+		return nil
+	}
+	deregisterStake := func(
+		cred common.Credential,
+		certificateType common.CertificateType,
+		supplied *int64,
+	) error {
+		state, err := loadStakeState(cred)
+		if err != nil {
+			return err
+		}
+		if !state.registered {
+			return StakeCredentialNotRegisteredError{Credential: cred}
+		}
+		if supplied != nil && (*supplied < 0 || uint64(*supplied) != state.deposit) {
+			return CertificateRefundIncorrectError{
+				CertificateType: certificateType,
+				Supplied:        *supplied,
+				Expected:        state.deposit,
+			}
+		}
+		if supplied == nil && state.deposit != keyDeposit {
+			return CertificateRefundIncorrectError{
+				CertificateType: certificateType,
+				Supplied:        int64(keyDeposit),
+				Expected:        state.deposit,
+			}
+		}
+		if state.balance != 0 {
+			return StakeCredentialNonZeroRewardBalanceError{
+				Credential: cred,
+				Balance:    state.balance,
+			}
+		}
+		state.registered = false
+		state.deposit = 0
+		storeStakeState(cred, state)
+		return nil
+	}
+
+	drepStates := make(
+		map[certificateStakeCredentialKey]*common.DRepRegistration,
+	)
+	loadDRep := func(cred common.Credential) (*common.DRepRegistration, error) {
+		key := stakeKey(cred)
+		if state, found := drepStates[key]; found {
+			return state, nil
+		}
+		state, err := ls.DRepRegistration(cred.Credential)
+		if err != nil {
+			return nil, err
+		}
+		drepStates[key] = state
+		return state, nil
+	}
+
+	for _, cert := range tx.Certificates() {
+		switch c := cert.(type) {
+		case *common.StakeRegistrationCertificate:
+			key := stakeKey(c.StakeCredential)
+			state, found := stakeStates[key]
+			if !found {
+				state.registered = ls.IsStakeCredentialRegistered(c.StakeCredential)
+			}
+			if state.registered {
+				return StakeCredentialAlreadyRegisteredError{
+					Credential: c.StakeCredential,
+				}
+			}
+			state.registered = true
+			state.deposit = keyDeposit
+			state.balance = 0
+			storeStakeState(c.StakeCredential, state)
+		case *common.RegistrationCertificate:
+			if err := registerStake(
+				c.StakeCredential,
+				common.CertificateType(c.CertType),
+				c.Amount,
+			); err != nil {
+				return err
+			}
+		case *common.StakeRegistrationDelegationCertificate:
+			if err := registerStake(
+				c.StakeCredential,
+				common.CertificateType(c.CertType),
+				c.Amount,
+			); err != nil {
+				return err
+			}
+		case *common.VoteRegistrationDelegationCertificate:
+			if err := registerStake(
+				c.StakeCredential,
+				common.CertificateType(c.CertType),
+				c.Amount,
+			); err != nil {
+				return err
+			}
+		case *common.StakeVoteRegistrationDelegationCertificate:
+			if err := registerStake(
+				c.StakeCredential,
+				common.CertificateType(c.CertType),
+				c.Amount,
+			); err != nil {
+				return err
+			}
+		case *common.StakeDeregistrationCertificate:
+			if err := deregisterStake(
+				c.StakeCredential,
+				common.CertificateType(c.CertType),
+				nil,
+			); err != nil {
+				return err
+			}
+		case *common.DeregistrationCertificate:
+			if err := deregisterStake(
+				c.StakeCredential,
+				common.CertificateType(c.CertType),
+				&c.Amount,
+			); err != nil {
+				return err
+			}
+		case *common.RegistrationDrepCertificate:
+			if c.Amount < 0 || uint64(c.Amount) != drepDeposit {
+				return CertificateDepositIncorrectError{
+					CertificateType: common.CertificateType(c.CertType),
+					Supplied:        c.Amount,
+					Expected:        drepDeposit,
+				}
+			}
+			registration, err := loadDRep(c.DrepCredential)
+			if err != nil {
+				return err
+			}
+			if registration != nil {
+				return DRepAlreadyRegisteredError{Credential: c.DrepCredential}
+			}
+			drepStates[stakeKey(c.DrepCredential)] = &common.DRepRegistration{
+				Credential: c.DrepCredential.Credential,
+				Deposit:    drepDeposit,
+			}
+		case *common.DeregistrationDrepCertificate:
+			registration, err := loadDRep(c.DrepCredential)
+			if err != nil {
+				return err
+			}
+			if registration == nil {
+				return DRepNotRegisteredError{Credential: c.DrepCredential}
+			}
+			if c.Amount < 0 || uint64(c.Amount) != registration.Deposit {
+				return CertificateRefundIncorrectError{
+					CertificateType: common.CertificateType(c.CertType),
+					Supplied:        c.Amount,
+					Expected:        registration.Deposit,
+				}
+			}
+			drepStates[stakeKey(c.DrepCredential)] = nil
 		}
 	}
 	return nil

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -1880,22 +1880,29 @@ func UtxoValidateValueNotConservedUtxo(
 		case *common.StakeDeregistrationCertificate:
 			// A legacy deregistration refunds the deposit recorded when the
 			// credential registered, which may predate a KeyDeposit change.
-			// The current parameter is only a fallback for a ledger state that
-			// cannot report the recorded deposit, and such a state is already
-			// rejected by UtxoValidateCertificateDeposits.
-			refund := new(big.Int).SetUint64(uint64(tmpPparams.KeyDeposit))
-			if depositState, ok := ls.(common.StakeCredentialDepositState); ok {
-				deposit, err := depositState.StakeCredentialDeposit(
-					tmpCert.StakeCredential,
-				)
-				if err != nil {
-					return err
-				}
-				if deposit != nil {
-					refund = new(big.Int).SetUint64(*deposit)
+			// UtxoValidateCertificateDeposits requires the same capability for
+			// the same certificate, so falling back to the current parameter
+			// here would leave the two rules disagreeing about what a state
+			// without it may do. Both fail closed.
+			depositState, ok := ls.(common.StakeCredentialDepositState)
+			if !ok {
+				return CertificateDepositStateUnavailableError{}
+			}
+			deposit, err := depositState.StakeCredentialDeposit(
+				tmpCert.StakeCredential,
+			)
+			if err != nil {
+				return err
+			}
+			if deposit == nil {
+				return CertificateDepositStateInconsistentError{
+					Credential: tmpCert.StakeCredential,
 				}
 			}
-			consumedValue.Add(consumedValue, refund)
+			consumedValue.Add(
+				consumedValue,
+				new(big.Int).SetUint64(*deposit),
+			)
 			// Note: PoolRetirementCertificate does NOT refund the deposit as part of the transaction.
 			// Pool deposits are refunded at epoch boundary after the retirement epoch has passed.
 		}
@@ -3437,18 +3444,10 @@ func UtxoValidateCertificateDeposits(
 		}
 	}
 
-	registerStake := func(
-		cred common.Credential,
-		certificateType common.CertificateType,
-		supplied int64,
-	) error {
-		if supplied < 0 || uint64(supplied) != keyDeposit {
-			return CertificateDepositIncorrectError{
-				CertificateType: certificateType,
-				Supplied:        supplied,
-				Expected:        keyDeposit,
-			}
-		}
+	// markStakeRegistered holds the registration transition itself. Legacy
+	// type-0 registration supplies no deposit to check, so it shares this
+	// rather than repeating the already-registered check and the state write.
+	markStakeRegistered := func(cred common.Credential) error {
 		key := stakeKey(cred)
 		state, found := stakeStates[key]
 		if !found {
@@ -3462,6 +3461,20 @@ func UtxoValidateCertificateDeposits(
 		state.balance = 0
 		storeStakeState(cred, state)
 		return nil
+	}
+	registerStake := func(
+		cred common.Credential,
+		certificateType common.CertificateType,
+		supplied int64,
+	) error {
+		if supplied < 0 || uint64(supplied) != keyDeposit {
+			return CertificateDepositIncorrectError{
+				CertificateType: certificateType,
+				Supplied:        supplied,
+				Expected:        keyDeposit,
+			}
+		}
+		return markStakeRegistered(cred)
 	}
 	deregisterStake := func(
 		cred common.Credential,
@@ -3513,20 +3526,9 @@ func UtxoValidateCertificateDeposits(
 	for _, cert := range tx.Certificates() {
 		switch c := cert.(type) {
 		case *common.StakeRegistrationCertificate:
-			key := stakeKey(c.StakeCredential)
-			state, found := stakeStates[key]
-			if !found {
-				state.registered = ls.IsStakeCredentialRegistered(c.StakeCredential)
+			if err := markStakeRegistered(c.StakeCredential); err != nil {
+				return err
 			}
-			if state.registered {
-				return StakeCredentialAlreadyRegisteredError{
-					Credential: c.StakeCredential,
-				}
-			}
-			state.registered = true
-			state.deposit = keyDeposit
-			state.balance = 0
-			storeStakeState(c.StakeCredential, state)
 		case *common.RegistrationCertificate:
 			if err := registerStake(
 				c.StakeCredential,

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -1393,7 +1393,19 @@ func TestUtxoValidateValueNotConservedUtxo(t *testing.T) {
 			},
 		},
 	}
-	testLedgerState := mockledger.NewLedgerStateBuilder().WithUtxos(utxos).Build()
+	// UtxoValidateValueNotConservedUtxo reads a legacy deregistration's refund
+	// from ledger state, so the state must report the recorded deposit.
+	testLedgerState := certificateDepositLedgerState{
+		LedgerState: mockledger.NewLedgerStateBuilder().
+			WithUtxos(utxos).
+			Build(),
+		deposits: map[certificateDepositCredentialKey]uint64{
+			{
+				credType: common.CredentialTypeAddrKeyHash,
+				hash:     common.Blake2b224{},
+			}: testStakeDeposit,
+		},
+	}
 	testSlot := uint64(0)
 	testProtocolParams := &conway.ConwayProtocolParameters{
 		KeyDeposit: uint(testStakeDeposit),

--- a/ledger/dijkstra/rules.go
+++ b/ledger/dijkstra/rules.go
@@ -84,6 +84,7 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateNativeScripts,
 	conway.UtxoValidateDelegation,
 	conway.UtxoValidateWithdrawals,
+	conway.UtxoValidateCertificateDeposits,
 	conway.UtxoValidateCommitteeCertificates,
 	conway.UtxoValidateUnknownVoters,
 	conway.UtxoValidateUnknownGovActionIds,


### PR DESCRIPTION
## Summary
Validate Conway certificate deposits and refunds against protocol parameters and ledger state.

## Changes
- Validate explicit registration deposits and legacy registration state transitions.
- Require registered credentials and exact recorded refunds on deregistration. A legacy deregistration supplies no refund, so the recorded deposit is the refund and is not compared against the current `KeyDeposit`.
- Take the legacy deregistration refund in value conservation from the deposit recorded in ledger state. A credential registered before a `KeyDeposit` change otherwise failed conservation. The current parameter remains the fallback for a state that cannot report the recorded deposit.
- Reject nonzero reward balances after applying transaction withdrawals.
- Add overflow-safe diagnostics and production-path coverage for key/script credentials and state folding.

## Consumers
`StakeCredentialDepositState` is a new optional ledger-state capability. Certificate validation requires it once a credential resolves as registered. Dingo's implementation is blinklabs-io/dingo#3642.

## Validation
- Focused normal and race tests for common, Conway, and Dijkstra
- 315 Amaru conformance vectors
- Focused golangci-lint
- Fail-before regression proof

Closes #2128