### PR TITLE
fix(ledger): enforce required redeemers for reference-script plutus spends

### DIFF
--- a/ledger/babbage/errors.go
+++ b/ledger/babbage/errors.go
@@ -58,6 +58,9 @@ type MissingPlutusScriptWitnessesError = common.MissingPlutusScriptWitnessesErro
 
 type ExtraneousPlutusScriptWitnessesError = common.ExtraneousPlutusScriptWitnessesError
 
+// MissingRedeemerForScriptError is an alias to common.MissingRedeemerForScriptError
+type MissingRedeemerForScriptError = common.MissingRedeemerForScriptError
+
 // Metadata / cost model / IsValid aliases
 type MissingTransactionMetadataError = common.MissingTransactionMetadataError
 

--- a/ledger/babbage/required_redeemers_test.go
+++ b/ledger/babbage/required_redeemers_test.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package babbage_test
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBabbageUtxoValidateRequiredRedeemersRegistered pins that Babbage
+// registers UtxoValidateRequiredRedeemers in its production rule list.
+// Babbage never executes Plutus itself, but a reference-script-backed
+// script-address input with no redeemer must still be rejected rather than
+// silently spent unexecuted (issue #2147: "across all supported eras").
+func TestBabbageUtxoValidateRequiredRedeemersRegistered(t *testing.T) {
+	want := reflect.ValueOf(babbage.UtxoValidateRequiredRedeemers).Pointer()
+	for _, rule := range babbage.UtxoValidationRules {
+		if reflect.ValueOf(rule).Pointer() == want {
+			return
+		}
+	}
+	t.Fatal("UtxoValidateRequiredRedeemers is not registered in UtxoValidationRules")
+}
+
+// TestBabbageUtxoValidateRequiredRedeemers covers a Plutus script-address
+// input satisfied by a CIP-33 reference script: missing its spend redeemer
+// must be rejected, and a valid redeemer must be accepted.
+func TestBabbageUtxoValidateRequiredRedeemers(t *testing.T) {
+	v1 := common.PlutusV1Script{0x01, 0x02, 0x03}
+	scriptAddr, err := common.NewAddressFromParts(
+		common.AddressTypeScriptNone,
+		common.AddressNetworkTestnet,
+		v1.Hash().Bytes(),
+		nil,
+	)
+	require.NoError(t, err)
+
+	input := shelley.NewShelleyTransactionInput(
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		0,
+	)
+	utxo := common.Utxo{
+		Id: input,
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAddress: scriptAddr,
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
+			TxOutScriptRef: &common.ScriptRef{
+				Type:   common.ScriptRefTypePlutusV1,
+				Script: v1,
+			},
+		},
+	}
+	ls := mockledger.NewLedgerStateBuilder().
+		WithUtxoById(func(id common.TransactionInput) (common.Utxo, error) {
+			if id.String() == input.String() {
+				return utxo, nil
+			}
+			return common.Utxo{}, errors.New("not found")
+		}).
+		Build()
+
+	newTx := func() *babbage.BabbageTransaction {
+		return &babbage.BabbageTransaction{
+			Body: babbage.BabbageTransactionBody{
+				TxInputs: shelley.NewShelleyTransactionInputSet(
+					[]shelley.ShelleyTransactionInput{input},
+				),
+			},
+			TxIsValid: true,
+		}
+	}
+
+	t.Run("missing redeemer for reference script rejected", func(t *testing.T) {
+		err := babbage.UtxoValidateRequiredRedeemers(
+			newTx(),
+			0,
+			ls,
+			&babbage.BabbageProtocolParameters{},
+		)
+		var missingErr common.MissingRedeemerForScriptError
+		require.ErrorAs(t, err, &missingErr)
+		require.Equal(t, v1.Hash(), missingErr.ScriptHash)
+		require.Equal(t, common.RedeemerTagSpend, missingErr.Tag)
+		require.Equal(t, uint32(0), missingErr.Index)
+	})
+
+	t.Run("valid redeemer accepted", func(t *testing.T) {
+		tx := newTx()
+		tx.WitnessSet.WsRedeemers = alonzo.AlonzoRedeemers{
+			Redeemers: []alonzo.AlonzoRedeemer{
+				{
+					Tag:     common.RedeemerTagSpend,
+					Index:   0,
+					ExUnits: common.ExUnits{Steps: 1, Memory: 1},
+				},
+			},
+		}
+		require.NoError(t, babbage.UtxoValidateRequiredRedeemers(
+			tx,
+			0,
+			ls,
+			&babbage.BabbageProtocolParameters{},
+		))
+	})
+}

