### PR TITLE
fix(script): validity-interval upper-bound closure is era-dependent (Conway exclusive, pre-Conway closed)

### DIFF
--- a/ledger/common/script/context.go
+++ b/ledger/common/script/context.go
@@ -194,12 +194,18 @@ func (t TxInfoV1) ToPlutusData() data.PlutusData {
 	)
 }
 
+// NewTxInfoV1FromTransaction builds a Plutus V1 TxInfo. strictValidityUpperBound
+// selects the era-dependent encoding of a finite validity-interval upper bound:
+// pass true in the Conway era or later (EXCLUSIVE upper bound in all cases) and
+// false in Alonzo/Babbage (CLOSED upper bound for an upper-only interval). See
+// the TimeRange.strictUpperBound documentation and cardano-ledger#3043.
 func NewTxInfoV1FromTransaction(
 	slotState lcommon.SlotState,
 	tx lcommon.Transaction,
 	resolvedInputs []lcommon.Utxo,
+	strictValidityUpperBound bool,
 ) (TxInfoV1, error) {
-	validityRange, err := validityRangeInfo(slotState, tx)
+	validityRange, err := validityRangeInfo(slotState, tx, strictValidityUpperBound)
 	if err != nil {
 		return TxInfoV1{}, err
 	}
@@ -307,12 +313,18 @@ func (t TxInfoV2) ToPlutusData() data.PlutusData {
 	)
 }
 
