### PR TITLE
fix(ledger): validate reference-provided native scripts

### DIFF
--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -285,15 +285,12 @@ func UtxoValidateInlineDatumsWithPlutusV1(
 	ls common.LedgerState,
 	pp common.ProtocolParameters,
 ) error {
-	view, err := script.NewTxScriptView(tx, ls)
+	// An unresolvable input yields an empty view rather than an error:
+	// UtxoValidateBadInputsUtxo reports it with the right error, and reporting
+	// it here as well would make this rule a second, competing source of
+	// input-resolution failures.
+	view, err := script.NewTxScriptViewSkippingUnresolved(tx, ls)
 	if err != nil {
-		if errors.Is(err, common.ErrInputResolution) ||
-			errors.Is(err, common.ErrReferenceInputResolution) {
-			// UtxoValidateBadInputsUtxo reports an unresolvable input with the
-			// right error; reporting it here as well would make this rule a
-			// second, competing source of input-resolution failures.
-			return nil
-		}
 		return err
 	}
 	needsV1 := view.NeedsAny(func(s common.Script) bool {
@@ -1067,14 +1064,41 @@ func UtxoValidateScriptWitnesses(
 	return common.ValidateScriptWitnesses(tx, ls)
 }
 
-// UtxoValidateNativeScripts evaluates native scripts in the transaction.
+// UtxoValidateNativeScripts evaluates the native scripts this transaction has
+// to satisfy.
+//
+// Babbage is the first era in which a script can reach a transaction as a
+// reference script rather than a witness, so unlike the Alonzo rule this
+// replaces, the scripts to evaluate come from the resolved transaction view
+// rather than the witness set alone: a native script some script purpose
+// requires counts whether the witness set, a reference input, or the spent
+// input's own reference-script field supplies it -- the same three sources
+// UtxoValidateScriptWitnesses accepts a required script from, so a script that
+// rule counts as provided is a script this rule evaluates rather than ignores.
 func UtxoValidateNativeScripts(
 	tx common.Transaction,
 	slot uint64,
 	ls common.LedgerState,
 	pp common.ProtocolParameters,
 ) error {
-	return alonzo.UtxoValidateNativeScripts(tx, slot, ls, pp)
+	view, err := script.NewTxScriptViewSkippingUnresolved(tx, ls)
+	if err != nil {
+		return err
+	}
+	env := script.NewNativeScriptEnv(tx, slot)
+	for _, nativeScript := range script.NativeScriptsToEvaluate(tx, view) {
+		if !nativeScript.Evaluate(
+			env.Slot,
+			env.ValidityStart,
+			env.ValidityEnd,
+			env.KeyHashes,
+		) {
+			return allegra.NativeScriptFailedError{
+				ScriptHash: nativeScript.Hash(),
+			}
+		}
+	}
+	return nil
 }
 
 // UtxoValidateWithdrawals validates withdrawals against ledger state.

--- a/ledger/common/reference_native_script_test.go
+++ b/ledger/common/reference_native_script_test.go
@@ -1,0 +1,300 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common_test
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/require"
+)
+
+// testPubkeyNativeScript builds a native script that is satisfied only when
+// vkey has signed the transaction, so a case toggles satisfied/unsatisfied by
+// adding or omitting the vkey witness rather than by moving the slot.
+func testPubkeyNativeScript(
+	t *testing.T,
+	vkey []byte,
+) common.NativeScript {
+	t.Helper()
+	scriptCbor, err := cbor.Encode(common.NativeScriptPubkey{
+		Type: 0,
+		Hash: common.Blake2b224Hash(vkey).Bytes(),
+	})
+	require.NoError(t, err)
+	var nativeScript common.NativeScript
+	require.NoError(t, nativeScript.UnmarshalCBOR(scriptCbor))
+	return nativeScript
+}
+
+func testScriptPaymentAddress(
+	t *testing.T,
+	scriptHash common.ScriptHash,
+) common.Address {
+	t.Helper()
+	addr, err := common.NewAddressFromParts(
+		common.AddressTypeScriptNone,
+		common.AddressNetworkMainnet,
+		scriptHash.Bytes(),
+		nil,
+	)
+	require.NoError(t, err)
+	return addr
+}
+
+func testKeyPaymentAddress(t *testing.T, vkey []byte) common.Address {
+	t.Helper()
+	addr, err := common.NewAddressFromParts(
+		common.AddressTypeKeyNone,
+		common.AddressNetworkMainnet,
+		common.Blake2b224Hash(vkey).Bytes(),
+		nil,
+	)
+	require.NoError(t, err)
+	return addr
+}
+
+// testOutput builds a Babbage output, optionally carrying scriptRef as its
+// reference script. Babbage is the first era with reference scripts and the
+// output type every later era wraps, so the same output serves all three
+// eras under test.
+func testOutput(
+	addr common.Address,
+	scriptRef common.Script,
+) common.TransactionOutput {
+	out := &babbage.BabbageTransactionOutput{OutputAddress: addr}
+	if scriptRef != nil {
+		out.TxOutScriptRef = &common.ScriptRef{
+			Type:   common.ScriptRefTypeNativeScript,
+			Script: scriptRef,
+		}
+	}
+	return out
+}
+
+// testLedgerState resolves exactly the inputs the case set up. An input the
+// case did not register fails to resolve, so a rule that reaches for one the
+// test did not intend is caught rather than handed a zero value.
+func testLedgerState(
+	outputs map[string]common.TransactionOutput,
+) common.LedgerState {
+	return mockledger.NewLedgerStateBuilder().
+		WithUtxoById(
+			func(input common.TransactionInput) (common.Utxo, error) {
+				output, ok := outputs[input.String()]
+				if !ok {
+					return common.Utxo{}, errors.New("unknown input")
+				}
+				return common.Utxo{Id: input, Output: output}, nil
+			},
+		).
+		Build()
+}
+
+// scriptAuthorizationRules picks the two rules that decide whether a needed
+// script is provided and whether it is satisfied out of an era's production
+// rule set, so a case runs the registered rules rather than a function the
+// era might not have wired in.
+func scriptAuthorizationRules(
+	t *testing.T,
+	rules []common.UtxoValidationRuleFunc,
+) []common.UtxoValidationRuleFunc {
+	t.Helper()
+	out := make([]common.UtxoValidationRuleFunc, 0, 2)
+	for _, rule := range rules {
+		name := runtime.FuncForPC(reflect.ValueOf(rule).Pointer()).Name()
+		if strings.HasSuffix(name, ".UtxoValidateScriptWitnesses") ||
+			strings.HasSuffix(name, ".UtxoValidateNativeScripts") {
+			out = append(out, rule)
+		}
+	}
+	require.Len(t, out, 2, "authorization rules are not registered")
+	return out
+}
+
+// A native script some purpose of the transaction requires must be evaluated
+// wherever the transaction supplies it. The rule used to read only
+// witnesses.NativeScripts(), so a script delivered as a reference script --
+// on a reference input or on the spent input itself, both permitted by
+// CIP-33 -- was never evaluated and an unsatisfied one passed phase-1.
+// cardano-ledger evaluates the needed native scripts out of the scripts the
+// whole transaction provides (Cardano.Ledger.Babbage.Rules.Utxow,
+// validateFailedBabbageScripts).
+func TestReferenceProvidedNativeScriptsAreValidated(t *testing.T) {
+	vkey := bytes.Repeat([]byte{0x61}, 32)
+	nativeScript := testPubkeyNativeScript(t, vkey)
+	scriptHash := nativeScript.Hash()
+	scriptAddr := testScriptPaymentAddress(t, scriptHash)
+
+	// An unrelated script parked on a reference input the transaction names
+	// but no purpose requires. It can never be satisfied, so evaluating it
+	// would reject a transaction the ledger accepts.
+	unusedVkey := bytes.Repeat([]byte{0x62}, 32)
+	unusedScript := testPubkeyNativeScript(t, unusedVkey)
+	keyAddr := testKeyPaymentAddress(t, vkey)
+
+	spentInput := shelley.NewShelleyTransactionInput(
+		"1111111111111111111111111111111111111111111111111111111111111111",
+		0,
+	)
+	refInput := shelley.NewShelleyTransactionInput(
+		"2222222222222222222222222222222222222222222222222222222222222222",
+		0,
+	)
+
+	witnessedTx := func(
+		signed bool,
+	) *mockledger.MockTransaction {
+		wits := mockledger.NewMockTransactionWitnessSet()
+		if signed {
+			wits = wits.WithVkeyWitnesses(common.VkeyWitness{Vkey: vkey})
+		}
+		return mockledger.NewTransactionBuilder().WithWitnesses(wits)
+	}
+
+	tests := []struct {
+		name    string
+		build   func() (*mockledger.MockTransaction, common.LedgerState)
+		wantErr bool
+	}{
+		{
+			name: "reference input provides unsatisfied script",
+			build: func() (*mockledger.MockTransaction, common.LedgerState) {
+				tx := witnessedTx(false)
+				tx.WithInputs(spentInput)
+				tx.WithReferenceInputs(refInput)
+				return tx, testLedgerState(
+					map[string]common.TransactionOutput{
+						spentInput.String(): testOutput(scriptAddr, nil),
+						refInput.String(): testOutput(
+							keyAddr,
+							nativeScript,
+						),
+					},
+				)
+			},
+			wantErr: true,
+		},
+		{
+			name: "spent input provides unsatisfied script",
+			build: func() (*mockledger.MockTransaction, common.LedgerState) {
+				tx := witnessedTx(false)
+				tx.WithInputs(spentInput)
+				return tx, testLedgerState(
+					map[string]common.TransactionOutput{
+						spentInput.String(): testOutput(
+							scriptAddr,
+							nativeScript,
+						),
+					},
+				)
+			},
+			wantErr: true,
+		},
+		{
+			name: "reference input provides satisfied script",
+			build: func() (*mockledger.MockTransaction, common.LedgerState) {
+				tx := witnessedTx(true)
+				tx.WithInputs(spentInput)
+				tx.WithReferenceInputs(refInput)
+				return tx, testLedgerState(
+					map[string]common.TransactionOutput{
+						spentInput.String(): testOutput(scriptAddr, nil),
+						refInput.String(): testOutput(
+							keyAddr,
+							nativeScript,
+						),
+					},
+				)
+			},
+		},
+		{
+			name: "spent input provides satisfied script",
+			build: func() (*mockledger.MockTransaction, common.LedgerState) {
+				tx := witnessedTx(true)
+				tx.WithInputs(spentInput)
+				return tx, testLedgerState(
+					map[string]common.TransactionOutput{
+						spentInput.String(): testOutput(
+							scriptAddr,
+							nativeScript,
+						),
+					},
+				)
+			},
+		},
+		{
+			name: "unused reference script is not evaluated",
+			build: func() (*mockledger.MockTransaction, common.LedgerState) {
+				tx := witnessedTx(false)
+				tx.WithInputs(spentInput)
+				tx.WithReferenceInputs(refInput)
+				return tx, testLedgerState(
+					map[string]common.TransactionOutput{
+						spentInput.String(): testOutput(keyAddr, nil),
+						refInput.String(): testOutput(
+							keyAddr,
+							unusedScript,
+						),
+					},
+				)
+			},
+		},
+	}
+
+	eras := []struct {
+		name  string
+		rules []common.UtxoValidationRuleFunc
+	}{
+		{name: "Babbage", rules: babbage.UtxoValidationRules},
+		{name: "Conway", rules: conway.UtxoValidationRules},
+		{name: "Dijkstra", rules: dijkstra.UtxoValidationRules},
+	}
+	for _, era := range eras {
+		t.Run(era.name, func(t *testing.T) {
+			rules := scriptAuthorizationRules(t, era.rules)
+			for _, test := range tests {
+				t.Run(test.name, func(t *testing.T) {
+					// Both rules run together on purpose: an
+					// unsatisfied case must fail as a script
+					// failure, not as a missing witness, which
+					// pins that the two rules agree the script
+					// was provided.
+					tx, ls := test.build()
+					err := common.VerifyTransaction(tx, 0, ls, nil, rules)
+					if !test.wantErr {
+						require.NoError(t, err)
+						return
+					}
+					var failed allegra.NativeScriptFailedError
+					require.ErrorAs(t, err, &failed)
+					require.Equal(t, scriptHash, failed.ScriptHash)
+				})
+			}
+		})
+	}
+}

--- a/ledger/common/reference_native_script_test.go
+++ b/ledger/common/reference_native_script_test.go
@@ -115,24 +115,33 @@ func testLedgerState(
 		Build()
 }
 
-// scriptAuthorizationRules picks the two rules that decide whether a needed
-// script is provided and whether it is satisfied out of an era's production
-// rule set, so a case runs the registered rules rather than a function the
-// era might not have wired in.
-func scriptAuthorizationRules(
+// selectRules picks named rules out of an era's production rule set, keeping
+// the order the era registered them in. A case therefore runs the rules the
+// era actually wired in, in the order it runs them, rather than functions
+// called directly.
+func selectRules(
 	t *testing.T,
 	rules []common.UtxoValidationRuleFunc,
+	suffixes ...string,
 ) []common.UtxoValidationRuleFunc {
 	t.Helper()
-	out := make([]common.UtxoValidationRuleFunc, 0, 2)
+	out := make([]common.UtxoValidationRuleFunc, 0, len(suffixes))
 	for _, rule := range rules {
 		name := runtime.FuncForPC(reflect.ValueOf(rule).Pointer()).Name()
-		if strings.HasSuffix(name, ".UtxoValidateScriptWitnesses") ||
-			strings.HasSuffix(name, ".UtxoValidateNativeScripts") {
-			out = append(out, rule)
+		for _, suffix := range suffixes {
+			if strings.HasSuffix(name, suffix) {
+				out = append(out, rule)
+				break
+			}
 		}
 	}
-	require.Len(t, out, 2, "authorization rules are not registered")
+	require.Len(
+		t,
+		out,
+		len(suffixes),
+		"expected rules are not registered: %v",
+		suffixes,
+	)
 	return out
 }
 
@@ -276,7 +285,12 @@ func TestReferenceProvidedNativeScriptsAreValidated(t *testing.T) {
 	}
 	for _, era := range eras {
 		t.Run(era.name, func(t *testing.T) {
-			rules := scriptAuthorizationRules(t, era.rules)
+			rules := selectRules(
+				t,
+				era.rules,
+				".UtxoValidateScriptWitnesses",
+				".UtxoValidateNativeScripts",
+			)
 			for _, test := range tests {
 				t.Run(test.name, func(t *testing.T) {
 					// Both rules run together on purpose: an
@@ -293,6 +307,112 @@ func TestReferenceProvidedNativeScriptsAreValidated(t *testing.T) {
 					var failed allegra.NativeScriptFailedError
 					require.ErrorAs(t, err, &failed)
 					require.Equal(t, scriptHash, failed.ScriptHash)
+				})
+			}
+		})
+	}
+}
+
+// The native-script rule reads an empty script view when an input cannot be
+// resolved, so it evaluates the witness set alone and contributes no
+// reference-provided script. That is safe only because a transaction with an
+// unresolvable input is rejected anyway, by a rule every era registers ahead
+// of the native-script rule: UtxoValidateBadInputsUtxo for a consumed input,
+// UtxoValidateScriptWitnesses for a reference input, which
+// UtxoValidateBadInputsUtxo does not cover. Resolving the reachable inputs
+// into a partial view instead would make the needed-script set depend on
+// which lookups happened to succeed, which is worse for a rule that has to
+// reach the same verdict on every node.
+func TestUnresolvableInputsAreRejectedBeforeNativeScripts(t *testing.T) {
+	vkey := bytes.Repeat([]byte{0x63}, 32)
+	nativeScript := testPubkeyNativeScript(t, vkey)
+	scriptAddr := testScriptPaymentAddress(t, nativeScript.Hash())
+	keyAddr := testKeyPaymentAddress(t, vkey)
+
+	scriptInput := shelley.NewShelleyTransactionInput(
+		"3333333333333333333333333333333333333333333333333333333333333333",
+		0,
+	)
+	refInput := shelley.NewShelleyTransactionInput(
+		"4444444444444444444444444444444444444444444444444444444444444444",
+		0,
+	)
+	missingInput := shelley.NewShelleyTransactionInput(
+		"5555555555555555555555555555555555555555555555555555555555555555",
+		0,
+	)
+
+	tests := []struct {
+		name   string
+		build  func() (*mockledger.MockTransaction, common.LedgerState)
+		assert func(t *testing.T, err error)
+	}{
+		{
+			name: "unresolvable consumed input",
+			build: func() (*mockledger.MockTransaction, common.LedgerState) {
+				tx := mockledger.NewTransactionBuilder()
+				tx.WithInputs(scriptInput, missingInput)
+				tx.WithReferenceInputs(refInput)
+				return tx, testLedgerState(
+					map[string]common.TransactionOutput{
+						scriptInput.String(): testOutput(scriptAddr, nil),
+						refInput.String(): testOutput(
+							keyAddr,
+							nativeScript,
+						),
+					},
+				)
+			},
+			assert: func(t *testing.T, err error) {
+				var badInputs shelley.BadInputsUtxoError
+				require.ErrorAs(t, err, &badInputs)
+			},
+		},
+		{
+			name: "unresolvable reference input",
+			build: func() (*mockledger.MockTransaction, common.LedgerState) {
+				tx := mockledger.NewTransactionBuilder()
+				tx.WithInputs(scriptInput)
+				tx.WithReferenceInputs(missingInput)
+				return tx, testLedgerState(
+					map[string]common.TransactionOutput{
+						scriptInput.String(): testOutput(scriptAddr, nil),
+					},
+				)
+			},
+			assert: func(t *testing.T, err error) {
+				require.ErrorIs(
+					t,
+					err,
+					common.ErrReferenceInputResolution,
+				)
+			},
+		},
+	}
+
+	eras := []struct {
+		name  string
+		rules []common.UtxoValidationRuleFunc
+	}{
+		{name: "Babbage", rules: babbage.UtxoValidationRules},
+		{name: "Conway", rules: conway.UtxoValidationRules},
+		{name: "Dijkstra", rules: dijkstra.UtxoValidationRules},
+	}
+	for _, era := range eras {
+		t.Run(era.name, func(t *testing.T) {
+			rules := selectRules(
+				t,
+				era.rules,
+				".UtxoValidateBadInputsUtxo",
+				".UtxoValidateScriptWitnesses",
+				".UtxoValidateNativeScripts",
+			)
+			for _, test := range tests {
+				t.Run(test.name, func(t *testing.T) {
+					tx, ls := test.build()
+					err := common.VerifyTransaction(tx, 0, ls, nil, rules)
+					require.Error(t, err)
+					test.assert(t, err)
 				})
 			}
 		})

--- a/ledger/common/script/native.go
+++ b/ledger/common/script/native.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package script
+
+import (
+	"bytes"
+	"errors"
+	"slices"
+
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// NativeScriptEnv is the transaction-derived input a native script evaluation
+// reads: the slot the transaction is validated at, its validity interval, and
+// the key hashes it witnesses.
+type NativeScriptEnv struct {
+	Slot          uint64
+	ValidityStart uint64
+	ValidityEnd   uint64
+	KeyHashes     map[lcommon.Blake2b224]bool
+}
+
+// NewNativeScriptEnv derives the evaluation environment from the transaction.
+// An absent validity upper bound becomes the maximum slot, so an
+// InvalidHereafter-free script is not rejected for lack of a bound.
+func NewNativeScriptEnv(
+	tx lcommon.Transaction,
+	slot uint64,
+) NativeScriptEnv {
+	env := NativeScriptEnv{
+		Slot:        slot,
+		KeyHashes:   make(map[lcommon.Blake2b224]bool),
+		ValidityEnd: ^uint64(0),
+	}
+	if tx == nil {
+		return env
+	}
+	env.ValidityStart = tx.ValidityIntervalStart()
+	if end, ok := lcommon.TransactionValidityIntervalUpperBound(tx); ok {
+		env.ValidityEnd = end
+	}
+	if witnesses := tx.Witnesses(); witnesses != nil {
+		for _, vkw := range witnesses.Vkey() {
+			env.KeyHashes[lcommon.Blake2b224Hash(vkw.Vkey)] = true
+		}
+		for _, bw := range witnesses.Bootstrap() {
+			env.KeyHashes[lcommon.Blake2b224Hash(bw.PublicKey)] = true
+		}
+	}
+	return env
+}
+
+// NewTxScriptViewSkippingUnresolved builds the transaction's script view and
+// reports an unresolvable input as an empty view rather than an error.
+//
+// UtxoValidateBadInputsUtxo already reports an unresolvable input with the
+// right error, so a rule that only reads the resolved view must not become a
+// second, competing source of input-resolution failures. Every other error is
+// returned unchanged.
+func NewTxScriptViewSkippingUnresolved(
+	tx lcommon.Transaction,
+	ls lcommon.LedgerState,
+) (TxScriptView, error) {
+	view, err := NewTxScriptView(tx, ls)
+	if err != nil {
+		if errors.Is(err, lcommon.ErrInputResolution) ||
+			errors.Is(err, lcommon.ErrReferenceInputResolution) {
+			return TxScriptView{}, nil
+		}
+		return TxScriptView{}, err
+	}
+	return view, nil
+}
+
+// NativeScriptsToEvaluate returns the native scripts a phase-1 rule must run
+// for this transaction: every native script in the witness set, plus every
+// native script some script purpose requires that only a reference script
+// supplies -- on a reference input or on the spent input itself, both
+// permitted by CIP-33.
+//
+// A reference script no purpose requires is deliberately excluded. Spending a
+// UTxO that happens to carry an unrelated reference script must not drag that
+// script into validation; cardano-ledger evaluates the needed subset of the
+// scripts the transaction provides
+// (Cardano.Ledger.Babbage.Rules.Utxow, validateFailedBabbageScripts).
+//
+// Witness scripts keep their witness-set order and reference-only scripts
+// follow sorted by hash, so a transaction with more than one failing script
+// reports the same hash on every run. An era before Babbage has no reference
+// scripts and can pass the zero view, which yields the witness scripts alone.
+func NativeScriptsToEvaluate(
+	tx lcommon.Transaction,
+	view TxScriptView,
+) []lcommon.NativeScript {
+	if tx == nil {
+		return nil
+	}
+	var witnessScripts []lcommon.NativeScript
+	if witnesses := tx.Witnesses(); witnesses != nil {
+		witnessScripts = witnesses.NativeScripts()
+	}
+	seen := make(map[lcommon.ScriptHash]struct{}, len(witnessScripts))
+	out := make([]lcommon.NativeScript, 0, len(witnessScripts))
+	for _, nativeScript := range witnessScripts {
+		hash := nativeScript.Hash()
+		if _, ok := seen[hash]; ok {
+			continue
+		}
+		seen[hash] = struct{}{}
+		out = append(out, nativeScript)
+	}
+	referenceOnly := make([]lcommon.NativeScript, 0, len(view.Needed))
+	for hash, needed := range view.Needed {
+		if _, ok := seen[hash]; ok {
+			continue
+		}
+		nativeScript, ok := asNativeScript(needed)
+		if !ok {
+			continue
+		}
+		seen[hash] = struct{}{}
+		referenceOnly = append(referenceOnly, nativeScript)
+	}
+	slices.SortFunc(
+		referenceOnly,
+		func(a, b lcommon.NativeScript) int {
+			aHash, bHash := a.Hash(), b.Hash()
+			return bytes.Compare(aHash.Bytes(), bHash.Bytes())
+		},
+	)
+	return append(out, referenceOnly...)
+}
+
+// asNativeScript unwraps a script that is a native script. A witness-set
+// script is held by value while a reference script arrives through the Script
+// interface and may be either, so both shapes are accepted.
+func asNativeScript(s lcommon.Script) (lcommon.NativeScript, bool) {
+	switch script := s.(type) {
+	case lcommon.NativeScript:
+		return script, true
+	case *lcommon.NativeScript:
+		if script == nil {
+			return lcommon.NativeScript{}, false
+		}
+		return *script, true
+	default:
+		return lcommon.NativeScript{}, false
+	}
+}

--- a/ledger/common/script/native_test.go
+++ b/ledger/common/script/native_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package script_test
+
+import (
+	"bytes"
+	"slices"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/common/script"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/require"
+)
+
+func nativeScriptHashes(scripts []common.NativeScript) []common.ScriptHash {
+	out := make([]common.ScriptHash, 0, len(scripts))
+	for _, nativeScript := range scripts {
+		out = append(out, nativeScript.Hash())
+	}
+	return out
+}
+
+// The rules report the first failing script's hash, so the order has to be
+// the same on every node and every run. Needed is a map, whose iteration order
+// Go randomizes, so the reference-only tail is sorted rather than taken as it
+// comes.
+func TestNativeScriptsToEvaluateOrderIsStable(t *testing.T) {
+	witnessFirst := testNativeScript(t, 1)
+	witnessSecond := testNativeScript(t, 2)
+	referenceOne := testNativeScript(t, 3)
+	referenceTwo := testNativeScript(t, 4)
+
+	tx := mockledger.NewTransactionBuilder().WithWitnesses(
+		mockledger.NewMockTransactionWitnessSet().
+			WithNativeScripts(witnessSecond, witnessFirst),
+	)
+	view := script.TxScriptView{
+		Needed: map[common.ScriptHash]common.Script{
+			witnessFirst.Hash(): witnessFirst,
+			referenceOne.Hash(): referenceOne,
+			referenceTwo.Hash(): &referenceTwo,
+		},
+	}
+
+	referenceTail := []common.ScriptHash{
+		referenceOne.Hash(),
+		referenceTwo.Hash(),
+	}
+	slices.SortFunc(referenceTail, func(a, b common.ScriptHash) int {
+		return bytes.Compare(a.Bytes(), b.Bytes())
+	})
+	want := append(
+		[]common.ScriptHash{witnessSecond.Hash(), witnessFirst.Hash()},
+		referenceTail...,
+	)
+
+	for range 20 {
+		require.Equal(
+			t,
+			want,
+			nativeScriptHashes(script.NativeScriptsToEvaluate(tx, view)),
+		)
+	}
+}
+
+// A reference script the transaction merely reaches, and a needed script that
+// is not native, are both left out: the first because spending a UTxO
+// carrying an unrelated reference script must not drag it into validation,
+// the second because a Plutus script runs under the phase-2 rules instead.
+func TestNativeScriptsToEvaluateSelection(t *testing.T) {
+	needed := testNativeScript(t, 1)
+	availableOnly := testNativeScript(t, 2)
+	plutus := common.PlutusV2Script([]byte{0x01})
+
+	tx := mockledger.NewTransactionBuilder()
+	view := script.TxScriptView{
+		Available: map[common.ScriptHash]common.Script{
+			needed.Hash():        needed,
+			availableOnly.Hash(): availableOnly,
+			plutus.Hash():        plutus,
+		},
+		Needed: map[common.ScriptHash]common.Script{
+			needed.Hash(): needed,
+			plutus.Hash(): plutus,
+		},
+	}
+
+	require.Equal(
+		t,
+		[]common.ScriptHash{needed.Hash()},
+		nativeScriptHashes(script.NativeScriptsToEvaluate(tx, view)),
+	)
+}
+
+// A script provided both as a witness and as a reference script is one
+// script, and must be evaluated once.
+func TestNativeScriptsToEvaluateDeduplicates(t *testing.T) {
+	nativeScript := testNativeScript(t, 1)
+	tx := mockledger.NewTransactionBuilder().WithWitnesses(
+		mockledger.NewMockTransactionWitnessSet().
+			WithNativeScripts(nativeScript, nativeScript),
+	)
+	view := script.TxScriptView{
+		Needed: map[common.ScriptHash]common.Script{
+			nativeScript.Hash(): nativeScript,
+		},
+	}
+	require.Equal(
+		t,
+		[]common.ScriptHash{nativeScript.Hash()},
+		nativeScriptHashes(script.NativeScriptsToEvaluate(tx, view)),
+	)
+}
+
+// An era before Babbage has no reference scripts and passes the zero view, so
+// the witness set alone has to survive it.
+func TestNativeScriptsToEvaluateZeroView(t *testing.T) {
+	nativeScript := testNativeScript(t, 1)
+	tx := mockledger.NewTransactionBuilder().WithWitnesses(
+		mockledger.NewMockTransactionWitnessSet().
+			WithNativeScripts(nativeScript),
+	)
+	require.Equal(
+		t,
+		[]common.ScriptHash{nativeScript.Hash()},
+		nativeScriptHashes(
+			script.NativeScriptsToEvaluate(tx, script.TxScriptView{}),
+		),
+	)
+	require.Empty(
+		t,
+		script.NativeScriptsToEvaluate(nil, script.TxScriptView{}),
+	)
+}
+
+func TestNewNativeScriptEnv(t *testing.T) {
+	vkey := bytes.Repeat([]byte{0x71}, 32)
+	bootstrapKey := bytes.Repeat([]byte{0x72}, 32)
+
+	t.Run("no transaction", func(t *testing.T) {
+		env := script.NewNativeScriptEnv(nil, 7)
+		require.Equal(t, uint64(7), env.Slot)
+		require.Equal(t, uint64(0), env.ValidityStart)
+		require.Equal(t, ^uint64(0), env.ValidityEnd)
+		require.Empty(t, env.KeyHashes)
+	})
+
+	t.Run("no upper bound", func(t *testing.T) {
+		tx := mockledger.NewTransactionBuilder()
+		require.Equal(
+			t,
+			^uint64(0),
+			script.NewNativeScriptEnv(tx, 0).ValidityEnd,
+			"an absent upper bound must not read as slot zero",
+		)
+	})
+
+	t.Run("witness key hashes", func(t *testing.T) {
+		tx := mockledger.NewTransactionBuilder().WithWitnesses(
+			mockledger.NewMockTransactionWitnessSet().
+				WithVkeyWitnesses(common.VkeyWitness{Vkey: vkey}).
+				WithBootstrapWitnesses(
+					common.BootstrapWitness{PublicKey: bootstrapKey},
+				),
+		)
+		tx.WithTTL(42)
+		env := script.NewNativeScriptEnv(tx, 0)
+		require.Equal(t, uint64(42), env.ValidityEnd)
+		require.True(t, env.KeyHashes[common.Blake2b224Hash(vkey)])
+		require.True(
+			t,
+			env.KeyHashes[common.Blake2b224Hash(bootstrapKey)],
+		)
+	})
+}

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -2994,58 +2994,17 @@ func UtxoValidatePlutusScripts(
 	return nil
 }
 
-// UtxoValidateNativeScripts evaluates native scripts in the transaction.
-// Native scripts (timelock scripts) are evaluated based on:
-// - Signatures present in the transaction
-// - Transaction's validity interval
-// This is phase-1 validation for native scripts.
+// UtxoValidateNativeScripts evaluates the native scripts this transaction has
+// to satisfy. Conway inherits Babbage's rule unchanged: the scripts to
+// evaluate are the needed ones the resolved transaction view provides, from
+// the witness set or from a reference script on any resolved input.
 func UtxoValidateNativeScripts(
 	tx common.Transaction,
 	slot uint64,
 	ls common.LedgerState,
 	pp common.ProtocolParameters,
 ) error {
-	witnesses := tx.Witnesses()
-	if witnesses == nil {
-		return nil
-	}
-
-	nativeScripts := witnesses.NativeScripts()
-	if len(nativeScripts) == 0 {
-		return nil
-	}
-
-	// Collect key hashes from VKey witnesses
-	keyHashes := make(map[common.Blake2b224]bool)
-	for _, vkw := range witnesses.Vkey() {
-		// VKey witnesses contain the public key, we need its hash
-		keyHash := common.Blake2b224Hash(vkw.Vkey)
-		keyHashes[keyHash] = true
-	}
-	// Also collect key hashes from bootstrap witnesses (Byron-era)
-	for _, bw := range witnesses.Bootstrap() {
-		keyHash := common.Blake2b224Hash(bw.PublicKey)
-		keyHashes[keyHash] = true
-	}
-
-	// Get transaction validity interval
-	validityStart := tx.ValidityIntervalStart()
-	validityEnd, validityEndPresent := common.TransactionValidityIntervalUpperBound(
-		tx,
-	)
-	if !validityEndPresent {
-		validityEnd = ^uint64(0) // Max uint64 if not set
-	}
-
-	// Evaluate each native script
-	for _, nscript := range nativeScripts {
-		scriptHash := nscript.Hash()
-		if !nscript.Evaluate(slot, validityStart, validityEnd, keyHashes) {
-			return NativeScriptFailedError{ScriptHash: scriptHash}
-		}
-	}
-
-	return nil
+	return babbage.UtxoValidateNativeScripts(tx, slot, ls, pp)
 }
 
 // UtxoValidateDelegation validates delegation certificates against ledger state.

--- a/ledger/dijkstra/rules.go
+++ b/ledger/dijkstra/rules.go
@@ -1608,45 +1608,37 @@ func scriptRefIsNativeHash(
 	}
 }
 
+// UtxoValidateNativeScripts evaluates the native scripts this transaction has
+// to satisfy, with Dijkstra's guard credentials in scope for RequireGuard.
+//
+// The scripts to evaluate come from the resolved transaction view, as in
+// Babbage: a native script some script purpose requires counts whether the
+// witness set, a reference input, or the spent input's own reference-script
+// field supplies it. Dijkstra keeps its own body rather than delegating to
+// Babbage because only it evaluates guards.
 func UtxoValidateNativeScripts(
 	tx common.Transaction,
 	slot uint64,
 	ls common.LedgerState,
 	pp common.ProtocolParameters,
 ) error {
-	witnesses := tx.Witnesses()
-	if witnesses == nil {
-		return nil
+	view, err := script.NewTxScriptViewSkippingUnresolved(tx, ls)
+	if err != nil {
+		return err
 	}
-	nativeScripts := witnesses.NativeScripts()
-	if len(nativeScripts) == 0 {
-		return nil
-	}
-	keyHashes := make(map[common.Blake2b224]bool)
-	for _, vkw := range witnesses.Vkey() {
-		keyHashes[common.Blake2b224Hash(vkw.Vkey)] = true
-	}
-	for _, bw := range witnesses.Bootstrap() {
-		keyHashes[common.Blake2b224Hash(bw.PublicKey)] = true
-	}
-	validityStart := tx.ValidityIntervalStart()
-	validityEnd, validityEndPresent := common.TransactionValidityIntervalUpperBound(
-		tx,
-	)
-	if !validityEndPresent {
-		validityEnd = ^uint64(0)
-	}
+	env := script.NewNativeScriptEnv(tx, slot)
 	guardCredentials := nativeScriptGuardCredentials(tx)
-	for _, nscript := range nativeScripts {
-		scriptHash := nscript.Hash()
-		if !nscript.EvaluateWithGuards(
-			slot,
-			validityStart,
-			validityEnd,
-			keyHashes,
+	for _, nativeScript := range script.NativeScriptsToEvaluate(tx, view) {
+		if !nativeScript.EvaluateWithGuards(
+			env.Slot,
+			env.ValidityStart,
+			env.ValidityEnd,
+			env.KeyHashes,
 			guardCredentials,
 		) {
-			return conway.NativeScriptFailedError{ScriptHash: scriptHash}
+			return conway.NativeScriptFailedError{
+				ScriptHash: nativeScript.Hash(),
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Closes #2149.

## Problem

`UtxoValidateNativeScripts` read only `witnesses.NativeScripts()`. A native script that a script purpose required but that arrived as a *reference* script — on a reference input, or on the spent input's own reference-script field, both permitted by CIP-33 — was never evaluated, so an unsatisfied one passed phase-1 validation.

## Change

Babbage, Conway and Dijkstra take the scripts to evaluate from the resolved `script.TxScriptView`:

- every native script in the witness set, as before;
- plus every **needed** native script that only a reference script supplies.

Those are the same three sources `UtxoValidateScriptWitnesses` accepts a required script from, so a script that rule counts as provided is one this rule evaluates. A reference script no purpose requires stays unevaluated, matching `validateFailedBabbageScripts` in `Cardano.Ledger.Babbage.Rules.Utxow`, so spending a UTxO that happens to carry an unrelated reference script remains valid.

Witness-set order followed by hash order keeps the reported script hash deterministic when more than one script fails.

Alonzo and earlier are untouched: they have no reference scripts.

Two cleanups fall out: Conway delegates to Babbage instead of keeping a copy of the loop, and the skip-unresolved-input idiom `babbage.UtxoValidateInlineDatumsWithPlutusV1` had inline moves into `script.NewTxScriptViewSkippingUnresolved`.

## Tests

`ledger/common/reference_native_script_test.go` drives Babbage, Conway and Dijkstra through their registered `UtxoValidationRules` (`UtxoValidateScriptWitnesses` + `UtxoValidateNativeScripts`, selected out of the production slice) for five cases each: reference-input and spent-input delivery of an unsatisfied script, both of those satisfied, and an unrelated unused reference script.

Against the pre-fix implementation the two unsatisfied cases fail in all three eras (6 subtests); the other three pass before and after:

```
--- FAIL: TestReferenceProvidedNativeScriptsAreValidated/Babbage/reference_input_provides_unsatisfied_script
--- FAIL: TestReferenceProvidedNativeScriptsAreValidated/Babbage/spent_input_provides_unsatisfied_script
--- FAIL: TestReferenceProvidedNativeScriptsAreValidated/Conway/reference_input_provides_unsatisfied_script
--- FAIL: TestReferenceProvidedNativeScriptsAreValidated/Conway/spent_input_provides_unsatisfied_script
--- FAIL: TestReferenceProvidedNativeScriptsAreValidated/Dijkstra/reference_input_provides_unsatisfied_script
--- FAIL: TestReferenceProvidedNativeScriptsAreValidated/Dijkstra/spent_input_provides_unsatisfied_script
```

`ledger/common/script/native_test.go` covers the shared helper directly: order stability across 20 runs, exclusion of available-but-unneeded and non-native needed scripts, deduplication of a script provided twice, the zero view, and `NewNativeScriptEnv`.

## Checks

`go build ./...`, `gofmt -l`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `go test -race ./...`, `go test ./internal/test/conformance/...`, and NilAway (`-include-pkgs=github.com/blinklabs-io/gouroboros`) all pass.

`golines --dry-run` reports one long line in `ledger/babbage/rules.go` around the ExUnits accumulation; it is present on `main` before this change and is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KaMGAPzVsZe1gpxMvfXJf1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes phase-1 native script validation so an unsatisfied native script supplied as a reference script — on a reference input or the spent input's own reference-script field, both allowed by CIP-33 — no longer passes. Babbage, Conway, and Dijkstra now evaluate every needed native script from the resolved transaction view instead of the witness set alone.

- Closes #2149.
- A reference script no script purpose requires stays unevaluated, so spending a UTxO carrying an unrelated reference script remains valid.
- The reported script hash stays deterministic when several scripts fail: witness-set order, then hash order.
- An unresolvable input yields an empty view; the earlier bad-inputs and script-witness rules reject such transactions, so this rule never competes with them.
- Conway delegates to Babbage, and the skip-unresolved-input idiom from the inline-datums rule moves into `script.NewTxScriptViewSkippingUnresolved`.
- Adds per-era tests for five delivery cases, unresolvable-input rejection, and unit tests for the new helper.
- Alonzo and earlier are untouched; they have no reference scripts.

<sup>Written for commit 585f342bd7104ac225c2aab014aad5b165d66da2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Native scripts can now be validated when supplied through reference scripts on reference inputs or spent outputs.
  - Validation is supported across Babbage, Conway, and Dijkstra transaction rules.

- **Bug Fixes**
  - Evaluates only native scripts required by the transaction.
  - Reports the specific failing script when validation fails.
  - Rejects unresolved consumed or reference inputs before native-script validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->