### PR TITLE
fix(leiosfetch): answer unconfigured requests instead of holding agency

### DIFF
--- a/protocol/leiosfetch/README.md
+++ b/protocol/leiosfetch/README.md
@@ -208,18 +208,24 @@ Errors from configured callbacks and transport failures are still propagated.
 
 ## Abandoned requests
 
-`BlockRequest` and `BlockTxsRequest` are bounded by the caller's context. A
-request whose context expires is abandoned: its delivery channel is cleared so
-a late response is dropped rather than mis-delivered, and the slot stays busy
-so the next request cannot be correlated with the outstanding response.
+`BlockRequest`, `BlockTxsRequest`, `VotesRequest`, and `BlockRangeRequest` are
+bounded by the caller's context. These requests share one connection-wide slot
+because their responses carry no request identifier. A request whose context
+expires is abandoned: its delivery channel is cleared so a late response is
+dropped rather than mis-delivered, and the slot stays busy so the next request
+cannot be correlated with the outstanding response. For `BlockRangeRequest`,
+this applies to the whole streaming exchange; the terminal response drains the
+abandoned slot.
 
 A later request waits a bounded grace period for that response to drain. If it
 arrives, the connection continues normally. If it does not, the exchange is
 desynchronised beyond recovery and the client fails the connection with
 `ErrRequestSlotAbandoned` so peer governance can drop and replace the peer.
 This is deliberately narrower than a protocol-level state timeout, which would
-also fire for a healthy relay that merely responded slowly, and is why
-`StateBlock` and `StateBlockTxs` still carry no `StateMap` timeout.
+also fire for a healthy relay that merely responded slowly. `StateBlock` and
+`StateBlockTxs` still carry no `StateMap` timeout; `StateVotes` and
+`StateBlockRange` retain their protocol-level timeout for exchanges that never
+return agency.
 
 ## Notes
 

--- a/protocol/leiosfetch/README.md
+++ b/protocol/leiosfetch/README.md
@@ -188,16 +188,38 @@ whole node-to-node connection.
 
 ## Optional server responders
 
-Leios fetch is optional, but not every request has a safe empty response. An
-unconfigured `VotesRequestFunc` returns `Votes` with an empty CBOR array,
-returning the protocol to `Idle` without a connection-level error. When a
-block, block-transactions, or block-range callback is unconfigured, the server
-enters the corresponding server-agency state and leaves the request pending.
-It sends no response because the available absence replies are either
-placeholder wire IDs or ambiguous with a real response. The requester cannot
-start another Leios fetch exchange, but other mini-protocols on the bearer
-remain usable. Errors from configured callbacks and transport failures are
-still propagated.
+Leios fetch is optional, but an unconfigured responder must never retain server
+agency. A server that accepts a request and never answers wedges the
+requester's client for the life of the connection: `protocol.sendLoop` waits
+for agency that only the missing response returns, so the requester can neither
+issue another Leios fetch request nor detect the condition.
+
+- An unconfigured `VotesRequestFunc` returns `Votes` with an empty CBOR array.
+- An unconfigured `BlockRequestFunc` returns `NoBlock`, and an unconfigured
+  `BlockTxsRequestFunc` returns `NoBlockTxs`. Both wire IDs are still
+  placeholders, but the configured not-available path already emits them, so
+  declining here adds no wire risk that the normal path does not already take.
+- An unconfigured `BlockRangeRequestFunc` returns a protocol error, because
+  `LastBlockAndTxsInRange` carries a mandatory block and there is no absence
+  reply to send. A connection-level error is diagnosable and lets the
+  requester's peer governance replace the peer; a silent hang is neither.
+
+Errors from configured callbacks and transport failures are still propagated.
+
+## Abandoned requests
+
+`BlockRequest` and `BlockTxsRequest` are bounded by the caller's context. A
+request whose context expires is abandoned: its delivery channel is cleared so
+a late response is dropped rather than mis-delivered, and the slot stays busy
+so the next request cannot be correlated with the outstanding response.
+
+A later request waits a bounded grace period for that response to drain. If it
+arrives, the connection continues normally. If it does not, the exchange is
+desynchronised beyond recovery and the client fails the connection with
+`ErrRequestSlotAbandoned` so peer governance can drop and replace the peer.
+This is deliberately narrower than a protocol-level state timeout, which would
+also fire for a healthy relay that merely responded slowly, and is why
+`StateBlock` and `StateBlockTxs` still carry no `StateMap` timeout.
 
 ## Notes
 

--- a/protocol/leiosfetch/client.go
+++ b/protocol/leiosfetch/client.go
@@ -39,7 +39,7 @@ type Client struct {
 }
 
 // requestSlot serializes a single outstanding request/response exchange for a
-// ping-pong leios-fetch state (Block or BlockTxs) and correlates the response
+// ping-pong or streaming leios-fetch state and correlates the response
 // with the caller that is actually waiting for it.
 //
 // These mini-protocol states carry no request identifier and the underlying
@@ -479,10 +479,10 @@ func (c *Client) BlockRangeRequest(
 				return ret, nil
 			}
 		case <-ctx.Done():
-			// release, not abandon, for the reason given in VotesRequest:
-			// a range response reaches blockRangeResultChan, never deliver,
-			// so an abandoned slot here would never drain.
-			c.blockRequestSlot.release(w)
+			// Range responses are delivered through the shared slot, including
+			// the terminal response. Keep the slot abandoned until that response
+			// drains so it cannot be delivered to a later request.
+			c.blockRequestSlot.abandon(w)
 			return nil, ctx.Err()
 		case <-c.DoneChan():
 			c.blockRequestSlot.release(w)

--- a/protocol/leiosfetch/client.go
+++ b/protocol/leiosfetch/client.go
@@ -33,11 +33,9 @@ type Client struct {
 	onceStop        sync.Once
 	// Block and BlockTxs share one slot because both requests use the same
 	// connection-wide agency and have no request identifier.
-	blockRequestSlot     requestSlot
-	blockSlot            requestSlot
-	blockTxsSlot         requestSlot
-	votesResultChan      chan protocol.Message
-	blockRangeResultChan chan protocol.Message
+	blockRequestSlot requestSlot
+	blockSlot        requestSlot
+	blockTxsSlot     requestSlot
 }
 
 // requestSlot serializes a single outstanding request/response exchange for a
@@ -220,8 +218,6 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 		// the response always has somewhere to land even if the caller has
 		// not reached its receive yet. Unbuffered, a response whose caller
 		// gave up on its context blocked the protocol receive loop forever.
-		votesResultChan:      make(chan protocol.Message, 1),
-		blockRangeResultChan: make(chan protocol.Message, 1),
 	}
 	c.callbackContext = CallbackContext{
 		Client:       c,
@@ -277,15 +273,6 @@ func (c *Client) Start() {
 			)
 		c.Protocol.Start()
 		// Start goroutine to cleanup resources on protocol shutdown.
-		// The Block/BlockTxs request slots are unblocked directly by the
-		// per-request select watching DoneChan (see BlockRequest /
-		// BlockTxsRequest), so only the shared Votes/BlockRange channels are
-		// closed here.
-		go func() {
-			<-c.DoneChan()
-			close(c.votesResultChan)
-			close(c.blockRangeResultChan)
-		}()
 	})
 }
 