+// NewTxInfoV2FromTransaction builds a Plutus V2 TxInfo. strictValidityUpperBound
+// selects the era-dependent encoding of a finite validity-interval upper bound:
+// pass true in the Conway era or later (EXCLUSIVE upper bound in all cases) and
+// false in Babbage (CLOSED upper bound for an upper-only interval). See the
+// TimeRange.strictUpperBound documentation and cardano-ledger#3043.
 func NewTxInfoV2FromTransaction(
 	slotState lcommon.SlotState,
 	tx lcommon.Transaction,
 	resolvedInputs []lcommon.Utxo,
+	strictValidityUpperBound bool,
 ) (TxInfoV2, error) {
-	validityRange, err := validityRangeInfo(slotState, tx)
+	validityRange, err := validityRangeInfo(slotState, tx, strictValidityUpperBound)
 	if err != nil {
 		return TxInfoV2{}, err
 	}
@@ -409,7 +421,9 @@ func NewTxInfoV3FromTransaction(
 	tx lcommon.Transaction,
 	resolvedInputs []lcommon.Utxo,
 ) (TxInfoV3, error) {
-	validityRange, err := validityRangeInfo(slotState, tx)
+	// Plutus V3 only exists in the Conway era and later, where cardano-ledger
+	// always uses an EXCLUSIVE (strict) validity-interval upper bound.
+	validityRange, err := validityRangeInfo(slotState, tx, true)
 	if err != nil {
 		return TxInfoV3{}, err
 	}
@@ -472,6 +486,26 @@ type TimeRange struct {
 	upperBound        uint64
 	lowerBoundPresent bool
 	upperBoundPresent bool
+	// strictUpperBound selects cardano-ledger's ERA-DEPENDENT encoding of a
+	// finite validity-interval upper bound (invalidHereafter).
+	//
+	// Conway and later eras (Conway.transValidityInterval, cardano-ledger#3043)
+	// always use `strictUpperBound` — an EXCLUSIVE upper bound — for a finite
+	// upper bound, whether or not a lower bound is present:
+	//   UpperBound (Finite t) False
+	//
+	// Pre-Conway eras (Alonzo/Babbage transVITime) use `PV1.to` for an
+	// upper-only interval, which is a CLOSED/INCLUSIVE upper bound
+	//   UpperBound (Finite t) True
+	// but already use `strictUpperBound` (exclusive) when BOTH bounds are
+	// present. cardano-ledger#3043 could not change this pre-Conway behavior
+	// because it would alter historical on-chain script validation, so the
+	// corrected exclusive bound was gated to the Conway era.
+	//
+	// Set strictUpperBound = true when building a Plutus context in the Conway
+	// era or later, false for Alonzo/Babbage. Plutus V3 only exists in Conway
+	// and later, so V3 contexts always set this true.
+	strictUpperBound bool
 }
 
 func (t TimeRange) ToPlutusData() data.PlutusData {
@@ -517,10 +551,17 @@ func (t TimeRange) ToPlutusData() data.PlutusData {
 			t.upperBound,
 			t.upperBoundPresent,
 			false,
-			// cardano-ledger uses `to` (closed upper) for an
-			// upper-only interval, but `strictUpperBound` when
-			// both bounds are present.
-			!t.lowerBoundPresent,
+			// Closure of a finite upper bound, matching cardano-ledger's
+			// ERA-DEPENDENT translation (see the strictUpperBound field):
+			//   - both bounds present (lowerBoundPresent): EXCLUSIVE (false)
+			//     in every era (transVITime / transValidityInterval both use
+			//     strictUpperBound for a two-sided interval).
+			//   - upper-only interval (no lower bound): EXCLUSIVE (false) in
+			//     Conway and later (Conway.transValidityInterval,
+			//     cardano-ledger#3043), INCLUSIVE (true) in Alonzo/Babbage
+			//     (transVITime uses PV1.to).
+			// i.e. closed iff it is an upper-only, pre-Conway interval.
+			!t.lowerBoundPresent && !t.strictUpperBound,
 		),
 	)
 }
@@ -598,8 +639,10 @@ func sortedRedeemerKeys(
 func validityRangeInfo(
 	slotState lcommon.SlotState,
 	tx lcommon.Transaction,
+	strictValidityUpperBound bool,
 ) (TimeRange, error) {
 	var ret TimeRange
+	ret.strictUpperBound = strictValidityUpperBound
 	startSlot := tx.ValidityIntervalStart()
 	endSlot, upperBoundPresent := lcommon.TransactionValidityIntervalUpperBound(
 		tx,

--- a/ledger/common/script/context_test.go
+++ b/ledger/common/script/context_test.go
@@ -85,6 +85,7 @@ func buildTxInfoV1(
 		slotState,
 		tx,
 		resolvedInputs,
+		false, // Alonzo era: pre-Conway, closed upper-only validity bound
 	)
 	if err != nil {
 		return nil, err
@@ -144,6 +145,7 @@ func buildTxInfoV2(
 		slotState,
 		tx,
 		resolvedInputs,
+		false, // Babbage era: pre-Conway, closed upper-only validity bound
 	)
 	if err != nil {
 		return nil, err
@@ -526,10 +528,12 @@ var scriptContextV3TestDefs = []struct {
 		redeemerTag:   lcommon.RedeemerTagReward,
 		redeemerIndex: 0,
 		slotState:     preprodSlotState,
-		// cardano-ledger translates an upper-only interval with PV1.to,
-		// whose finite upper bound is closed. This transaction has key 3
-		// (upper) and no key 8 (lower).
-		expectedCbor: "d8799fd8799f9fd8799fd8799f5820000000000000000000000000000000000000000000000000000000000000000000ffd8799fd8799fd87a9f581c04036eecadc2f19e95f831b4bc08919cde1d1088d74602bd3dcd78a2ffd8799fd8799fd87a9f581c04036eecadc2f19e95f831b4bc08919cde1d1088d74602bd3dcd78a2ffffffffa140a1401a000f4240d87b9fd87980ffd8799f581c04036eecadc2f19e95f831b4bc08919cde1d1088d74602bd3dcd78a2ffffffff809fd8799fd8799fd8799f581c00000000000000000000000000000000000000000000000000000000ffd8799fd8799fd87a9f581c11111111111111111111111111111111111111111111111111111111ffffffffa140a1401a000f4240d87980d87a80ffd8799fd8799fd8799f581c00000000000000000000000000000000000000000000000000000000ffd8799fd87a9f1a00261ec3181b03ffffffa140a1401a000f4240d87980d87a80ffd8799fd8799fd87a9f581c11111111111111111111111111111111111111111111111111111111ffd8799fd87a9f1a00261ec3181b03ffffffa140a1401a000f4240d87980d87a80ffff182aa080a1d87a9f581c04036eecadc2f19e95f831b4bc08919cde1d1088d74602bd3dcd78a2ff00d8799fd8799fd87980d87a80ffd8799fd87a9f1b000001739c890420ffd87a80ffff9f581c00000000000000000000000000000000000000000000000000000000ffa2d87a9fd8799f5820000000000000000000000000000000000000000000000000000000000000000000ffffd87a81d87980d87b9fd87a9f581c04036eecadc2f19e95f831b4bc08919cde1d1088d74602bd3dcd78a2ffffd87980a0582040bee3b25a585a854fe73f3448a6f6b417fe669c813a1881e665971f34a9e984a080d87a80d8799f01ffffd87980d87b9fd87a9f581c04036eecadc2f19e95f831b4bc08919cde1d1088d74602bd3dcd78a2ffffff",
+		// cardano-ledger translates the validity-interval upper bound
+		// with PV1.strictUpperBound (EXCLUSIVE), so a finite upper bound
+		// is OPEN (closure False) even for an upper-only interval. This
+		// transaction has key 3 (upper, invalidHereafter) and no key 8
+		// (lower).
+		expectedCbor: "d8799fd8799f9fd8799fd8799f5820000000000000000000000000000000000000000000000000000000000000000000ffd8799fd8799fd87a9f581c04036eecadc2f19e95f831b4bc08919cde1d1088d74602bd3dcd78a2ffd8799fd8799fd87a9f581c04036eecadc2f19e95f831b4bc08919cde1d1088d74602bd3dcd78a2ffffffffa140a1401a000f4240d87b9fd87980ffd8799f581c04036eecadc2f19e95f831b4bc08919cde1d1088d74602bd3dcd78a2ffffffff809fd8799fd8799fd8799f581c00000000000000000000000000000000000000000000000000000000ffd8799fd8799fd87a9f581c11111111111111111111111111111111111111111111111111111111ffffffffa140a1401a000f4240d87980d87a80ffd8799fd8799fd8799f581c00000000000000000000000000000000000000000000000000000000ffd8799fd87a9f1a00261ec3181b03ffffffa140a1401a000f4240d87980d87a80ffd8799fd8799fd87a9f581c11111111111111111111111111111111111111111111111111111111ffd8799fd87a9f1a00261ec3181b03ffffffa140a1401a000f4240d87980d87a80ffff182aa080a1d87a9f581c04036eecadc2f19e95f831b4bc08919cde1d1088d74602bd3dcd78a2ff00d8799fd8799fd87980d87a80ffd8799fd87a9f1b000001739c890420ffd87980ffff9f581c00000000000000000000000000000000000000000000000000000000ffa2d87a9fd8799f5820000000000000000000000000000000000000000000000000000000000000000000ffffd87a81d87980d87b9fd87a9f581c04036eecadc2f19e95f831b4bc08919cde1d1088d74602bd3dcd78a2ffffd87980a0582040bee3b25a585a854fe73f3448a6f6b417fe669c813a1881e665971f34a9e984a080d87a80d8799f01ffffd87980d87b9fd87a9f581c04036eecadc2f19e95f831b4bc08919cde1d1088d74602bd3dcd78a2ffffff",
 	},
 	{
 		name:          "Voting",
@@ -639,6 +643,7 @@ func TestNewTxInfoFromTransactionUnmatchedRedeemer(t *testing.T) {
 			preprodSlotState,
 			newTx(),
 			nil,
+			true, // Conway tx (error path; flag does not affect the assertion)
 		)
 		require.Error(t, err)
 		var unmatchedErr script.UnmatchedRedeemerError
@@ -650,6 +655,7 @@ func TestNewTxInfoFromTransactionUnmatchedRedeemer(t *testing.T) {
 			preprodSlotState,
 			newTx(),
 			nil,
+			true, // Conway tx (error path; flag does not affect the assertion)
 		)
 		require.Error(t, err)
 		var unmatchedErr script.UnmatchedRedeemerError
@@ -689,6 +695,7 @@ func TestNewTxInfoFromTransactionUnknownRedeemerTag(t *testing.T) {
 			preprodSlotState,
 			newTx(),
 			nil,
+			true, // Conway tx (error path; flag does not affect the assertion)
 		)
 		require.Error(t, err)
 		var unmatchedErr script.UnmatchedRedeemerError
@@ -700,6 +707,7 @@ func TestNewTxInfoFromTransactionUnknownRedeemerTag(t *testing.T) {
 			preprodSlotState,
 			newTx(),
 			nil,
+			true, // Conway tx (error path; flag does not affect the assertion)
 		)
 		require.Error(t, err)
 		var unmatchedErr script.UnmatchedRedeemerError

--- a/ledger/common/script/context_timerange_test.go
+++ b/ledger/common/script/context_timerange_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package script
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/plutigo/data"
+	"github.com/stretchr/testify/require"
+)
+
+// boolConstr is the Plutus encoding of a Haskell Bool: Constr 0 [] for False,
+// Constr 1 [] for True (mirrors toPlutusData(bool)).
+func boolConstr(v bool) data.PlutusData {
+	if v {
+		return data.NewConstr(1)
+	}
+	return data.NewConstr(0)
+}
+
+// finiteBound builds Constr 0 [ Constr 1 [ Integer value ], <closureBool> ] —
+// the Plutus encoding of a Finite `Extended` bound with the given closure.
+func finiteBound(value uint64, closed bool) data.PlutusData {
+	return data.NewConstr(
+		0,
+		data.NewConstr(1, data.NewInteger(new(big.Int).SetUint64(value))),
+		boolConstr(closed),
+	)
+}
+
+// infBound builds an infinite `Extended` bound: NegInf -> Constr 0, PosInf ->
+// Constr 2; both carry closure True by the Plutus "infinite bounds are always
+// exclusive" convention.
+func infBound(posInf bool) data.PlutusData {
+	tag := uint64(0)
+	if posInf {
+		tag = 2
+	}
+	return data.NewConstr(0, data.NewConstr(tag), boolConstr(true))
+}
+
+func wholeRange(lower, upper data.PlutusData) data.PlutusData {
+	return data.NewConstr(0, lower, upper)
+}
+
+// TestTimeRangeToPlutusDataUpperBoundEraDependent pins cardano-ledger's
+// ERA-DEPENDENT encoding of a finite validity-interval upper bound
+// (invalidHereafter):
+//
+//   - Conway and later (strictUpperBound == true): the upper bound is EXCLUSIVE
+//     in every case (Conway.transValidityInterval / cardano-ledger#3043).
+//   - Alonzo/Babbage (strictUpperBound == false): an upper-only interval uses
+//     PV1.to, a CLOSED/INCLUSIVE upper bound; a two-sided interval already uses
+//     strictUpperBound (EXCLUSIVE).
+//
+// The bug that motivated this test: gouroboros previously emitted
+// `!lowerBoundPresent` for every era, giving Conway-era TTL-only transactions
+// an INCLUSIVE upper bound and mis-computing script execution units.
+func TestTimeRangeToPlutusDataUpperBoundEraDependent(t *testing.T) {
+	tests := []struct {
+		name string
+		tr   TimeRange
+		want data.PlutusData
+	}{
+		// --- Conway and later: upper bound always EXCLUSIVE ---
+		{
+			// invalidHereafter set, no invalidBefore, Conway+. This is
+			// the case the bug affected. Upper must be EXCLUSIVE.
+			name: "conway ttl only (upper present, lower absent)",
+			tr: TimeRange{
+				upperBound:        1000,
+				upperBoundPresent: true,
+				strictUpperBound:  true,
+			},
+			want: wholeRange(
+				infBound(false),          // NegInf
+				finiteBound(1000, false), // Finite 1000, EXCLUSIVE
+			),
+		},
+		{
+			name: "conway both bounds present",
+			tr: TimeRange{
+				lowerBound:        500,
+				upperBound:        1000,
+				lowerBoundPresent: true,
+				upperBoundPresent: true,
+				strictUpperBound:  true,
+			},
+			want: wholeRange(
+				finiteBound(500, true),   // Finite 500, INCLUSIVE
+				finiteBound(1000, false), // Finite 1000, EXCLUSIVE
+			),
+		},
+		// --- Alonzo/Babbage: upper-only is INCLUSIVE, two-sided EXCLUSIVE ---
+		{
+			// invalidHereafter set, no invalidBefore, pre-Conway. Upper
+			// must be INCLUSIVE (PV1.to). A version/language-only gate
+			// that keyed off "V1/V2" would get this right but would then
+			// wrongly apply it to Conway-era V1/V2 as well — hence the
+			// gate is on the ERA, not the Plutus version.
+			name: "preconway ttl only (upper present, lower absent)",
+			tr: TimeRange{
+				upperBound:        1000,
+				upperBoundPresent: true,
+				strictUpperBound:  false,
+			},
+			want: wholeRange(
+				infBound(false),         // NegInf
+				finiteBound(1000, true), // Finite 1000, INCLUSIVE
+			),
+		},
+		{
+			// Two-sided interval is EXCLUSIVE-upper even pre-Conway
+			// (transVITime uses strictUpperBound when both bounds exist).
+			name: "preconway both bounds present",
+			tr: TimeRange{
+				lowerBound:        500,
+				upperBound:        1000,
+				lowerBoundPresent: true,
+				upperBoundPresent: true,
+				strictUpperBound:  false,
+			},
+			want: wholeRange(
+				finiteBound(500, true),   // Finite 500, INCLUSIVE
+				finiteBound(1000, false), // Finite 1000, EXCLUSIVE
+			),
+		},
+		// --- era-invariant shapes ---
+		{
+			name: "lower only (upper absent) - conway",
+			tr: TimeRange{
+				lowerBound:        500,
+				lowerBoundPresent: true,
+				strictUpperBound:  true,
+			},
+			want: wholeRange(finiteBound(500, true), infBound(true)),
+		},
+		{
+			name: "lower only (upper absent) - preconway",
+			tr: TimeRange{
+				lowerBound:        500,
+				lowerBoundPresent: true,
+				strictUpperBound:  false,
+			},
+			want: wholeRange(finiteBound(500, true), infBound(true)),
+		},
+		{
+			name: "unbounded - conway",
+			tr:   TimeRange{strictUpperBound: true},
+			want: wholeRange(infBound(false), infBound(true)),
+		},
+		{
+			name: "unbounded - preconway",
+			tr:   TimeRange{strictUpperBound: false},
+			want: wholeRange(infBound(false), infBound(true)),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.tr.ToPlutusData()
+			require.True(
+				t,
+				tc.want.Equal(got),
+				"TimeRange.ToPlutusData mismatch:\n got: %s\nwant: %s",
+				got,
+				tc.want,
+			)
+		})
+	}
+}

--- a/ledger/common/script/context_validity_test.go
+++ b/ledger/common/script/context_validity_test.go
@@ -83,6 +83,13 @@ func expectedValidityRange(
 	if endPresent {
 		endValue = *end
 	}
+	// These fixtures build V1/V2 TxInfo from Alonzo/Babbage transactions, i.e.
+	// the PRE-CONWAY eras. cardano-ledger's transVITime translates an upper-only
+	// interval there with PV1.to, a CLOSED (inclusive) upper bound, while a
+	// two-sided interval uses strictUpperBound (exclusive). So the upper-bound
+	// closure is inclusive iff there is no lower bound (upper-only). The Conway
+	// era corrects the upper-only case to exclusive (cardano-ledger#3043); that
+	// is covered separately in the strictUpperBound=true tests.
 	return data.NewConstr(
 		0,
 		validityBound(startPresent, startValue, true, true),
@@ -116,6 +123,7 @@ func TestValidityRangeMatchesCardanoLedger(t *testing.T) {
 					validitySlotState{},
 					tx,
 					nil,
+					false, // Alonzo era: pre-Conway, closed upper-only bound
 				)
 				require.NoError(t, err)
 				requireValidityRange(
@@ -135,6 +143,7 @@ func TestValidityRangeMatchesCardanoLedger(t *testing.T) {
 					validitySlotState{},
 					tx,
 					nil,
+					false, // Babbage era: pre-Conway, closed upper-only bound
 				)
 				require.NoError(t, err)
 				requireValidityRange(

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -2924,7 +2924,7 @@ func UtxoValidatePlutusScripts(
 			// Build V2 TxInfo lazily
 			if !txInfoV2Built {
 				var err error
-				txInfoV2, err = script.NewTxInfoV2FromTransaction(ls, tx, resolvedInputs)
+				txInfoV2, err = script.NewTxInfoV2FromTransaction(ls, tx, resolvedInputs, true)
 				if err != nil {
 					return ScriptContextConstructionError{Err: err}
 				}
@@ -2956,7 +2956,7 @@ func UtxoValidatePlutusScripts(
 			// Build V1 TxInfo lazily
 			if !txInfoV1Built {
 				var err error
-				txInfoV1, err = script.NewTxInfoV1FromTransaction(ls, tx, resolvedInputs)
+				txInfoV1, err = script.NewTxInfoV1FromTransaction(ls, tx, resolvedInputs, true)
 				if err != nil {
 					return ScriptContextConstructionError{Err: err}
 				}

--- a/ledger/dijkstra/rules.go
+++ b/ledger/dijkstra/rules.go
@@ -581,6 +581,7 @@ func validateGuardingPlutusScripts(
 					ls,
 					transactionWithoutGuardingRedeemers{Transaction: tx},
 					resolvedInputs,
+					true,
 				)
 				if err != nil {
 					return conway.ScriptContextConstructionError{Err: err}
@@ -614,6 +615,7 @@ func validateGuardingPlutusScripts(
 					ls,
 					transactionWithoutGuardingRedeemers{Transaction: tx},
 					resolvedInputs,
+					true,
 				)
 				if err != nil {
 					return conway.ScriptContextConstructionError{Err: err}

--- a/ledger/dijkstra/rules_test.go
+++ b/ledger/dijkstra/rules_test.go
@@ -1116,11 +1116,11 @@ func TestNewTxInfoFromTransactionGuardingRedeemer(t *testing.T) {
 	ls := mockledger.NewLedgerStateBuilder().Build()
 
 	t.Run("unwrapped fails closed", func(t *testing.T) {
-		_, err := script.NewTxInfoV1FromTransaction(ls, tx, nil)
+		_, err := script.NewTxInfoV1FromTransaction(ls, tx, nil, true)
 		var unmatchedErr script.UnmatchedRedeemerError
 		require.ErrorAs(t, err, &unmatchedErr)
 
-		_, err = script.NewTxInfoV2FromTransaction(ls, tx, nil)
+		_, err = script.NewTxInfoV2FromTransaction(ls, tx, nil, true)
 		require.ErrorAs(t, err, &unmatchedErr)
 
 		_, err = script.NewTxInfoV3FromTransaction(ls, tx, nil)
@@ -1130,10 +1130,10 @@ func TestNewTxInfoFromTransactionGuardingRedeemer(t *testing.T) {
 	t.Run("wrapped succeeds", func(t *testing.T) {
 		wrapped := transactionWithoutGuardingRedeemers{Transaction: tx}
 
-		_, err := script.NewTxInfoV1FromTransaction(ls, wrapped, nil)
+		_, err := script.NewTxInfoV1FromTransaction(ls, wrapped, nil, true)
 		require.NoError(t, err)
 
-		_, err = script.NewTxInfoV2FromTransaction(ls, wrapped, nil)
+		_, err = script.NewTxInfoV2FromTransaction(ls, wrapped, nil, true)
 		require.NoError(t, err)
 
 		_, err = script.NewTxInfoV3FromTransaction(ls, wrapped, nil)


### PR DESCRIPTION
## Problem
`TimeRange.ToPlutusData` rendered the validity-interval upper bound with a single closure for all Plutus versions/eras. cardano-ledger's `transValidityInterval` makes the upper-bound closure **era-dependent**: pre-Conway (Alonzo/Babbage) Plutus V1/V2 render a TTL-only (`invalidHereafter`, upper-only) interval as a **closed** upper bound `UpperBound (Finite t) True`, while Conway renders it **exclusive** `UpperBound (Finite t) False` (cardano-ledger#3043). A single closure diverges from the node on one side, causing ExUnits / script-evaluation divergence.

## Fix
Gate the closure on the target era. Thread a `strictValidityUpperBound bool` through `NewTxInfoV1FromTransaction` / `NewTxInfoV2FromTransaction` (Plutus V3 is always strict). `TimeRange` carries a `strictUpperBound` field; the finite upper-bound closure is computed as `!lowerBoundPresent && !strictUpperBound` — closed only for a pre-Conway upper-only interval, exclusive when strict (Conway/Dijkstra) or when both bounds are present. Callers in `ledger/conway/rules.go` and `ledger/dijkstra/rules.go` pass `true`.

## Tests
- New `context_timerange_test.go`: pre-Conway (closed) vs Conway (exclusive) rendering for upper-only, both-bounds, and lower-only intervals.
- `context_validity_test.go`: V1/V2 Alonzo/Babbage reverted to the inclusive expectation.
- `context_test.go`: V3 golden keeps the exclusive bound.

Refs cardano-ledger#3043.

_(Re-files #2159, which GitHub auto-closed after its branch lost common history with `main` — it had been based on a vendored snapshot rather than a fork of main. Same change, rebuilt cleanly on current main.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Plutus validity-interval upper bound so it matches cardano-ledger per era, preventing ExUnits and script-evaluation divergence. Pre-Conway V1/V2 keep a closed upper-only bound; Conway and later now render it exclusive (cardano-ledger#3043).

**Migration**

- `NewTxInfoV1FromTransaction` and `NewTxInfoV2FromTransaction` now take a `strictValidityUpperBound bool` argument; pass `false` for Alonzo/Babbage and `true` for Conway and later.
- `NewTxInfoV3FromTransaction` is unchanged and always uses the exclusive bound.

<sup>Written for commit e3a446a028de705d44a7c1ddef3398c122b31876. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected validity-interval encoding for script validation.
  - In Conway and later eras, upper-only validity intervals are now treated as exclusive.
  - In Alonzo and Babbage eras, upper-only intervals retain inclusive behavior.
  - Two-sided, lower-only, and unbounded validity intervals continue to use consistent encoding across eras.
  - Added coverage to verify validity-interval behavior across supported eras.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->