--- a/ledger/babbage/required_redeemers_test.go
+++ b/ledger/babbage/required_redeemers_test.go
@@ -17,6 +17,7 @@ package babbage_test
 import (
 	"errors"
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
@@ -34,13 +35,41 @@ import (
 // script-address input with no redeemer must still be rejected rather than
 // silently spent unexecuted (issue #2147: "across all supported eras").
 func TestBabbageUtxoValidateRequiredRedeemersRegistered(t *testing.T) {
-	want := reflect.ValueOf(babbage.UtxoValidateRequiredRedeemers).Pointer()
-	for _, rule := range babbage.UtxoValidationRules {
-		if reflect.ValueOf(rule).Pointer() == want {
-			return
+	indexOf := func(rule common.UtxoValidationRuleFunc) int {
+		t.Helper()
+		want := reflect.ValueOf(rule).Pointer()
+		for idx, r := range babbage.UtxoValidationRules {
+			if reflect.ValueOf(r).Pointer() == want {
+				return idx
+			}
 		}
+		t.Fatalf(
+			"rule %s is not registered in UtxoValidationRules",
+			runtime.FuncForPC(want).Name(),
+		)
+		return -1
 	}
-	t.Fatal("UtxoValidateRequiredRedeemers is not registered in UtxoValidationRules")
+
+	requiredRedeemersIdx := indexOf(babbage.UtxoValidateRequiredRedeemers)
+	badInputsIdx := indexOf(babbage.UtxoValidateBadInputsUtxo)
+	scriptWitnessesIdx := indexOf(babbage.UtxoValidateScriptWitnesses)
+
+	require.Greater(
+		t,
+		requiredRedeemersIdx,
+		badInputsIdx,
+		"UtxoValidateRequiredRedeemers must run after UtxoValidateBadInputsUtxo "+
+			"so an unresolvable input surfaces as BadInputsUtxo, not a raw "+
+			"input-resolution error",
+	)
+	require.Greater(
+		t,
+		requiredRedeemersIdx,
+		scriptWitnessesIdx,
+		"UtxoValidateRequiredRedeemers must run after UtxoValidateScriptWitnesses "+
+			"so a missing script is reported by the latter, not masked as a "+
+			"missing redeemer",
+	)
 }
 
 // TestBabbageUtxoValidateRequiredRedeemers covers a Plutus script-address

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -48,6 +48,7 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateNoCollateralInputs,
 	UtxoValidateBadInputsUtxo,
 	UtxoValidateScriptWitnesses,
+	UtxoValidateRequiredRedeemers,
 	UtxoValidateValueNotConservedUtxo,
 	UtxoValidateOutputTooSmallUtxo,
 	UtxoValidateOutputTooBigUtxo,
@@ -1065,6 +1066,22 @@ func UtxoValidateScriptWitnesses(
 	pp common.ProtocolParameters,
 ) error {
 	return common.ValidateScriptWitnesses(tx, ls)
+}
+
+// UtxoValidateRequiredRedeemers checks that every Plutus script-address
+// input -- whether its script is provided as an explicit witness or as a
+// CIP-33 reference script -- has a matching spend redeemer. See
+// script.ValidateRequiredRedeemers for details on the gap this closes.
+// Babbage never executes Plutus itself (see UtxoValidatePlutusScripts
+// below), but a reference-script-backed input with no redeemer must still
+// be rejected rather than silently spent unexecuted.
+func UtxoValidateRequiredRedeemers(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return script.ValidateRequiredRedeemers(tx, ls)
 }
 
 // UtxoValidateNativeScripts evaluates native scripts in the transaction.

--- a/ledger/common/errors.go
+++ b/ledger/common/errors.go
@@ -269,6 +269,24 @@ func (e ExtraneousRedeemerError) Error() string {
 	)
 }
 
+// MissingRedeemerForScriptError indicates a script-address input's Plutus
+// script is reachable -- via an explicit witness or a CIP-33 reference
+// script -- but no redeemer exists for its spend index. See
+// script.ValidateRequiredRedeemers for why this must be checked separately
+// from script presence.
+type MissingRedeemerForScriptError struct {
+	ScriptHash ScriptHash
+	Tag        RedeemerTag
+	Index      uint32
+}
+
+func (e MissingRedeemerForScriptError) Error() string {
+	return fmt.Sprintf(
+		"missing redeemer for script %x: tag=%d, index=%d",
+		e.ScriptHash[:], e.Tag, e.Index,
+	)
+}
+
 // BlockExUnitsTooBigError indicates the sum of transaction execution units
 // across an entire block exceeds the protocol's maximum block execution-unit
 // budget (ppMaxBlockExUnits). This is a block-wide (BBODY) check in addition

--- a/ledger/common/script/redeemers.go
+++ b/ledger/common/script/redeemers.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package script
+
+import (
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// ValidateRequiredRedeemers checks that every script-address input whose
+// spending script is Plutus and resolvable -- whether provided as an
+// explicit witness script or as a CIP-33 reference script -- has a matching
+// spend redeemer at its canonical sorted-input position.
+//
+// This closes a gap left by the existing script/redeemer checks:
+// ValidateScriptWitnesses only confirms the script itself is reachable
+// (explicit witness or reference script), and UtxoValidatePlutusScripts only
+// executes redeemers that already exist in the witness set. A reference
+// script satisfies the former without ever requiring a redeemer, so a
+// script-locked input backed by a reference script -- or, just as easily, an
+// explicit witness script missing its own redeemer while other redeemers are
+// present -- previously spent with no script execution and no error at all.
+//
+// Eras share this single implementation rather than each re-deriving the
+// sorted-input walk and its script-availability lookup.
+func ValidateRequiredRedeemers(
+	tx lcommon.Transaction,
+	ls lcommon.LedgerState,
+) error {
+	if ls == nil || !tx.IsValid() {
+		return nil
+	}
+	view, err := NewTxScriptView(tx, ls)
+	if err != nil {
+		return err
+	}
+	if len(view.Available) == 0 {
+		return nil
+	}
+	var redeemers lcommon.TransactionWitnessRedeemers
+	if wits := tx.Witnesses(); wits != nil {
+		redeemers = wits.Redeemers()
+	}
+	spendIndexes := make(map[uint32]struct{})
+	if redeemers != nil {
+		for _, idx := range redeemers.Indexes(lcommon.RedeemerTagSpend) {
+			spendIndexes[uint32(idx)] = struct{}{} // #nosec G115 -- input count is bounded
+		}
+	}
+	byId := make(map[string]lcommon.Utxo, len(view.ResolvedInputs))
+	for _, utxo := range view.ResolvedInputs {
+		if utxo.Id != nil {
+			byId[utxo.Id.String()] = utxo
+		}
+	}
+	for idx, input := range SortInputs(tx.Inputs()) {
+		utxo, ok := byId[input.String()]
+		if !ok || utxo.Output == nil {
+			continue
+		}
+		addr := utxo.Output.Address()
+		if addr.Type()&lcommon.AddressTypeScriptBit == 0 {
+			continue
+		}
+		scriptHash := lcommon.ScriptHash(addr.PaymentKeyHash())
+		s, available := view.Available[scriptHash]
+		if !available {
+			// A script that is missing entirely is
+			// ValidateScriptWitnesses's error to report, not this check's.
+			continue
+		}
+		if _, isPlutus := lcommon.PlutusScriptVersion(s); !isPlutus {
+			continue
+		}
+		index := uint32(idx) // #nosec G115 -- input count is bounded
+		if _, ok := spendIndexes[index]; !ok {
+			return lcommon.MissingRedeemerForScriptError{
+				ScriptHash: scriptHash,
+				Tag:        lcommon.RedeemerTagSpend,
+				Index:      index,
+			}
+		}
+	}
+	return nil
+}

--- a/ledger/common/script/redeemers.go
+++ b/ledger/common/script/redeemers.go
@@ -34,13 +34,31 @@ import (
 //
 // Eras share this single implementation rather than each re-deriving the
 // sorted-input walk and its script-availability lookup.
+//
+// This check applies regardless of the transaction's IsValid flag.
+// AlonzoUTXOW's hasExactSetOfRedeemers (the source of AlonzoUtxowPredFailure
+// MissingRedeemers) is a witnessing-completeness check, not a phase-2
+// execution check: IsValid is read only by UTXOS to decide how an already
+// phase-1-valid transaction is applied to the ledger state, never by UTXOW to
+// decide which witnesses are required. A transaction the submitter marked
+// invalid still must carry every redeemer its script-locked inputs require.
 func ValidateRequiredRedeemers(
 	tx lcommon.Transaction,
 	ls lcommon.LedgerState,
 ) error {
-	if tx == nil || ls == nil || !tx.IsValid() {
+	if tx == nil || ls == nil {
 		return nil
 	}
+	// NewTxScriptView resolves every input, so an unresolvable one surfaces
+	// here as InputResolutionError/ReferenceInputResolutionError even though
+	// shelley.UtxoValidateBadInputsUtxo and
+	// common.ValidateRedeemerAndScriptWitnesses -- both registered ahead of
+	// this rule in every era's rule list -- already report the same failure
+	// more specifically. Not reachable in production today because of that
+	// ordering, but reachable by any caller that runs this check first.
+	// TODO(#2162): switch to NewTxScriptViewSkippingUnresolved once it
+	// lands, so this rule -- which only ever reads the resolved view --
+	// stops being a second, competing source of input-resolution failures.
 	view, err := NewTxScriptView(tx, ls)
 	if err != nil {
 		return err

--- a/ledger/common/script/redeemers.go
+++ b/ledger/common/script/redeemers.go
@@ -38,7 +38,7 @@ func ValidateRequiredRedeemers(
 	tx lcommon.Transaction,
 	ls lcommon.LedgerState,
 ) error {
-	if ls == nil || !tx.IsValid() {
+	if tx == nil || ls == nil || !tx.IsValid() {
 		return nil
 	}
 	view, err := NewTxScriptView(tx, ls)

--- a/ledger/common/script/redeemers_test.go
+++ b/ledger/common/script/redeemers_test.go
@@ -314,6 +314,74 @@ func TestValidateRequiredRedeemersMixedInputs(t *testing.T) {
 	require.Equal(t, uint32(1), missingErr.Index)
 }
 
+// TestValidateRequiredRedeemersMixedInputsBothRedeemed is
+// TestValidateRequiredRedeemersMixedInputs's positive counterpart: the same
+// two script-address inputs (one witness-backed, one reference-backed),
+// each correctly redeemed at its own sorted-input index, must pass.
+func TestValidateRequiredRedeemersMixedInputsBothRedeemed(t *testing.T) {
+	v1 := common.PlutusV1Script{0x01}
+	v2 := common.PlutusV2Script{0x02}
+
+	// Sorts after "aaaa...", so v1's input lands at sorted index 1.
+	inputWitness := shelley.NewShelleyTransactionInput(
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		0,
+	)
+	inputRef := shelley.NewShelleyTransactionInput(
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		0,
+	)
+
+	utxoWitness := common.Utxo{
+		Id: inputWitness,
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAddress: scriptAddress(t, v1),
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
+		},
+	}
+	utxoRef := common.Utxo{
+		Id: inputRef,
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAddress: scriptAddress(t, v2),
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
+			TxOutScriptRef: &common.ScriptRef{
+				Type:   common.ScriptRefTypePlutusV2,
+				Script: v2,
+			},
+		},
+	}
+	ls := ledgerStateWithUtxos(utxoWitness, utxoRef)
+
+	tx := &conway.ConwayTransaction{
+		Body: conway.ConwayTransactionBody{
+			TxInputs: conway.NewConwayTransactionInputSet(
+				[]shelley.ShelleyTransactionInput{inputWitness, inputRef},
+			),
+		},
+		WitnessSet: conway.ConwayTransactionWitnessSet{
+			WsPlutusV1Scripts: cbor.NewSetType(
+				[]common.PlutusV1Script{v1},
+				false,
+			),
+			WsRedeemers: conway.ConwayRedeemers{
+				Redeemers: map[common.RedeemerKey]common.RedeemerValue{
+					// inputRef (v2, reference-backed) at sorted index 0.
+					{Tag: common.RedeemerTagSpend, Index: 0}: {
+						ExUnits: common.ExUnits{Steps: 1, Memory: 1},
+					},
+					// inputWitness (v1, witness-backed) at sorted index 1.
+					{Tag: common.RedeemerTagSpend, Index: 1}: {
+						ExUnits: common.ExUnits{Steps: 1, Memory: 1},
+					},
+				},
+			},
+		},
+		TxIsValid: true,
+	}
+
+	require.NoError(t, script.ValidateRequiredRedeemers(tx, ls))
+}
+
 // TestValidateRequiredRedeemersSkipsNonScriptAddress ensures a key-address
 // input is never treated as requiring a redeemer.
 func TestValidateRequiredRedeemersSkipsNonScriptAddress(t *testing.T) {
@@ -389,11 +457,171 @@ func TestValidateRequiredRedeemersSkipsNativeScript(t *testing.T) {
 	require.NoError(t, script.ValidateRequiredRedeemers(tx, ls))
 }
 
-// TestValidateRequiredRedeemersSkipsInvalidTx mirrors
-// ValidateScriptWitnesses: a phase-2-invalid transaction is expected to fail
-// phase-2 validation, so phase-1 checks like this one must not additionally
-// reject it for a missing redeemer.
-func TestValidateRequiredRedeemersSkipsInvalidTx(t *testing.T) {
+// TestValidateRequiredRedeemersSkipsNativeWitnessScript is
+// TestValidateRequiredRedeemersSkipsNativeScript's explicit-witness
+// counterpart: a native script provided in the witness set, not as a
+// reference script, must not be treated as requiring a redeemer either.
+func TestValidateRequiredRedeemersSkipsNativeWitnessScript(t *testing.T) {
+	nsCbor, err := cbor.Encode(
+		common.NativeScriptInvalidBefore{Type: 4, Slot: 0},
+	)
+	require.NoError(t, err)
+	var ns common.NativeScript
+	require.NoError(t, ns.UnmarshalCBOR(nsCbor))
+
+	input := shelley.NewShelleyTransactionInput(
+		"6666666666666666666666666666666666666666666666666666666666666666",
+		0,
+	)
+	utxo := common.Utxo{
+		Id: input,
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAddress: scriptAddress(t, ns),
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
+		},
+	}
+	ls := ledgerStateWithUtxos(utxo)
+
+	tx := &conway.ConwayTransaction{
+		Body: conway.ConwayTransactionBody{
+			TxInputs: conway.NewConwayTransactionInputSet(
+				[]shelley.ShelleyTransactionInput{input},
+			),
+		},
+		WitnessSet: conway.ConwayTransactionWitnessSet{
+			WsNativeScripts: cbor.NewSetType(
+				[]common.NativeScript{ns},
+				false,
+			),
+		},
+		TxIsValid: true,
+	}
+
+	require.NoError(t, script.ValidateRequiredRedeemers(tx, ls))
+}
+
+// TestValidateRequiredRedeemersSkipsScriptEntirelyMissing ensures a
+// script-address input whose script is reachable via neither an explicit
+// witness nor a reference script is not reported by this check. That
+// absence is ValidateScriptWitnesses's error to report (MissingScriptWitnessesError);
+// this check must not also fire, or must not fire a *different* error, for
+// the same missing script.
+func TestValidateRequiredRedeemersSkipsScriptEntirelyMissing(t *testing.T) {
+	v1 := common.PlutusV1Script{0x01, 0x02, 0x03}
+	input := shelley.NewShelleyTransactionInput(
+		"7777777777777777777777777777777777777777777777777777777777777777",
+		0,
+	)
+	utxo := common.Utxo{
+		Id: input,
+		Output: &babbage.BabbageTransactionOutput{
+			// scriptAddress requires v1's hash, but v1 is never provided as
+			// a witness or a reference script anywhere in this transaction.
+			OutputAddress: scriptAddress(t, v1),
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
+		},
+	}
+	ls := ledgerStateWithUtxos(utxo)
+
+	tx := &conway.ConwayTransaction{
+		Body: conway.ConwayTransactionBody{
+			TxInputs: conway.NewConwayTransactionInputSet(
+				[]shelley.ShelleyTransactionInput{input},
+			),
+		},
+		TxIsValid: true,
+	}
+
+	require.NoError(t, script.ValidateRequiredRedeemers(tx, ls))
+}
+
+// TestValidateRequiredRedeemersPropagatesInputResolutionError pins the
+// current resolution-error contract: an unresolvable consumed input
+// surfaces as common.InputResolutionError, the same error
+// NewTxScriptView/ResolveTxInputs report, even though
+// shelley.UtxoValidateBadInputsUtxo already reports the same failure more
+// specifically and is registered ahead of this rule in every era's
+// production rule list. This test pins today's actual behavior so a future
+// switch to NewTxScriptViewSkippingUnresolved (#2162) changes it
+// deliberately rather than silently.
+func TestValidateRequiredRedeemersPropagatesInputResolutionError(t *testing.T) {
+	input := shelley.NewShelleyTransactionInput(
+		"8888888888888888888888888888888888888888888888888888888888888888",
+		0,
+	)
+	// No UTxOs registered, so every UtxoById call fails.
+	ls := ledgerStateWithUtxos()
+
+	tx := &conway.ConwayTransaction{
+		Body: conway.ConwayTransactionBody{
+			TxInputs: conway.NewConwayTransactionInputSet(
+				[]shelley.ShelleyTransactionInput{input},
+			),
+		},
+		TxIsValid: true,
+	}
+
+	err := script.ValidateRequiredRedeemers(tx, ls)
+	require.ErrorAs(t, err, &common.InputResolutionError{})
+}
+
+// TestValidateRequiredRedeemersMissingRedeemerPlutusV3AndV4 extends the
+// missing-redeemer coverage beyond PlutusV1/V2 to PlutusV3 and PlutusV4
+// reference scripts.
+func TestValidateRequiredRedeemersMissingRedeemerPlutusV3AndV4(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		script  common.Script
+		refType uint
+	}{
+		{"PlutusV3", common.PlutusV3Script{0x01}, common.ScriptRefTypePlutusV3},
+		{"PlutusV4", common.PlutusV4Script{0x01}, common.ScriptRefTypePlutusV4},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			input := shelley.NewShelleyTransactionInput(
+				"9999999999999999999999999999999999999999999999999999999999999999",
+				0,
+			)
+			utxo := common.Utxo{
+				Id: input,
+				Output: &babbage.BabbageTransactionOutput{
+					OutputAddress: scriptAddress(t, tc.script),
+					OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
+					TxOutScriptRef: &common.ScriptRef{
+						Type:   tc.refType,
+						Script: tc.script,
+					},
+				},
+			}
+			ls := ledgerStateWithUtxos(utxo)
+
+			tx := &conway.ConwayTransaction{
+				Body: conway.ConwayTransactionBody{
+					TxInputs: conway.NewConwayTransactionInputSet(
+						[]shelley.ShelleyTransactionInput{input},
+					),
+				},
+				TxIsValid: true,
+			}
+
+			err := script.ValidateRequiredRedeemers(tx, ls)
+			var missingErr common.MissingRedeemerForScriptError
+			require.ErrorAs(t, err, &missingErr)
+			require.Equal(t, tc.script.Hash(), missingErr.ScriptHash)
+			require.Equal(t, uint32(0), missingErr.Index)
+		})
+	}
+}
+
+// TestValidateRequiredRedeemersAppliesRegardlessOfIsValid pins that this
+// check is NOT gated on the transaction's IsValid flag, unlike
+// ValidateScriptWitnesses. AlonzoUTXOW's hasExactSetOfRedeemers (the source
+// of AlonzoUtxowPredFailure.MissingRedeemers) is a witnessing-completeness
+// check that cardano-ledger enforces unconditionally; IsValid is read only
+// by UTXOS, never by UTXOW, to decide which witnesses are required. A
+// submitter marking a transaction invalid does not excuse it from carrying
+// every redeemer its script-locked inputs require.
+func TestValidateRequiredRedeemersAppliesRegardlessOfIsValid(t *testing.T) {
 	v1 := common.PlutusV1Script{0x01}
 	input := shelley.NewShelleyTransactionInput(
 		"5555555555555555555555555555555555555555555555555555555555555555",
@@ -421,7 +649,11 @@ func TestValidateRequiredRedeemersSkipsInvalidTx(t *testing.T) {
 		TxIsValid: false,
 	}
 
-	require.NoError(t, script.ValidateRequiredRedeemers(tx, ls))
+	err := script.ValidateRequiredRedeemers(tx, ls)
+	var missingErr common.MissingRedeemerForScriptError
+	require.ErrorAs(t, err, &missingErr)
+	require.Equal(t, v1.Hash(), missingErr.ScriptHash)
+	require.Equal(t, uint32(0), missingErr.Index)
 }
 
 // TestValidateRequiredRedeemersNilLedgerState mirrors

--- a/ledger/common/script/redeemers_test.go
+++ b/ledger/common/script/redeemers_test.go
@@ -1,0 +1,433 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package script_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/common/script"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/require"
+)
+
+// scriptAddress builds a script-only (no staking part) address whose payment
+// part is s's hash, so an output at that address requires s as its spending
+// script.
+func scriptAddress(t *testing.T, s common.Script) common.Address {
+	t.Helper()
+	addr, err := common.NewAddressFromParts(
+		common.AddressTypeScriptNone,
+		common.AddressNetworkTestnet,
+		s.Hash().Bytes(),
+		nil,
+	)
+	require.NoError(t, err)
+	return addr
+}
+
+func ledgerStateWithUtxos(utxos ...common.Utxo) common.LedgerState {
+	return mockledger.NewLedgerStateBuilder().
+		WithUtxoById(func(id common.TransactionInput) (common.Utxo, error) {
+			for _, u := range utxos {
+				if u.Id != nil && u.Id.String() == id.String() {
+					return u, nil
+				}
+			}
+			return common.Utxo{}, errors.New("utxo not found")
+		}).
+		Build()
+}
+
+func withSpendRedeemer(index uint32) conway.ConwayRedeemers {
+	return conway.ConwayRedeemers{
+		Redeemers: map[common.RedeemerKey]common.RedeemerValue{
+			{Tag: common.RedeemerTagSpend, Index: index}: {
+				ExUnits: common.ExUnits{Steps: 1, Memory: 1},
+			},
+		},
+	}
+}
+
+// TestValidateRequiredRedeemersMissingReferenceScript pins the exact bug
+// #2147 describes: a script-address input satisfied entirely by a CIP-33
+// reference script, with no redeemer at all. ValidateScriptWitnesses accepts
+// this (the script is reachable via the reference), so nothing but this
+// check catches the missing redeemer.
+func TestValidateRequiredRedeemersMissingReferenceScript(t *testing.T) {
+	v1 := common.PlutusV1Script{0x01, 0x02, 0x03}
+	input := shelley.NewShelleyTransactionInput(
+		"1111111111111111111111111111111111111111111111111111111111111111",
+		0,
+	)
+	utxo := common.Utxo{
+		Id: input,
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAddress: scriptAddress(t, v1),
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
+			TxOutScriptRef: &common.ScriptRef{
+				Type:   common.ScriptRefTypePlutusV1,
+				Script: v1,
+			},
+		},
+	}
+	ls := ledgerStateWithUtxos(utxo)
+
+	tx := &conway.ConwayTransaction{
+		Body: conway.ConwayTransactionBody{
+			TxInputs: conway.NewConwayTransactionInputSet(
+				[]shelley.ShelleyTransactionInput{input},
+			),
+		},
+		TxIsValid: true,
+	}
+
+	err := script.ValidateRequiredRedeemers(tx, ls)
+	var missingErr common.MissingRedeemerForScriptError
+	require.ErrorAs(t, err, &missingErr)
+	require.Equal(t, v1.Hash(), missingErr.ScriptHash)
+	require.Equal(t, common.RedeemerTagSpend, missingErr.Tag)
+	require.Equal(t, uint32(0), missingErr.Index)
+}
+
+// TestValidateRequiredRedeemersValidReferenceScript is the corresponding
+// happy path: the same reference-script-backed input, but with its spend
+// redeemer present.
+func TestValidateRequiredRedeemersValidReferenceScript(t *testing.T) {
+	v1 := common.PlutusV1Script{0x01, 0x02, 0x03}
+	input := shelley.NewShelleyTransactionInput(
+		"1111111111111111111111111111111111111111111111111111111111111111",
+		0,
+	)
+	utxo := common.Utxo{
+		Id: input,
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAddress: scriptAddress(t, v1),
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
+			TxOutScriptRef: &common.ScriptRef{
+				Type:   common.ScriptRefTypePlutusV1,
+				Script: v1,
+			},
+		},
+	}
+	ls := ledgerStateWithUtxos(utxo)
+
+	tx := &conway.ConwayTransaction{
+		Body: conway.ConwayTransactionBody{
+			TxInputs: conway.NewConwayTransactionInputSet(
+				[]shelley.ShelleyTransactionInput{input},
+			),
+		},
+		WitnessSet: conway.ConwayTransactionWitnessSet{
+			WsRedeemers: withSpendRedeemer(0),
+		},
+		TxIsValid: true,
+	}
+
+	require.NoError(t, script.ValidateRequiredRedeemers(tx, ls))
+}
+
+// TestValidateRequiredRedeemersScriptViaSeparateReferenceInput covers the
+// canonical CIP-33 shape: the Plutus script lives on a dedicated reference
+// input (TxReferenceInputs), not on the output actually being spent. The
+// spent input's own output carries no script at all.
+func TestValidateRequiredRedeemersScriptViaSeparateReferenceInput(t *testing.T) {
+	v1 := common.PlutusV1Script{0x01, 0x02, 0x03}
+	spentInput := shelley.NewShelleyTransactionInput(
+		"9999999999999999999999999999999999999999999999999999999999999999",
+		0,
+	)
+	refInput := shelley.NewShelleyTransactionInput(
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		0,
+	)
+	spentUtxo := common.Utxo{
+		Id: spentInput,
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAddress: scriptAddress(t, v1),
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
+		},
+	}
+	refUtxo := common.Utxo{
+		Id: refInput,
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAmount: mary.MaryTransactionOutputValue{Amount: 1000},
+			TxOutScriptRef: &common.ScriptRef{
+				Type:   common.ScriptRefTypePlutusV1,
+				Script: v1,
+			},
+		},
+	}
+	ls := ledgerStateWithUtxos(spentUtxo, refUtxo)
+
+	newTx := func() *conway.ConwayTransaction {
+		return &conway.ConwayTransaction{
+			Body: conway.ConwayTransactionBody{
+				TxInputs: conway.NewConwayTransactionInputSet(
+					[]shelley.ShelleyTransactionInput{spentInput},
+				),
+				TxReferenceInputs: cbor.NewSetType(
+					[]shelley.ShelleyTransactionInput{refInput},
+					false,
+				),
+			},
+			TxIsValid: true,
+		}
+	}
+
+	t.Run("missing redeemer rejected", func(t *testing.T) {
+		err := script.ValidateRequiredRedeemers(newTx(), ls)
+		var missingErr common.MissingRedeemerForScriptError
+		require.ErrorAs(t, err, &missingErr)
+		require.Equal(t, v1.Hash(), missingErr.ScriptHash)
+		require.Equal(t, uint32(0), missingErr.Index)
+	})
+
+	t.Run("valid redeemer accepted", func(t *testing.T) {
+		tx := newTx()
+		tx.WitnessSet.WsRedeemers = withSpendRedeemer(0)
+		require.NoError(t, script.ValidateRequiredRedeemers(tx, ls))
+	})
+}
+
+// TestValidateRequiredRedeemersMissingWitnessScript shows the gap isn't
+// unique to reference scripts: an explicit Plutus witness script on a
+// script-address input still needs its own redeemer even when other
+// redeemers exist in the transaction.
+func TestValidateRequiredRedeemersMissingWitnessScript(t *testing.T) {
+	v1 := common.PlutusV1Script{0x01, 0x02, 0x03}
+	input := shelley.NewShelleyTransactionInput(
+		"2222222222222222222222222222222222222222222222222222222222222222",
+		0,
+	)
+	utxo := common.Utxo{
+		Id: input,
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAddress: scriptAddress(t, v1),
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
+		},
+	}
+	ls := ledgerStateWithUtxos(utxo)
+
+	tx := &conway.ConwayTransaction{
+		Body: conway.ConwayTransactionBody{
+			TxInputs: conway.NewConwayTransactionInputSet(
+				[]shelley.ShelleyTransactionInput{input},
+			),
+		},
+		WitnessSet: conway.ConwayTransactionWitnessSet{
+			WsPlutusV1Scripts: cbor.NewSetType(
+				[]common.PlutusV1Script{v1},
+				false,
+			),
+			// A redeemer at some other purpose's index -- not this input's
+			// spend index -- must not satisfy this input's requirement.
+			WsRedeemers: withSpendRedeemer(1),
+		},
+		TxIsValid: true,
+	}
+
+	err := script.ValidateRequiredRedeemers(tx, ls)
+	var missingErr common.MissingRedeemerForScriptError
+	require.ErrorAs(t, err, &missingErr)
+	require.Equal(t, uint32(0), missingErr.Index)
+}
+
+// TestValidateRequiredRedeemersMixedInputs spends two script-address inputs
+// sorted (TxId, Index) so the second input comes first; only the second has
+// a redeemer. The first (sorted index 1) must be reported missing, and the
+// reference-script/witness-script distinction between the two inputs must
+// not matter.
+func TestValidateRequiredRedeemersMixedInputs(t *testing.T) {
+	v1 := common.PlutusV1Script{0x01}
+	v2 := common.PlutusV2Script{0x02}
+
+	// Sorts after "aaaa...", so v1's input lands at sorted index 1.
+	inputWitness := shelley.NewShelleyTransactionInput(
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		0,
+	)
+	inputRef := shelley.NewShelleyTransactionInput(
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		0,
+	)
+
+	utxoWitness := common.Utxo{
+		Id: inputWitness,
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAddress: scriptAddress(t, v1),
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
+		},
+	}
+	utxoRef := common.Utxo{
+		Id: inputRef,
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAddress: scriptAddress(t, v2),
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
+			TxOutScriptRef: &common.ScriptRef{
+				Type:   common.ScriptRefTypePlutusV2,
+				Script: v2,
+			},
+		},
+	}
+	ls := ledgerStateWithUtxos(utxoWitness, utxoRef)
+
+	tx := &conway.ConwayTransaction{
+		Body: conway.ConwayTransactionBody{
+			TxInputs: conway.NewConwayTransactionInputSet(
+				[]shelley.ShelleyTransactionInput{inputWitness, inputRef},
+			),
+		},
+		WitnessSet: conway.ConwayTransactionWitnessSet{
+			WsPlutusV1Scripts: cbor.NewSetType(
+				[]common.PlutusV1Script{v1},
+				false,
+			),
+			// Only the reference-script input (sorted index 0) gets a redeemer.
+			WsRedeemers: withSpendRedeemer(0),
+		},
+		TxIsValid: true,
+	}
+
+	err := script.ValidateRequiredRedeemers(tx, ls)
+	var missingErr common.MissingRedeemerForScriptError
+	require.ErrorAs(t, err, &missingErr)
+	require.Equal(t, v1.Hash(), missingErr.ScriptHash)
+	require.Equal(t, uint32(1), missingErr.Index)
+}
+
+// TestValidateRequiredRedeemersSkipsNonScriptAddress ensures a key-address
+// input is never treated as requiring a redeemer.
+func TestValidateRequiredRedeemersSkipsNonScriptAddress(t *testing.T) {
+	input := shelley.NewShelleyTransactionInput(
+		"3333333333333333333333333333333333333333333333333333333333333333",
+		0,
+	)
+	keyAddr, err := common.NewAddressFromParts(
+		common.AddressTypeKeyNone,
+		common.AddressNetworkTestnet,
+		make([]byte, 28),
+		nil,
+	)
+	require.NoError(t, err)
+	utxo := common.Utxo{
+		Id: input,
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAddress: keyAddr,
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
+		},
+	}
+	ls := ledgerStateWithUtxos(utxo)
+
+	tx := &conway.ConwayTransaction{
+		Body: conway.ConwayTransactionBody{
+			TxInputs: conway.NewConwayTransactionInputSet(
+				[]shelley.ShelleyTransactionInput{input},
+			),
+		},
+		TxIsValid: true,
+	}
+
+	require.NoError(t, script.ValidateRequiredRedeemers(tx, ls))
+}
+
+// TestValidateRequiredRedeemersSkipsNativeScript ensures a script-address
+// input backed by a native (non-Plutus) reference script is not required to
+// carry a redeemer.
+func TestValidateRequiredRedeemersSkipsNativeScript(t *testing.T) {
+	nsCbor, err := cbor.Encode(
+		common.NativeScriptInvalidBefore{Type: 4, Slot: 0},
+	)
+	require.NoError(t, err)
+	var ns common.NativeScript
+	require.NoError(t, ns.UnmarshalCBOR(nsCbor))
+
+	input := shelley.NewShelleyTransactionInput(
+		"4444444444444444444444444444444444444444444444444444444444444444",
+		0,
+	)
+	utxo := common.Utxo{
+		Id: input,
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAddress: scriptAddress(t, ns),
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
+			TxOutScriptRef: &common.ScriptRef{
+				Type:   common.ScriptRefTypeNativeScript,
+				Script: ns,
+			},
+		},
+	}
+	ls := ledgerStateWithUtxos(utxo)
+
+	tx := &conway.ConwayTransaction{
+		Body: conway.ConwayTransactionBody{
+			TxInputs: conway.NewConwayTransactionInputSet(
+				[]shelley.ShelleyTransactionInput{input},
+			),
+		},
+		TxIsValid: true,
+	}
+
+	require.NoError(t, script.ValidateRequiredRedeemers(tx, ls))
+}
+
+// TestValidateRequiredRedeemersSkipsInvalidTx mirrors
+// ValidateScriptWitnesses: a phase-2-invalid transaction is expected to fail
+// phase-2 validation, so phase-1 checks like this one must not additionally
+// reject it for a missing redeemer.
+func TestValidateRequiredRedeemersSkipsInvalidTx(t *testing.T) {
+	v1 := common.PlutusV1Script{0x01}
+	input := shelley.NewShelleyTransactionInput(
+		"5555555555555555555555555555555555555555555555555555555555555555",
+		0,
+	)
+	utxo := common.Utxo{
+		Id: input,
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAddress: scriptAddress(t, v1),
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
+			TxOutScriptRef: &common.ScriptRef{
+				Type:   common.ScriptRefTypePlutusV1,
+				Script: v1,
+			},
+		},
+	}
+	ls := ledgerStateWithUtxos(utxo)
+
+	tx := &conway.ConwayTransaction{
+		Body: conway.ConwayTransactionBody{
+			TxInputs: conway.NewConwayTransactionInputSet(
+				[]shelley.ShelleyTransactionInput{input},
+			),
+		},
+		TxIsValid: false,
+	}
+
+	require.NoError(t, script.ValidateRequiredRedeemers(tx, ls))
+}
+
+// TestValidateRequiredRedeemersNilLedgerState mirrors
+// ValidateScriptWitnesses's contract: without a LedgerState, script
+// resolution isn't possible, so the check must not report a false positive.
+func TestValidateRequiredRedeemersNilLedgerState(t *testing.T) {
+	tx := &conway.ConwayTransaction{}
+	require.NoError(t, script.ValidateRequiredRedeemers(tx, nil))
+}

