### PR TITLE
fix(conway): enforce committee term limit

### DIFF
--- a/internal/test/conformance/conformance_test.go
+++ b/internal/test/conformance/conformance_test.go
@@ -17,8 +17,70 @@ package conformance
 import (
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/ouroboros-mock/conformance"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
 )
+
+type currentEpochStateProvider struct {
+	*mockledger.MockLedgerState
+	currentEpoch uint64
+}
+
+func (p currentEpochStateProvider) CurrentEpoch() uint64 {
+	return p.currentEpoch
+}
+
+type currentEpochStateManager struct {
+	*conformance.MockStateManager
+	currentEpoch uint64
+}
+
+func newCurrentEpochStateManager() *currentEpochStateManager {
+	return &currentEpochStateManager{
+		MockStateManager: conformance.NewMockStateManager(),
+	}
+}
+
+func (m *currentEpochStateManager) LoadInitialState(
+	state *conformance.ParsedInitialState,
+	pp common.ProtocolParameters,
+) error {
+	if err := m.MockStateManager.LoadInitialState(state, pp); err != nil {
+		return err
+	}
+	m.currentEpoch = state.CurrentEpoch
+	return nil
+}
+
+func (m *currentEpochStateManager) ProcessEpochBoundary(
+	newEpoch uint64,
+) error {
+	if err := m.MockStateManager.ProcessEpochBoundary(newEpoch); err != nil {
+		return err
+	}
+	m.currentEpoch = newEpoch
+	return nil
+}
+
+func (m *currentEpochStateManager) GetStateProvider() conformance.StateProvider {
+	state, ok := m.MockStateManager.GetStateProvider().(*mockledger.MockLedgerState)
+	if !ok {
+		panic("ouroboros-mock returned an unexpected state provider")
+	}
+	return currentEpochStateProvider{
+		MockLedgerState: state,
+		currentEpoch:    m.currentEpoch,
+	}
+}
+
+func (m *currentEpochStateManager) Reset() error {
+	if err := m.MockStateManager.Reset(); err != nil {
+		return err
+	}
+	m.currentEpoch = 0
+	return nil
+}
 
 // TestRulesConformanceVectors runs the Amaru ledger rules conformance test vectors
 // using the shared harness from ouroboros-mock/conformance.
@@ -36,7 +98,7 @@ func TestRulesConformanceVectors(t *testing.T) {
 		t.Fatalf("failed to extract embedded testdata: %v", err)
 	}
 