@@ -444,8 +431,7 @@ func (c *Client) VotesRequest(
 		return nil, err
 	}
 	select {
-	case resp, ok := <-c.votesResultChan:
-		c.blockRequestSlot.release(w)
+	case resp, ok := <-w:
 		if !ok {
 			return nil, protocol.ErrProtocolShuttingDown
 		}
@@ -482,7 +468,7 @@ func (c *Client) BlockRangeRequest(
 	ret := make([]protocol.Message, 0, 20)
 	for {
 		select {
-		case resp, ok := <-c.blockRangeResultChan:
+		case resp, ok := <-w:
 			if !ok {
 				c.blockRequestSlot.release(w)
 				return nil, protocol.ErrProtocolShuttingDown
@@ -590,25 +576,19 @@ func (c *Client) handleNoBlockTxs(msg protocol.Message) {
 // waiting. The send must not block: the protocol receive loop runs it, and a
 // caller whose context expired is gone for good.
 func (c *Client) handleVotes(msg protocol.Message) {
-	select {
-	case c.votesResultChan <- msg:
-	default:
+	if !c.blockRequestSlot.deliver(msg) {
 		c.logDroppedResponse(msg)
 	}
 }
 
 func (c *Client) handleNextBlockAndTxsInRange(msg protocol.Message) {
-	select {
-	case c.blockRangeResultChan <- msg:
-	default:
+	if !c.blockRequestSlot.deliver(msg) {
 		c.logDroppedResponse(msg)
 	}
 }
 
 func (c *Client) handleLastBlockAndTxsInRange(msg protocol.Message) {
-	select {
-	case c.blockRangeResultChan <- msg:
-	default:
+	if !c.blockRequestSlot.deliver(msg) {
 		c.logDroppedResponse(msg)
 	}
 }

--- a/protocol/leiosfetch/client.go
+++ b/protocol/leiosfetch/client.go
@@ -16,6 +16,7 @@ package leiosfetch
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -119,8 +120,9 @@ func (s *requestSlot) acquire(
 // abandon clears the live waiter so that a late response is dropped by deliver
 // rather than mis-delivered, while leaving the slot busy until that response
 // arrives (or the protocol shuts down). Subsequent acquire calls have a bounded
-// grace period while the slot is abandoned instead of parking indefinitely. It
-// is used when a caller's context expires before a response is received.
+// grace period while the slot is abandoned instead of parking indefinitely, and
+// on its expiry the client fails the connection (see acquireSlot). It is used
+// when a caller's context expires before a response is received.
 //
 // The caller passes the delivery channel it registered in acquire. The slot is
 // only mutated while that channel is still the live waiter (s.waiter == w). If
@@ -212,12 +214,17 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 	// Update state map with timeout
 	stateMap := StateMap.Copy()
 	// NOTE: StateBlock and StateBlockTxs intentionally do NOT get a
-	// protocol-level timeout. A missing response to a BlockRequest /
+	// protocol-level timeout. A slow response to a BlockRequest /
 	// BlockTxsRequest must fail only that individual request (bounded by the
 	// caller-supplied context), never tear down the shared multiplexed
 	// connection. The protocol-level timeout fires p.SendError(), which is
 	// fatal to every mini-protocol on the same bearer (chainsync, blockfetch,
-	// etc.), so it must not be wired for these two states.
+	// etc.), so it must not be wired for these two states: it would fire for
+	// a healthy relay that merely responded later than the timeout.
+	//
+	// A response that never arrives at all is a different case and IS fatal,
+	// but only once acquireSlot has proven the exchange is desynchronised --
+	// see acquireSlot.
 	if entry, ok := stateMap[StateVotes]; ok {
 		entry.Timeout = c.config.Timeout
 		stateMap[StateVotes] = entry
@@ -281,6 +288,44 @@ func (c *Client) Stop() error {
 	return err
 }
 
+// acquireSlot acquires slot for a new request in the given server-agency
+// state.
+//
+// A slot that is still holding an abandoned request's response means the peer
+// took leios-fetch agency and never returned it. That is not recoverable on
+// this connection: protocol.sendLoop waits on sendReadyChan for agency the
+// state map only grants once the missing response arrives, so no later
+// leios-fetch request can ever be written to this bearer. Keeping the bearer
+// alive therefore keeps a permanently dead leios-fetch client attached to a
+// peer that still looks healthy, which is exactly how dingo issue #3623
+// stalled a node's ledger indefinitely.
+//
+// Fail the connection instead, so the consumer's peer governance drops and
+// replaces the peer. This does not reintroduce the mis-delivery hazard the
+// slot exists to prevent: the slot is never reused, the connection is
+// discarded.
+func (c *Client) acquireSlot(
+	ctx context.Context,
+	slot *requestSlot,
+	state protocol.State,
+) (chan protocol.Message, error) {
+	w, err := slot.acquire(ctx, c.DoneChan())
+	if err == nil {
+		return w, nil
+	}
+	if errors.Is(err, ErrRequestSlotAbandoned) {
+		c.SendError(
+			fmt.Errorf(
+				"%s: peer retained agency in state %s after an abandoned request: %w",
+				ProtocolName,
+				state,
+				err,
+			),
+		)
+	}
+	return nil, err
+}
+
 // BlockRequest fetches the requested EB identified by the specified point.
 //
 // The wait for a response is bounded by the provided context. If the context
@@ -289,12 +334,14 @@ func (c *Client) Stop() error {
 // NOT emit a protocol error and does NOT tear down the shared multiplexed
 // connection. A response that arrives after the context is done is dropped by
 // the receive path (see handleBlock/handleNoBlock), and a subsequent request
-// waits for that late response to drain so it can never be mis-delivered.
+// waits for that late response to drain so it can never be mis-delivered. If
+// the late response never arrives, that subsequent request fails the
+// connection rather than reusing the slot (see acquireSlot).
 func (c *Client) BlockRequest(
 	ctx context.Context,
 	point pcommon.Point,
 ) (protocol.Message, error) {
-	w, err := c.blockSlot.acquire(ctx, c.DoneChan())
+	w, err := c.acquireSlot(ctx, &c.blockSlot, StateBlock)
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +376,7 @@ func (c *Client) BlockTxsRequest(
 	point pcommon.Point,
 	bitmaps map[uint16]uint64,
 ) (protocol.Message, error) {
-	w, err := c.blockTxsSlot.acquire(ctx, c.DoneChan())
+	w, err := c.acquireSlot(ctx, &c.blockTxsSlot, StateBlockTxs)
 	if err != nil {
 		return nil, err
 	}

--- a/protocol/leiosfetch/client.go
+++ b/protocol/leiosfetch/client.go
@@ -413,43 +413,89 @@ func (c *Client) BlockTxsRequest(
 	}
 }
 
-// VotesRequest fetches the requested votes
+// VotesRequest fetches the requested votes.
+//
+// Admission goes through the same slot as BlockRequest and BlockTxsRequest.
+// The leios-fetch states share one connection-wide agency and carry no request
+// identifier, so a block request whose caller gave up leaves the peer holding
+// agency and nothing can be written to this bearer afterwards. Acquiring the
+// slot here makes that condition surface as ErrRequestSlotAbandoned and fail
+// the connection, instead of blocking this caller forever with no diagnosis.
+//
+// The votes response does not arrive through the slot, so unlike BlockRequest
+// this releases it explicitly on success. A context that expires with the
+// response still outstanding abandons instead: the peer still owes a reply and
+// still holds agency, so the slot has to stay busy until that reply drains it.
 func (c *Client) VotesRequest(
+	ctx context.Context,
 	voteIds []MsgVotesRequestVoteId,
 ) (protocol.Message, error) {
-	msg := NewMsgVotesRequest(voteIds)
-	if err := c.SendMessage(msg); err != nil {
+	w, err := c.acquireSlot(ctx, &c.blockRequestSlot, StateVotes)
+	if err != nil {
 		return nil, err
 	}
-	resp, ok := <-c.votesResultChan
-	if !ok {
+	msg := NewMsgVotesRequest(voteIds)
+	if err := c.SendMessageContext(ctx, msg); err != nil {
+		c.blockRequestSlot.release(w)
+		return nil, err
+	}
+	select {
+	case resp, ok := <-c.votesResultChan:
+		c.blockRequestSlot.release(w)
+		if !ok {
+			return nil, protocol.ErrProtocolShuttingDown
+		}
+		return resp, nil
+	case <-ctx.Done():
+		c.blockRequestSlot.abandon(w)
+		return nil, ctx.Err()
+	case <-c.DoneChan():
+		c.blockRequestSlot.release(w)
 		return nil, protocol.ErrProtocolShuttingDown
 	}
-	return resp, nil
 }
 
 // BlockRangeRequest fetches a range of EBs and their TXs that are certified by RBs within the provided range.
 // This function will block until all EBs and TXs in the requested range have been received
+// Admission goes through the same slot as BlockRequest, for the reason given
+// on VotesRequest: one abandoned block request otherwise makes this block
+// forever with no diagnosis. The slot is held for the whole multi-message
+// range exchange and released once the last message arrives.
 func (c *Client) BlockRangeRequest(
+	ctx context.Context,
 	start pcommon.Point,
 	end pcommon.Point,
 ) ([]protocol.Message, error) {
+	w, err := c.acquireSlot(ctx, &c.blockRequestSlot, StateBlockRange)
+	if err != nil {
+		return nil, err
+	}
 	msg := NewMsgBlockRangeRequest(start, end)
-	if err := c.SendMessage(msg); err != nil {
+	if err := c.SendMessageContext(ctx, msg); err != nil {
+		c.blockRequestSlot.release(w)
 		return nil, err
 	}
 	ret := make([]protocol.Message, 0, 20)
 	for {
-		resp, ok := <-c.blockRangeResultChan
-		if !ok {
+		select {
+		case resp, ok := <-c.blockRangeResultChan:
+			if !ok {
+				c.blockRequestSlot.release(w)
+				return nil, protocol.ErrProtocolShuttingDown
+			}
+			ret = append(ret, resp)
+			if _, ok := resp.(*MsgLastBlockAndTxsInRange); ok {
+				c.blockRequestSlot.release(w)
+				return ret, nil
+			}
+		case <-ctx.Done():
+			c.blockRequestSlot.abandon(w)
+			return nil, ctx.Err()
+		case <-c.DoneChan():
+			c.blockRequestSlot.release(w)
 			return nil, protocol.ErrProtocolShuttingDown
 		}
-		ret = append(ret, resp)
-		if _, ok := resp.(*MsgLastBlockAndTxsInRange); ok {
-			break
-		}
 	}
-	return ret, nil
 }
 
 func (c *Client) messageHandler(msg protocol.Message) error {

--- a/protocol/leiosfetch/client.go
+++ b/protocol/leiosfetch/client.go
@@ -27,10 +27,13 @@ import (
 
 type Client struct {
 	*protocol.Protocol
-	config               *Config
-	callbackContext      CallbackContext
-	onceStart            sync.Once
-	onceStop             sync.Once
+	config          *Config
+	callbackContext CallbackContext
+	onceStart       sync.Once
+	onceStop        sync.Once
+	// Block and BlockTxs share one slot because both requests use the same
+	// connection-wide agency and have no request identifier.
+	blockRequestSlot     requestSlot
 	blockSlot            requestSlot
 	blockTxsSlot         requestSlot
 	votesResultChan      chan protocol.Message
@@ -87,7 +90,16 @@ func (s *requestSlot) acquire(
 				timer.Stop()
 				return nil, protocol.ErrProtocolShuttingDown
 			case <-timer.C:
-				return nil, ErrRequestSlotAbandoned
+				// A response may drain the abandoned request at the same
+				// instant the grace timer fires. Prefer recovery when that
+				// response has already arrived.
+				select {
+				case <-drained:
+					s.mu.Lock()
+					continue
+				default:
+					return nil, ErrRequestSlotAbandoned
+				}
 			}
 			timer.Stop()
 			s.mu.Lock()
@@ -341,13 +353,13 @@ func (c *Client) BlockRequest(
 	ctx context.Context,
 	point pcommon.Point,
 ) (protocol.Message, error) {
-	w, err := c.acquireSlot(ctx, &c.blockSlot, StateBlock)
+	w, err := c.acquireSlot(ctx, &c.blockRequestSlot, StateBlock)
 	if err != nil {
 		return nil, err
 	}
 	msg := NewMsgBlockRequest(point)
 	if err := c.SendMessageContext(ctx, msg); err != nil {
-		c.blockSlot.release(w)
+		c.blockRequestSlot.release(w)
 		return nil, err
 	}
 	select {
@@ -358,10 +370,10 @@ func (c *Client) BlockRequest(
 		}
 		return resp, nil
 	case <-ctx.Done():
-		c.blockSlot.abandon(w)
+		c.blockRequestSlot.abandon(w)
 		return nil, ctx.Err()
 	case <-c.DoneChan():
-		c.blockSlot.release(w)
+		c.blockRequestSlot.release(w)
 		return nil, protocol.ErrProtocolShuttingDown
 	}
 }
@@ -376,13 +388,13 @@ func (c *Client) BlockTxsRequest(
 	point pcommon.Point,
 	bitmaps map[uint16]uint64,
 ) (protocol.Message, error) {
-	w, err := c.acquireSlot(ctx, &c.blockTxsSlot, StateBlockTxs)
+	w, err := c.acquireSlot(ctx, &c.blockRequestSlot, StateBlockTxs)
 	if err != nil {
 		return nil, err
 	}
 	msg := NewMsgBlockTxsRequest(point, bitmaps)
 	if err := c.SendMessageContext(ctx, msg); err != nil {
-		c.blockTxsSlot.release(w)
+		c.blockRequestSlot.release(w)
 		return nil, err
 	}
 	select {
@@ -393,10 +405,10 @@ func (c *Client) BlockTxsRequest(
 		}
 		return resp, nil
 	case <-ctx.Done():
-		c.blockTxsSlot.abandon(w)
+		c.blockRequestSlot.abandon(w)
 		return nil, ctx.Err()
 	case <-c.DoneChan():
-		c.blockTxsSlot.release(w)
+		c.blockRequestSlot.release(w)
 		return nil, protocol.ErrProtocolShuttingDown
 	}
 }
@@ -484,7 +496,7 @@ func (c *Client) logDroppedResponse(msg protocol.Message) {
 }
 
 func (c *Client) handleBlock(msg protocol.Message) {
-	if !c.blockSlot.deliver(msg) {
+	if !c.blockRequestSlot.deliver(msg) && !c.blockSlot.deliver(msg) {
 		c.logDroppedResponse(msg)
 	}
 }
@@ -497,13 +509,13 @@ func (c *Client) handleNoBlock(msg protocol.Message) {
 			"role", "client",
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
-	if !c.blockSlot.deliver(msg) {
+	if !c.blockRequestSlot.deliver(msg) && !c.blockSlot.deliver(msg) {
 		c.logDroppedResponse(msg)
 	}
 }
 
 func (c *Client) handleBlockTxs(msg protocol.Message) {
-	if !c.blockTxsSlot.deliver(msg) {
+	if !c.blockRequestSlot.deliver(msg) && !c.blockTxsSlot.deliver(msg) {
 		c.logDroppedResponse(msg)
 	}
 }
@@ -516,7 +528,7 @@ func (c *Client) handleNoBlockTxs(msg protocol.Message) {
 			"role", "client",
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
-	if !c.blockTxsSlot.deliver(msg) {
+	if !c.blockRequestSlot.deliver(msg) && !c.blockTxsSlot.deliver(msg) {
 		c.logDroppedResponse(msg)
 	}
 }

--- a/protocol/leiosfetch/client.go
+++ b/protocol/leiosfetch/client.go
@@ -215,9 +215,13 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 		cfg = &tmpCfg
 	}
 	c := &Client{
-		config:               cfg,
-		votesResultChan:      make(chan protocol.Message),
-		blockRangeResultChan: make(chan protocol.Message),
+		config: cfg,
+		// Capacity 1: the caller registers before its request is sent, so
+		// the response always has somewhere to land even if the caller has
+		// not reached its receive yet. Unbuffered, a response whose caller
+		// gave up on its context blocked the protocol receive loop forever.
+		votesResultChan:      make(chan protocol.Message, 1),
+		blockRangeResultChan: make(chan protocol.Message, 1),
 	}
 	c.callbackContext = CallbackContext{
 		Client:       c,
@@ -489,7 +493,10 @@ func (c *Client) BlockRangeRequest(
 				return ret, nil
 			}
 		case <-ctx.Done():
-			c.blockRequestSlot.abandon(w)
+			// release, not abandon, for the reason given in VotesRequest:
+			// a range response reaches blockRangeResultChan, never deliver,
+			// so an abandoned slot here would never drain.
+			c.blockRequestSlot.release(w)
 			return nil, ctx.Err()
 		case <-c.DoneChan():
 			c.blockRequestSlot.release(w)
@@ -579,14 +586,29 @@ func (c *Client) handleNoBlockTxs(msg protocol.Message) {
 	}
 }
 
+// handleVotes hands a votes response to its caller, dropping it if none is
+// waiting. The send must not block: the protocol receive loop runs it, and a
+// caller whose context expired is gone for good.
 func (c *Client) handleVotes(msg protocol.Message) {
-	c.votesResultChan <- msg
+	select {
+	case c.votesResultChan <- msg:
+	default:
+		c.logDroppedResponse(msg)
+	}
 }
 
 func (c *Client) handleNextBlockAndTxsInRange(msg protocol.Message) {
-	c.blockRangeResultChan <- msg
+	select {
+	case c.blockRangeResultChan <- msg:
+	default:
+		c.logDroppedResponse(msg)
+	}
 }
 
 func (c *Client) handleLastBlockAndTxsInRange(msg protocol.Message) {
-	c.blockRangeResultChan <- msg
+	select {
+	case c.blockRangeResultChan <- msg:
+	default:
+		c.logDroppedResponse(msg)
+	}
 }

--- a/protocol/leiosfetch/client.go
+++ b/protocol/leiosfetch/client.go
@@ -34,8 +34,6 @@ type Client struct {
 	// Block and BlockTxs share one slot because both requests use the same
 	// connection-wide agency and have no request identifier.
 	blockRequestSlot requestSlot
-	blockSlot        requestSlot
-	blockTxsSlot     requestSlot
 }
 
 // requestSlot serializes a single outstanding request/response exchange for a
@@ -535,7 +533,7 @@ func (c *Client) logDroppedResponse(msg protocol.Message) {
 }
 
 func (c *Client) handleBlock(msg protocol.Message) {
-	if !c.blockRequestSlot.deliver(msg) && !c.blockSlot.deliver(msg) {
+	if !c.blockRequestSlot.deliver(msg) {
 		c.logDroppedResponse(msg)
 	}
 }
@@ -548,13 +546,13 @@ func (c *Client) handleNoBlock(msg protocol.Message) {
 			"role", "client",
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
-	if !c.blockRequestSlot.deliver(msg) && !c.blockSlot.deliver(msg) {
+	if !c.blockRequestSlot.deliver(msg) {
 		c.logDroppedResponse(msg)
 	}
 }
 
 func (c *Client) handleBlockTxs(msg protocol.Message) {
-	if !c.blockRequestSlot.deliver(msg) && !c.blockTxsSlot.deliver(msg) {
+	if !c.blockRequestSlot.deliver(msg) {
 		c.logDroppedResponse(msg)
 	}
 }
@@ -567,7 +565,7 @@ func (c *Client) handleNoBlockTxs(msg protocol.Message) {
 			"role", "client",
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
-	if !c.blockRequestSlot.deliver(msg) && !c.blockTxsSlot.deliver(msg) {
+	if !c.blockRequestSlot.deliver(msg) {
 		c.logDroppedResponse(msg)
 	}
 }

--- a/protocol/leiosfetch/client.go
+++ b/protocol/leiosfetch/client.go
@@ -53,10 +53,88 @@ type Client struct {
 type requestSlot struct {
 	mu              sync.Mutex
 	waiter          chan protocol.Message
+	delivery        *requestDelivery
 	busy            bool
 	abandoned       bool
 	drainedCh       chan struct{}
 	beforeDrainWait func() // test hook for an acquirer reaching the drain wait
+}
+
+type requestDelivery struct {
+	mu      sync.Mutex
+	queue   []queuedResponse
+	signal  chan struct{}
+	stopped chan struct{}
+	once    sync.Once
+	out     chan protocol.Message
+}
+
+type queuedResponse struct {
+	msg      protocol.Message
+	terminal bool
+}
+
+func newRequestDelivery(out chan protocol.Message) *requestDelivery {
+	d := &requestDelivery{
+		signal:  make(chan struct{}, 1),
+		stopped: make(chan struct{}),
+		out:     out,
+	}
+	go d.run()
+	return d
+}
+
+func (d *requestDelivery) enqueue(msg protocol.Message, terminal bool) bool {
+	d.mu.Lock()
+	select {
+	case <-d.stopped:
+		d.mu.Unlock()
+		return false
+	default:
+	}
+	d.queue = append(d.queue, queuedResponse{msg: msg, terminal: terminal})
+	d.mu.Unlock()
+	select {
+	case d.signal <- struct{}{}:
+	default:
+	}
+	return true
+}
+
+func (d *requestDelivery) stop() {
+	d.once.Do(func() {
+		close(d.stopped)
+		d.mu.Lock()
+		d.queue = nil
+		d.mu.Unlock()
+	})
+}
+
+func (d *requestDelivery) run() {
+	for {
+		d.mu.Lock()
+		if len(d.queue) == 0 {
+			d.mu.Unlock()
+			select {
+			case <-d.signal:
+				continue
+			case <-d.stopped:
+				return
+			}
+		}
+		response := d.queue[0]
+		d.queue = d.queue[1:]
+		d.mu.Unlock()
+		select {
+		case d.out <- response.msg:
+		case <-d.stopped:
+			return
+		}
+		if response.terminal {
+			d.stop()
+			return
+		}
+	}
 }
 
 const abandonedRequestWait = time.Second
@@ -118,6 +196,7 @@ func (s *requestSlot) acquire(
 	}
 	w := make(chan protocol.Message, 1)
 	s.waiter = w
+	s.delivery = newRequestDelivery(w)
 	s.busy = true
 	s.abandoned = false
 	s.drainedCh = make(chan struct{})
@@ -141,6 +220,8 @@ func (s *requestSlot) abandon(w chan protocol.Message) {
 	s.mu.Lock()
 	if s.waiter == w {
 		s.waiter = nil
+		s.delivery.stop()
+		s.delivery = nil
 		s.abandoned = true
 		// Acquirers that started before this request was abandoned are
 		// waiting on the current channel through the non-abandoned path.
@@ -167,28 +248,34 @@ func (s *requestSlot) release(w chan protocol.Message) {
 	s.mu.Lock()
 	if s.waiter == w {
 		s.waiter = nil
+		s.delivery.stop()
+		s.delivery = nil
 		s.freeLocked()
 	}
 	s.mu.Unlock()
 }
 
-// deliver routes a received response to the waiting caller, if any, and frees
-// the slot. It returns true when a caller received the response and false when
-// the response was dropped (no caller waiting, e.g. after abandonment).
-func (s *requestSlot) deliver(msg protocol.Message) bool {
+// deliver queues a received response for the waiting caller. Streaming range
+// responses retain the slot until terminal is true.
+func (s *requestSlot) deliver(msg protocol.Message, terminal bool) bool {
 	s.mu.Lock()
 	w := s.waiter
-	s.waiter = nil
-	s.freeLocked()
+	d := s.delivery
+	if w == nil && d == nil && terminal && s.abandoned {
+		s.freeLocked()
+		s.mu.Unlock()
+		return true
+	}
+	if terminal && w != nil {
+		s.waiter = nil
+		s.delivery = nil
+		s.freeLocked()
+	}
 	s.mu.Unlock()
-	if w == nil {
+	if w == nil || d == nil {
 		return false
 	}
-	// The channel has capacity 1 and receives at most one response per
-	// request (the state machine rejects a second server message before it
-	// reaches this handler), so this send never blocks the receive loop.
-	w <- msg
-	return true
+	return d.enqueue(msg, terminal)
 }
 
 // freeLocked marks the slot as no longer busy and wakes any goroutine waiting
@@ -212,10 +299,8 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 	}
 	c := &Client{
 		config: cfg,
-		// Capacity 1: the caller registers before its request is sent, so
-		// the response always has somewhere to land even if the caller has
-		// not reached its receive yet. Unbuffered, a response whose caller
-		// gave up on its context blocked the protocol receive loop forever.
+		// Each request uses a delivery queue so streaming range responses do
+		// not block the protocol receive loop or get dropped.
 	}
 	c.callbackContext = CallbackContext{
 		Client:       c,
@@ -270,7 +355,6 @@ func (c *Client) Start() {
 				"connection_id", c.callbackContext.ConnectionId.String(),
 			)
 		c.Protocol.Start()
-		// Start goroutine to cleanup resources on protocol shutdown.
 	})
 }
 
@@ -533,7 +617,7 @@ func (c *Client) logDroppedResponse(msg protocol.Message) {
 }
 
 func (c *Client) handleBlock(msg protocol.Message) {
-	if !c.blockRequestSlot.deliver(msg) {
+	if !c.blockRequestSlot.deliver(msg, true) {
 		c.logDroppedResponse(msg)
 	}
 }
@@ -546,13 +630,13 @@ func (c *Client) handleNoBlock(msg protocol.Message) {
 			"role", "client",
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
-	if !c.blockRequestSlot.deliver(msg) {
+	if !c.blockRequestSlot.deliver(msg, true) {
 		c.logDroppedResponse(msg)
 	}
 }
 
 func (c *Client) handleBlockTxs(msg protocol.Message) {
-	if !c.blockRequestSlot.deliver(msg) {
+	if !c.blockRequestSlot.deliver(msg, true) {
 		c.logDroppedResponse(msg)
 	}
 }
@@ -565,7 +649,7 @@ func (c *Client) handleNoBlockTxs(msg protocol.Message) {
 			"role", "client",
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
-	if !c.blockRequestSlot.deliver(msg) {
+	if !c.blockRequestSlot.deliver(msg, true) {
 		c.logDroppedResponse(msg)
 	}
 }
@@ -574,19 +658,19 @@ func (c *Client) handleNoBlockTxs(msg protocol.Message) {
 // waiting. The send must not block: the protocol receive loop runs it, and a
 // caller whose context expired is gone for good.
 func (c *Client) handleVotes(msg protocol.Message) {
-	if !c.blockRequestSlot.deliver(msg) {
+	if !c.blockRequestSlot.deliver(msg, true) {
 		c.logDroppedResponse(msg)
 	}
 }
 
 func (c *Client) handleNextBlockAndTxsInRange(msg protocol.Message) {
-	if !c.blockRequestSlot.deliver(msg) {
+	if !c.blockRequestSlot.deliver(msg, false) {
 		c.logDroppedResponse(msg)
 	}
 }
 
 func (c *Client) handleLastBlockAndTxsInRange(msg protocol.Message) {
-	if !c.blockRequestSlot.deliver(msg) {
+	if !c.blockRequestSlot.deliver(msg, true) {
 		c.logDroppedResponse(msg)
 	}
 }

--- a/protocol/leiosfetch/client_test.go
+++ b/protocol/leiosfetch/client_test.go
@@ -122,24 +122,10 @@ func TestClientMessageHandler(t *testing.T) {
 			// the request under test.
 			var deliverCh chan protocol.Message
 			switch tc.msg.Type() {
-			case MessageTypeBlock, MessageTypeNoBlock:
-				w, err := client.blockSlot.acquire(
-					context.Background(),
-					client.DoneChan(),
-				)
-				require.NoError(t, err)
-				deliverCh = w
-			case MessageTypeBlockTxs, MessageTypeNoBlockTxs:
-				w, err := client.blockTxsSlot.acquire(
-					context.Background(),
-					client.DoneChan(),
-				)
-				require.NoError(t, err)
-				deliverCh = w
-			case MessageTypeVotes, MessageTypeNextBlockAndTxsInRange, MessageTypeLastBlockAndTxsInRange:
+			case MessageTypeBlock, MessageTypeNoBlock, MessageTypeBlockTxs, MessageTypeNoBlockTxs,
+				MessageTypeVotes, MessageTypeNextBlockAndTxsInRange, MessageTypeLastBlockAndTxsInRange:
 				w, err := client.blockRequestSlot.acquire(
-					context.Background(),
-					client.DoneChan(),
+					context.Background(), client.DoneChan(),
 				)
 				require.NoError(t, err)
 				deliverCh = w
@@ -193,26 +179,26 @@ func TestRequestSlotAbandonAfterDeliverKeepsNextWaiter(t *testing.T) {
 	client := NewClient(protocol.ProtocolOptions{ConnectionId: connId}, nil)
 
 	// Request A acquires the slot and registers its delivery channel.
-	wA, err := client.blockSlot.acquire(context.Background(), client.DoneChan())
+	wA, err := client.blockRequestSlot.acquire(context.Background(), client.DoneChan())
 	require.NoError(t, err)
 
 	// A's response arrives: delivered to wA and the slot is freed.
 	msgA := NewMsgBlock([]byte{0xaa, 0xbb})
-	require.True(t, client.blockSlot.deliver(msgA))
+	require.True(t, client.blockRequestSlot.deliver(msgA))
 
 	// Request B acquires the now-free slot and registers its own channel.
-	wB, err := client.blockSlot.acquire(context.Background(), client.DoneChan())
+	wB, err := client.blockRequestSlot.acquire(context.Background(), client.DoneChan())
 	require.NoError(t, err)
 
 	// A's late context cancellation abandons using A's own channel. B owns the
 	// slot now, so this must not disturb B's registration.
-	client.blockSlot.abandon(wA)
+	client.blockRequestSlot.abandon(wA)
 
 	// B's response must be delivered to B (not dropped).
 	msgB := NewMsgBlock([]byte{0xcc, 0xdd})
 	require.True(
 		t,
-		client.blockSlot.deliver(msgB),
+		client.blockRequestSlot.deliver(msgB),
 		"B's response was dropped: abandon(wA) erased B's waiter",
 	)
 
@@ -244,11 +230,11 @@ func TestRequestSlotAbandonAfterDeliverKeepsNextWaiter(t *testing.T) {
 // ErrRequestSlotAbandoned entirely.
 func TestRequestSlotAbandonWakesExistingAcquirer(t *testing.T) {
 	client := NewClient(protocol.ProtocolOptions{}, nil)
-	wA, err := client.blockSlot.acquire(context.Background(), client.DoneChan())
+	wA, err := client.blockRequestSlot.acquire(context.Background(), client.DoneChan())
 	require.NoError(t, err)
 
 	bWaiting := make(chan struct{})
-	client.blockSlot.beforeDrainWait = func() {
+	client.blockRequestSlot.beforeDrainWait = func() {
 		close(bWaiting)
 	}
 	bResult := make(chan error, 1)
@@ -258,12 +244,12 @@ func TestRequestSlotAbandonWakesExistingAcquirer(t *testing.T) {
 	)
 	defer cancelB()
 	go func() {
-		_, err := client.blockSlot.acquire(ctxB, client.DoneChan())
+		_, err := client.blockRequestSlot.acquire(ctxB, client.DoneChan())
 		bResult <- err
 	}()
 	<-bWaiting
 
-	client.blockSlot.abandon(wA)
+	client.blockRequestSlot.abandon(wA)
 	require.ErrorIs(t, <-bResult, ErrRequestSlotAbandoned)
 }
 
@@ -278,21 +264,21 @@ func TestRequestSlotReleaseAfterReacquireKeepsNextWaiter(t *testing.T) {
 	}
 	client := NewClient(protocol.ProtocolOptions{ConnectionId: connId}, nil)
 
-	wA, err := client.blockSlot.acquire(context.Background(), client.DoneChan())
+	wA, err := client.blockRequestSlot.acquire(context.Background(), client.DoneChan())
 	require.NoError(t, err)
 	// Free the slot via a delivery, then reacquire for request B.
-	require.True(t, client.blockSlot.deliver(NewMsgBlock([]byte{0x01})))
+	require.True(t, client.blockRequestSlot.deliver(NewMsgBlock([]byte{0x01})))
 	<-wA
-	wB, err := client.blockSlot.acquire(context.Background(), client.DoneChan())
+	wB, err := client.blockRequestSlot.acquire(context.Background(), client.DoneChan())
 	require.NoError(t, err)
 
 	// A stale release using A's channel must not touch B's registration.
-	client.blockSlot.release(wA)
+	client.blockRequestSlot.release(wA)
 
 	msgB := NewMsgBlock([]byte{0x02})
 	require.True(
 		t,
-		client.blockSlot.deliver(msgB),
+		client.blockRequestSlot.deliver(msgB),
 		"B's response was dropped: release(wA) erased B's waiter",
 	)
 	select {

--- a/protocol/leiosfetch/client_test.go
+++ b/protocol/leiosfetch/client_test.go
@@ -117,12 +117,9 @@ func TestClientMessageHandler(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// The Block/BlockTxs handlers deliver results to a per-request slot
 			// (a non-blocking send), so register a waiter first. The
-			// Votes/BlockRange handlers deliver with a blocking send to a shared
-			// channel, so the main goroutine below acts as the parked receiver.
-			// messageHandler runs in a helper goroutine: for a slot delivery it
-			// returns immediately, and for a blocking-send delivery it unblocks
-			// as soon as the main goroutine receives. Either way the helper is
-			// guaranteed to exit, so no goroutine dangles on a failed subtest.
+			// Every response handler delivers through the request slot. Register
+			// a waiter before invoking the handler so delivery is correlated with
+			// the request under test.
 			var deliverCh chan protocol.Message
 			switch tc.msg.Type() {
 			case MessageTypeBlock, MessageTypeNoBlock:
@@ -139,10 +136,13 @@ func TestClientMessageHandler(t *testing.T) {
 				)
 				require.NoError(t, err)
 				deliverCh = w
-			case MessageTypeVotes:
-				deliverCh = client.votesResultChan
-			case MessageTypeNextBlockAndTxsInRange, MessageTypeLastBlockAndTxsInRange:
-				deliverCh = client.blockRangeResultChan
+			case MessageTypeVotes, MessageTypeNextBlockAndTxsInRange, MessageTypeLastBlockAndTxsInRange:
+				w, err := client.blockRequestSlot.acquire(
+					context.Background(),
+					client.DoneChan(),
+				)
+				require.NoError(t, err)
+				deliverCh = w
 			}
 			errCh := make(chan error, 1)
 			go func() {

--- a/protocol/leiosfetch/client_test.go
+++ b/protocol/leiosfetch/client_test.go
@@ -142,6 +142,7 @@ func TestClientMessageHandler(t *testing.T) {
 			case <-time.After(time.Second):
 				t.Fatal("handler did not route message")
 			}
+			client.blockRequestSlot.release(deliverCh)
 
 			// Confirm the handler returned (and its error expectation) under a
 			// bounded deadline so the helper goroutine cannot dangle.
@@ -184,7 +185,7 @@ func TestRequestSlotAbandonAfterDeliverKeepsNextWaiter(t *testing.T) {
 
 	// A's response arrives: delivered to wA and the slot is freed.
 	msgA := NewMsgBlock([]byte{0xaa, 0xbb})
-	require.True(t, client.blockRequestSlot.deliver(msgA))
+	require.True(t, client.blockRequestSlot.deliver(msgA, true))
 
 	// Request B acquires the now-free slot and registers its own channel.
 	wB, err := client.blockRequestSlot.acquire(context.Background(), client.DoneChan())
@@ -198,7 +199,7 @@ func TestRequestSlotAbandonAfterDeliverKeepsNextWaiter(t *testing.T) {
 	msgB := NewMsgBlock([]byte{0xcc, 0xdd})
 	require.True(
 		t,
-		client.blockRequestSlot.deliver(msgB),
+		client.blockRequestSlot.deliver(msgB, true),
 		"B's response was dropped: abandon(wA) erased B's waiter",
 	)
 
@@ -267,7 +268,7 @@ func TestRequestSlotReleaseAfterReacquireKeepsNextWaiter(t *testing.T) {
 	wA, err := client.blockRequestSlot.acquire(context.Background(), client.DoneChan())
 	require.NoError(t, err)
 	// Free the slot via a delivery, then reacquire for request B.
-	require.True(t, client.blockRequestSlot.deliver(NewMsgBlock([]byte{0x01})))
+	require.True(t, client.blockRequestSlot.deliver(NewMsgBlock([]byte{0x01}), true))
 	<-wA
 	wB, err := client.blockRequestSlot.acquire(context.Background(), client.DoneChan())
 	require.NoError(t, err)
@@ -278,7 +279,7 @@ func TestRequestSlotReleaseAfterReacquireKeepsNextWaiter(t *testing.T) {
 	msgB := NewMsgBlock([]byte{0x02})
 	require.True(
 		t,
-		client.blockRequestSlot.deliver(msgB),
+		client.blockRequestSlot.deliver(msgB, true),
 		"B's response was dropped: release(wA) erased B's waiter",
 	)
 	select {

--- a/protocol/leiosfetch/error.go
+++ b/protocol/leiosfetch/error.go
@@ -35,10 +35,12 @@ var ErrBlockTxsNotFound = errors.New(
 )
 
 // ErrRequestSlotAbandoned signals that an earlier request on the same
-// leios-fetch connection timed out before its response arrived. The
-// connection cannot safely issue another request until the protocol receives
-// and discards the late response, so callers should fail over to another
-// connection rather than wait indefinitely.
+// leios-fetch connection timed out before its response arrived, and the peer
+// still had not answered after the bounded grace period. The connection cannot
+// safely issue another request until the protocol receives and discards the
+// late response, and the mini-protocol cannot even write one while the peer
+// holds agency, so the client fails the connection when it returns this error.
+// Callers should fail over to another connection.
 var ErrRequestSlotAbandoned = errors.New(
 	"leios-fetch request slot awaiting abandoned response",
 )

--- a/protocol/leiosfetch/leiosfetch_test.go
+++ b/protocol/leiosfetch/leiosfetch_test.go
@@ -544,6 +544,82 @@ func TestBlockRequestSubsequentAfterAbandoned(t *testing.T) {
 	)
 }
 
+// TestBlockRangeRequestSubsequentAfterAbandoned verifies that a late terminal
+// response from an abandoned range exchange cannot be delivered to a later
+// range request. Range responses use the shared request slot, so the first
+// request must remain quarantined until its terminal response drains.
+func TestBlockRangeRequestSubsequentAfterAbandoned(t *testing.T) {
+	conversation := append(
+		conversationHandshake,
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  leiosfetch.ProtocolId,
+			MessageType: leiosfetch.MessageTypeBlockRangeRequest,
+		},
+		ouroboros_mock.ConversationEntrySleep{
+			Duration: 300 * time.Millisecond,
+		},
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: leiosfetch.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				leiosfetch.NewMsgLastBlockAndTxsInRange(
+					[]byte{0x82, 0x01, 0x02},
+					nil,
+				),
+			},
+		},
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  leiosfetch.ProtocolId,
+			MessageType: leiosfetch.MessageTypeBlockRangeRequest,
+		},
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: leiosfetch.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				leiosfetch.NewMsgLastBlockAndTxsInRange(
+					[]byte{0x82, 0x03, 0x04},
+					nil,
+				),
+			},
+		},
+	)
+	runTest(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			client := oConn.LeiosFetch().Client
+			ctx1, cancel1 := context.WithTimeout(
+				context.Background(),
+				100*time.Millisecond,
+			)
+			defer cancel1()
+			resp1, err1 := client.BlockRangeRequest(
+				ctx1,
+				pcommon.NewPoint(12345, []byte{0x01}),
+				pcommon.NewPoint(12346, []byte{0x02}),
+			)
+			require.ErrorIs(t, err1, context.DeadlineExceeded)
+			assert.Nil(t, resp1)
+
+			ctx2, cancel2 := context.WithTimeout(
+				context.Background(),
+				2*time.Second,
+			)
+			defer cancel2()
+			resp2, err2 := client.BlockRangeRequest(
+				ctx2,
+				pcommon.NewPoint(23456, []byte{0x03}),
+				pcommon.NewPoint(23457, []byte{0x04}),
+			)
+			require.NoError(t, err2)
+			require.Len(t, resp2, 1)
+			last, ok := resp2[0].(*leiosfetch.MsgLastBlockAndTxsInRange)
+			require.True(t, ok)
+			assert.Equal(t, []byte{0x82, 0x03, 0x04}, []byte(last.BlockRaw))
+		},
+	)
+}
+
 // TestNonBlockRequestsAfterAbandonedBlockRequestFailFast pins that every
 // leios-fetch request path goes through the same admission slot.
 //

--- a/protocol/leiosfetch/leiosfetch_test.go
+++ b/protocol/leiosfetch/leiosfetch_test.go
@@ -92,6 +92,65 @@ func runTest(
 	}
 }
 
+// runTestCollectingConnErrors is runTest with the shared connection ErrorChan
+// drained into a channel instead of panicking, so a test can assert that a
+// desynchronised leios-fetch exchange fails the connection. Every wait is
+// bounded: the bug under test is a park, so a hang must fail the test rather
+// than hang the suite.
+func runTestCollectingConnErrors(
+	t *testing.T,
+	conversation []ouroboros_mock.ConversationEntry,
+	innerFunc func(*testing.T, *ouroboros.Connection, <-chan error),
+) {
+	defer goleak.VerifyNone(t)
+	mockConn := ouroboros_mock.NewConnection(
+		ouroboros_mock.ProtocolRoleClient,
+		conversation,
+	)
+	// Drain the mock's error channel so the mock conversation goroutine is
+	// never gated on a reader.
+	mockDone := make(chan struct{})
+	go func() {
+		defer close(mockDone)
+		for range mockConn.(*ouroboros_mock.Connection).ErrorChan() {
+		}
+	}()
+	oConn, err := ouroboros.New(
+		ouroboros.WithConnection(mockConn),
+		ouroboros.WithNetworkMagic(ouroboros_mock.MockNetworkMagic),
+		ouroboros.WithNodeToNode(true),
+	)
+	require.NoError(t, err)
+	connErrChan := make(chan error, 16)
+	connDone := make(chan struct{})
+	go func() {
+		defer close(connDone)
+		for err := range oConn.ErrorChan() {
+			if err == nil {
+				continue
+			}
+			select {
+			case connErrChan <- err:
+			default:
+			}
+		}
+	}()
+	innerFunc(t, oConn, connErrChan)
+	// The connection may already be closing because the test asserted a
+	// protocol error, so a Close error is not itself a failure.
+	_ = oConn.Close()
+	select {
+	case <-connDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("connection did not shut down within timeout")
+	}
+	select {
+	case <-mockDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("mock connection did not shut down within timeout")
+	}
+}
+
 var conversationHandshake = []ouroboros_mock.ConversationEntry{
 	ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
 	ouroboros_mock.ConversationEntryHandshakeNtNResponse,
@@ -205,11 +264,15 @@ func TestBlockRequestSuccess(t *testing.T) {
 
 // TestBlockRequestSubsequentAfterAbandonedNoResponse verifies that when a
 // BlockRequest is abandoned via its context and NO response ever arrives, a
-// subsequent BlockRequest still fails cleanly with its own context error and
-// does NOT tear down the shared multiplexed connection. The runTest harness
-// panics on any error delivered to the connection ErrorChan, so completing
-// without a panic proves the connection stays alive (no SendError / fatal
-// teardown from a request issued after an abandoned one).
+// subsequent BlockRequest fails fast with ErrRequestSlotAbandoned and fails the
+// connection.
+//
+// The peer holds leios-fetch server agency, so protocol.sendLoop can never
+// regain the agency it needs to write another request on this bearer: the
+// exchange is desynchronised for the life of the connection. Failing it is what
+// lets peer governance drop and replace the peer instead of leaving a
+// permanently dead leios-fetch client attached to an apparently healthy peer
+// (dingo issue #3623).
 func TestBlockRequestSubsequentAfterAbandonedNoResponse(t *testing.T) {
 	conversation := append(
 		conversationHandshake,
@@ -221,10 +284,14 @@ func TestBlockRequestSubsequentAfterAbandonedNoResponse(t *testing.T) {
 			MessageType: leiosfetch.MessageTypeBlockRequest,
 		},
 	)
-	runTest(
+	runTestCollectingConnErrors(
 		t,
 		conversation,
-		func(t *testing.T, oConn *ouroboros.Connection) {
+		func(
+			t *testing.T,
+			oConn *ouroboros.Connection,
+			connErrs <-chan error,
+		) {
 			client := oConn.LeiosFetch().Client
 			ctx1, cancel1 := context.WithTimeout(
 				context.Background(),
@@ -235,24 +302,114 @@ func TestBlockRequestSubsequentAfterAbandonedNoResponse(t *testing.T) {
 				ctx1,
 				pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}),
 			)
-			require.Error(t, err1)
-			assert.True(
-				t,
-				errors.Is(err1, context.DeadlineExceeded),
-				"expected context deadline error, got %v",
-				err1,
-			)
+			require.ErrorIs(t, err1, context.DeadlineExceeded)
 			assert.Nil(t, resp1)
 
 			// A subsequent request must fail after the bounded grace period
 			// while the first request's response is still outstanding. Reusing
 			// the slot would allow a late response to be mis-delivered here.
-			resp2, err2 := client.BlockRequest(
+			// Bound the call itself: without the fix this is where #3623
+			// parks.
+			type reqResult struct {
+				resp protocol.Message
+				err  error
+			}
+			resultChan := make(chan reqResult, 1)
+			go func() {
+				resp, err := client.BlockRequest(
+					context.Background(),
+					pcommon.NewPoint(23456, []byte{0x05, 0x06, 0x07, 0x08}),
+				)
+				resultChan <- reqResult{resp: resp, err: err}
+			}()
+			select {
+			case result := <-resultChan:
+				require.ErrorIs(
+					t,
+					result.err,
+					leiosfetch.ErrRequestSlotAbandoned,
+				)
+				assert.Nil(t, result.resp)
+			case <-time.After(10 * time.Second):
+				t.Fatal(
+					"subsequent BlockRequest parked instead of failing fast",
+				)
+			}
+
+			// The desynchronised exchange must fail the connection so peer
+			// governance can replace the peer.
+			select {
+			case err := <-connErrs:
+				require.ErrorIs(t, err, leiosfetch.ErrRequestSlotAbandoned)
+				require.ErrorContains(t, err, "retained agency")
+			case <-time.After(10 * time.Second):
+				t.Fatal(
+					"desynchronised leios-fetch exchange did not fail the connection",
+				)
+			}
+		},
+	)
+}
+
+// TestBlockTxsRequestSubsequentAfterAbandonedNoResponse is the BlockTxs
+// equivalent, which is the exact path dingo issue #3623 stalled on
+// (fetchLeiosEbTxsBatchedUntilWithValidator -> BlockTxsRequest).
+func TestBlockTxsRequestSubsequentAfterAbandonedNoResponse(t *testing.T) {
+	conversation := append(
+		conversationHandshake,
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  leiosfetch.ProtocolId,
+			MessageType: leiosfetch.MessageTypeBlockTxsRequest,
+		},
+	)
+	runTestCollectingConnErrors(
+		t,
+		conversation,
+		func(
+			t *testing.T,
+			oConn *ouroboros.Connection,
+			connErrs <-chan error,
+		) {
+			client := oConn.LeiosFetch().Client
+			bitmaps := map[uint16]uint64{0: 0xff00000000000000}
+			ctx1, cancel1 := context.WithTimeout(
 				context.Background(),
-				pcommon.NewPoint(23456, []byte{0x05, 0x06, 0x07, 0x08}),
+				150*time.Millisecond,
 			)
-			require.ErrorIs(t, err2, leiosfetch.ErrRequestSlotAbandoned)
-			assert.Nil(t, resp2)
+			defer cancel1()
+			_, err1 := client.BlockTxsRequest(
+				ctx1,
+				pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+				bitmaps,
+			)
+			require.ErrorIs(t, err1, context.DeadlineExceeded)
+
+			errChan := make(chan error, 1)
+			go func() {
+				_, err := client.BlockTxsRequest(
+					context.Background(),
+					pcommon.NewPoint(23456, []byte{0x05, 0x06, 0x07, 0x08}),
+					bitmaps,
+				)
+				errChan <- err
+			}()
+			select {
+			case err := <-errChan:
+				require.ErrorIs(t, err, leiosfetch.ErrRequestSlotAbandoned)
+			case <-time.After(10 * time.Second):
+				t.Fatal(
+					"subsequent BlockTxsRequest parked instead of failing fast",
+				)
+			}
+			select {
+			case err := <-connErrs:
+				require.ErrorIs(t, err, leiosfetch.ErrRequestSlotAbandoned)
+				require.ErrorContains(t, err, "BlockTxs")
+			case <-time.After(10 * time.Second):
+				t.Fatal(
+					"desynchronised leios-fetch exchange did not fail the connection",
+				)
+			}
 		},
 	)
 }

--- a/protocol/leiosfetch/leiosfetch_test.go
+++ b/protocol/leiosfetch/leiosfetch_test.go
@@ -620,6 +620,35 @@ func TestBlockRangeRequestSubsequentAfterAbandoned(t *testing.T) {
 	)
 }
 
+func TestBlockRangeRequestStreamsMultipleMessages(t *testing.T) {
+	conversation := append(
+		conversationHandshake,
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  leiosfetch.ProtocolId,
+			MessageType: leiosfetch.MessageTypeBlockRangeRequest,
+		},
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: leiosfetch.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				leiosfetch.NewMsgNextBlockAndTxsInRange([]byte{0x82, 0x01, 0x01}, nil),
+				leiosfetch.NewMsgNextBlockAndTxsInRange([]byte{0x82, 0x01, 0x02}, nil),
+				leiosfetch.NewMsgLastBlockAndTxsInRange([]byte{0x82, 0x01, 0x03}, nil),
+			},
+		},
+	)
+	runTest(t, conversation, func(t *testing.T, oConn *ouroboros.Connection) {
+		client := oConn.LeiosFetch().Client
+		resp, err := client.BlockRangeRequest(
+			context.Background(),
+			pcommon.NewPoint(12345, []byte{0x01}),
+			pcommon.NewPoint(12346, []byte{0x02}),
+		)
+		require.NoError(t, err)
+		require.Len(t, resp, 3)
+	})
+}
+
 // TestNonBlockRequestsAfterAbandonedBlockRequestFailFast pins that every
 // leios-fetch request path goes through the same admission slot.
 //

--- a/protocol/leiosfetch/leiosfetch_test.go
+++ b/protocol/leiosfetch/leiosfetch_test.go
@@ -543,3 +543,148 @@ func TestBlockRequestSubsequentAfterAbandoned(t *testing.T) {
 		},
 	)
 }
+
+// TestVotesRequestAfterAbandonedBlockRequestFailsFast pins that a votes
+// request goes through the same admission slot as a block request.
+//
+// The leios-fetch states share one connection-wide agency, so a block request
+// whose caller gave up leaves the peer holding agency and nothing further can
+// be written to the bearer. Before VotesRequest acquired the slot it skipped
+// that diagnosis entirely and blocked forever on votesResultChan with no
+// context and no recovery.
+func TestVotesRequestAfterAbandonedBlockRequestFailsFast(t *testing.T) {
+	conversation := append(
+		conversationHandshake,
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  leiosfetch.ProtocolId,
+			MessageType: leiosfetch.MessageTypeBlockRequest,
+		},
+	)
+	runTestCollectingConnErrors(
+		t,
+		conversation,
+		func(
+			t *testing.T,
+			oConn *ouroboros.Connection,
+			connErrs <-chan error,
+		) {
+			client := oConn.LeiosFetch().Client
+			ctx1, cancel1 := context.WithTimeout(
+				context.Background(),
+				150*time.Millisecond,
+			)
+			defer cancel1()
+			_, err1 := client.BlockRequest(
+				ctx1,
+				pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+			)
+			require.ErrorIs(t, err1, context.DeadlineExceeded)
+
+			type reqResult struct {
+				resp protocol.Message
+				err  error
+			}
+			resultChan := make(chan reqResult, 1)
+			go func() {
+				resp, err := client.VotesRequest(
+					context.Background(),
+					[]leiosfetch.MsgVotesRequestVoteId{},
+				)
+				resultChan <- reqResult{resp: resp, err: err}
+			}()
+			select {
+			case result := <-resultChan:
+				require.ErrorIs(
+					t,
+					result.err,
+					leiosfetch.ErrRequestSlotAbandoned,
+				)
+				assert.Nil(t, result.resp)
+			case <-time.After(10 * time.Second):
+				t.Fatal(
+					"VotesRequest parked behind an abandoned block request",
+				)
+			}
+
+			select {
+			case err := <-connErrs:
+				require.ErrorIs(t, err, leiosfetch.ErrRequestSlotAbandoned)
+				require.ErrorContains(t, err, "retained agency")
+			case <-time.After(10 * time.Second):
+				t.Fatal(
+					"desynchronised leios-fetch exchange did not fail the connection",
+				)
+			}
+		},
+	)
+}
+
+// TestBlockRangeRequestAfterAbandonedBlockRequestFailsFast is the range-request
+// counterpart of TestVotesRequestAfterAbandonedBlockRequestFailsFast.
+func TestBlockRangeRequestAfterAbandonedBlockRequestFailsFast(t *testing.T) {
+	conversation := append(
+		conversationHandshake,
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  leiosfetch.ProtocolId,
+			MessageType: leiosfetch.MessageTypeBlockRequest,
+		},
+	)
+	runTestCollectingConnErrors(
+		t,
+		conversation,
+		func(
+			t *testing.T,
+			oConn *ouroboros.Connection,
+			connErrs <-chan error,
+		) {
+			client := oConn.LeiosFetch().Client
+			ctx1, cancel1 := context.WithTimeout(
+				context.Background(),
+				150*time.Millisecond,
+			)
+			defer cancel1()
+			_, err1 := client.BlockRequest(
+				ctx1,
+				pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+			)
+			require.ErrorIs(t, err1, context.DeadlineExceeded)
+
+			type rangeResult struct {
+				resp []protocol.Message
+				err  error
+			}
+			resultChan := make(chan rangeResult, 1)
+			go func() {
+				resp, err := client.BlockRangeRequest(
+					context.Background(),
+					pcommon.NewPoint(23456, []byte{0x05, 0x06, 0x07, 0x08}),
+					pcommon.NewPoint(34567, []byte{0x09, 0x0a, 0x0b, 0x0c}),
+				)
+				resultChan <- rangeResult{resp: resp, err: err}
+			}()
+			select {
+			case result := <-resultChan:
+				require.ErrorIs(
+					t,
+					result.err,
+					leiosfetch.ErrRequestSlotAbandoned,
+				)
+				assert.Nil(t, result.resp)
+			case <-time.After(10 * time.Second):
+				t.Fatal(
+					"BlockRangeRequest parked behind an abandoned block request",
+				)
+			}
+
+			select {
+			case err := <-connErrs:
+				require.ErrorIs(t, err, leiosfetch.ErrRequestSlotAbandoned)
+				require.ErrorContains(t, err, "retained agency")
+			case <-time.After(10 * time.Second):
+				t.Fatal(
+					"desynchronised leios-fetch exchange did not fail the connection",
+				)
+			}
+		},
+	)
+}

--- a/protocol/leiosfetch/leiosfetch_test.go
+++ b/protocol/leiosfetch/leiosfetch_test.go
@@ -544,147 +544,102 @@ func TestBlockRequestSubsequentAfterAbandoned(t *testing.T) {
 	)
 }
 
-// TestVotesRequestAfterAbandonedBlockRequestFailsFast pins that a votes
-// request goes through the same admission slot as a block request.
+// TestNonBlockRequestsAfterAbandonedBlockRequestFailFast pins that every
+// leios-fetch request path goes through the same admission slot.
 //
-// The leios-fetch states share one connection-wide agency, so a block request
-// whose caller gave up leaves the peer holding agency and nothing further can
-// be written to the bearer. Before VotesRequest acquired the slot it skipped
-// that diagnosis entirely and blocked forever on votesResultChan with no
+// The states share one connection-wide agency, so a block request whose
+// caller gave up leaves the peer holding agency and nothing further can be
+// written to the bearer. Before these paths acquired the slot they skipped
+// that diagnosis and blocked forever on their own result channels, with no
 // context and no recovery.
-func TestVotesRequestAfterAbandonedBlockRequestFailsFast(t *testing.T) {
-	conversation := append(
-		conversationHandshake,
-		ouroboros_mock.ConversationEntryInput{
-			ProtocolId:  leiosfetch.ProtocolId,
-			MessageType: leiosfetch.MessageTypeBlockRequest,
-		},
-	)
-	runTestCollectingConnErrors(
-		t,
-		conversation,
-		func(
-			t *testing.T,
-			oConn *ouroboros.Connection,
-			connErrs <-chan error,
-		) {
-			client := oConn.LeiosFetch().Client
-			ctx1, cancel1 := context.WithTimeout(
-				context.Background(),
-				150*time.Millisecond,
-			)
-			defer cancel1()
-			_, err1 := client.BlockRequest(
-				ctx1,
-				pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}),
-			)
-			require.ErrorIs(t, err1, context.DeadlineExceeded)
-
-			type reqResult struct {
-				resp protocol.Message
-				err  error
-			}
-			resultChan := make(chan reqResult, 1)
-			go func() {
-				resp, err := client.VotesRequest(
+func TestNonBlockRequestsAfterAbandonedBlockRequestFailFast(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		request func(*leiosfetch.Client) error
+	}{
+		{
+			name: "VotesRequest",
+			request: func(c *leiosfetch.Client) error {
+				_, err := c.VotesRequest(
 					context.Background(),
 					[]leiosfetch.MsgVotesRequestVoteId{},
 				)
-				resultChan <- reqResult{resp: resp, err: err}
-			}()
-			select {
-			case result := <-resultChan:
-				require.ErrorIs(
-					t,
-					result.err,
-					leiosfetch.ErrRequestSlotAbandoned,
-				)
-				assert.Nil(t, result.resp)
-			case <-time.After(10 * time.Second):
-				t.Fatal(
-					"VotesRequest parked behind an abandoned block request",
-				)
-			}
-
-			select {
-			case err := <-connErrs:
-				require.ErrorIs(t, err, leiosfetch.ErrRequestSlotAbandoned)
-				require.ErrorContains(t, err, "retained agency")
-			case <-time.After(10 * time.Second):
-				t.Fatal(
-					"desynchronised leios-fetch exchange did not fail the connection",
-				)
-			}
+				return err
+			},
 		},
-	)
-}
-
-// TestBlockRangeRequestAfterAbandonedBlockRequestFailsFast is the range-request
-// counterpart of TestVotesRequestAfterAbandonedBlockRequestFailsFast.
-func TestBlockRangeRequestAfterAbandonedBlockRequestFailsFast(t *testing.T) {
-	conversation := append(
-		conversationHandshake,
-		ouroboros_mock.ConversationEntryInput{
-			ProtocolId:  leiosfetch.ProtocolId,
-			MessageType: leiosfetch.MessageTypeBlockRequest,
-		},
-	)
-	runTestCollectingConnErrors(
-		t,
-		conversation,
-		func(
-			t *testing.T,
-			oConn *ouroboros.Connection,
-			connErrs <-chan error,
-		) {
-			client := oConn.LeiosFetch().Client
-			ctx1, cancel1 := context.WithTimeout(
-				context.Background(),
-				150*time.Millisecond,
-			)
-			defer cancel1()
-			_, err1 := client.BlockRequest(
-				ctx1,
-				pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}),
-			)
-			require.ErrorIs(t, err1, context.DeadlineExceeded)
-
-			type rangeResult struct {
-				resp []protocol.Message
-				err  error
-			}
-			resultChan := make(chan rangeResult, 1)
-			go func() {
-				resp, err := client.BlockRangeRequest(
+		{
+			name: "BlockRangeRequest",
+			request: func(c *leiosfetch.Client) error {
+				_, err := c.BlockRangeRequest(
 					context.Background(),
 					pcommon.NewPoint(23456, []byte{0x05, 0x06, 0x07, 0x08}),
 					pcommon.NewPoint(34567, []byte{0x09, 0x0a, 0x0b, 0x0c}),
 				)
-				resultChan <- rangeResult{resp: resp, err: err}
-			}()
-			select {
-			case result := <-resultChan:
-				require.ErrorIs(
-					t,
-					result.err,
-					leiosfetch.ErrRequestSlotAbandoned,
-				)
-				assert.Nil(t, result.resp)
-			case <-time.After(10 * time.Second):
-				t.Fatal(
-					"BlockRangeRequest parked behind an abandoned block request",
-				)
-			}
-
-			select {
-			case err := <-connErrs:
-				require.ErrorIs(t, err, leiosfetch.ErrRequestSlotAbandoned)
-				require.ErrorContains(t, err, "retained agency")
-			case <-time.After(10 * time.Second):
-				t.Fatal(
-					"desynchronised leios-fetch exchange did not fail the connection",
-				)
-			}
+				return err
+			},
 		},
-	)
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conversation := append(
+				conversationHandshake,
+				ouroboros_mock.ConversationEntryInput{
+					ProtocolId:  leiosfetch.ProtocolId,
+					MessageType: leiosfetch.MessageTypeBlockRequest,
+				},
+			)
+			runTestCollectingConnErrors(
+				t,
+				conversation,
+				func(
+					t *testing.T,
+					oConn *ouroboros.Connection,
+					connErrs <-chan error,
+				) {
+					client := oConn.LeiosFetch().Client
+					ctx1, cancel1 := context.WithTimeout(
+						context.Background(),
+						150*time.Millisecond,
+					)
+					defer cancel1()
+					_, err1 := client.BlockRequest(
+						ctx1,
+						pcommon.NewPoint(
+							12345,
+							[]byte{0x01, 0x02, 0x03, 0x04},
+						),
+					)
+					require.ErrorIs(t, err1, context.DeadlineExceeded)
+
+					errChan := make(chan error, 1)
+					go func() { errChan <- tc.request(client) }()
+					select {
+					case err := <-errChan:
+						require.ErrorIs(
+							t,
+							err,
+							leiosfetch.ErrRequestSlotAbandoned,
+						)
+					case <-time.After(10 * time.Second):
+						t.Fatal(
+							"request parked behind an abandoned block request",
+						)
+					}
+
+					select {
+					case err := <-connErrs:
+						require.ErrorIs(
+							t,
+							err,
+							leiosfetch.ErrRequestSlotAbandoned,
+						)
+						require.ErrorContains(t, err, "retained agency")
+					case <-time.After(10 * time.Second):
+						t.Fatal(
+							"desynchronised leios-fetch exchange did not fail the connection",
+						)
+					}
+				},
+			)
+		})
+	}
 }

--- a/protocol/leiosfetch/server.go
+++ b/protocol/leiosfetch/server.go
@@ -103,10 +103,16 @@ func (s *Server) handleBlockRequest(msg protocol.Message) error {
 			"connection_id", s.callbackContext.ConnectionId.String(),
 		)
 	if s.config == nil || s.config.BlockRequestFunc == nil {
-		// The unconfirmed NoBlock wire ID cannot safely be emitted by default.
-		// Keep server agency in StateBlock so the optional protocol remains
-		// pending without terminating the shared bearer.
-		return nil
+		// NOTE: this MUST answer, not return nil. Returning nil left the
+		// protocol in StateBlock holding server agency forever, which wedges
+		// the requester's client permanently: its send loop waits for agency
+		// that only this response can return, so it can never issue another
+		// leios-fetch request on the connection (dingo issue #3623). The
+		// MessageTypeNoBlock wire ID is a placeholder, but a configured
+		// callback that reports ErrBlockNotFound already emits it below, so
+		// declining here adds no wire risk that the normal path does not
+		// already take.
+		return s.SendMessage(NewMsgNoBlock())
 	}
 	msgBlockRequest := msg.(*MsgBlockRequest)
 	resp, err := s.config.BlockRequestFunc(
@@ -153,9 +159,12 @@ func (s *Server) handleBlockTxsRequest(msg protocol.Message) error {
 			"connection_id", s.callbackContext.ConnectionId.String(),
 		)
 	if s.config == nil || s.config.BlockTxsRequestFunc == nil {
-		// The unconfirmed NoBlockTxs wire ID cannot safely be emitted by
-		// default. Keep server agency without failing the shared bearer.
-		return nil
+		// NOTE: as with handleBlockRequest, this MUST answer. Retaining
+		// server agency in StateBlockTxs permanently desynchronises the
+		// requester's leios-fetch client (dingo issue #3623), and the
+		// configured not-available path below already puts this wire ID on
+		// the wire.
+		return s.SendMessage(NewMsgNoBlockTxs())
 	}
 	msgBlockTxsRequest := msg.(*MsgBlockTxsRequest)
 	resp, err := s.config.BlockTxsRequestFunc(
@@ -233,10 +242,16 @@ func (s *Server) handleBlockRangeRequest(msg protocol.Message) error {
 			"connection_id", s.callbackContext.ConnectionId.String(),
 		)
 	if s.config == nil || s.config.BlockRangeRequestFunc == nil {
-		// The protocol has no empty range response. Keep server agency in
-		// StateBlockRange instead of fabricating a payload or failing the
-		// bearer.
-		return nil
+		// NOTE: unlike Block/BlockTxs there is no absence reply for a range
+		// request -- MsgLastBlockAndTxsInRange carries a mandatory block --
+		// so this cannot decline gracefully. Fail the connection rather than
+		// retain server agency in StateBlockRange forever: a silent hang
+		// leaves the requester's leios-fetch client permanently wedged with
+		// no way to detect it, while an error lets its peer governance drop
+		// and replace this peer (dingo issue #3623).
+		return errors.New(
+			"received leios-fetch BlockRangeRequest message but no callback function is defined",
+		)
 	}
 	msgBlockRangeRequest := msg.(*MsgBlockRangeRequest)
 	err := s.config.BlockRangeRequestFunc(

--- a/protocol/leiosfetch/server_test.go
+++ b/protocol/leiosfetch/server_test.go
@@ -75,16 +75,30 @@ func writeLeiosFetchTestSegment(
 	require.NoError(t, err)
 }
 
-func TestUnconfiguredRequestsRemainPendingAndPreserveSharedBearer(t *testing.T) {
+// TestUnconfiguredBlockResponderAnswersAbsence proves that an unconfigured
+// BlockRequestFunc / BlockTxsRequestFunc answers with the absence message
+// instead of retaining server agency. Retaining agency wedges the requester's
+// leios-fetch client permanently (dingo issue #3623): its send loop waits for
+// agency that only the missing response returns, so it can never issue another
+// request on that connection and cannot detect the condition.
+//
+// sendNotFoundTest performs the exchange twice and then probes an unrelated
+// mini-protocol, so this also proves the protocol returns to Idle and the
+// shared bearer stays usable.
+func TestUnconfiguredBlockResponderAnswersAbsence(t *testing.T) {
 	tests := []struct {
-		name    string
-		request protocol.Message
+		name            string
+		request         protocol.Message
+		expectedType    uint
+		expectedPayload []byte
 	}{
 		{
 			name: "block",
 			request: NewMsgBlockRequest(
 				pcommon.NewPoint(12345, []byte{0x01, 0x02}),
 			),
+			expectedType:    uint(MessageTypeNoBlock),
+			expectedPayload: []byte{0x81, MessageTypeNoBlock},
 		},
 		{
 			name: "block transactions",
@@ -92,112 +106,115 @@ func TestUnconfiguredRequestsRemainPendingAndPreserveSharedBearer(t *testing.T) 
 				pcommon.NewPoint(12345, []byte{0x01, 0x02}),
 				nil,
 			),
-		},
-		{
-			name: "block range",
-			request: NewMsgBlockRangeRequest(
-				pcommon.NewPoint(12345, []byte{0x01, 0x02}),
-				pcommon.NewPoint(23456, []byte{0x03, 0x04}),
-			),
+			expectedType:    uint(MessageTypeNoBlockTxs),
+			expectedPayload: []byte{0x81, MessageTypeNoBlockTxs},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			connId := testLeiosFetchConnectionId()
-			connA, connB := net.Pipe()
-			m := muxer.New(connA)
-			protocolErrors := make(chan error, 1)
-			leiosServer := NewServer(
-				protocol.ProtocolOptions{
-					ConnectionId: connId,
-					ErrorChan:    protocolErrors,
-					Muxer:        m,
-				},
-				nil,
-			)
-			peerSharingCfg := peersharing.NewConfig(
-				peersharing.WithShareRequestFunc(
-					func(
-						peersharing.CallbackContext,
-						int,
-					) ([]peersharing.PeerAddress, error) {
-						return []peersharing.PeerAddress{}, nil
-					},
-				),
-			)
-			peerSharingServer := peersharing.NewServer(
-				protocol.ProtocolOptions{
-					ConnectionId: connId,
-					ErrorChan:    protocolErrors,
-					Muxer:        m,
-				},
-				&peerSharingCfg,
-			)
-			leiosServer.Start()
-			peerSharingServer.Start()
-			m.Start()
-			t.Cleanup(func() {
-				leiosServer.Stop()
-				peerSharingServer.Stop()
-				m.Stop()
-				_ = connA.Close()
-				_ = connB.Close()
-			})
-
-			requestData, err := cbor.Encode(test.request)
-			require.NoError(t, err)
-			writeLeiosFetchTestSegment(
-				t,
-				connB,
-				muxer.NewSegment(ProtocolId, requestData, false),
-			)
-			require.Never(t, func() bool {
-				select {
-				case <-protocolErrors:
-					return true
-				default:
-					return false
-				}
-			}, 20*time.Millisecond, time.Millisecond,
-				"unconfigured request reported a protocol error",
-			)
-			require.Eventually(t, func() bool {
-				return !leiosServer.ProtocolInstance().
-					IsInTerminalOrIdleState()
-			}, time.Second, time.Millisecond,
-				"request did not enter its server-agency state",
-			)
-
-			peerRequestData, err := cbor.Encode(
-				peersharing.NewMsgShareRequest(1),
-			)
-			require.NoError(t, err)
-			writeLeiosFetchTestSegment(
-				t,
-				connB,
-				muxer.NewSegment(
-					peersharing.ProtocolId,
-					peerRequestData,
-					false,
-				),
-			)
-			require.NoError(
-				t,
-				connB.SetReadDeadline(time.Now().Add(time.Second)),
-			)
-			segment, err := readLeiosFetchTestSegment(t, connB)
-			require.NoError(t, err)
-			require.Equal(
-				t,
-				uint16(peersharing.ProtocolId),
-				segment.GetProtocolId(),
-			)
-			require.Equal(
-				t,
-				[]byte{0x82, peersharing.MessageTypeSharePeers, 0x80},
-				segment.Payload,
-			)
+			msgType, payload := sendNotFoundTest(t, NewConfig(), test.request)
+			require.Equal(t, test.expectedType, msgType)
+			require.Equal(t, test.expectedPayload, payload)
 		})
+	}
+}
+
+// TestUnconfiguredBlockResponderAnswersAbsenceNilConfig covers the same
+// contract for a server constructed with no Config at all, which is what any
+// gouroboros consumer that does not pass WithLeiosFetchConfig gets: the
+// leios-fetch server is registered and started unconditionally for every
+// node-to-node connection, so an unconfigured peer must still answer.
+func TestUnconfiguredBlockResponderAnswersAbsenceNilConfig(t *testing.T) {
+	connId := testLeiosFetchConnectionId()
+	connA, connB := net.Pipe()
+	m := muxer.New(connA)
+	protocolErrors := make(chan error, 1)
+	server := NewServer(
+		protocol.ProtocolOptions{
+			ConnectionId: connId,
+			ErrorChan:    protocolErrors,
+			Muxer:        m,
+		},
+		nil,
+	)
+	server.Start()
+	m.Start()
+	t.Cleanup(func() {
+		server.Protocol.Stop()
+		m.Stop()
+		_ = connA.Close()
+		_ = connB.Close()
+	})
+
+	requestData, err := cbor.Encode(
+		NewMsgBlockTxsRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02}), nil),
+	)
+	require.NoError(t, err)
+	writeLeiosFetchTestSegment(
+		t,
+		connB,
+		muxer.NewSegment(ProtocolId, requestData, false),
+	)
+	require.NoError(t, connB.SetReadDeadline(time.Now().Add(2*time.Second)))
+	segment, err := readLeiosFetchTestSegment(t, connB)
+	require.NoError(t, err)
+	require.True(t, segment.IsResponse())
+	require.Equal(t, uint16(ProtocolId), segment.GetProtocolId())
+	require.Equal(t, []byte{0x81, MessageTypeNoBlockTxs}, segment.Payload)
+	select {
+	case err := <-protocolErrors:
+		require.NoError(t, err)
+	default:
+	}
+}
+
+// TestUnconfiguredBlockRangeResponderFailsConnection proves that an
+// unconfigured BlockRangeRequestFunc reports a protocol error rather than
+// leaving the request pending forever. There is no absence reply for a range
+// request, so failing the connection is the only outcome that lets the
+// requester recover; a silent hang leaves its leios-fetch client wedged with
+// no way to detect it.
+func TestUnconfiguredBlockRangeResponderFailsConnection(t *testing.T) {
+	connId := testLeiosFetchConnectionId()
+	connA, connB := net.Pipe()
+	m := muxer.New(connA)
+	protocolErrors := make(chan error, 1)
+	server := NewServer(
+		protocol.ProtocolOptions{
+			ConnectionId: connId,
+			ErrorChan:    protocolErrors,
+			Muxer:        m,
+		},
+		nil,
+	)
+	server.Start()
+	m.Start()
+	t.Cleanup(func() {
+		server.Protocol.Stop()
+		m.Stop()
+		_ = connA.Close()
+		_ = connB.Close()
+	})
+
+	requestData, err := cbor.Encode(
+		NewMsgBlockRangeRequest(
+			pcommon.NewPoint(12345, []byte{0x01, 0x02}),
+			pcommon.NewPoint(23456, []byte{0x03, 0x04}),
+		),
+	)
+	require.NoError(t, err)
+	writeLeiosFetchTestSegment(
+		t,
+		connB,
+		muxer.NewSegment(ProtocolId, requestData, false),
+	)
+	select {
+	case err := <-protocolErrors:
+		require.ErrorContains(t, err, "BlockRangeRequest")
+	case <-time.After(2 * time.Second):
+		t.Fatal(
+			"unconfigured BlockRangeRequest left the request pending instead of failing the connection",
+		)
 	}
 }
 
@@ -348,26 +365,13 @@ func TestHandleBlockRequest_CallbackIsCalled(t *testing.T) {
 }
 
 func TestHandleBlockRequest_NilCallback(t *testing.T) {
-	cfg := NewConfig()
-	server := NewServer(
-		protocol.ProtocolOptions{ConnectionId: testLeiosFetchConnectionId()},
-		&cfg,
-	)
-	err := server.handleBlockRequest(
+	msgType, payload := sendNotFoundTest(
+		t,
+		NewConfig(),
 		NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02})),
 	)
-	require.NoError(t, err)
-}
-
-func TestHandleBlockRequest_NilConfig(t *testing.T) {
-	server := NewServer(
-		protocol.ProtocolOptions{ConnectionId: testLeiosFetchConnectionId()},
-		nil,
-	)
-	err := server.handleBlockRequest(
-		NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02})),
-	)
-	require.NoError(t, err)
+	require.Equal(t, uint(MessageTypeNoBlock), msgType)
+	require.Equal(t, []byte{0x81, MessageTypeNoBlock}, payload)
 }
 
 func TestHandleBlockRequest_CallbackError(t *testing.T) {
@@ -533,15 +537,13 @@ func TestHandleBlockTxsRequest_CallbackIsCalled(t *testing.T) {
 }
 
 func TestHandleBlockTxsRequest_NilCallback(t *testing.T) {
-	cfg := NewConfig()
-	server := NewServer(
-		protocol.ProtocolOptions{ConnectionId: testLeiosFetchConnectionId()},
-		&cfg,
-	)
-	err := server.handleBlockTxsRequest(
+	msgType, payload := sendNotFoundTest(
+		t,
+		NewConfig(),
 		NewMsgBlockTxsRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02}), nil),
 	)
-	require.NoError(t, err)
+	require.Equal(t, uint(MessageTypeNoBlockTxs), msgType)
+	require.Equal(t, []byte{0x81, MessageTypeNoBlockTxs}, payload)
 }
 
 func TestHandleVotesRequest_CallbackIsCalled(t *testing.T) {
@@ -626,7 +628,7 @@ func TestHandleBlockRangeRequest_NilCallback(t *testing.T) {
 	err := server.handleBlockRangeRequest(
 		NewMsgBlockRangeRequest(pcommon.Point{}, pcommon.Point{}),
 	)
-	require.NoError(t, err)
+	require.ErrorContains(t, err, "BlockRangeRequest")
 }
 
 func TestServerMessageHandler_UnexpectedType(t *testing.T) {


### PR DESCRIPTION
Keep block-range delivery alive through the terminal response.

Closes #3623

Tests: `go test -race ./protocol/leiosfetch -count=1`