--- a/ledger/common/script/redeemers_test.go
+++ b/ledger/common/script/redeemers_test.go
@@ -431,3 +431,14 @@ func TestValidateRequiredRedeemersNilLedgerState(t *testing.T) {
 	tx := &conway.ConwayTransaction{}
 	require.NoError(t, script.ValidateRequiredRedeemers(tx, nil))
 }
+
+// TestValidateRequiredRedeemersNilTransaction pins that a nil Transaction
+// interface value is rejected before tx.IsValid() is called on it -- calling
+// a method on a nil interface panics, so the nil check must short-circuit
+// first (matching NewTxScriptView's own "tx == nil || ls == nil" guard).
+func TestValidateRequiredRedeemersNilTransaction(t *testing.T) {
+	require.NotPanics(t, func() {
+		err := script.ValidateRequiredRedeemers(nil, nil)
+		require.NoError(t, err)
+	})
+}

--- a/ledger/conway/errors.go
+++ b/ledger/conway/errors.go
@@ -210,17 +210,8 @@ func (e ExtraRedeemerError) Error() string {
 	)
 }
 
-// MissingRedeemerForScriptError indicates a script purpose requires a redeemer but none was provided
-type MissingRedeemerForScriptError struct {
-	ScriptHash common.ScriptHash
-	Tag        common.RedeemerTag
-	Index      uint32
-}
-
-func (e MissingRedeemerForScriptError) Error() string {
-	return fmt.Sprintf("missing redeemer for script %x: tag=%d, index=%d",
-		e.ScriptHash[:], e.Tag, e.Index)
-}
+// MissingRedeemerForScriptError is an alias to common.MissingRedeemerForScriptError
+type MissingRedeemerForScriptError = common.MissingRedeemerForScriptError
 
 // ProtocolParameterUpdateEmptyError indicates that a PPU has no fields set
 type ProtocolParameterUpdateEmptyError struct{}

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -68,6 +68,7 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateBadInputsUtxo,
 	// Ensure script witness presence/absence is validated after redeemer/script relation
 	UtxoValidateScriptWitnesses,
