### PR TITLE
fix(pipeline): make drain boundary exact

### DIFF
--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -121,14 +121,30 @@ func NewBlockPipeline(opts ...PipelineOption) *BlockPipeline {
 }
 
 func (p *BlockPipeline) lockSubmit(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if p.ctx.Err() != nil {
+		return ErrPipelineStopped
+	}
+
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-p.ctx.Done():
 		return ErrPipelineStopped
 	case <-p.submitGate:
-		return nil
 	}
+
+	if err := ctx.Err(); err != nil {
+		p.unlockSubmit()
+		return err
+	}
+	if p.ctx.Err() != nil {
+		p.unlockSubmit()
+		return ErrPipelineStopped
+	}
+	return nil
 }
 
 func (p *BlockPipeline) unlockSubmit() {
@@ -264,17 +280,27 @@ func (p *BlockPipeline) Submit(
 		p.testSubmitLocked()
 	}
 
-	// Check stopping under the gate to ensure we don't race with Stop.
-	if p.stopping.Load() || p.stopped.Load() {
-		return ErrPipelineStopped
-	}
-
 	// Commit a sequence number only after its item was successfully enqueued.
 	// Keeping the provisional ID under submitGate makes successful IDs unique and
 	// contiguous in queue order, while canceled or backpressured submissions do
 	// not create positions that Fence must wait for.
 	sequence := p.sequenceCounter.Load()
 	item := NewBlockItem(blockType, rawCbor, tip, sequence)
+
+	// Preserve cancellation precedence over an immediately writable input.
+	// These checks are repeated under submitGate so cancellation that occurred
+	// while acquiring the gate cannot lose a ready select tie to the enqueue.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if p.ctx.Err() != nil {
+		return ErrPipelineStopped
+	}
+	// Check stopping under the gate to ensure we don't race with Stop. This
+	// follows the context checks so caller cancellation keeps precedence.
+	if p.stopping.Load() || p.stopped.Load() {
+		return ErrPipelineStopped
+	}
 
 	select {
 	case p.submitChan <- item:

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -82,6 +82,7 @@ type BlockPipeline struct {
 	ctx               context.Context
 	cancel            context.CancelFunc
 	started           atomic.Bool
+	stopping          atomic.Bool
 	stopped           atomic.Bool
 	wg                sync.WaitGroup
 	mu                sync.Mutex // protects Start/Stop
@@ -90,9 +91,10 @@ type BlockPipeline struct {
 	submitGate     chan struct{}
 	completionMu   sync.Mutex
 	completionChan chan struct{}
-	// The test hook makes blocked Submit/Fence interleavings deterministic
-	// without changing production behavior.
-	testSubmitLocked func()
+	// Test hooks must be installed before Start. They make blocked Submit/Fence
+	// interleavings deterministic without changing production behavior.
+	testSubmitLocked  func()
+	testFenceBoundary func(uint64)
 }
 
 // NewBlockPipeline creates a new BlockPipeline using functional options.
@@ -138,7 +140,7 @@ func (p *BlockPipeline) Start(ctx context.Context) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if p.stopped.Load() {
+	if p.stopping.Load() || p.stopped.Load() {
 		return ErrPipelineStopped
 	}
 
@@ -262,8 +264,8 @@ func (p *BlockPipeline) Submit(
 		p.testSubmitLocked()
 	}
 
-	// Check stopped under lock to ensure we don't race with Stop()
-	if p.stopped.Load() {
+	// Check stopping under the gate to ensure we don't race with Stop.
+	if p.stopping.Load() || p.stopped.Load() {
 		return ErrPipelineStopped
 	}
 
@@ -301,12 +303,15 @@ func (p *BlockPipeline) Fence(ctx context.Context) error {
 	if err := p.lockSubmit(ctx); err != nil {
 		return err
 	}
-	if p.stopped.Load() {
+	if p.stopping.Load() || p.stopped.Load() {
 		p.unlockSubmit()
 		return ErrPipelineStopped
 	}
 	target := p.sequenceCounter.Load()
 	p.unlockSubmit()
+	if p.testFenceBoundary != nil {
+		p.testFenceBoundary(target)
+	}
 	if target == 0 {
 		return nil
 	}
@@ -368,10 +373,11 @@ func (p *BlockPipeline) Stop() error {
 		return nil
 	}
 
-	// Cancel context FIRST to unblock any Submit() calls waiting on channel send.
-	// This must happen before acquiring submitGate to avoid deadlock: Submit()
-	// holds the gate while blocking on the channel, and we need it to unblock
-	// via ctx.Done() before we can acquire the gate.
+	// Publish the explicit stop before canceling the pipeline context so drain
+	// waiters can distinguish Stop from cancellation inherited from Start.
+	p.stopping.Store(true)
+	// Cancel before acquiring submitGate to avoid deadlock: Submit holds the
+	// gate while blocked on a channel send and needs ctx.Done to unblock.
 	p.cancel()
 
 	// Now acquire the gate to ensure no Submit() calls are in progress.
@@ -437,23 +443,26 @@ func (p *BlockPipeline) PendingCount() int {
 // completed ordered processing, or the context is cancelled. This is useful
 // before handling rollbacks to ensure no earlier block is applied afterward.
 func (p *BlockPipeline) WaitForDrain(ctx context.Context) error {
-	if !p.started.Load() {
-		return ErrPipelineNotStarted
-	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	// Preserve the historical lifecycle contract: once Stop has completed,
-	// there can be no accepted work left to drain.
-	if p.stopped.Load() {
+	if !p.started.Load() {
+		return ErrPipelineNotStarted
+	}
+	// Preserve the historical lifecycle contract: explicit shutdown makes the
+	// drain vacuous, including while Stop waits for the submission gate.
+	if p.stopping.Load() || p.stopped.Load() {
 		return nil
 	}
 	err := p.Fence(ctx)
-	if errors.Is(err, ErrPipelineStopped) && p.stopped.Load() {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return ctxErr
-		}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	if p.stopping.Load() || p.stopped.Load() {
 		return nil
+	}
+	if p.ctx.Err() != nil {
+		return ErrPipelineStopped
 	}
 	return err
 }

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -410,9 +410,11 @@ func (p *BlockPipeline) Stats() PipelineStats {
 	return p.metrics.Stats()
 }
 
-// PendingCount returns the approximate number of items still being processed.
-// This includes items in inter-stage channels and items buffered in the apply stage.
-// Useful for coordinating with rollback operations.
+// PendingCount returns an observational snapshot of the approximate number of
+// items still being processed. It includes items in inter-stage channels and
+// items buffered or active in the apply stage, but not work executing in other
+// stages. It must not be used as a completion barrier; use Fence or
+// WaitForDrain instead.
 func (p *BlockPipeline) PendingCount() int {
 	if !p.started.Load() {
 		return 0
@@ -431,27 +433,29 @@ func (p *BlockPipeline) PendingCount() int {
 	return channelDepth + applyPending
 }
 
-// WaitForDrain blocks until all currently submitted items have been processed
-// or the context is cancelled. This is useful before handling rollbacks to
-// ensure no blocks are applied after the rollback.
+// WaitForDrain blocks until every block accepted before the drain boundary has
+// completed ordered processing, or the context is cancelled. This is useful
+// before handling rollbacks to ensure no earlier block is applied afterward.
 func (p *BlockPipeline) WaitForDrain(ctx context.Context) error {
 	if !p.started.Load() {
 		return ErrPipelineNotStarted
 	}
-
-	ticker := time.NewTicker(10 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
-			if p.PendingCount() == 0 {
-				return nil
-			}
-		}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
+	// Preserve the historical lifecycle contract: once Stop has completed,
+	// there can be no accepted work left to drain.
+	if p.stopped.Load() {
+		return nil
+	}
+	err := p.Fence(ctx)
+	if errors.Is(err, ErrPipelineStopped) && p.stopped.Load() {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return nil
+	}
+	return err
 }
 
 // metricsCollector collects metrics from processed items.

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -1453,9 +1453,7 @@ func TestBlockPipelineWaitForDrainConcurrentStopWithSubmitGateHeld(
 	release()
 	select {
 	case err := <-submitDone:
-		if err != nil {
-			require.ErrorIs(t, err, ErrPipelineStopped)
-		}
+		require.ErrorIs(t, err, ErrPipelineStopped)
 	case <-time.After(time.Second):
 		t.Fatal("submission did not return after release")
 	}

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -1247,6 +1247,260 @@ func TestBlockPipelineWaitForDrainLifecycle(t *testing.T) {
 	})
 }
 
+func TestBlockPipelineWaitForDrainConcurrentStopWithSubmitGateHeld(
+	t *testing.T,
+) {
+	submitLocked := make(chan struct{})
+	releaseSubmit := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseSubmit) })
+	}
+	p := NewBlockPipeline(
+		WithValidateWorkers(0),
+		WithSkipBodyHashValidation(true),
+	)
+	p.testSubmitLocked = func() {
+		close(submitLocked)
+		<-releaseSubmit
+	}
+	require.NoError(t, p.Start(context.Background()))
+	defer func() {
+		release()
+		require.NoError(t, p.Stop())
+	}()
+
+	rawCbor := getValidBlockCbor(t)
+	submitDone := make(chan error, 1)
+	go func() {
+		submitDone <- p.Submit(
+			context.Background(),
+			uint(ledger.BlockTypeConway),
+			rawCbor,
+			createTestTip(1000, 500),
+		)
+	}()
+	select {
+	case <-submitLocked:
+	case <-time.After(time.Second):
+		t.Fatal("submission did not acquire the pipeline boundary")
+	}
+
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- p.Stop() }()
+	select {
+	case <-p.ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not cancel the pipeline context")
+	}
+
+	require.NoError(
+		t,
+		p.WaitForDrain(context.Background()),
+		"an explicit Stop should make the drain boundary successful",
+	)
+	release()
+	select {
+	case err := <-submitDone:
+		if err != nil {
+			require.ErrorIs(t, err, ErrPipelineStopped)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("submission did not return after release")
+	}
+	select {
+	case err := <-stopDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not return after submission released the boundary")
+	}
+}
+
+func TestBlockPipelineWaitForDrainParentCancellationWithoutPendingWork(
+	t *testing.T,
+) {
+	t.Run("parent canceled before Start", func(t *testing.T) {
+		parentCtx, cancelParent := context.WithCancel(context.Background())
+		cancelParent()
+		p := NewBlockPipeline(WithValidateWorkers(0))
+		require.NoError(t, p.Start(parentCtx))
+		defer func() { require.NoError(t, p.Stop()) }()
+
+		require.ErrorIs(
+			t,
+			p.WaitForDrain(context.Background()),
+			ErrPipelineStopped,
+		)
+	})
+
+	t.Run("parent canceled at captured boundary", func(t *testing.T) {
+		boundaryCaptured := make(chan uint64, 1)
+		releaseBoundary := make(chan struct{})
+		var releaseOnce sync.Once
+		release := func() {
+			releaseOnce.Do(func() { close(releaseBoundary) })
+		}
+		parentCtx, cancelParent := context.WithCancel(context.Background())
+		defer cancelParent()
+		p := NewBlockPipeline(WithValidateWorkers(0))
+		p.testFenceBoundary = func(target uint64) {
+			boundaryCaptured <- target
+			<-releaseBoundary
+		}
+		require.NoError(t, p.Start(parentCtx))
+		defer func() {
+			release()
+			require.NoError(t, p.Stop())
+		}()
+
+		drainDone := make(chan error, 1)
+		go func() {
+			drainDone <- p.WaitForDrain(context.Background())
+		}()
+		select {
+		case target := <-boundaryCaptured:
+			require.Zero(t, target)
+		case <-time.After(time.Second):
+			t.Fatal("WaitForDrain did not capture the zero-work boundary")
+		}
+
+		cancelParent()
+		select {
+		case <-p.ctx.Done():
+		case <-time.After(time.Second):
+			t.Fatal("parent cancellation did not reach the pipeline context")
+		}
+		release()
+		select {
+		case err := <-drainDone:
+			require.ErrorIs(t, err, ErrPipelineStopped)
+		case <-time.After(time.Second):
+			t.Fatal("WaitForDrain did not return after parent cancellation")
+		}
+	})
+}
+
+func TestBlockPipelineWaitForDrainParentCancellationWithInFlightWork(
+	t *testing.T,
+) {
+	applyStarted := make(chan struct{})
+	releaseApply := make(chan struct{})
+	boundaryCaptured := make(chan uint64, 1)
+	releaseBoundary := make(chan struct{})
+	var releaseApplyOnce sync.Once
+	releaseApplyFunc := func() {
+		releaseApplyOnce.Do(func() { close(releaseApply) })
+	}
+	var releaseBoundaryOnce sync.Once
+	releaseBoundaryFunc := func() {
+		releaseBoundaryOnce.Do(func() { close(releaseBoundary) })
+	}
+	parentCtx, cancelParent := context.WithCancel(context.Background())
+	defer cancelParent()
+	p := NewBlockPipeline(
+		WithValidateWorkers(0),
+		WithSkipBodyHashValidation(true),
+		WithApplyFunc(func(*BlockItem) error {
+			close(applyStarted)
+			<-releaseApply
+			return nil
+		}),
+	)
+	p.testFenceBoundary = func(target uint64) {
+		boundaryCaptured <- target
+		<-releaseBoundary
+	}
+	require.NoError(t, p.Start(parentCtx))
+	defer func() {
+		releaseApplyFunc()
+		releaseBoundaryFunc()
+		require.NoError(t, p.Stop())
+	}()
+	require.NoError(
+		t,
+		p.Submit(
+			context.Background(),
+			uint(ledger.BlockTypeConway),
+			getValidBlockCbor(t),
+			createTestTip(1000, 500),
+		),
+	)
+	select {
+	case <-applyStarted:
+	case <-time.After(time.Second):
+		t.Fatal("pipeline apply did not start")
+	}
+
+	drainDone := make(chan error, 1)
+	go func() { drainDone <- p.WaitForDrain(context.Background()) }()
+	select {
+	case target := <-boundaryCaptured:
+		require.Equal(t, uint64(1), target)
+	case <-time.After(time.Second):
+		t.Fatal("WaitForDrain did not capture the accepted-work boundary")
+	}
+	p.completionMu.Lock()
+	processed := p.completionChan
+	p.completionMu.Unlock()
+
+	cancelParent()
+	select {
+	case <-p.ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("parent cancellation did not reach the pipeline context")
+	}
+	releaseApplyFunc()
+	select {
+	case <-processed:
+	case <-time.After(time.Second):
+		t.Fatal("accepted in-flight work did not complete")
+	}
+	releaseBoundaryFunc()
+	select {
+	case err := <-drainDone:
+		require.ErrorIs(t, err, ErrPipelineStopped)
+	case <-time.After(time.Second):
+		t.Fatal("WaitForDrain did not return after parent cancellation")
+	}
+}
+
+func TestBlockPipelineWaitForDrainPrefersCallerContext(t *testing.T) {
+	boundaryCaptured := make(chan uint64, 1)
+	releaseBoundary := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseBoundary) })
+	}
+	p := NewBlockPipeline(WithValidateWorkers(0))
+	p.testFenceBoundary = func(target uint64) {
+		boundaryCaptured <- target
+		<-releaseBoundary
+	}
+	require.NoError(t, p.Start(context.Background()))
+	defer func() {
+		release()
+		require.NoError(t, p.Stop())
+	}()
+
+	drainCtx, cancelDrain := context.WithCancel(context.Background())
+	drainDone := make(chan error, 1)
+	go func() { drainDone <- p.WaitForDrain(drainCtx) }()
+	select {
+	case target := <-boundaryCaptured:
+		require.Zero(t, target)
+	case <-time.After(time.Second):
+		t.Fatal("WaitForDrain did not capture the zero-work boundary")
+	}
+	cancelDrain()
+	release()
+	select {
+	case err := <-drainDone:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("WaitForDrain did not return after caller cancellation")
+	}
+}
+
 func TestApplyStage_PendingCount(t *testing.T) {
 	rawCbor := getValidBlockCbor(t)
 

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -1117,6 +1117,136 @@ func TestBlockPipelineFenceIgnoresCanceledBackpressuredSubmission(
 	appliedMu.Unlock()
 }
 
+func TestBlockPipelineWaitForDrainWaitsForInFlightValidation(t *testing.T) {
+	const eta0 = "00000000000000000000000000000000" +
+		"00000000000000000000000000000000"
+	validationStarted := make(chan struct{})
+	releaseValidation := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseValidation) })
+	}
+	p := NewBlockPipeline(
+		WithDecodeWorkers(1),
+		WithValidateWorkers(1),
+		WithSkipBodyHashValidation(true),
+		WithEta0Provider(func(uint64) (string, error) {
+			close(validationStarted)
+			<-releaseValidation
+			return eta0, nil
+		}),
+		WithSlotsPerKesPeriod(129600),
+		WithVerifyConfig(common.VerifyConfig{
+			SkipBodyHashValidation:    true,
+			SkipTransactionValidation: true,
+			SkipStakePoolValidation:   true,
+		}),
+	)
+	require.NoError(t, p.Start(context.Background()))
+	defer func() {
+		release()
+		require.NoError(t, p.Stop())
+	}()
+
+	require.NoError(
+		t,
+		p.Submit(
+			context.Background(),
+			uint(ledger.BlockTypeConway),
+			getValidBlockCbor(t),
+			createTestTip(1000, 500),
+		),
+	)
+	select {
+	case <-validationStarted:
+	case <-time.After(time.Second):
+		t.Fatal("pipeline validation did not start")
+	}
+	require.Zero(
+		t,
+		p.PendingCount(),
+		"observational count should miss validation work already in flight",
+	)
+
+	drainDone := make(chan error, 1)
+	go func() { drainDone <- p.WaitForDrain(context.Background()) }()
+	select {
+	case err := <-drainDone:
+		t.Fatalf(
+			"WaitForDrain returned while an accepted block was in flight: %v",
+			err,
+		)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	release()
+	select {
+	case err := <-drainDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("WaitForDrain did not complete after validation was released")
+	}
+}
+
+func TestBlockPipelineWaitForDrainLifecycle(t *testing.T) {
+	t.Run("not started", func(t *testing.T) {
+		p := NewBlockPipeline()
+		require.ErrorIs(
+			t,
+			p.WaitForDrain(context.Background()),
+			ErrPipelineNotStarted,
+		)
+	})
+
+	t.Run("stopped", func(t *testing.T) {
+		p := NewBlockPipeline(WithValidateWorkers(0))
+		require.NoError(t, p.Start(context.Background()))
+		require.NoError(t, p.Stop())
+		require.NoError(t, p.WaitForDrain(context.Background()))
+	})
+
+	t.Run("context canceled", func(t *testing.T) {
+		applyStarted := make(chan struct{})
+		releaseApply := make(chan struct{})
+		var releaseOnce sync.Once
+		release := func() {
+			releaseOnce.Do(func() { close(releaseApply) })
+		}
+		p := NewBlockPipeline(
+			WithValidateWorkers(0),
+			WithSkipBodyHashValidation(true),
+			WithApplyFunc(func(*BlockItem) error {
+				close(applyStarted)
+				<-releaseApply
+				return nil
+			}),
+		)
+		require.NoError(t, p.Start(context.Background()))
+		defer func() {
+			release()
+			require.NoError(t, p.Stop())
+		}()
+		require.NoError(
+			t,
+			p.Submit(
+				context.Background(),
+				uint(ledger.BlockTypeConway),
+				getValidBlockCbor(t),
+				createTestTip(1000, 500),
+			),
+		)
+		select {
+		case <-applyStarted:
+		case <-time.After(time.Second):
+			t.Fatal("pipeline apply did not start")
+		}
+
+		drainCtx, cancelDrain := context.WithCancel(context.Background())
+		cancelDrain()
+		require.ErrorIs(t, p.WaitForDrain(drainCtx), context.Canceled)
+	})
+}
+
 func TestApplyStage_PendingCount(t *testing.T) {
 	rawCbor := getValidBlockCbor(t)
 

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -52,6 +52,12 @@ func createTestTip(slot uint64, blockNum uint64) pcommon.Tip {
 	}
 }
 