-	sm := conformance.NewMockStateManager()
+	sm := newCurrentEpochStateManager()
 	harness := conformance.NewHarness(sm, conformance.HarnessConfig{
 		TestdataRoot: testdataRoot,
 		Debug:        testing.Verbose(),
@@ -53,7 +115,7 @@ func TestRulesConformanceVectorsWithResults(t *testing.T) {
 		t.Fatalf("failed to extract embedded testdata: %v", err)
 	}
 
-	sm := conformance.NewMockStateManager()
+	sm := newCurrentEpochStateManager()
 	harness := conformance.NewHarness(sm, conformance.HarnessConfig{
 		TestdataRoot: testdataRoot,
 		Debug:        false,

--- a/ledger/common/pparams.go
+++ b/ledger/common/pparams.go
@@ -40,6 +40,13 @@ type ProtocolParameters interface {
 	Utxorpc() (*cardano.PParams, error)
 }
 
+// CommitteeMaxTermLengthProvider is the optional protocol-parameter
+// capability used by Conway committee certificate validation. The boolean is
+// false when the parameter is unavailable; zero is a present, valid limit.
+type CommitteeMaxTermLengthProvider interface {
+	CommitteeMaxTermLength() (uint64, bool)
+}
+
 type ExUnitPrice struct {
 	cbor.StructAsArray
 	MemPrice  *cbor.Rat

--- a/ledger/common/state.go
+++ b/ledger/common/state.go
@@ -119,6 +119,12 @@ type SlotState interface {
 	TimeToSlot(time.Time) (uint64, error)
 }
 
+// CurrentEpochState is the optional ledger-state capability used by rules
+// whose protocol bounds are expressed relative to the current epoch.
+type CurrentEpochState interface {
+	CurrentEpoch() uint64
+}
+
 // Minimal placeholder types used by the extended interface. These are intentionally
 // lightweight so tests and era packages can compile while we wire real parsing.
 type (

--- a/ledger/conway/committee_term_test.go
+++ b/ledger/conway/committee_term_test.go
@@ -1,0 +1,275 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conway_test
+
+import (
+	"math"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type committeeTermLedgerState struct {
+	common.LedgerState
+	currentEpoch uint64
+}
+
+func (s committeeTermLedgerState) CurrentEpoch() uint64 {
+	return s.currentEpoch
+}
+
+func committeeCertificateRule(
+	t *testing.T,
+) common.UtxoValidationRuleFunc {
+	t.Helper()
+	for _, rule := range conway.UtxoValidationRules {
+		name := runtime.FuncForPC(reflect.ValueOf(rule).Pointer()).Name()
+		if strings.HasSuffix(
+			name,
+			"ledger/conway.UtxoValidateCommitteeCertificates",
+		) {
+			return rule
+		}
+	}
+	t.Fatal("committee certificate rule is not registered")
+	return nil
+}
+
+func committeeCertificateTx(
+	credential common.Credential,
+	resign bool,
+) *conway.ConwayTransaction {
+	var cert common.Certificate
+	var certType common.CertificateType
+	if resign {
+		certType = common.CertificateTypeResignCommitteeCold
+		cert = &common.ResignCommitteeColdCertificate{
+			CertType:       uint(certType),
+			ColdCredential: credential,
+		}
+	} else {
+		certType = common.CertificateTypeAuthCommitteeHot
+		cert = &common.AuthCommitteeHotCertificate{
+			CertType:       uint(certType),
+			ColdCredential: credential,
+			HotCredential: common.Credential{
+				CredType: common.CredentialTypeAddrKeyHash,
+				Credential: common.Blake2b224Hash(
+					[]byte("committee-hot-key"),
+				),
+			},
+		}
+	}
+	return &conway.ConwayTransaction{
+		Body: conway.ConwayTransactionBody{
+			TxCertificates: []common.CertificateWrapper{{
+				Type:        uint(certType),
+				Certificate: cert,
+			}},
+		},
+	}
+}
+
+func verifyCommitteeCertificate(
+	t *testing.T,
+	tx common.Transaction,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	t.Helper()
+	return common.VerifyTransaction(
+		tx,
+		0,
+		ls,
+		pp,
+		[]common.UtxoValidationRuleFunc{committeeCertificateRule(t)},
+	)
+}
+
+func TestCommitteeCertificateTermLimitProductionRule(t *testing.T) {
+	coldKey := common.Blake2b224Hash([]byte("committee-cold-key"))
+	credential := common.Credential{
+		CredType:   common.CredentialTypeAddrKeyHash,
+		Credential: coldKey,
+	}
+
+	tests := []struct {
+		name         string
+		currentEpoch uint64
+		expiryEpoch  uint64
+		maxTerm      uint64
+		proposed     bool
+		resign       bool
+		wantTooLong  bool
+	}{
+		{
+			name:         "below boundary",
+			currentEpoch: 100,
+			expiryEpoch:  109,
+			maxTerm:      10,
+		},
+		{
+			name:         "at boundary",
+			currentEpoch: 100,
+			expiryEpoch:  110,
+			maxTerm:      10,
+		},
+		{
+			name:         "over boundary",
+			currentEpoch: 100,
+			expiryEpoch:  111,
+			maxTerm:      10,
+			wantTooLong:  true,
+		},
+		{
+			name:         "zero limit at current epoch",
+			currentEpoch: 100,
+			expiryEpoch:  100,
+			maxTerm:      0,
+			proposed:     true,
+		},
+		{
+			name:         "zero limit with positive remaining term",
+			currentEpoch: 100,
+			expiryEpoch:  101,
+			maxTerm:      0,
+			proposed:     true,
+			wantTooLong:  true,
+		},
+		{
+			name:         "proposed member resignation over boundary",
+			currentEpoch: 100,
+			expiryEpoch:  111,
+			maxTerm:      10,
+			proposed:     true,
+			resign:       true,
+			wantTooLong:  true,
+		},
+		{
+			name:         "uint64 addition would overflow",
+			currentEpoch: math.MaxUint64 - 2,
+			expiryEpoch:  math.MaxUint64,
+			maxTerm:      5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := mockledger.NewLedgerStateBuilder()
+			if tt.proposed {
+				builder.WithProposedCommitteeMembers(
+					map[common.Blake2b224]uint64{
+						coldKey: tt.expiryEpoch,
+					},
+				)
+			} else {
+				builder.WithCommitteeMembers([]common.CommitteeMember{{
+					ColdKey:     coldKey,
+					ExpiryEpoch: tt.expiryEpoch,
+				}})
+			}
+			ls := committeeTermLedgerState{
+				LedgerState:  builder.Build(),
+				currentEpoch: tt.currentEpoch,
+			}
+			pp := &conway.ConwayProtocolParameters{
+				CommitteeTermLimit: tt.maxTerm,
+			}
+			err := verifyCommitteeCertificate(
+				t,
+				committeeCertificateTx(credential, tt.resign),
+				ls,
+				pp,
+			)
+			if !tt.wantTooLong {
+				require.NoError(t, err)
+				return
+			}
+			var termErr conway.CommitteeTermTooLongError
+			require.ErrorAs(t, err, &termErr)
+			assert.Equal(t, coldKey, termErr.Credential)
+			assert.Equal(t, tt.currentEpoch, termErr.CurrentEpoch)
+			assert.Equal(t, tt.expiryEpoch, termErr.ExpiryEpoch)
+			assert.Equal(t, tt.maxTerm, termErr.MaxTermLength)
+		})
+	}
+}
+
+func TestCommitteeCertificateTermLimitUnavailable(t *testing.T) {
+	coldKey := common.Blake2b224Hash([]byte("committee-cold-key"))
+	credential := common.Credential{
+		CredType:   common.CredentialTypeAddrKeyHash,
+		Credential: coldKey,
+	}
+	ls := committeeTermLedgerState{
+		LedgerState: mockledger.NewLedgerStateBuilder().
+			WithCommitteeMembers([]common.CommitteeMember{{
+				ColdKey:     coldKey,
+				ExpiryEpoch: 101,
+			}}).
+			Build(),
+		currentEpoch: 100,
+	}
+	tx := committeeCertificateTx(credential, false)
+	var nilPparams *conway.ConwayProtocolParameters
+
+	for name, pp := range map[string]common.ProtocolParameters{
+		"unsupported parameters": &mockledger.MockProtocolParamsRules{},
+		"typed nil parameters":   nilPparams,
+	} {
+		t.Run(name, func(t *testing.T) {
+			var err error
+			require.NotPanics(t, func() {
+				err = verifyCommitteeCertificate(t, tx, ls, pp)
+			})
+			var unavailable conway.CommitteeTermLimitUnavailableError
+			require.ErrorAs(t, err, &unavailable)
+		})
+	}
+}
+
+func TestCommitteeCertificateCurrentEpochUnavailable(t *testing.T) {
+	coldKey := common.Blake2b224Hash([]byte("committee-cold-key"))
+	credential := common.Credential{
+		CredType:   common.CredentialTypeAddrKeyHash,
+		Credential: coldKey,
+	}
+	ls := mockledger.NewLedgerStateBuilder().
+		WithCommitteeMembers([]common.CommitteeMember{{
+			ColdKey:     coldKey,
+			ExpiryEpoch: 101,
+		}}).
+		Build()
+	pp := &conway.ConwayProtocolParameters{CommitteeTermLimit: 10}
+
+	var err error
+	require.NotPanics(t, func() {
+		err = verifyCommitteeCertificate(
+			t,
+			committeeCertificateTx(credential, false),
+			ls,
+			pp,
+		)
+	})
+	var unavailable conway.CurrentEpochStateUnavailableError
+	require.ErrorAs(t, err, &unavailable)
+}

--- a/ledger/conway/errors.go
+++ b/ledger/conway/errors.go
@@ -423,6 +423,41 @@ func (e CommitteeMemberLookupError) Unwrap() error {
 	return e.Err
 }
 
+// CommitteeTermLimitUnavailableError indicates that protocol parameters do
+// not expose the constitutional committee maximum term length.
+type CommitteeTermLimitUnavailableError struct{}
+
+func (CommitteeTermLimitUnavailableError) Error() string {
+	return "constitutional committee maximum term length is unavailable"
+}
+
+// CurrentEpochStateUnavailableError indicates that committee term validation
+// cannot determine the current epoch.
+type CurrentEpochStateUnavailableError struct{}
+
+func (CurrentEpochStateUnavailableError) Error() string {
+	return "ledger state does not expose the current epoch"
+}
+
+// CommitteeTermTooLongError indicates that a committee member's expiry is
+// beyond the configured maximum term measured from the current epoch.
+type CommitteeTermTooLongError struct {
+	Credential    common.Blake2b224
+	CurrentEpoch  uint64
+	ExpiryEpoch   uint64
+	MaxTermLength uint64
+}
+
+func (e CommitteeTermTooLongError) Error() string {
+	return fmt.Sprintf(
+		"CC member %x expires at epoch %d, beyond current epoch %d plus maximum term length %d",
+		e.Credential[:],
+		e.ExpiryEpoch,
+		e.CurrentEpoch,
+		e.MaxTermLength,
+	)
+}
+
 // DuplicateVrfKeyError indicates a pool registration attempted to use a VRF key
 // already registered by another pool. Introduced in Protocol Version 11.
 type DuplicateVrfKeyError struct {

--- a/ledger/conway/pparams.go
+++ b/ledger/conway/pparams.go
@@ -62,9 +62,21 @@ type ConwayProtocolParameters struct {
 	MinFeeRefScriptCostPerByte *cbor.Rat
 }
 
+var _ common.CommitteeMaxTermLengthProvider = (*ConwayProtocolParameters)(nil)
+
 // ProtocolMajorVersion returns the active major protocol version.
 func (p *ConwayProtocolParameters) ProtocolMajorVersion() uint {
 	return p.ProtocolVersion.Major
+}
+
+// CommitteeMaxTermLength returns the configured maximum constitutional
+// committee term in epochs. A nil receiver represents an unavailable
+// parameter, while zero remains a present and enforceable limit.
+func (p *ConwayProtocolParameters) CommitteeMaxTermLength() (uint64, bool) {
+	if p == nil {
+		return 0, false
+	}
+	return p.CommitteeTermLimit, true
 }
 
 // KeyDepositAmount returns the key deposit as a *big.Int

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -3319,6 +3319,13 @@ func UtxoValidateCommitteeCertificates(
 			if member != nil && member.Resigned {
 				return ResignedCommitteeMemberHotKeyError{ColdKey: coldHash}
 			}
+			if member != nil {
+				if err := validateCommitteeTerm(
+					coldHash, member.ExpiryEpoch, ls, pp,
+				); err != nil {
+					return err
+				}
+			}
 
 		case *common.ResignCommitteeColdCertificate:
 			coldHash := c.ColdCredential.Credential
@@ -3329,6 +3336,50 @@ func UtxoValidateCommitteeCertificates(
 			if member == nil && hasCommitteeState {
 				return NotCommitteeMemberError{Credential: coldHash, Operation: "resign"}
 			}
+			if member != nil {
+				if err := validateCommitteeTerm(
+					coldHash, member.ExpiryEpoch, ls, pp,
+				); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// validateCommitteeTerm mirrors validCommitteeTerm in
+// Cardano.Ledger.Conway.Rules.Ratify. CommitteeMember includes proposed
+// members, so the same bound must hold before a committee certificate can
+// authorize or resign one of them.
+func validateCommitteeTerm(
+	credential common.Blake2b224,
+	expiryEpoch uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	termParams, ok := pp.(common.CommitteeMaxTermLengthProvider)
+	if !ok {
+		return CommitteeTermLimitUnavailableError{}
+	}
+	maxTermLength, ok := termParams.CommitteeMaxTermLength()
+	if !ok {
+		return CommitteeTermLimitUnavailableError{}
+	}
+	epochState, ok := ls.(common.CurrentEpochState)
+	if !ok {
+		return CurrentEpochStateUnavailableError{}
+	}
+	currentEpoch := epochState.CurrentEpoch()
+	// This is equivalent to expiryEpoch > currentEpoch+maxTermLength,
+	// without overflowing when the sum exceeds uint64.
+	if expiryEpoch > currentEpoch &&
+		expiryEpoch-currentEpoch > maxTermLength {
+		return CommitteeTermTooLongError{
+			Credential:    credential,
+			CurrentEpoch:  currentEpoch,
+			ExpiryEpoch:   expiryEpoch,
+			MaxTermLength: maxTermLength,
 		}
 	}
 	return nil

--- a/ledger/dijkstra/pparams.go
+++ b/ledger/dijkstra/pparams.go
@@ -34,6 +34,8 @@ type DijkstraProtocolParameters struct {
 	QuorumStakeThreshold     *cbor.Rat
 }
 
+var _ common.CommitteeMaxTermLengthProvider = (*DijkstraProtocolParameters)(nil)
+
 type dijkstraProtocolParametersCbor struct {
 	cbor.StructAsArray
 	MinFeeA                    uint


### PR DESCRIPTION
Enforce the configured maximum constitutional-committee term with an
overflow-safe current-epoch bound. Reject validation when required protocol or
epoch state is unavailable.

Fixes #2144
