### PR TITLE
fix(ledger): validate withdrawal reward accounts

### DIFF
--- a/ledger/allegra/allegra.go
+++ b/ledger/allegra/allegra.go
@@ -232,6 +232,9 @@ func (b *AllegraTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
 		return err
 	}
+	if err := common.ValidateWithdrawalAddresses(tmp.TxWithdrawals); err != nil {
+		return err
+	}
 	*b = AllegraTransactionBody(tmp)
 	if err := b.DecodeValidityIntervalUpperBoundPresence(cborData, b.Ttl); err != nil {
 		return err

--- a/ledger/allegra/rules.go
+++ b/ledger/allegra/rules.go
@@ -30,6 +30,7 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateNoDuplicateInputs,
 	UtxoValidateFeeTooSmallUtxo,
 	UtxoValidateBadInputsUtxo,
+	UtxoValidateScriptWitnesses,
 	UtxoValidateWrongNetwork,
 	UtxoValidateWrongNetworkWithdrawal,
 	UtxoValidateValueNotConservedUtxo,
@@ -84,6 +85,16 @@ func UtxoValidateInputSetEmptyUtxo(
 	pp common.ProtocolParameters,
 ) error {
 	return shelley.UtxoValidateInputSetEmptyUtxo(tx, slot, ls, pp)
+}
+
+// UtxoValidateScriptWitnesses checks that every required script is provided.
+func UtxoValidateScriptWitnesses(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return shelley.UtxoValidateScriptWitnesses(tx, slot, ls, pp)
 }
 
 func UtxoValidateNoDuplicateInputs(
@@ -238,45 +249,9 @@ func UtxoValidateNativeScripts(
 	ls common.LedgerState,
 	pp common.ProtocolParameters,
 ) error {
-	witnesses := tx.Witnesses()
-	if witnesses == nil {
-		return nil
+	if scriptHash, failed := common.FirstInvalidNativeScript(tx, slot); failed {
+		return NativeScriptFailedError{ScriptHash: scriptHash}
 	}
-
-	nativeScripts := witnesses.NativeScripts()
-	if len(nativeScripts) == 0 {
-		return nil
-	}
-
-	// Collect key hashes from VKey witnesses
-	keyHashes := make(map[common.Blake2b224]bool)
-	for _, vkw := range witnesses.Vkey() {
-		keyHash := common.Blake2b224Hash(vkw.Vkey)
-		keyHashes[keyHash] = true
-	}
-	// Also collect key hashes from bootstrap witnesses (Byron-era)
-	for _, bw := range witnesses.Bootstrap() {
-		keyHash := common.Blake2b224Hash(bw.PublicKey)
-		keyHashes[keyHash] = true
-	}
-
-	// Get transaction validity interval
-	validityStart := tx.ValidityIntervalStart()
-	validityEnd, validityEndPresent := common.TransactionValidityIntervalUpperBound(
-		tx,
-	)
-	if !validityEndPresent {
-		validityEnd = ^uint64(0) // Max uint64 if not set
-	}
-
-	// Evaluate each native script
-	for _, nscript := range nativeScripts {
-		scriptHash := nscript.Hash()
-		if !nscript.Evaluate(slot, validityStart, validityEnd, keyHashes) {
-			return NativeScriptFailedError{ScriptHash: scriptHash}
-		}
-	}
-
 	return nil
 }
 

--- a/ledger/allegra/rules_test.go
+++ b/ledger/allegra/rules_test.go
@@ -431,13 +431,11 @@ func TestUtxoValidateWrongNetwork(t *testing.T) {
 
 func TestUtxoValidateWrongNetworkWithdrawal(t *testing.T) {
 	testCorrectNetworkAddr, _ := common.NewAddress(
-		"addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd",
+		"stake1uyehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gh6ffgw",
 	)
 	testWrongNetworkAddr, _ := common.NewAddress(
-		"addr_test1qqx80sj9nwxdnglmzdl95v2k40d9422au0klwav8jz2dj985v0wma0mza32f8z6pv2jmkn7cen50f9vn9jmp7dd0njcqqpce07",
+		"stake_test1uqehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gssrtvn",
 	)
-	testCorrectNetworkAddr = *testCorrectNetworkAddr.StakeAddress()
-	testWrongNetworkAddr = *testWrongNetworkAddr.StakeAddress()
 	testTx := &allegra.AllegraTransaction{
 		Body: allegra.AllegraTransactionBody{
 			TxWithdrawals: map[*common.Address]uint64{},

--- a/ledger/allegra/rules_test.go
+++ b/ledger/allegra/rules_test.go
@@ -436,6 +436,8 @@ func TestUtxoValidateWrongNetworkWithdrawal(t *testing.T) {
 	testWrongNetworkAddr, _ := common.NewAddress(
 		"addr_test1qqx80sj9nwxdnglmzdl95v2k40d9422au0klwav8jz2dj985v0wma0mza32f8z6pv2jmkn7cen50f9vn9jmp7dd0njcqqpce07",
 	)
+	testCorrectNetworkAddr = *testCorrectNetworkAddr.StakeAddress()
+	testWrongNetworkAddr = *testWrongNetworkAddr.StakeAddress()
 	testTx := &allegra.AllegraTransaction{
 		Body: allegra.AllegraTransactionBody{
 			TxWithdrawals: map[*common.Address]uint64{},

--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -276,6 +276,9 @@ func (b *AlonzoTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
 		return err
 	}
+	if err := common.ValidateWithdrawalAddresses(tmp.TxWithdrawals); err != nil {
+		return err
+	}
 	tmp.TxCollateral = coalesceUntaggedTransactionInputs(tmp.TxCollateral)
 	if err := tmp.TxCollateral.CheckForDuplicates(); err != nil {
 		return fmt.Errorf("collateral inputs: %w", err)

--- a/ledger/alonzo/rules_test.go
+++ b/ledger/alonzo/rules_test.go
@@ -442,6 +442,8 @@ func TestUtxoValidateWrongNetworkWithdrawal(t *testing.T) {
 	testWrongNetworkAddr, _ := common.NewAddress(
 		"addr_test1qqx80sj9nwxdnglmzdl95v2k40d9422au0klwav8jz2dj985v0wma0mza32f8z6pv2jmkn7cen50f9vn9jmp7dd0njcqqpce07",
 	)
+	testCorrectNetworkAddr = *testCorrectNetworkAddr.StakeAddress()
+	testWrongNetworkAddr = *testWrongNetworkAddr.StakeAddress()
 	testTx := &alonzo.AlonzoTransaction{
 		Body: alonzo.AlonzoTransactionBody{
 			TxWithdrawals: map[*common.Address]uint64{},

--- a/ledger/alonzo/rules_test.go
+++ b/ledger/alonzo/rules_test.go
@@ -437,13 +437,11 @@ func TestUtxoValidateWrongNetwork(t *testing.T) {
 
 func TestUtxoValidateWrongNetworkWithdrawal(t *testing.T) {
 	testCorrectNetworkAddr, _ := common.NewAddress(
-		"addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd",
+		"stake1uyehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gh6ffgw",
 	)
 	testWrongNetworkAddr, _ := common.NewAddress(
-		"addr_test1qqx80sj9nwxdnglmzdl95v2k40d9422au0klwav8jz2dj985v0wma0mza32f8z6pv2jmkn7cen50f9vn9jmp7dd0njcqqpce07",
+		"stake_test1uqehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gssrtvn",
 	)
-	testCorrectNetworkAddr = *testCorrectNetworkAddr.StakeAddress()
-	testWrongNetworkAddr = *testWrongNetworkAddr.StakeAddress()
 	testTx := &alonzo.AlonzoTransaction{
 		Body: alonzo.AlonzoTransactionBody{
 			TxWithdrawals: map[*common.Address]uint64{},

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -417,6 +417,9 @@ func (b *BabbageTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
 		return err
 	}
+	if err := common.ValidateWithdrawalAddresses(tmp.TxWithdrawals); err != nil {
+		return err
+	}
 	tmp.TxCollateral = coalesceUntaggedTransactionInputs(tmp.TxCollateral)
 	tmp.TxReferenceInputs = coalesceUntaggedTransactionInputs(
 		tmp.TxReferenceInputs,

--- a/ledger/babbage/rules_test.go
+++ b/ledger/babbage/rules_test.go
@@ -436,13 +436,11 @@ func TestUtxoValidateWrongNetwork(t *testing.T) {
 
 func TestUtxoValidateWrongNetworkWithdrawal(t *testing.T) {
 	testCorrectNetworkAddr, _ := common.NewAddress(
-		"addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd",
+		"stake1uyehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gh6ffgw",
 	)
 	testWrongNetworkAddr, _ := common.NewAddress(
-		"addr_test1qqx80sj9nwxdnglmzdl95v2k40d9422au0klwav8jz2dj985v0wma0mza32f8z6pv2jmkn7cen50f9vn9jmp7dd0njcqqpce07",
+		"stake_test1uqehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gssrtvn",
 	)
-	testCorrectNetworkAddr = *testCorrectNetworkAddr.StakeAddress()
-	testWrongNetworkAddr = *testWrongNetworkAddr.StakeAddress()
 	testTx := &babbage.BabbageTransaction{
 		Body: babbage.BabbageTransactionBody{
 			TxWithdrawals: map[*common.Address]uint64{},

--- a/ledger/babbage/rules_test.go
+++ b/ledger/babbage/rules_test.go
@@ -441,6 +441,8 @@ func TestUtxoValidateWrongNetworkWithdrawal(t *testing.T) {
 	testWrongNetworkAddr, _ := common.NewAddress(
 		"addr_test1qqx80sj9nwxdnglmzdl95v2k40d9422au0klwav8jz2dj985v0wma0mza32f8z6pv2jmkn7cen50f9vn9jmp7dd0njcqqpce07",
 	)
+	testCorrectNetworkAddr = *testCorrectNetworkAddr.StakeAddress()
+	testWrongNetworkAddr = *testWrongNetworkAddr.StakeAddress()
 	testTx := &babbage.BabbageTransaction{
 		Body: babbage.BabbageTransactionBody{
 			TxWithdrawals: map[*common.Address]uint64{},

--- a/ledger/common/address.go
+++ b/ledger/common/address.go
@@ -738,6 +738,73 @@ func (a *Address) StakeCredential() (Credential, bool) {
 	}
 }
 
+// RewardAccountCredential returns the credential carried by a valid reward
+// account address. Withdrawal map keys are restricted to the two CIP-0019
+// reward-account forms (key and script) and must use their exact 29-byte wire
+// representation.
+func (a *Address) RewardAccountCredential() (Credential, error) {
+	if a == nil {
+		return Credential{}, errors.New("nil withdrawal address")
+	}
+	var wantType uint = CredentialTypeAddrKeyHash
+	switch a.addressType {
+	case AddressTypeNoneKey:
+	case AddressTypeNoneScript:
+		wantType = CredentialTypeScriptHash
+	default:
+		return Credential{}, fmt.Errorf(
+			"withdrawal address type %d is not a reward account",
+			a.addressType,
+		)
+	}
+	if a.networkId != AddressNetworkTestnet &&
+		a.networkId != AddressNetworkMainnet {
+		return Credential{}, fmt.Errorf(
+			"withdrawal address has invalid network ID %d",
+			a.networkId,
+		)
+	}
+	raw, err := a.Bytes()
+	if err != nil {
+		return Credential{}, fmt.Errorf("encode withdrawal address: %w", err)
+	}
+	if len(raw) != 1+AddressHashSize {
+		return Credential{}, fmt.Errorf(
+			"withdrawal address has invalid length %d, want %d",
+			len(raw),
+			1+AddressHashSize,
+		)
+	}
+	credential, ok := a.StakeCredential()
+	if !ok || credential.CredType != wantType {
+		return Credential{}, errors.New(
+			"withdrawal address credential does not match its header",
+		)
+	}
+	return credential, nil
+}
+
+// ValidateWithdrawalAddresses validates every withdrawal map key and rejects
+// semantically duplicate reward accounts even when their CBOR encodings differ.
+func ValidateWithdrawalAddresses[T any](withdrawals map[*Address]T) error {
+	seen := make(map[string]struct{}, len(withdrawals))
+	for addr := range withdrawals {
+		if _, err := addr.RewardAccountCredential(); err != nil {
+			return fmt.Errorf("invalid withdrawal address: %w", err)
+		}
+		raw, err := addr.Bytes()
+		if err != nil {
+			return fmt.Errorf("encode withdrawal address: %w", err)
+		}
+		key := string(raw)
+		if _, ok := seen[key]; ok {
+			return errors.New("duplicate withdrawal reward account")
+		}
+		seen[key] = struct{}{}
+	}
+	return nil
+}
+
 func (a *Address) ByronAttr() ByronAddressAttributes {
 	return a.byronAddressAttr
 }

--- a/ledger/common/rules.go
+++ b/ledger/common/rules.go
@@ -204,14 +204,18 @@ func (e ExtraneousScriptWitnessesError) Error() string {
 // vkey witness. This includes explicitly required signers and key-based reward
 // withdrawal credentials.
 func ValidateRequiredVKeyWitnesses(tx Transaction) error {
+	if err := ValidateWithdrawalAddresses(tx.Withdrawals()); err != nil {
+		return err
+	}
 	required := make([]Blake2b224, 0, len(tx.RequiredSigners())+len(tx.Withdrawals()))
 	required = append(required, tx.RequiredSigners()...)
 	for addr := range tx.Withdrawals() {
-		if addr == nil {
-			continue
+		credential, err := addr.RewardAccountCredential()
+		if err != nil {
+			return err
 		}
-		if payload, ok := addr.StakingPayload().(AddressPayloadKeyHash); ok {
-			required = append(required, payload.Hash)
+		if credential.CredType == CredentialTypeAddrKeyHash {
+			required = append(required, credential.Credential)
 		}
 	}
 	if len(required) == 0 {
@@ -252,6 +256,9 @@ func ValidateUnsupportedPlutusExecution(tx Transaction, era string) error {
 // ValidateScriptWitnesses checks that script witnesses are provided for all script address inputs
 // and that there are no extraneous script witnesses.
 func ValidateScriptWitnesses(tx Transaction, ls LedgerState) error {
+	if err := ValidateWithdrawalAddresses(tx.Withdrawals()); err != nil {
+		return err
+	}
 	if ls == nil {
 		return nil
 	}
@@ -430,10 +437,12 @@ func ValidateScriptWitnesses(tx Transaction, ls LedgerState) error {
 
 	// Collect script hashes required by withdrawals
 	for addr := range tx.Withdrawals() {
-		// For stake addresses, check if stake credential is script (LSB of type indicates script)
-		if (addr.Type() & AddressTypeScriptBit) != 0 {
-			stakeScriptHash := addr.StakeKeyHash()
-			requiredScriptHashes[ScriptHash(stakeScriptHash)] = struct{}{}
+		credential, err := addr.RewardAccountCredential()
+		if err != nil {
+			return err
+		}
+		if credential.CredType == CredentialTypeScriptHash {
+			requiredScriptHashes[ScriptHash(credential.Credential)] = struct{}{}
 		}
 	}
 

--- a/ledger/common/script.go
+++ b/ledger/common/script.go
@@ -540,6 +540,50 @@ func (n NativeScript) MarshalCBOR() ([]byte, error) {
 	return cbor.Encode(n.item)
 }
 
+// FirstInvalidNativeScript evaluates each native-script witness against the
+// transaction's validity interval and key witnesses. It returns the hash of
+// the first script that fails.
+func FirstInvalidNativeScript(
+	tx Transaction,
+	slot uint64,
+) (ScriptHash, bool) {
+	witnesses := tx.Witnesses()
+	if witnesses == nil {
+		return ScriptHash{}, false
+	}
+
+	nativeScripts := witnesses.NativeScripts()
+	if len(nativeScripts) == 0 {
+		return ScriptHash{}, false
+	}
+
+	keyHashes := make(map[Blake2b224]bool)
+	for _, vkw := range witnesses.Vkey() {
+		keyHashes[Blake2b224Hash(vkw.Vkey)] = true
+	}
+	for _, bw := range witnesses.Bootstrap() {
+		keyHashes[Blake2b224Hash(bw.PublicKey)] = true
+	}
+
+	validityStart := tx.ValidityIntervalStart()
+	validityEnd, validityEndPresent := TransactionValidityIntervalUpperBound(tx)
+	if !validityEndPresent {
+		validityEnd = ^uint64(0)
+	}
+
+	for _, nativeScript := range nativeScripts {
+		if !nativeScript.Evaluate(
+			slot,
+			validityStart,
+			validityEnd,
+			keyHashes,
+		) {
+			return nativeScript.Hash(), true
+		}
+	}
+	return ScriptHash{}, false
+}
+
 type NativeScriptPubkey struct {
 	cbor.StructAsArray
 	Type uint

--- a/ledger/common/withdrawal_authorization_test.go
+++ b/ledger/common/withdrawal_authorization_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithdrawalAuthorizationUsesRewardCredentialType(t *testing.T) {
+	vkey := bytes.Repeat([]byte{0x31}, 32)
+	keyHash := common.Blake2b224Hash(vkey)
+	keyAddr, err := common.NewAddressFromParts(
+		common.AddressTypeNoneKey,
+		common.AddressNetworkMainnet,
+		nil,
+		keyHash.Bytes(),
+	)
+	require.NoError(t, err)
+
+	nativeScriptCbor, err := cbor.Encode(common.NativeScriptPubkey{
+		Type: 0,
+		Hash: keyHash.Bytes(),
+	})
+	require.NoError(t, err)
+	var nativeScript common.NativeScript
+	require.NoError(t, nativeScript.UnmarshalCBOR(nativeScriptCbor))
+	scriptHash := nativeScript.Hash()
+	scriptAddr, err := common.NewAddressFromParts(
+		common.AddressTypeNoneScript,
+		common.AddressNetworkMainnet,
+		nil,
+		scriptHash.Bytes(),
+	)
+	require.NoError(t, err)
+
+	keyTx := mockledger.NewTransactionBuilder().WithWithdrawals(
+		map[*common.Address]uint64{&keyAddr: 1},
+	)
+	require.ErrorAs(
+		t,
+		common.ValidateRequiredVKeyWitnesses(keyTx),
+		&common.MissingVKeyWitnessesError{},
+	)
+	keyTx.WithWitnesses(
+		mockledger.NewMockTransactionWitnessSet().WithVkeyWitnesses(
+			common.VkeyWitness{Vkey: vkey},
+		),
+	)
+	require.NoError(t, common.ValidateRequiredVKeyWitnesses(keyTx))
+
+	scriptTx := mockledger.NewTransactionBuilder().WithWithdrawals(
+		map[*common.Address]uint64{&scriptAddr: 1},
+	)
+	require.NoError(t, common.ValidateRequiredVKeyWitnesses(scriptTx))
+	ls := mockledger.NewLedgerStateBuilder().Build()
+	require.ErrorAs(
+		t,
+		common.ValidateScriptWitnesses(scriptTx, ls),
+		&common.MissingScriptWitnessesError{},
+	)
+	scriptTx.WithWitnesses(
+		mockledger.NewMockTransactionWitnessSet().WithNativeScripts(nativeScript),
+	)
+	require.NoError(t, common.ValidateScriptWitnesses(scriptTx, ls))
+}
+
+func TestWithdrawalAuthorizationRejectsNonRewardAddress(t *testing.T) {
+	hash := bytes.Repeat([]byte{0x44}, common.AddressHashSize)
+	baseAddr, err := common.NewAddressFromParts(
+		common.AddressTypeKeyKey,
+		common.AddressNetworkMainnet,
+		hash,
+		hash,
+	)
+	require.NoError(t, err)
+	tx := mockledger.NewTransactionBuilder().WithWithdrawals(
+		map[*common.Address]uint64{&baseAddr: 1},
+	)
+	require.ErrorContains(
+		t,
+		common.ValidateRequiredVKeyWitnesses(tx),
+		"not a reward account",
+	)
+	require.ErrorContains(
+		t,
+		common.ValidateScriptWitnesses(
+			tx,
+			mockledger.NewLedgerStateBuilder().Build(),
+		),
+		"not a reward account",
+	)
+}

--- a/ledger/common/withdrawal_authorization_test.go
+++ b/ledger/common/withdrawal_authorization_test.go
@@ -16,10 +16,16 @@ package common_test
 
 import (
 	"bytes"
+	"reflect"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
 	"github.com/stretchr/testify/require"
 )
@@ -77,7 +83,8 @@ func TestWithdrawalAuthorizationUsesRewardCredentialType(t *testing.T) {
 		&common.MissingScriptWitnessesError{},
 	)
 	scriptTx.WithWitnesses(
-		mockledger.NewMockTransactionWitnessSet().WithNativeScripts(nativeScript),
+		mockledger.NewMockTransactionWitnessSet().
+			WithNativeScripts(nativeScript),
 	)
 	require.NoError(t, common.ValidateScriptWitnesses(scriptTx, ls))
 }
@@ -107,4 +114,83 @@ func TestWithdrawalAuthorizationRejectsNonRewardAddress(t *testing.T) {
 		),
 		"not a reward account",
 	)
+}
+
+func TestShelleyFamilyValidationRulesEnforceWithdrawalScriptAuthorization(
+	t *testing.T,
+) {
+	vkey := bytes.Repeat([]byte{0x52}, 32)
+	nativeScriptCbor, err := cbor.Encode(common.NativeScriptPubkey{
+		Type: 0,
+		Hash: common.Blake2b224Hash(vkey).Bytes(),
+	})
+	require.NoError(t, err)
+	var nativeScript common.NativeScript
+	require.NoError(t, nativeScript.UnmarshalCBOR(nativeScriptCbor))
+	scriptHash := nativeScript.Hash()
+	scriptAddr, err := common.NewAddressFromParts(
+		common.AddressTypeNoneScript,
+		common.AddressNetworkMainnet,
+		nil,
+		scriptHash.Bytes(),
+	)
+	require.NoError(t, err)
+	ls := mockledger.NewLedgerStateBuilder().Build()
+
+	tests := []struct {
+		name  string
+		rules []common.UtxoValidationRuleFunc
+	}{
+		{name: "Shelley", rules: shelley.UtxoValidationRules},
+		{name: "Allegra", rules: allegra.UtxoValidationRules},
+		{name: "Mary", rules: mary.UtxoValidationRules},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			authRules := make([]common.UtxoValidationRuleFunc, 0, 2)
+			for _, rule := range test.rules {
+				name := runtime.FuncForPC(reflect.ValueOf(rule).Pointer()).
+					Name()
+				if strings.HasSuffix(name, ".UtxoValidateScriptWitnesses") ||
+					strings.HasSuffix(name, ".UtxoValidateNativeScripts") {
+					authRules = append(authRules, rule)
+				}
+			}
+			require.Len(
+				t,
+				authRules,
+				2,
+				"authorization rules are not registered",
+			)
+
+			tx := mockledger.NewTransactionBuilder().WithWithdrawals(
+				map[*common.Address]uint64{&scriptAddr: 1},
+			)
+			err := common.VerifyTransaction(tx, 0, ls, nil, authRules)
+			var missing common.MissingScriptWitnessesError
+			require.ErrorAs(t, err, &missing)
+			require.Equal(t, scriptHash, missing.ScriptHash)
+
+			tx.WithWitnesses(
+				mockledger.NewMockTransactionWitnessSet().WithNativeScripts(
+					nativeScript,
+				),
+			)
+			require.ErrorContains(
+				t,
+				common.VerifyTransaction(tx, 0, ls, nil, authRules),
+				"native script failed",
+			)
+
+			tx.WithWitnesses(
+				mockledger.NewMockTransactionWitnessSet().
+					WithNativeScripts(nativeScript).
+					WithVkeyWitnesses(common.VkeyWitness{Vkey: vkey}),
+			)
+			require.NoError(
+				t,
+				common.VerifyTransaction(tx, 0, ls, nil, authRules),
+			)
+		})
+	}
 }

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -634,6 +634,9 @@ func (b *ConwayTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
 		return err
 	}
+	if err := common.ValidateWithdrawalAddresses(tmp.TxWithdrawals); err != nil {
+		return err
+	}
 	if err := validateConwayCertificateTypes(tmp.TxCertificates); err != nil {
 		return err
 	}

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -1303,6 +1303,8 @@ func TestUtxoValidateWrongNetworkWithdrawal(t *testing.T) {
 	testWrongNetworkAddr, _ := common.NewAddress(
 		"addr_test1qqx80sj9nwxdnglmzdl95v2k40d9422au0klwav8jz2dj985v0wma0mza32f8z6pv2jmkn7cen50f9vn9jmp7dd0njcqqpce07",
 	)
+	testCorrectNetworkAddr = *testCorrectNetworkAddr.StakeAddress()
+	testWrongNetworkAddr = *testWrongNetworkAddr.StakeAddress()
 	testTx := &conway.ConwayTransaction{
 		Body: conway.ConwayTransactionBody{
 			TxWithdrawals: map[*common.Address]uint64{},

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -1298,13 +1298,11 @@ func TestUtxoValidateWrongNetwork(t *testing.T) {
 
 func TestUtxoValidateWrongNetworkWithdrawal(t *testing.T) {
 	testCorrectNetworkAddr, _ := common.NewAddress(
-		"addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd",
+		"stake1uyehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gh6ffgw",
 	)
 	testWrongNetworkAddr, _ := common.NewAddress(
-		"addr_test1qqx80sj9nwxdnglmzdl95v2k40d9422au0klwav8jz2dj985v0wma0mza32f8z6pv2jmkn7cen50f9vn9jmp7dd0njcqqpce07",
+		"stake_test1uqehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gssrtvn",
 	)
-	testCorrectNetworkAddr = *testCorrectNetworkAddr.StakeAddress()
-	testWrongNetworkAddr = *testWrongNetworkAddr.StakeAddress()
 	testTx := &conway.ConwayTransaction{
 		Body: conway.ConwayTransactionBody{
 			TxWithdrawals: map[*common.Address]uint64{},

--- a/ledger/dijkstra/dijkstra.go
+++ b/ledger/dijkstra/dijkstra.go
@@ -761,6 +761,9 @@ func (b *DijkstraTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
 		return err
 	}
+	if err := common.ValidateWithdrawalAddresses(tmp.TxWithdrawals); err != nil {
+		return err
+	}
 	if err := validateDijkstraCertificateTypes(tmp.TxCertificates); err != nil {
 		return err
 	}
@@ -1048,6 +1051,9 @@ func (b *DijkstraSubTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	type tDijkstraSubTransactionBody DijkstraSubTransactionBody
 	var tmp tDijkstraSubTransactionBody
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+		return err
+	}
+	if err := common.ValidateWithdrawalAddresses(tmp.TxWithdrawals); err != nil {
 		return err
 	}
 	if err := validateDijkstraCertificateTypes(tmp.TxCertificates); err != nil {

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -236,6 +236,9 @@ func (b *MaryTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
 		return err
 	}
+	if err := common.ValidateWithdrawalAddresses(tmp.TxWithdrawals); err != nil {
+		return err
+	}
 	if err := tmp.TxMint.ValidateMintQuantities(); err != nil {
 		return fmt.Errorf("mint: %w", err)
 	}

--- a/ledger/mary/rules.go
+++ b/ledger/mary/rules.go
@@ -37,6 +37,7 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateNoDuplicateInputs,
 	UtxoValidateFeeTooSmallUtxo,
 	UtxoValidateBadInputsUtxo,
+	UtxoValidateScriptWitnesses,
 	UtxoValidateWrongNetwork,
 	UtxoValidateWrongNetworkWithdrawal,
 	UtxoValidateValueNotConservedUtxo,
@@ -104,6 +105,16 @@ func UtxoValidateInputSetEmptyUtxo(
 	pp common.ProtocolParameters,
 ) error {
 	return shelley.UtxoValidateInputSetEmptyUtxo(tx, slot, ls, pp)
+}
+
+// UtxoValidateScriptWitnesses checks that every required script is provided.
+func UtxoValidateScriptWitnesses(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return shelley.UtxoValidateScriptWitnesses(tx, slot, ls, pp)
 }
 
 func UtxoValidateNoDuplicateInputs(

--- a/ledger/mary/rules_test.go
+++ b/ledger/mary/rules_test.go
@@ -430,13 +430,11 @@ func TestUtxoValidateWrongNetwork(t *testing.T) {
 
 func TestUtxoValidateWrongNetworkWithdrawal(t *testing.T) {
 	testCorrectNetworkAddr, _ := common.NewAddress(
-		"addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd",
+		"stake1uyehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gh6ffgw",
 	)
 	testWrongNetworkAddr, _ := common.NewAddress(
-		"addr_test1qqx80sj9nwxdnglmzdl95v2k40d9422au0klwav8jz2dj985v0wma0mza32f8z6pv2jmkn7cen50f9vn9jmp7dd0njcqqpce07",
+		"stake_test1uqehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gssrtvn",
 	)
-	testCorrectNetworkAddr = *testCorrectNetworkAddr.StakeAddress()
-	testWrongNetworkAddr = *testWrongNetworkAddr.StakeAddress()
 	testTx := &mary.MaryTransaction{
 		Body: mary.MaryTransactionBody{
 			TxWithdrawals: map[*common.Address]uint64{},

--- a/ledger/mary/rules_test.go
+++ b/ledger/mary/rules_test.go
@@ -435,6 +435,8 @@ func TestUtxoValidateWrongNetworkWithdrawal(t *testing.T) {
 	testWrongNetworkAddr, _ := common.NewAddress(
 		"addr_test1qqx80sj9nwxdnglmzdl95v2k40d9422au0klwav8jz2dj985v0wma0mza32f8z6pv2jmkn7cen50f9vn9jmp7dd0njcqqpce07",
 	)
+	testCorrectNetworkAddr = *testCorrectNetworkAddr.StakeAddress()
+	testWrongNetworkAddr = *testWrongNetworkAddr.StakeAddress()
 	testTx := &mary.MaryTransaction{
 		Body: mary.MaryTransactionBody{
 			TxWithdrawals: map[*common.Address]uint64{},

--- a/ledger/shelley/errors.go
+++ b/ledger/shelley/errors.go
@@ -85,6 +85,14 @@ func (e BadInputsUtxoError) Error() string {
 	return "bad input(s): " + strings.Join(tmpInputs, ", ")
 }
 
+type NativeScriptFailedError struct {
+	ScriptHash common.ScriptHash
+}
+
+func (e NativeScriptFailedError) Error() string {
+	return fmt.Sprintf("native script failed (hash=%x)", e.ScriptHash[:])
+}
+
 type WrongNetworkError struct {
 	NetId uint
 	Addrs []common.Address

--- a/ledger/shelley/rules.go
+++ b/ledger/shelley/rules.go
@@ -206,7 +206,7 @@ func UtxoValidateWrongNetworkWithdrawal(
 		badAddrs = append(badAddrs, *addr)
 	}
 	if len(badAddrs) == 0 {
-		return nil
+		return common.ValidateWithdrawalAddresses(tx.Withdrawals())
 	}
 	return WrongNetworkWithdrawalError{
 		NetId: networkId,
@@ -627,6 +627,9 @@ func UtxoValidateWithdrawals(
 	if withdrawals == nil {
 		return nil
 	}
+	if err := common.ValidateWithdrawalAddresses(withdrawals); err != nil {
+		return err
+	}
 
 	requireExactAmount := true
 	if versionedPparams, ok := pp.(interface {
@@ -646,9 +649,9 @@ func UtxoValidateWithdrawals(
 	}
 
 	for addr, amount := range withdrawals {
-		cred, ok := addr.StakeCredential()
-		if !ok {
-			continue
+		cred, err := addr.RewardAccountCredential()
+		if err != nil {
+			return err
 		}
 
 		balance, err := ls.RewardAccountBalance(cred)

--- a/ledger/shelley/rules.go
+++ b/ledger/shelley/rules.go
@@ -41,6 +41,8 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateNoDuplicateInputs,
 	UtxoValidateFeeTooSmallUtxo,
 	UtxoValidateBadInputsUtxo,
+	UtxoValidateNativeScripts,
+	UtxoValidateScriptWitnesses,
 	UtxoValidateWrongNetwork,
 	UtxoValidateWrongNetworkWithdrawal,
 	UtxoValidateValueNotConservedUtxo,
@@ -79,6 +81,29 @@ func UtxoValidateInputSetEmptyUtxo(
 		return nil
 	}
 	return InputSetEmptyUtxoError{}
+}
+
+// UtxoValidateScriptWitnesses checks that every required script is provided.
+func UtxoValidateScriptWitnesses(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return common.ValidateScriptWitnesses(tx, ls)
+}
+
+// UtxoValidateNativeScripts evaluates native scripts in the transaction.
+func UtxoValidateNativeScripts(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	if scriptHash, failed := common.FirstInvalidNativeScript(tx, slot); failed {
+		return NativeScriptFailedError{ScriptHash: scriptHash}
+	}
+	return nil
 }
 
 // UtxoValidateNoDuplicateInputs ensures that there are no duplicate inputs in any input set

--- a/ledger/shelley/rules_test.go
+++ b/ledger/shelley/rules_test.go
@@ -488,13 +488,11 @@ func TestUtxoValidateWrongNetwork(t *testing.T) {
 
 func TestUtxoValidateWrongNetworkWithdrawal(t *testing.T) {
 	testCorrectNetworkAddr, _ := common.NewAddress(
-		"addr1qytna5k2fq9ler0fuk45j7zfwv7t2zwhp777nvdjqqfr5tz8ztpwnk8zq5ngetcz5k5mckgkajnygtsra9aej2h3ek5seupmvd",
+		"stake1uyehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gh6ffgw",
 	)
 	testWrongNetworkAddr, _ := common.NewAddress(
-		"addr_test1qqx80sj9nwxdnglmzdl95v2k40d9422au0klwav8jz2dj985v0wma0mza32f8z6pv2jmkn7cen50f9vn9jmp7dd0njcqqpce07",
+		"stake_test1uqehkck0lajq8gr28t9uxnuvgcqrc6070x3k9r8048z8y5gssrtvn",
 	)
-	testCorrectNetworkAddr = *testCorrectNetworkAddr.StakeAddress()
-	testWrongNetworkAddr = *testWrongNetworkAddr.StakeAddress()
 	testTx := &shelley.ShelleyTransaction{
 		Body: shelley.ShelleyTransactionBody{
 			TxWithdrawals: map[*common.Address]uint64{},

--- a/ledger/shelley/rules_test.go
+++ b/ledger/shelley/rules_test.go
@@ -493,6 +493,8 @@ func TestUtxoValidateWrongNetworkWithdrawal(t *testing.T) {
 	testWrongNetworkAddr, _ := common.NewAddress(
 		"addr_test1qqx80sj9nwxdnglmzdl95v2k40d9422au0klwav8jz2dj985v0wma0mza32f8z6pv2jmkn7cen50f9vn9jmp7dd0njcqqpce07",
 	)
+	testCorrectNetworkAddr = *testCorrectNetworkAddr.StakeAddress()
+	testWrongNetworkAddr = *testWrongNetworkAddr.StakeAddress()
 	testTx := &shelley.ShelleyTransaction{
 		Body: shelley.ShelleyTransactionBody{
 			TxWithdrawals: map[*common.Address]uint64{},

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -359,6 +359,9 @@ func (b *ShelleyTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
 		return err
 	}
+	if err := common.ValidateWithdrawalAddresses(tmp.TxWithdrawals); err != nil {
+		return err
+	}
 	*b = ShelleyTransactionBody(tmp)
 	b.SetCbor(cborData)
 	return nil

--- a/ledger/shelley/withdrawals_decode_test.go
+++ b/ledger/shelley/withdrawals_decode_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shelley_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/stretchr/testify/require"
+)
+
+func rewardAccountBytes(header byte, credential []byte) []byte {
+	return append([]byte{header}, credential...)
+}
+
+func encodeWithdrawalBody(
+	t *testing.T,
+	withdrawals map[cbor.ByteString]uint64,
+) []byte {
+	t.Helper()
+	ret, err := cbor.Encode(map[uint64]any{5: withdrawals})
+	require.NoError(t, err)
+	return ret
+}
+
+func TestShelleyTransactionBodyWithdrawalAddressForms(t *testing.T) {
+	credential := bytes.Repeat([]byte{0x42}, common.AddressHashSize)
+	keyAddr := rewardAccountBytes(0xe1, credential)
+	scriptAddr := rewardAccountBytes(0xf1, credential)
+
+	bodyCbor := encodeWithdrawalBody(t, map[cbor.ByteString]uint64{
+		cbor.NewByteString(keyAddr):    1,
+		cbor.NewByteString(scriptAddr): 2,
+	})
+	var body shelley.ShelleyTransactionBody
+	_, err := cbor.Decode(bodyCbor, &body)
+	require.NoError(t, err)
+	require.Len(t, body.TxWithdrawals, 2)
+
+	credentialTypes := make(map[uint]struct{}, 2)
+	for addr := range body.TxWithdrawals {
+		decoded, err := addr.RewardAccountCredential()
+		require.NoError(t, err)
+		credentialTypes[decoded.CredType] = struct{}{}
+		require.Equal(t, common.NewBlake2b224(credential), decoded.Credential)
+	}
+	require.Contains(t, credentialTypes, uint(common.CredentialTypeAddrKeyHash))
+	require.Contains(t, credentialTypes, uint(common.CredentialTypeScriptHash))
+}
+
+func TestShelleyTransactionBodyRejectsInvalidWithdrawalAddresses(t *testing.T) {
+	hash := bytes.Repeat([]byte{0x33}, common.AddressHashSize)
+	tests := []struct {
+		name string
+		addr []byte
+	}{
+		{
+			name: "base address",
+			addr: append(rewardAccountBytes(0x01, hash), hash...),
+		},
+		{
+			name: "enterprise address",
+			addr: rewardAccountBytes(0x61, hash),
+		},
+		{
+			name: "reserved header",
+			addr: rewardAccountBytes(0x91, hash),
+		},
+		{
+			name: "invalid network tag",
+			addr: rewardAccountBytes(0xe2, hash),
+		},
+		{
+			name: "short key credential",
+			addr: rewardAccountBytes(0xe1, hash[:len(hash)-1]),
+		},
+		{
+			name: "short script credential",
+			addr: rewardAccountBytes(0xf1, hash[:len(hash)-1]),
+		},
+		{
+			// Address parsing preserves a small mainnet trailing-byte
+			// compatibility whitelist. Reward accounts are not part of that
+			// historical exception and must retain their exact 29-byte form.
+			name: "trailing byte",
+			addr: append(rewardAccountBytes(0xe1, hash), 0x00),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bodyCbor := encodeWithdrawalBody(t, map[cbor.ByteString]uint64{
+				cbor.NewByteString(test.addr): 1,
+			})
+			var body shelley.ShelleyTransactionBody
+			_, err := cbor.Decode(bodyCbor, &body)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestShelleyTransactionBodyRejectsSemanticDuplicateWithdrawal(t *testing.T) {
+	addr := rewardAccountBytes(
+		0xe1,
+		bytes.Repeat([]byte{0x55}, common.AddressHashSize),
+	)
+	// {5: {_ <addr>: 1, <addr>: 2}}. The first key is an indefinite-length
+	// byte string and the second is definite-length. Both decode to the same
+	// reward account and must not survive as distinct pointer map keys.
+	bodyCbor := []byte{0xa1, 0x05, 0xa2, 0x5f, 0x58, 0x1d}
+	bodyCbor = append(bodyCbor, addr...)
+	bodyCbor = append(bodyCbor, 0xff, 0x01, 0x58, 0x1d)
+	bodyCbor = append(bodyCbor, addr...)
+	bodyCbor = append(bodyCbor, 0x02)
+
+	var body shelley.ShelleyTransactionBody
+	_, err := cbor.Decode(bodyCbor, &body)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "duplicate withdrawal reward account")
+}
+
+func TestShelleyFamilyBodiesRejectNonRewardWithdrawals(t *testing.T) {
+	hash := bytes.Repeat([]byte{0x66}, common.AddressHashSize)
+	baseAddr := append(rewardAccountBytes(0x01, hash), hash...)
+	bodyCbor := encodeWithdrawalBody(t, map[cbor.ByteString]uint64{
+		cbor.NewByteString(baseAddr): 1,
+	})
+	tests := []struct {
+		name string
+		dest func() any
+	}{
+		{"Shelley", func() any { return &shelley.ShelleyTransactionBody{} }},
+		{"Allegra", func() any { return &allegra.AllegraTransactionBody{} }},
+		{"Mary", func() any { return &mary.MaryTransactionBody{} }},
+		{"Alonzo", func() any { return &alonzo.AlonzoTransactionBody{} }},
+		{"Babbage", func() any { return &babbage.BabbageTransactionBody{} }},
+		{"Conway", func() any { return &conway.ConwayTransactionBody{} }},
+		{"Dijkstra", func() any { return &dijkstra.DijkstraTransactionBody{} }},
+		{
+			"Dijkstra subtransaction",
+			func() any { return &dijkstra.DijkstraSubTransactionBody{} },
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := cbor.Decode(bodyCbor, test.dest())
+			require.ErrorContains(t, err, "not a reward account")
+		})
+	}
+}


### PR DESCRIPTION
Summary:
- validate withdrawal addresses as reward accounts before credential extraction
- preserve wrong-network error precedence across eras
- cover key/script credentials and malformed encoded addresses

Validation:
- GOWORK=off go test -race ./... -count=1
- focused affected-package normal/race tests
- focused golangci-lint (0 issues)
- fail-before regression proof
- git diff --check

Closes #2131

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates withdrawal addresses as CIP-0019 reward accounts during transaction body decoding across all eras, and enforces withdrawal authorization by requiring vkey witnesses for key credentials and native scripts for script credentials.

**Behavior changes**
- Non-reward, malformed, and semantically duplicate withdrawal addresses now fail decoding across Shelley through Dijkstra, including subtransactions; wrong-network errors are still reported.
- Reward credentials use their strict 29-byte wire representation; the mainnet trailing-byte compatibility whitelist no longer applies to withdrawals.
- Shelley, Allegra, and Mary now require script witnesses and evaluate native scripts for withdrawals.

**Migration**
- Transactions with invalid or duplicate withdrawals, or with missing witnesses for their reward credentials, now fail.

Closes #2131.

<sup>Written for commit bdabe71b854da8177e28009ec5886912f1b2bef8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of withdrawal addresses across supported ledger eras.
  * Rejects malformed, incorrect-network, duplicate, or non-reward withdrawal addresses earlier.
  * Correctly enforces authorization for key- and script-based withdrawals.
  * Added validation for native script witnesses and clearer failures when scripts do not validate.
* **Tests**
  * Expanded coverage for withdrawal address formats, credential types, network validation, duplicates, and script authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->