+// readyCancellationTieAttempts proves precedence when the old implementation
+// offered an already-canceled context and the submit gate to the same select.
+// Repetition is needed only because Go deliberately randomizes that ready tie;
+// the structural hook and sequence assertions identify any lost cancellation.
+const readyCancellationTieAttempts = 64
+
 // ============================================================================
 // TestBlockItem tests
 // ============================================================================
@@ -991,6 +997,151 @@ func TestBlockPipelineFenceCancelsWhileWaitingForBlockedSubmit(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("canceled fence did not return while submit held the boundary")
 	}
+}
+
+func TestBlockPipelineSubmitCancellationPrecedence(t *testing.T) {
+	t.Run("pre-canceled caller", func(t *testing.T) {
+		p := NewBlockPipeline(
+			WithValidateWorkers(0),
+			WithSkipBodyHashValidation(true),
+		)
+		var gateAcquisitions atomic.Uint64
+		p.testSubmitLocked = func() { gateAcquisitions.Add(1) }
+		require.NoError(t, p.Start(context.Background()))
+		defer func() { require.NoError(t, p.Stop()) }()
+
+		submitCtx, cancelSubmit := context.WithCancel(context.Background())
+		cancelSubmit()
+		unexpectedResults := 0
+		for range readyCancellationTieAttempts {
+			err := p.Submit(submitCtx, 0, nil, pcommon.Tip{})
+			if !errors.Is(err, context.Canceled) {
+				unexpectedResults++
+			}
+		}
+
+		assert.Zero(
+			t,
+			unexpectedResults,
+			"pre-canceled caller lost cancellation precedence",
+		)
+		assert.Zero(
+			t,
+			gateAcquisitions.Load(),
+			"pre-canceled caller acquired the submit gate",
+		)
+		assert.Zero(t, p.sequenceCounter.Load())
+		assert.Zero(t, p.Stats().BlocksSubmitted)
+	})
+
+	t.Run("canceled Start parent", func(t *testing.T) {
+		parentCtx, cancelParent := context.WithCancel(context.Background())
+		cancelParent()
+		p := NewBlockPipeline(
+			WithValidateWorkers(0),
+			WithSkipBodyHashValidation(true),
+		)
+		var gateAcquisitions atomic.Uint64
+		p.testSubmitLocked = func() { gateAcquisitions.Add(1) }
+		require.NoError(t, p.Start(parentCtx))
+		defer func() { require.NoError(t, p.Stop()) }()
+
+		// Wait for every worker started with the canceled parent to exit before
+		// proving that Submit cannot commit work into their abandoned queue.
+		p.decodePool.Stop()
+		p.applyRunner.Stop()
+		p.wg.Wait()
+
+		unexpectedResults := 0
+		for range readyCancellationTieAttempts {
+			err := p.Submit(context.Background(), 0, nil, pcommon.Tip{})
+			if !errors.Is(err, ErrPipelineStopped) {
+				unexpectedResults++
+			}
+		}
+
+		assert.Zero(
+			t,
+			unexpectedResults,
+			"canceled pipeline lost shutdown precedence",
+		)
+		assert.Zero(
+			t,
+			gateAcquisitions.Load(),
+			"canceled pipeline acquired the submit gate",
+		)
+		assert.Zero(t, p.sequenceCounter.Load())
+		assert.Zero(t, p.Stats().BlocksSubmitted)
+		assert.Empty(t, p.submitChan)
+	})
+}
+
+func TestBlockPipelineFenceCancellationPrecedence(t *testing.T) {
+	t.Run("pre-canceled caller", func(t *testing.T) {
+		p := NewBlockPipeline(WithValidateWorkers(0))
+		var boundaryCaptures atomic.Uint64
+		p.testFenceBoundary = func(uint64) { boundaryCaptures.Add(1) }
+		require.NoError(t, p.Start(context.Background()))
+		defer func() { require.NoError(t, p.Stop()) }()
+
+		fenceCtx, cancelFence := context.WithCancel(context.Background())
+		cancelFence()
+		unexpectedResults := 0
+		for range readyCancellationTieAttempts {
+			if err := p.Fence(fenceCtx); !errors.Is(err, context.Canceled) {
+				unexpectedResults++
+			}
+		}
+
+		assert.Zero(
+			t,
+			unexpectedResults,
+			"pre-canceled caller lost cancellation precedence",
+		)
+		assert.Zero(
+			t,
+			boundaryCaptures.Load(),
+			"pre-canceled caller captured a fence boundary",
+		)
+		assert.Zero(t, p.sequenceCounter.Load())
+		assert.Zero(t, p.Stats().BlocksSubmitted)
+		assert.Empty(t, p.submitChan)
+	})
+
+	t.Run("canceled Start parent", func(t *testing.T) {
+		parentCtx, cancelParent := context.WithCancel(context.Background())
+		cancelParent()
+		p := NewBlockPipeline(WithValidateWorkers(0))
+		var boundaryCaptures atomic.Uint64
+		p.testFenceBoundary = func(uint64) { boundaryCaptures.Add(1) }
+		require.NoError(t, p.Start(parentCtx))
+		defer func() { require.NoError(t, p.Stop()) }()
+
+		p.decodePool.Stop()
+		p.applyRunner.Stop()
+		p.wg.Wait()
+
+		unexpectedResults := 0
+		for range readyCancellationTieAttempts {
+			if err := p.Fence(context.Background()); !errors.Is(err, ErrPipelineStopped) {
+				unexpectedResults++
+			}
+		}
+
+		assert.Zero(
+			t,
+			unexpectedResults,
+			"canceled pipeline lost shutdown precedence",
+		)
+		assert.Zero(
+			t,
+			boundaryCaptures.Load(),
+			"canceled pipeline captured a fence boundary",
+		)
+		assert.Zero(t, p.sequenceCounter.Load())
+		assert.Zero(t, p.Stats().BlocksSubmitted)
+		assert.Empty(t, p.submitChan)
+	})
 }
 
 func TestBlockPipelineFenceIgnoresCanceledBackpressuredSubmission(


### PR DESCRIPTION
## Summary

- wait on the exact accepted-submission boundary before reporting pipeline drain completion
- preserve caller cancellation, parent cancellation, and explicit shutdown semantics
- document approximate pending counts and add deterministic lifecycle regressions

## Validation

- `make test`
- `make lint`
- focused pipeline and ChainSync tests with the race detector
- `go build ./...`

Fixes #2150

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2150 by making pipeline drain completion wait on the exact accepted-submission boundary. `WaitForDrain` previously polled `PendingCount`, so it could return while an accepted block was still in flight; it now uses the same fence boundary as `Fence`. Submission and fencing now also reject work as soon as shutdown begins, so a stopped pipeline never accepts new work even when the submit gate is ready.

**Lifecycle semantics**
- An explicit `Stop` makes drain succeed even with work in flight; parent context cancellation makes drain return `ErrPipelineStopped`.
- Caller cancellation takes precedence in `Submit`, `Fence`, and `WaitForDrain` and returns `context.Canceled`.
- `Submit` and `Fence` now reject pre-canceled callers and canceled pipelines without entering the submit gate, and refuse work once `Stop` has begun.
- `PendingCount` is now documented as an observational snapshot, not a completion barrier; use `Fence` or `WaitForDrain` instead.

<sup>Written for commit 756bd98f13d9424f9a795e9cec20f21c202e8419. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pipeline shutdown and cancellation handling to prevent work from being accepted after stopping begins.
  * Improved drain waiting behavior for more reliable completion detection.
  * Prevented sequence gaps during concurrent submission, cancellation, and shutdown scenarios.

* **Tests**
  * Added comprehensive coverage for submission, fencing, draining, cancellation, and concurrent shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->