+	UtxoValidateRequiredRedeemers,
 	UtxoValidateValueNotConservedUtxo,
 	UtxoValidateOutputTooSmallUtxo,
 	UtxoValidateOutputTooBigUtxo,
@@ -1399,6 +1400,19 @@ func UtxoValidateScriptWitnesses(
 	pp common.ProtocolParameters,
 ) error {
 	return common.ValidateScriptWitnesses(tx, ls)
+}
+
+// UtxoValidateRequiredRedeemers checks that every Plutus script-address
+// input -- whether its script is provided as an explicit witness or as a
+// CIP-33 reference script -- has a matching spend redeemer. See
+// script.ValidateRequiredRedeemers for details on the gap this closes.
+func UtxoValidateRequiredRedeemers(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	return script.ValidateRequiredRedeemers(tx, ls)
 }
 
 // UtxoValidateExtraneousRedeemers checks that all redeemers have valid purposes.

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -994,6 +994,142 @@ func TestUtxoValidateWitnessRules_Conway(t *testing.T) {
 	)
 }
 
+// TestUtxoValidateRequiredRedeemersRegistered pins that Conway registers
+// UtxoValidateRequiredRedeemers in its production rule list (issue #2147).
+func TestUtxoValidateRequiredRedeemersRegistered(t *testing.T) {
+	want := reflect.ValueOf(conway.UtxoValidateRequiredRedeemers).Pointer()
+	for _, rule := range conway.UtxoValidationRules {
+		if reflect.ValueOf(rule).Pointer() == want {
+			return
+		}
+	}
+	t.Fatal("UtxoValidateRequiredRedeemers is not registered in UtxoValidationRules")
+}
+
+// TestUtxoValidateRequiredRedeemers covers issue #2147's acceptance
+// criteria directly: a Plutus script-address input satisfied by a CIP-33
+// reference script must not spend without a matching redeemer, a regular
+// (non-script) input is unaffected, and a valid redeemer passes.
+func TestUtxoValidateRequiredRedeemers(t *testing.T) {
+	v1 := common.PlutusV1Script{0x01, 0x02, 0x03}
+	scriptAddr, err := common.NewAddressFromParts(
+		common.AddressTypeScriptNone,
+		common.AddressNetworkTestnet,
+		v1.Hash().Bytes(),
+		nil,
+	)
+	require.NoError(t, err)
+
+	input := shelley.NewShelleyTransactionInput(
+		"7777777777777777777777777777777777777777777777777777777777777777",
+		0,
+	)
+	utxo := common.Utxo{
+		Id: input,
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAddress: scriptAddr,
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
+			TxOutScriptRef: &common.ScriptRef{
+				Type:   common.ScriptRefTypePlutusV1,
+				Script: v1,
+			},
+		},
+	}
+	ls := mockledger.NewLedgerStateBuilder().
+		WithUtxoById(func(id common.TransactionInput) (common.Utxo, error) {
+			if id.String() == input.String() {
+				return utxo, nil
+			}
+			return common.Utxo{}, errors.New("not found")
+		}).
+		Build()
+
+	newTx := func() *conway.ConwayTransaction {
+		return &conway.ConwayTransaction{
+			Body: conway.ConwayTransactionBody{
+				TxInputs: conway.NewConwayTransactionInputSet(
+					[]shelley.ShelleyTransactionInput{input},
+				),
+			},
+			TxIsValid: true,
+		}
+	}
+
+	t.Run("missing redeemer for reference script rejected", func(t *testing.T) {
+		err := conway.UtxoValidateRequiredRedeemers(
+			newTx(),
+			0,
+			ls,
+			&conway.ConwayProtocolParameters{},
+		)
+		var missingErr common.MissingRedeemerForScriptError
+		require.ErrorAs(t, err, &missingErr)
+		require.Equal(t, v1.Hash(), missingErr.ScriptHash)
+		require.Equal(t, common.RedeemerTagSpend, missingErr.Tag)
+		require.Equal(t, uint32(0), missingErr.Index)
+	})
+
+	t.Run("valid redeemer accepted", func(t *testing.T) {
+		tx := newTx()
+		tx.WitnessSet.WsRedeemers = conway.ConwayRedeemers{
+			Redeemers: map[common.RedeemerKey]common.RedeemerValue{
+				{Tag: common.RedeemerTagSpend, Index: 0}: {
+					ExUnits: common.ExUnits{Steps: 1, Memory: 1},
+				},
+			},
+		}
+		require.NoError(t, conway.UtxoValidateRequiredRedeemers(
+			tx,
+			0,
+			ls,
+			&conway.ConwayProtocolParameters{},
+		))
+	})
+
+	t.Run("non-script input unaffected", func(t *testing.T) {
+		keyInput := shelley.NewShelleyTransactionInput(
+			"8888888888888888888888888888888888888888888888888888888888888888",
+			0,
+		)
+		keyAddr, err := common.NewAddressFromParts(
+			common.AddressTypeKeyNone,
+			common.AddressNetworkTestnet,
+			make([]byte, 28),
+			nil,
+		)
+		require.NoError(t, err)
+		keyUtxo := common.Utxo{
+			Id: keyInput,
+			Output: &babbage.BabbageTransactionOutput{
+				OutputAddress: keyAddr,
+				OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
+			},
+		}
+		keyLs := mockledger.NewLedgerStateBuilder().
+			WithUtxoById(func(id common.TransactionInput) (common.Utxo, error) {
+				if id.String() == keyInput.String() {
+					return keyUtxo, nil
+				}
+				return common.Utxo{}, errors.New("not found")
+			}).
+			Build()
+		tx := &conway.ConwayTransaction{
+			Body: conway.ConwayTransactionBody{
+				TxInputs: conway.NewConwayTransactionInputSet(
+					[]shelley.ShelleyTransactionInput{keyInput},
+				),
+			},
+			TxIsValid: true,
+		}
+		require.NoError(t, conway.UtxoValidateRequiredRedeemers(
+			tx,
+			0,
+			keyLs,
+			&conway.ConwayProtocolParameters{},
+		))
+	})
+}
+
 func TestUtxoValidateExtraneousRedeemersUnknownTag(t *testing.T) {
 	redeemerKey := common.RedeemerKey{Tag: common.RedeemerTag(99)}
 	tx := &conway.ConwayTransaction{}

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -23,6 +23,7 @@ import (
 	"math"
 	"math/big"
 	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -997,13 +998,41 @@ func TestUtxoValidateWitnessRules_Conway(t *testing.T) {
 // TestUtxoValidateRequiredRedeemersRegistered pins that Conway registers
 // UtxoValidateRequiredRedeemers in its production rule list (issue #2147).
 func TestUtxoValidateRequiredRedeemersRegistered(t *testing.T) {
-	want := reflect.ValueOf(conway.UtxoValidateRequiredRedeemers).Pointer()
-	for _, rule := range conway.UtxoValidationRules {
-		if reflect.ValueOf(rule).Pointer() == want {
-			return
+	indexOf := func(rule common.UtxoValidationRuleFunc) int {
+		t.Helper()
+		want := reflect.ValueOf(rule).Pointer()
+		for idx, r := range conway.UtxoValidationRules {
+			if reflect.ValueOf(r).Pointer() == want {
+				return idx
+			}
 		}
+		t.Fatalf(
+			"rule %s is not registered in UtxoValidationRules",
+			runtime.FuncForPC(want).Name(),
+		)
+		return -1
 	}
-	t.Fatal("UtxoValidateRequiredRedeemers is not registered in UtxoValidationRules")
+
+	requiredRedeemersIdx := indexOf(conway.UtxoValidateRequiredRedeemers)
+	badInputsIdx := indexOf(conway.UtxoValidateBadInputsUtxo)
+	scriptWitnessesIdx := indexOf(conway.UtxoValidateScriptWitnesses)
+
+	require.Greater(
+		t,
+		requiredRedeemersIdx,
+		badInputsIdx,
+		"UtxoValidateRequiredRedeemers must run after UtxoValidateBadInputsUtxo "+
+			"so an unresolvable input surfaces as BadInputsUtxo, not a raw "+
+			"input-resolution error",
+	)
+	require.Greater(
+		t,
+		requiredRedeemersIdx,
+		scriptWitnessesIdx,
+		"UtxoValidateRequiredRedeemers must run after UtxoValidateScriptWitnesses "+
+			"so a missing script is reported by the latter, not masked as a "+
+			"missing redeemer",
+	)
 }
 
 // TestUtxoValidateRequiredRedeemers covers issue #2147's acceptance

--- a/ledger/dijkstra/required_redeemers_test.go
+++ b/ledger/dijkstra/required_redeemers_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dijkstra
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUtxoValidateRequiredRedeemersRegistered pins that Dijkstra's rule list
+// reuses conway.UtxoValidateRequiredRedeemers directly, rather than each era
+// re-deriving the reference-script-implies-redeemer check on its own (issue
+// #2147's "avoid duplicating era-specific guards" requirement).
+func TestUtxoValidateRequiredRedeemersRegistered(t *testing.T) {
+	dijkstraValidationRule(t, "ledger/conway.UtxoValidateRequiredRedeemers")
+}
+
+// TestUtxoValidateRequiredRedeemersDijkstra exercises issue #2147's scenario
+// through the Dijkstra entry point: a script-address input satisfied by a
+// CIP-33 reference script, spent with no redeemer at all. Conway and
+// Dijkstra must behave consistently here since they share one function.
+func TestUtxoValidateRequiredRedeemersDijkstra(t *testing.T) {
+	v1 := common.PlutusV1Script{0x01, 0x02, 0x03}
+	scriptAddr, err := common.NewAddressFromParts(
+		common.AddressTypeScriptNone,
+		common.AddressNetworkTestnet,
+		v1.Hash().Bytes(),
+		nil,
+	)
+	require.NoError(t, err)
+
+	input := shelley.NewShelleyTransactionInput(
+		"6666666666666666666666666666666666666666666666666666666666666666",
+		0,
+	)
+	utxo := common.Utxo{
+		Id: input,
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAddress: scriptAddr,
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
+			TxOutScriptRef: &common.ScriptRef{
+				Type:   common.ScriptRefTypePlutusV1,
+				Script: v1,
+			},
+		},
+	}
+	ls := mockledger.NewLedgerStateBuilder().
+		WithUtxoById(func(id common.TransactionInput) (common.Utxo, error) {
+			if id.String() == input.String() {
+				return utxo, nil
+			}
+			return common.Utxo{}, errors.New("not found")
+		}).
+		Build()
+
+	newTx := func() *DijkstraTransaction {
+		return &DijkstraTransaction{
+			Body: DijkstraTransactionBody{
+				TxInputs: conway.NewConwayTransactionInputSet(
+					[]shelley.ShelleyTransactionInput{input},
+				),
+			},
+			TxIsValid: true,
+		}
+	}
+
+	// No redeemer at all: the reference script satisfies script-presence
+	// checks, but the spend is left completely unexecuted -- exactly the
+	// gap issue #2147 describes.
+	missingTx := newTx()
+	err = conway.UtxoValidateRequiredRedeemers(
+		missingTx,
+		0,
+		ls,
+		&DijkstraProtocolParameters{},
+	)
+	var missingErr common.MissingRedeemerForScriptError
+	require.ErrorAs(t, err, &missingErr)
+	require.Equal(t, v1.Hash(), missingErr.ScriptHash)
+	require.Equal(t, uint32(0), missingErr.Index)
+
+	// With the matching spend redeemer present, the same input passes.
+	validTx := newTx()
+	validTx.WitnessSet = DijkstraTransactionWitnessSet{
+		WsRedeemers: DijkstraRedeemers{
+			Redeemers: map[common.RedeemerKey]common.RedeemerValue{
+				{Tag: common.RedeemerTagSpend, Index: 0}: {
+					ExUnits: common.ExUnits{Steps: 1, Memory: 1},
+				},
+			},
+		},
+	}
+	require.NoError(t, conway.UtxoValidateRequiredRedeemers(
+		validTx,
+		0,
+		ls,
+		&DijkstraProtocolParameters{},
+	))
+}

--- a/ledger/dijkstra/required_redeemers_test.go
+++ b/ledger/dijkstra/required_redeemers_test.go
@@ -32,7 +32,35 @@ import (
 // re-deriving the reference-script-implies-redeemer check on its own (issue
 // #2147's "avoid duplicating era-specific guards" requirement).
 func TestUtxoValidateRequiredRedeemersRegistered(t *testing.T) {
-	dijkstraValidationRule(t, "ledger/conway.UtxoValidateRequiredRedeemers")
+	_, requiredRedeemersIdx := dijkstraValidationRule(
+		t,
+		"ledger/conway.UtxoValidateRequiredRedeemers",
+	)
+	_, badInputsIdx := dijkstraValidationRule(
+		t,
+		"ledger/conway.UtxoValidateBadInputsUtxo",
+	)
+	_, scriptWitnessesIdx := dijkstraValidationRule(
+		t,
+		"ledger/conway.UtxoValidateScriptWitnesses",
+	)
+
+	require.Greater(
+		t,
+		requiredRedeemersIdx,
+		badInputsIdx,
+		"UtxoValidateRequiredRedeemers must run after UtxoValidateBadInputsUtxo "+
+			"so an unresolvable input surfaces as BadInputsUtxo, not a raw "+
+			"input-resolution error",
+	)
+	require.Greater(
+		t,
+		requiredRedeemersIdx,
+		scriptWitnessesIdx,
+		"UtxoValidateRequiredRedeemers must run after UtxoValidateScriptWitnesses "+
+			"so a missing script is reported by the latter, not masked as a "+
+			"missing redeemer",
+	)
 }
 
 // TestUtxoValidateRequiredRedeemersDijkstra exercises issue #2147's scenario

--- a/ledger/dijkstra/rules.go
+++ b/ledger/dijkstra/rules.go
@@ -67,6 +67,7 @@ var UtxoValidationRules = []common.UtxoValidationRuleFunc{
 	UtxoValidateNoCollateralInputs,
 	conway.UtxoValidateBadInputsUtxo,
 	conway.UtxoValidateScriptWitnesses,
+	conway.UtxoValidateRequiredRedeemers,
 	UtxoValidateValueNotConservedUtxo,
 	UtxoValidateOutputTooSmallUtxo,
 	UtxoValidateOutputTooBigUtxo,


### PR DESCRIPTION
### Summary
- Adds a single shared validation function that checks every Plutus script-address
  input — whether its script is provided as an explicit witness or a CIP-33
  reference script — has a matching spend redeemer at its canonical sorted-input
  position.
- Closes a gap where a reference script satisfied existing "script is present"
  checks without ever requiring a redeemer, letting a script-locked input spend
  with no script execution and no error at all.
- Wired into Babbage, Conway, and Dijkstra via one implementation — no
  duplicated era-specific guards.

### Changes by file

**`ledger/common/script/redeemers.go`** (new)
- `ValidateRequiredRedeemers(tx, ls)`: walks `SortInputs(tx.Inputs())`, and for
  each script-address input whose resolved script (witness or reference) is
  Plutus, requires a spend redeemer at that index. Skips invalid txs, nil
  ledger state, and non-Plutus (native) scripts. Lives in the `script`
  subpackage since it reuses `SortInputs`/`NewTxScriptView` (avoids an import
  cycle with `ledger/common`).

**`ledger/common/errors.go`**
- Added `MissingRedeemerForScriptError` (mirrors `ExtraneousRedeemerError`'s
  style), returned by the new check.

**`ledger/babbage/errors.go`**
- Added `MissingRedeemerForScriptError` as an alias to the common type.

**`ledger/babbage/rules.go`**
- Added `UtxoValidateRequiredRedeemers` wrapper (delegates to
  `script.ValidateRequiredRedeemers`), registered in `UtxoValidationRules`
  right after `UtxoValidateScriptWitnesses`. Babbage doesn't execute Plutus,
  but must still reject an unexecuted reference-script-backed spend.

**`ledger/conway/errors.go`**
- Converted the pre-existing, never-wired-up `MissingRedeemerForScriptError`
  into a type alias to `common.MissingRedeemerForScriptError` (was dead code
  since PR #1418).

**`ledger/conway/rules.go`**
- Added `UtxoValidateRequiredRedeemers` wrapper, registered in
  `UtxoValidationRules` right after `UtxoValidateScriptWitnesses`.

**`ledger/dijkstra/rules.go`**
- Registered `conway.UtxoValidateRequiredRedeemers` directly in
  `UtxoValidationRules` (same reuse pattern as `conway.UtxoValidateScriptWitnesses`)
  — no Dijkstra-specific wrapper needed.

**`ledger/common/script/redeemers_test.go`** (new)
- Unit tests for the shared function: missing/valid redeemer via reference
  script (both attached-to-spent-output and separate-reference-input shapes),
  missing redeemer via explicit witness script, mixed script inputs (only one
  redeemed), non-script address skipped, native reference script skipped,
  invalid tx skipped, nil ledger state skipped.

**`ledger/babbage/required_redeemers_test.go`** (new)
- Wiring test (`UtxoValidateRequiredRedeemers` present in
  `UtxoValidationRules`) + missing/valid redeemer regression test.

**`ledger/conway/rules_test.go`**
- Added wiring test + missing/valid/non-script regression tests for
  `conway.UtxoValidateRequiredRedeemers`.

**`ledger/dijkstra/required_redeemers_test.go`** (new)
- Confirms Dijkstra registers Conway's shared function and behaves
  identically through the Dijkstra transaction type.

### Testing
- `go build ./...`, `go vet ./...` — clean
- `golangci-lint run ./...` — 0 issues
- `go test ./...` — all pass
- `go test -race ./ledger/...` — all pass
- Ledger rule conformance — 315/315 vectors pass (unchanged from baseline)

Closes #2147 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Requires every Plutus script-address spend — whether backed by an explicit witness or a CIP-33 reference script — to include its matching spend redeemer across Babbage, Conway, and Dijkstra, including transactions marked invalid (`IsValid=false`). Previously, a reference script could satisfy script-presence checks without a redeemer, letting a Plutus-locked input spend unexecuted. Closes #2147.

**Bug Fixes**

- Adds shared validation using canonical sorted-input indexes and `MissingRedeemerForScriptError`.
- Adds regression coverage for reference scripts, witness scripts, mixed inputs, missing scripts, native scripts, invalid transactions, and PlutusV3/V4.

<sup>Written for commit 75e91a1cdc859cb3f47e9801f58e7573c12f675c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Transactions spending Plutus script addresses now require the appropriate spend redeemer.
  - This validation applies to scripts supplied directly or through reference scripts.
  - Transactions missing a required redeemer are rejected with a clear validation error identifying the affected script and input.
  - Key-address and native-script transactions remain unaffected.
  - Consistent redeemer validation is now enforced across Babbage, Conway, and Dijkstra transaction validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->