### PR TITLE
fix(ledger): enforce constitution guardrails

### DIFF
--- a/ledger/common/gov.go
+++ b/ledger/common/gov.go
@@ -752,7 +752,7 @@ func (a *TreasuryWithdrawalGovAction) ToPlutusData() data.PlutusData {
 		})
 	}
 	policyHash := data.NewConstr(1)
-	if len(a.PolicyHash) > 0 {
+	if a.PolicyHash != nil {
 		policyHash = data.NewConstr(
 			0,
 			data.NewByteString(a.PolicyHash),
@@ -791,7 +791,7 @@ func NewTreasuryWithdrawalGovAction(
 			)
 		}
 	}
-	if len(policyHash) != 0 && len(policyHash) != Blake2b224Size {
+	if policyHash != nil && len(policyHash) != Blake2b224Size {
 		return nil, fmt.Errorf(
 			"invalid policy hash length: expected %d bytes, got %d",
 			Blake2b224Size,
@@ -949,7 +949,7 @@ func (a *NewConstitutionGovAction) ToPlutusData() data.PlutusData {
 		actionId = data.NewConstr(0, a.ActionId.ToPlutusData())
 	}
 	scriptHash := data.NewConstr(1)
-	if len(a.Constitution.ScriptHash) > 0 {
+	if a.Constitution.ScriptHash != nil {
 		scriptHash = data.NewConstr(
 			0,
 			data.NewByteString(a.Constitution.ScriptHash),
@@ -973,7 +973,7 @@ func NewNewConstitutionGovAction(
 	anchor GovAnchor,
 	scriptHash []byte,
 ) (*NewConstitutionGovAction, error) {
-	if len(scriptHash) != 0 && len(scriptHash) != Blake2b224Size {
+	if scriptHash != nil && len(scriptHash) != Blake2b224Size {
 		return nil, fmt.Errorf(
 			"invalid script hash length: expected %d bytes, got %d",
 			Blake2b224Size,

--- a/ledger/common/gov_constructors_test.go
+++ b/ledger/common/gov_constructors_test.go
@@ -113,6 +113,8 @@ func TestNewTreasuryWithdrawalGovAction(t *testing.T) {
 	// Negative: non-empty policy hash must be 28 bytes
 	_, err = NewTreasuryWithdrawalGovAction(withdrawals, []byte{1, 2})
 	require.Error(t, err)
+	_, err = NewTreasuryWithdrawalGovAction(withdrawals, []byte{})
+	require.Error(t, err)
 	// Negative: a nil address key would panic in ToPlutusData
 	_, err = NewTreasuryWithdrawalGovAction(
 		map[*Address]uint64{nil: 5_000_000},
@@ -217,13 +219,16 @@ func TestNewNewConstitutionGovAction(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, uint(GovActionTypeNewConstitution), decoded.Type)
 
-	// Empty script hash is valid (optional guardrail script)
+	// A nil script hash represents an absent optional guardrail script.
 	noScript, err := NewNewConstitutionGovAction(nil, anchor, nil)
 	require.NoError(t, err)
-	assert.Empty(t, noScript.Constitution.ScriptHash)
+	assert.Nil(t, noScript.Constitution.ScriptHash)
 
-	// Negative: non-empty script hash must be 28 bytes
+	// A present script hash, including an explicit empty byte string, must be
+	// exactly 28 bytes.
 	_, err = NewNewConstitutionGovAction(nil, anchor, []byte{1, 2})
+	require.Error(t, err)
+	_, err = NewNewConstitutionGovAction(nil, anchor, []byte{})
 	require.Error(t, err)
 }
 

--- a/ledger/common/rules.go
+++ b/ledger/common/rules.go
@@ -465,8 +465,8 @@ func ValidateScriptWitnesses(tx Transaction, ls LedgerState) error {
 				var hash ScriptHash
 				copy(hash[:], policyHash)
 				requiredScriptHashes[hash] = struct{}{}
-			} else if len(policyHash) != 0 {
-				// Non-empty but invalid length - fail fast to surface upstream bugs
+			} else if policyHash != nil {
+				// Present but invalid length - fail fast to surface upstream bugs
 				return fmt.Errorf(
 					"malformed governance policy hash: got %d bytes, want %d",
 					len(policyHash),

--- a/ledger/common/state.go
+++ b/ledger/common/state.go
@@ -119,10 +119,18 @@ type SlotState interface {
 	TimeToSlot(time.Time) (uint64, error)
 }
 
-// Minimal placeholder types used by the extended interface. These are intentionally
-// lightweight so tests and era packages can compile while we wire real parsing.
+// Constitution is the current enacted constitution. ScriptHash is the
+// optional guardrails script hash: nil means that the constitution has no
+// guardrails script.
+type Constitution struct {
+	Anchor     GovAnchor
+	ScriptHash []byte
+}
+
+// Minimal placeholder types used by the extended interface. These are
+// intentionally lightweight so tests and era packages can compile while we
+// wire real parsing.
 type (
-	Constitution   struct{}
 	PlutusLanguage uint8
 	CostModel      struct{}
 )

--- a/ledger/conway/errors.go
+++ b/ledger/conway/errors.go
@@ -621,6 +621,57 @@ func (e MalformedGovActionError) Error() string {
 	return "malformed governance action: " + e.Reason
 }
 
+// ConstitutionLookupError indicates that the current constitution could not
+// be read while validating a governance action.
+type ConstitutionLookupError struct {
+	Err error
+}
+
+func (e ConstitutionLookupError) Error() string {
+	return fmt.Sprintf("failed to look up current constitution: %v", e.Err)
+}
+
+func (e ConstitutionLookupError) Unwrap() error {
+	return e.Err
+}
+
+// MalformedConstitutionError indicates that the current constitution carries
+// a non-nil guardrails script hash of an invalid length.
+type MalformedConstitutionError struct {
+	ScriptHashLength int
+}
+
+func (e MalformedConstitutionError) Error() string {
+	return fmt.Sprintf(
+		"current constitution guardrails script hash has invalid length %d, expected %d",
+		e.ScriptHashLength,
+		common.Blake2b224Size,
+	)
+}
+
+// InvalidGuardrailsScriptHashError indicates that a parameter-change or
+// treasury-withdrawal proposal's optional policy hash does not exactly match
+// the current constitution's optional guardrails script hash.
+type InvalidGuardrailsScriptHashError struct {
+	Actual   []byte
+	Expected []byte
+}
+
+func (e InvalidGuardrailsScriptHashError) Error() string {
+	return fmt.Sprintf(
+		"invalid guardrails script hash: supplied %s, expected %s",
+		formatOptionalScriptHash(e.Actual),
+		formatOptionalScriptHash(e.Expected),
+	)
+}
+
+func formatOptionalScriptHash(hash []byte) string {
+	if hash == nil {
+		return "<absent>"
+	}
+	return hex.EncodeToString(hash)
+}
+
 // BadHardForkProtocolVersionError indicates a HardForkInitiation governance
 // action proposes a protocol version that cannot legally follow the current
 // (or referenced ancestor) protocol version

--- a/ledger/conway/gov.go
+++ b/ledger/conway/gov.go
@@ -126,7 +126,7 @@ func (a *ConwayParameterChangeGovAction) ToPlutusData() data.PlutusData {
 		actionId = data.NewConstr(0, a.ActionId.ToPlutusData())
 	}
 	policyHash := data.NewConstr(1)
-	if len(a.PolicyHash) > 0 {
+	if a.PolicyHash != nil {
 		policyHash = data.NewConstr(
 			0,
 			data.NewByteString(a.PolicyHash),
@@ -172,7 +172,7 @@ func NewConwayParameterChangeGovAction(
 	paramUpdate ConwayProtocolParameterUpdate,
 	policyHash []byte,
 ) (*ConwayParameterChangeGovAction, error) {
-	if len(policyHash) != 0 && len(policyHash) != common.Blake2b224Size {
+	if policyHash != nil && len(policyHash) != common.Blake2b224Size {
 		return nil, fmt.Errorf(
 			"invalid policy hash length: expected %d bytes, got %d",
 			common.Blake2b224Size,

--- a/ledger/conway/gov_constructors_test.go
+++ b/ledger/conway/gov_constructors_test.go
@@ -60,13 +60,16 @@ func TestNewConwayParameterChangeGovAction(t *testing.T) {
 		decodedAction.Type,
 	)
 
-	// Empty policy hash is valid (optional field)
+	// A nil policy hash represents an absent optional field.
 	noPolicy, err := NewConwayParameterChangeGovAction(nil, paramUpdate, nil)
 	require.NoError(t, err)
-	assert.Empty(t, noPolicy.PolicyHash)
+	assert.Nil(t, noPolicy.PolicyHash)
 
-	// Negative: non-empty policy hash must be 28 bytes
+	// A present policy hash, including an explicit empty byte string, must be
+	// exactly 28 bytes.
 	_, err = NewConwayParameterChangeGovAction(nil, paramUpdate, []byte{1, 2})
+	require.Error(t, err)
+	_, err = NewConwayParameterChangeGovAction(nil, paramUpdate, []byte{})
 	require.Error(t, err)
 }
 

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -772,6 +772,9 @@ func UtxoValidateGuardrailsScriptHash(
 	ls common.LedgerState,
 	pp common.ProtocolParameters,
 ) error {
+	if !tx.IsValid() {
+		return nil
+	}
 	var actions []common.GovActionWithPolicy
 	for _, proposal := range tx.ProposalProcedures() {
 		if proposal == nil {

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -689,7 +689,7 @@ func UtxoValidateGovActionWellFormedness(
 		// hash.
 		if withPolicy, ok := govAction.(common.GovActionWithPolicy); ok {
 			policyHash := withPolicy.GetPolicyHash()
-			if len(policyHash) != 0 &&
+			if policyHash != nil &&
 				len(policyHash) != common.Blake2b224Size {
 				return MalformedGovActionError{
 					Reason: fmt.Sprintf(
@@ -703,7 +703,7 @@ func UtxoValidateGovActionWellFormedness(
 
 		switch a := govAction.(type) {
 		case *common.NewConstitutionGovAction:
-			if l := len(a.Constitution.ScriptHash); l != 0 &&
+			if l := len(a.Constitution.ScriptHash); a.Constitution.ScriptHash != nil &&
 				l != common.Blake2b224Size {
 				return MalformedGovActionError{
 					Reason: fmt.Sprintf(
@@ -755,6 +755,65 @@ func UtxoValidateGovActionWellFormedness(
 					},
 				)
 				return ConflictingCommitteeUpdateError{Credentials: conflicting}
+			}
+		}
+	}
+	return UtxoValidateGuardrailsScriptHash(tx, slot, ls, pp)
+}
+
+// UtxoValidateGuardrailsScriptHash requires parameter-change and
+// treasury-withdrawal proposals to carry exactly the optional guardrails
+// script hash of the current constitution. Nil is the absent representation,
+// so absent/absent succeeds while either one-sided presence or differing
+// hashes fails.
+func UtxoValidateGuardrailsScriptHash(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	var actions []common.GovActionWithPolicy
+	for _, proposal := range tx.ProposalProcedures() {
+		if proposal == nil {
+			continue
+		}
+		govAction := proposal.GovAction()
+		if isNilGovAction(govAction) {
+			continue
+		}
+		withPolicy, ok := govAction.(common.GovActionWithPolicy)
+		if ok {
+			actions = append(actions, withPolicy)
+		}
+	}
+	if len(actions) == 0 {
+		return nil
+	}
+	if ls == nil {
+		return ConstitutionLookupError{
+			Err: errors.New("ledger state is nil"),
+		}
+	}
+	constitution, err := ls.Constitution()
+	if err != nil {
+		return ConstitutionLookupError{Err: err}
+	}
+	var expected []byte
+	if constitution != nil {
+		expected = constitution.ScriptHash
+		if expected != nil && len(expected) != common.Blake2b224Size {
+			return MalformedConstitutionError{
+				ScriptHashLength: len(expected),
+			}
+		}
+	}
+	for _, action := range actions {
+		actual := action.GetPolicyHash()
+		if (actual == nil) != (expected == nil) ||
+			!bytes.Equal(actual, expected) {
+			return InvalidGuardrailsScriptHashError{
+				Actual:   bytes.Clone(actual),
+				Expected: bytes.Clone(expected),
 			}
 		}
 	}

--- a/ledger/conway/rules_guardrails_test.go
+++ b/ledger/conway/rules_guardrails_test.go
@@ -1,0 +1,306 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conway_test
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/require"
+)
+
+func guardrailsState(scriptHash []byte) common.LedgerState {
+	return mockledger.NewLedgerStateBuilder().
+		WithConstitutionValue(&common.Constitution{
+			ScriptHash: bytes.Clone(scriptHash),
+		}).
+		Build()
+}
+
+func guardrailsParameterChange(policyHash []byte) common.GovAction {
+	minFeeA := uint(44)
+	return &conway.ConwayParameterChangeGovAction{
+		Type: uint(common.GovActionTypeParameterChange),
+		ParamUpdate: conway.ConwayProtocolParameterUpdate{
+			MinFeeA: &minFeeA,
+		},
+		PolicyHash: bytes.Clone(policyHash),
+	}
+}
+
+func guardrailsTreasuryWithdrawal(
+	t *testing.T,
+	policyHash []byte,
+) common.GovAction {
+	t.Helper()
+	rewardAddress := makeConwayRewardAddress(
+		t,
+		common.Blake2b224Hash([]byte("guardrails-withdrawal")),
+	)
+	return &common.TreasuryWithdrawalGovAction{
+		Type: uint(common.GovActionTypeTreasuryWithdrawal),
+		Withdrawals: map[*common.Address]uint64{
+			&rewardAddress: 1,
+		},
+		PolicyHash: bytes.Clone(policyHash),
+	}
+}
+
+func TestUtxoValidateGuardrailsScriptHash(t *testing.T) {
+	guardrailsHash := common.Blake2b224Hash([]byte("constitution-guardrails"))
+	differentHash := common.Blake2b224Hash([]byte("different-guardrails"))
+
+	for _, actionFactory := range []struct {
+		name string
+		new  func(*testing.T, []byte) common.GovAction
+	}{
+		{
+			name: "parameter change",
+			new: func(_ *testing.T, hash []byte) common.GovAction {
+				return guardrailsParameterChange(hash)
+			},
+		},
+		{
+			name: "treasury withdrawal",
+			new:  guardrailsTreasuryWithdrawal,
+		},
+	} {
+		t.Run(actionFactory.name, func(t *testing.T) {
+			tests := []struct {
+				name         string
+				constitution []byte
+				policy       []byte
+				wantErr      bool
+				wantActual   []byte
+				wantExpected []byte
+			}{
+				{
+					name:         "matching hashes",
+					constitution: guardrailsHash.Bytes(),
+					policy:       guardrailsHash.Bytes(),
+				},
+				{name: "both absent"},
+				{
+					name:         "proposal absent",
+					constitution: guardrailsHash.Bytes(),
+					wantErr:      true,
+					wantExpected: guardrailsHash.Bytes(),
+				},
+				{
+					name:       "constitution absent",
+					policy:     guardrailsHash.Bytes(),
+					wantErr:    true,
+					wantActual: guardrailsHash.Bytes(),
+				},
+				{
+					name:         "different hashes",
+					constitution: guardrailsHash.Bytes(),
+					policy:       differentHash.Bytes(),
+					wantErr:      true,
+					wantActual:   differentHash.Bytes(),
+					wantExpected: guardrailsHash.Bytes(),
+				},
+			}
+
+			for _, tc := range tests {
+				t.Run(tc.name, func(t *testing.T) {
+					tx := mkProposalTx(
+						0,
+						common.Address{},
+						actionFactory.new(t, tc.policy),
+					)
+					err := conway.UtxoValidateGovActionWellFormedness(
+						tx,
+						0,
+						guardrailsState(tc.constitution),
+						nil,
+					)
+					if !tc.wantErr {
+						require.NoError(t, err)
+						return
+					}
+					var target conway.InvalidGuardrailsScriptHashError
+					require.ErrorAs(t, err, &target)
+					require.Equal(t, tc.wantActual, target.Actual)
+					require.Equal(t, tc.wantExpected, target.Expected)
+				})
+			}
+		})
+	}
+}
+
+func TestUtxoValidateGuardrailsScriptHashStateFailures(t *testing.T) {
+	tx := mkProposalTx(
+		0,
+		common.Address{},
+		guardrailsParameterChange(nil),
+	)
+
+	t.Run("nil ledger state", func(t *testing.T) {
+		err := conway.UtxoValidateGuardrailsScriptHash(tx, 0, nil, nil)
+		var target conway.ConstitutionLookupError
+		require.ErrorAs(t, err, &target)
+	})
+
+	t.Run("lookup error", func(t *testing.T) {
+		lookupErr := errors.New("constitution unavailable")
+		state := mockledger.NewLedgerStateBuilder().
+			WithConstitution(func() (*common.Constitution, error) {
+				return nil, lookupErr
+			}).
+			Build()
+		err := conway.UtxoValidateGuardrailsScriptHash(tx, 0, state, nil)
+		var target conway.ConstitutionLookupError
+		require.ErrorAs(t, err, &target)
+		require.ErrorIs(t, err, lookupErr)
+	})
+
+	t.Run("malformed constitution", func(t *testing.T) {
+		err := conway.UtxoValidateGuardrailsScriptHash(
+			tx,
+			0,
+			guardrailsState([]byte{}),
+			nil,
+		)
+		var target conway.MalformedConstitutionError
+		require.ErrorAs(t, err, &target)
+		require.Zero(t, target.ScriptHashLength)
+	})
+
+	t.Run(
+		"unrelated action does not need constitution state",
+		func(t *testing.T) {
+			infoTx := mkProposalTx(
+				0,
+				common.Address{},
+				&common.InfoGovAction{},
+			)
+			require.NoError(t, conway.UtxoValidateGuardrailsScriptHash(
+				infoTx,
+				0,
+				nil,
+				nil,
+			))
+		},
+	)
+}
+
+func TestUtxoValidateGuardrailsRejectsExplicitEmptyPolicy(t *testing.T) {
+	for _, action := range []common.GovAction{
+		guardrailsParameterChange([]byte{}),
+		guardrailsTreasuryWithdrawal(t, []byte{}),
+	} {
+		tx := mkProposalTx(0, common.Address{}, action)
+		err := conway.UtxoValidateGovActionWellFormedness(
+			tx,
+			0,
+			guardrailsState(nil),
+			nil,
+		)
+		var target conway.MalformedGovActionError
+		require.ErrorAs(t, err, &target)
+	}
+}
+
+func TestConwayValidationRulesEnforceGuardrailsOnDecodedTransaction(
+	t *testing.T,
+) {
+	guardrailsHash := common.Blake2b224Hash([]byte("constitution-guardrails"))
+	state := guardrailsState(guardrailsHash.Bytes())
+
+	decodeTx := func(t *testing.T, policyHash []byte) *conway.ConwayTransaction {
+		t.Helper()
+		rewardAddress := makeConwayRewardAddress(
+			t,
+			common.Blake2b224Hash([]byte("guardrails-return-account")),
+		)
+		tx := mkProposalTx(
+			0,
+			rewardAddress,
+			guardrailsParameterChange(policyHash),
+		)
+		tx.TxIsValid = true
+		encoded, err := cbor.Encode(tx)
+		require.NoError(t, err)
+		decoded, err := conway.NewConwayTransactionFromCbor(encoded)
+		require.NoError(t, err)
+		return decoded
+	}
+
+	// The guardrails check is part of the existing well-formedness rule. Run
+	// the production rule list through that rule to prove registration without
+	// relying on a second rule or changing consumer-visible rule indices.
+	guardrailsRules := conway.UtxoValidationRules[:3]
+	require.NoError(t, common.VerifyTransaction(
+		decodeTx(t, guardrailsHash.Bytes()),
+		0,
+		state,
+		&conway.ConwayProtocolParameters{},
+		guardrailsRules,
+	))
+
+	err := common.VerifyTransaction(
+		decodeTx(t, nil),
+		0,
+		state,
+		&conway.ConwayProtocolParameters{},
+		guardrailsRules,
+	)
+	var target conway.InvalidGuardrailsScriptHashError
+	require.ErrorAs(t, err, &target)
+}
+
+func TestGuardrailsPolicyRequiresScriptAuthorization(t *testing.T) {
+	nativeScriptBytes, err := cbor.Encode(&common.NativeScriptAll{
+		Type:    1,
+		Scripts: []common.NativeScript{},
+	})
+	require.NoError(t, err)
+	var nativeScript common.NativeScript
+	_, err = cbor.Decode(nativeScriptBytes, &nativeScript)
+	require.NoError(t, err)
+	policyHash := nativeScript.Hash()
+
+	tx := mkProposalTx(
+		0,
+		common.Address{},
+		guardrailsParameterChange(policyHash[:]),
+	)
+	tx.TxIsValid = true
+	state := guardrailsState(policyHash[:])
+	require.NoError(t, conway.UtxoValidateGovActionWellFormedness(
+		tx,
+		0,
+		state,
+		nil,
+	))
+
+	err = conway.UtxoValidateScriptWitnesses(tx, 0, state, nil)
+	var missing common.MissingScriptWitnessesError
+	require.ErrorAs(t, err, &missing)
+	require.Equal(t, policyHash, missing.ScriptHash)
+
+	tx.WitnessSet.WsNativeScripts = cbor.NewSetType(
+		[]common.NativeScript{nativeScript},
+		false,
+	)
+	require.NoError(t, conway.UtxoValidateScriptWitnesses(tx, 0, state, nil))
+	require.NoError(t, conway.UtxoValidateNativeScripts(tx, 0, state, nil))
+}

--- a/ledger/conway/rules_guardrails_test.go
+++ b/ledger/conway/rules_guardrails_test.go
@@ -34,6 +34,16 @@ func guardrailsState(scriptHash []byte) common.LedgerState {
 		Build()
 }
 
+func validGuardrailsProposalTx(
+	deposit uint64,
+	rewardAccount common.Address,
+	action common.GovAction,
+) *conway.ConwayTransaction {
+	tx := mkProposalTx(deposit, rewardAccount, action)
+	tx.TxIsValid = true
+	return tx
+}
+
 func guardrailsParameterChange(policyHash []byte) common.GovAction {
 	minFeeA := uint(44)
 	return &conway.ConwayParameterChangeGovAction{
@@ -121,7 +131,7 @@ func TestUtxoValidateGuardrailsScriptHash(t *testing.T) {
 
 			for _, tc := range tests {
 				t.Run(tc.name, func(t *testing.T) {
-					tx := mkProposalTx(
+					tx := validGuardrailsProposalTx(
 						0,
 						common.Address{},
 						actionFactory.new(t, tc.policy),
@@ -147,7 +157,7 @@ func TestUtxoValidateGuardrailsScriptHash(t *testing.T) {
 }
 
 func TestUtxoValidateGuardrailsScriptHashStateFailures(t *testing.T) {
-	tx := mkProposalTx(
+	tx := validGuardrailsProposalTx(
 		0,
 		common.Address{},
 		guardrailsParameterChange(nil),
@@ -187,7 +197,7 @@ func TestUtxoValidateGuardrailsScriptHashStateFailures(t *testing.T) {
 	t.Run(
 		"unrelated action does not need constitution state",
 		func(t *testing.T) {
-			infoTx := mkProposalTx(
+			infoTx := validGuardrailsProposalTx(
 				0,
 				common.Address{},
 				&common.InfoGovAction{},
@@ -207,7 +217,7 @@ func TestUtxoValidateGuardrailsRejectsExplicitEmptyPolicy(t *testing.T) {
 		guardrailsParameterChange([]byte{}),
 		guardrailsTreasuryWithdrawal(t, []byte{}),
 	} {
-		tx := mkProposalTx(0, common.Address{}, action)
+		tx := validGuardrailsProposalTx(0, common.Address{}, action)
 		err := conway.UtxoValidateGovActionWellFormedness(
 			tx,
 			0,
@@ -225,7 +235,11 @@ func TestConwayValidationRulesEnforceGuardrailsOnDecodedTransaction(
 	guardrailsHash := common.Blake2b224Hash([]byte("constitution-guardrails"))
 	state := guardrailsState(guardrailsHash.Bytes())
 
-	decodeTx := func(t *testing.T, policyHash []byte) *conway.ConwayTransaction {
+	decodeTx := func(
+		t *testing.T,
+		isValid bool,
+		policyHash []byte,
+	) *conway.ConwayTransaction {
 		t.Helper()
 		rewardAddress := makeConwayRewardAddress(
 			t,
@@ -236,7 +250,7 @@ func TestConwayValidationRulesEnforceGuardrailsOnDecodedTransaction(
 			rewardAddress,
 			guardrailsParameterChange(policyHash),
 		)
-		tx.TxIsValid = true
+		tx.TxIsValid = isValid
 		encoded, err := cbor.Encode(tx)
 		require.NoError(t, err)
 		decoded, err := conway.NewConwayTransactionFromCbor(encoded)
@@ -244,12 +258,29 @@ func TestConwayValidationRulesEnforceGuardrailsOnDecodedTransaction(
 		return decoded
 	}
 
-	// The guardrails check is part of the existing well-formedness rule. Run
-	// the production rule list through that rule to prove registration without
-	// relying on a second rule or changing consumer-visible rule indices.
-	guardrailsRules := conway.UtxoValidationRules[:3]
+	// Locate the registered rule by its valid-transaction behavior. This keeps
+	// the regression attached to the production rule list without depending on
+	// a rule index or on whether phase-valid rules have been composed.
+	validMismatch := decodeTx(t, true, nil)
+	var guardrailsRule common.UtxoValidationRuleFunc
+	for _, rule := range conway.UtxoValidationRules {
+		err := rule(
+			validMismatch,
+			0,
+			state,
+			&conway.ConwayProtocolParameters{},
+		)
+		var target conway.InvalidGuardrailsScriptHashError
+		if errors.As(err, &target) {
+			guardrailsRule = rule
+			break
+		}
+	}
+	require.NotNil(t, guardrailsRule, "guardrails validation rule is not registered")
+	guardrailsRules := []common.UtxoValidationRuleFunc{guardrailsRule}
+
 	require.NoError(t, common.VerifyTransaction(
-		decodeTx(t, guardrailsHash.Bytes()),
+		decodeTx(t, true, guardrailsHash.Bytes()),
 		0,
 		state,
 		&conway.ConwayProtocolParameters{},
@@ -257,7 +288,7 @@ func TestConwayValidationRulesEnforceGuardrailsOnDecodedTransaction(
 	))
 
 	err := common.VerifyTransaction(
-		decodeTx(t, nil),
+		validMismatch,
 		0,
 		state,
 		&conway.ConwayProtocolParameters{},
@@ -265,6 +296,14 @@ func TestConwayValidationRulesEnforceGuardrailsOnDecodedTransaction(
 	)
 	var target conway.InvalidGuardrailsScriptHashError
 	require.ErrorAs(t, err, &target)
+
+	require.NoError(t, common.VerifyTransaction(
+		decodeTx(t, false, nil),
+		0,
+		state,
+		&conway.ConwayProtocolParameters{},
+		guardrailsRules,
+	))
 }
 
 func TestGuardrailsPolicyRequiresScriptAuthorization(t *testing.T) {

--- a/ledger/dijkstra/gov.go
+++ b/ledger/dijkstra/gov.go
@@ -132,7 +132,7 @@ func (a *DijkstraParameterChangeGovAction) ToPlutusData() data.PlutusData {
 		actionId = data.NewConstr(0, a.ActionId.ToPlutusData())
 	}
 	policyHash := data.NewConstr(1)
-	if len(a.PolicyHash) > 0 {
+	if a.PolicyHash != nil {
 		policyHash = data.NewConstr(
 			0,
 			data.NewByteString(a.PolicyHash),

--- a/ledger/dijkstra/rules_test.go
+++ b/ledger/dijkstra/rules_test.go
@@ -84,16 +84,19 @@ func TestDijkstraGovernanceValidationRules(t *testing.T) {
 
 func TestDijkstraGovernanceValidationEnforcesGuardrails(t *testing.T) {
 	guardrailsHash := common.Blake2b224Hash([]byte("constitution-guardrails"))
-	newTx := func(policyHash []byte) *DijkstraTransaction {
-		return &DijkstraTransaction{Body: DijkstraTransactionBody{
-			TxProposalProcedures: []DijkstraProposalProcedure{{
-				PPGovAction: DijkstraGovAction{
-					Action: &DijkstraParameterChangeGovAction{
-						PolicyHash: policyHash,
+	newTx := func(isValid bool, policyHash []byte) *DijkstraTransaction {
+		return &DijkstraTransaction{
+			Body: DijkstraTransactionBody{
+				TxProposalProcedures: []DijkstraProposalProcedure{{
+					PPGovAction: DijkstraGovAction{
+						Action: &DijkstraParameterChangeGovAction{
+							PolicyHash: policyHash,
+						},
 					},
-				},
-			}},
-		}}
+				}},
+			},
+			TxIsValid: isValid,
+		}
 	}
 	state := mockledger.NewLedgerStateBuilder().
 		WithConstitutionValue(&common.Constitution{
@@ -105,15 +108,20 @@ func TestDijkstraGovernanceValidationEnforcesGuardrails(t *testing.T) {
 		"ledger/conway.UtxoValidateGovActionWellFormedness",
 	)
 
-	require.NoError(t, rule(
-		newTx(guardrailsHash.Bytes()),
-		0,
-		state,
-		&DijkstraProtocolParameters{},
-	))
-	err := rule(newTx(nil), 0, state, &DijkstraProtocolParameters{})
+	validate := func(tx common.Transaction) error {
+		return common.VerifyTransaction(
+			tx,
+			0,
+			state,
+			&DijkstraProtocolParameters{},
+			[]common.UtxoValidationRuleFunc{rule},
+		)
+	}
+	require.NoError(t, validate(newTx(true, guardrailsHash.Bytes())))
+	err := validate(newTx(true, nil))
 	var target conway.InvalidGuardrailsScriptHashError
 	require.ErrorAs(t, err, &target)
+	require.NoError(t, validate(newTx(false, nil)))
 }
 
 func TestConwayGovActionRejectsDijkstraParameterChange(t *testing.T) {

--- a/ledger/dijkstra/rules_test.go
+++ b/ledger/dijkstra/rules_test.go
@@ -82,6 +82,40 @@ func TestDijkstraGovernanceValidationRules(t *testing.T) {
 	}
 }
 
+func TestDijkstraGovernanceValidationEnforcesGuardrails(t *testing.T) {
+	guardrailsHash := common.Blake2b224Hash([]byte("constitution-guardrails"))
+	newTx := func(policyHash []byte) *DijkstraTransaction {
+		return &DijkstraTransaction{Body: DijkstraTransactionBody{
+			TxProposalProcedures: []DijkstraProposalProcedure{{
+				PPGovAction: DijkstraGovAction{
+					Action: &DijkstraParameterChangeGovAction{
+						PolicyHash: policyHash,
+					},
+				},
+			}},
+		}}
+	}
+	state := mockledger.NewLedgerStateBuilder().
+		WithConstitutionValue(&common.Constitution{
+			ScriptHash: guardrailsHash.Bytes(),
+		}).
+		Build()
+	rule, _ := dijkstraValidationRule(
+		t,
+		"ledger/conway.UtxoValidateGovActionWellFormedness",
+	)
+
+	require.NoError(t, rule(
+		newTx(guardrailsHash.Bytes()),
+		0,
+		state,
+		&DijkstraProtocolParameters{},
+	))
+	err := rule(newTx(nil), 0, state, &DijkstraProtocolParameters{})
+	var target conway.InvalidGuardrailsScriptHashError
+	require.ErrorAs(t, err, &target)
+}
+
 func TestConwayGovActionRejectsDijkstraParameterChange(t *testing.T) {
 	_, err := conway.NewConwayGovAction(&DijkstraParameterChangeGovAction{})
 	require.Error(t, err)


### PR DESCRIPTION
Fixes #2136

Carry the Conway constitution anchor and guardrails policy hash through the ledger contract and enforce exact guardrails-script authorization for constitution parameter changes and treasury withdrawals. Adds malformed, mismatch, and authorization regression coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the Conway constitution's optional guardrails script hash: parameter-change and treasury-withdrawal proposals must carry exactly the current constitution's guardrails policy hash, or none at all; invalid transactions skip this check. Also treats only `nil` as absent for optional policy/script hashes; an explicit empty byte string is now rejected as malformed.

- The ledger's `Constitution` now carries the anchor and optional script hash, read from state during well-formedness checks.
- Adds `ConstitutionLookupError`, `MalformedConstitutionError`, and `InvalidGuardrailsScriptHashError` for the new validation paths.
- Adds regression coverage for matching, absent, mismatched, empty, and malformed hashes, plus script-witness authorization and invalid-transaction skipping.

<sup>Written for commit fa5d22f0a70b3cb733c63030398d0d2b63862e2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added governance validation requiring proposal policy hashes to match the constitution’s guardrails script hash.
  * Added clear errors for missing, mismatched, malformed, or unavailable constitution guardrails data.
  * Added concrete constitution support for anchors and optional guardrails script hashes.

* **Bug Fixes**
  * Optional hashes now consistently distinguish absent (`nil`) values from explicitly empty hashes.
  * Invalid empty or incorrectly sized hashes are rejected during governance validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
