### PR TITLE
fix(byron): use exported main block signing tag

### DIFF
--- a/consensus/byron/validate.go
+++ b/consensus/byron/validate.go
@@ -385,7 +385,7 @@ func (v *HeaderValidator) domainSeparateMainBlock(toSign []byte) ([]byte, error)
 		return nil, fmt.Errorf("failed to encode protocol magic: %w", err)
 	}
 	signed := make([]byte, 0, 1+len(pmBytes)+len(toSign))
-	signed = append(signed, byronSignTagMainBlock)
+	signed = append(signed, byron.SignTagMainBlock)
 	signed = append(signed, pmBytes...)
 	signed = append(signed, toSign...)
 	return signed, nil


### PR DESCRIPTION
Summary:
- use the exported Byron main-block signing tag in header verification
- restore tests, builds, lint, and static analysis on `main`

Validation:
- focused Byron tests and race tests
- `go build ./...`
- `golangci-lint run ./...`
- `nilaway -include-pkgs=github.com/blinklabs-io/gouroboros ./...`

Fixes #2152
