### PR TITLE
fix(blockfetch): deliver undecodable blocks to BlockRawFunc

### DIFF
--- a/protocol/blockfetch/client.go
+++ b/protocol/blockfetch/client.go
@@ -1107,6 +1107,14 @@ func (c *Client) handleBlock(msgGeneric protocol.Message) error {
 			SkipBodyHashValidation: c.config.SkipBlockValidation,
 		},
 	)
+	if decodeErr != nil {
+		// The era decoders return a typed nil pointer alongside their error
+		// (see conway.NewConwayBlockFromCbor), and an interface holding one
+		// is not itself nil, so a `block != nil` check would pass and every
+		// method call on it would panic. Normalize to an untyped nil so a
+		// failed decode cannot be mistaken for a usable block below.
+		block = nil
+	}
 	// A raw callback decodes the payload itself, so a generic type decoder
 	// that cannot represent the full wire layout must not fail the request
 	// before the callback ever runs. This is how a block whose era tag
@@ -1126,26 +1134,35 @@ func (c *Client) handleBlock(msgGeneric protocol.Message) error {
 	if decodeErr != nil && !rawFallback {
 		return c.failRequest(req, decodeErr)
 	}
+	if decodeErr == nil && block == nil {
+		// Not reachable through any current decoder, but the rest of this
+		// function hands the block to a consumer, so state the contract
+		// rather than relying on it.
+		return c.failRequest(req, fmt.Errorf(
+			"%s: block decoder returned no block and no error",
+			ProtocolName,
+		))
+	}
 	// Range correlation applies either way. Without a decoded block its
 	// inputs are read straight from the block header CBOR, so a peer still
 	// cannot inject an unrelated block into a valid batch by sending one the
 	// type decoder rejects.
 	var blockPoint pcommon.Point
 	var prevHash []byte
-	if rawFallback {
-		info, err := rawBlockHeaderInfoFromCbor(wrappedBlock.RawBlock)
-		if err != nil {
-			return c.failRequest(req, errors.Join(decodeErr, err))
-		}
-		blockPoint = info.point
-		prevHash = info.prevHash
-	} else {
+	if block != nil {
 		blockPoint = pcommon.NewPoint(
 			block.SlotNumber(),
 			block.Hash().Bytes(),
 		)
 		blockPrevHash := block.PrevHash()
 		prevHash = blockPrevHash.Bytes()
+	} else {
+		info, err := rawBlockHeaderInfoFromCbor(wrappedBlock.RawBlock)
+		if err != nil {
+			return c.failRequest(req, errors.Join(decodeErr, err))
+		}
+		blockPoint = info.point
+		prevHash = info.prevHash
 	}
 	c.queueMutex.Lock()
 	err = req.recordBlock(blockPoint, prevHash)

--- a/protocol/blockfetch/client.go
+++ b/protocol/blockfetch/client.go
@@ -1100,22 +1100,55 @@ func (c *Client) handleBlock(msgGeneric protocol.Message) error {
 			fmt.Errorf("%s: decode error: %w", ProtocolName, err),
 		)
 	}
-	block, err := ledger.NewBlockFromCbor(
+	block, decodeErr := ledger.NewBlockFromCbor(
 		wrappedBlock.Type,
 		wrappedBlock.RawBlock,
 		lcommon.VerifyConfig{
 			SkipBodyHashValidation: c.config.SkipBlockValidation,
 		},
 	)
-	if err != nil {
-		return c.failRequest(req, err)
+	// A raw callback decodes the payload itself, so a generic type decoder
+	// that cannot represent the full wire layout must not fail the request
+	// before the callback ever runs. This is how a block whose era tag
+	// understates its actual shape -- a Dijkstra-shaped block tagged Conway,
+	// say -- reaches a consumer that does understand it.
+	//
+	// The condition is exactly "the raw callback is the consumer that would
+	// receive this block", matching the delivery decisions made below. Every
+	// other consumer wants a decoded block and keeps failing here: GetBlock,
+	// which hands its caller a ledger.Block; BlockFunc; and the block
+	// pipeline, which takes precedence over BlockRawFunc and does its own
+	// typed decode (pipeline.decodeStage).
+	rawFallback := decodeErr != nil &&
+		req.delivery == deliveryCallback &&
+		c.config.Pipeline == nil &&
+		c.config.BlockRawFunc != nil
+	if decodeErr != nil && !rawFallback {
+		return c.failRequest(req, decodeErr)
 	}
-	blockPoint := pcommon.NewPoint(
-		block.SlotNumber(),
-		block.Hash().Bytes(),
-	)
+	// Range correlation applies either way. Without a decoded block its
+	// inputs are read straight from the block header CBOR, so a peer still
+	// cannot inject an unrelated block into a valid batch by sending one the
+	// type decoder rejects.
+	var blockPoint pcommon.Point
+	var prevHash []byte
+	if rawFallback {
+		info, err := rawBlockHeaderInfoFromCbor(wrappedBlock.RawBlock)
+		if err != nil {
+			return c.failRequest(req, errors.Join(decodeErr, err))
+		}
+		blockPoint = info.point
+		prevHash = info.prevHash
+	} else {
+		blockPoint = pcommon.NewPoint(
+			block.SlotNumber(),
+			block.Hash().Bytes(),
+		)
+		blockPrevHash := block.PrevHash()
+		prevHash = blockPrevHash.Bytes()
+	}
 	c.queueMutex.Lock()
-	err = req.recordBlock(block, blockPoint)
+	err = req.recordBlock(blockPoint, prevHash)
 	c.queueMutex.Unlock()
 	if err != nil {
 		return c.failRequest(req, err)
@@ -1217,11 +1250,13 @@ func pointsEqual(a, b pcommon.Point) bool {
 
 // recordBlock validates and records the next block in a requested inclusive
 // range. BlockFetch does not carry the expected interior points on the wire,
-// so continuity is established from each decoded block's previous hash. The
-// caller must hold queueMutex.
+// so continuity is established from each block's previous hash. It takes the
+// point and previous hash rather than a block so it applies equally to a
+// block delivered raw, whose typed decode is the consumer's job. The caller
+// must hold queueMutex.
 func (req *rangeRequest) recordBlock(
-	block ledger.Block,
 	blockPoint pcommon.Point,
+	prevHash []byte,
 ) error {
 	if !pointInRange(blockPoint, req.start, req.end) {
 		return fmt.Errorf(
@@ -1257,8 +1292,7 @@ func (req *rangeRequest) recordBlock(
 				req.lastPoint.Slot,
 			)
 		}
-		prevHash := block.PrevHash()
-		if !bytes.Equal(prevHash[:], req.lastPoint.Hash) {
+		if !bytes.Equal(prevHash, req.lastPoint.Hash) {
 			return fmt.Errorf(
 				"%s: received block does not follow previous range point: slot=%d hash=%x previous_hash=%x",
 				ProtocolName,

--- a/protocol/blockfetch/client.go
+++ b/protocol/blockfetch/client.go
@@ -1121,16 +1121,22 @@ func (c *Client) handleBlock(msgGeneric protocol.Message) error {
 	// understates its actual shape -- a Dijkstra-shaped block tagged Conway,
 	// say -- reaches a consumer that does understand it.
 	//
-	// The condition is exactly "the raw callback is the consumer that would
-	// receive this block", matching the delivery decisions made below. Every
-	// other consumer wants a decoded block and keeps failing here: GetBlock,
-	// which hands its caller a ledger.Block; BlockFunc; and the block
-	// pipeline, which takes precedence over BlockRawFunc and does its own
-	// typed decode (pipeline.decodeStage).
+	// A block the decoder rejected on validation is excluded: it was
+	// representable, so the verdict stands and must not be routed around
+	// (see blockLayoutRepresentable). What remains is the layout it could
+	// not read at all.
+	//
+	// The rest of the condition is exactly "the raw callback is the consumer
+	// that would receive this block", matching the delivery decisions made
+	// below. Every other consumer wants a decoded block and keeps failing
+	// here: GetBlock, which hands its caller a ledger.Block; BlockFunc; and
+	// the block pipeline, which takes precedence over BlockRawFunc and does
+	// its own typed decode (pipeline.decodeStage).
 	rawFallback := decodeErr != nil &&
 		req.delivery == deliveryCallback &&
 		c.config.Pipeline == nil &&
-		c.config.BlockRawFunc != nil
+		c.config.BlockRawFunc != nil &&
+		!blockLayoutRepresentable(wrappedBlock.Type, wrappedBlock.RawBlock)
 	if decodeErr != nil && !rawFallback {
 		return c.failRequest(req, decodeErr)
 	}

--- a/protocol/blockfetch/client_raw_test.go
+++ b/protocol/blockfetch/client_raw_test.go
@@ -729,5 +729,13 @@ func runTestExpectingError(
 		require.Fail(t, "connection did not report an error within timeout")
 	}
 	_ = oConn.Close()
+	// Wait for connection shutdown before the deferred leak check runs.
+	// Close only starts the teardown, so returning here would race the
+	// connection's own goroutines and report them as leaks.
+	select {
+	case <-oConn.ErrorChan():
+	case <-time.After(10 * time.Second):
+		t.Error("connection did not shut down within timeout")
+	}
 	return connErr
 }

--- a/protocol/blockfetch/client_raw_test.go
+++ b/protocol/blockfetch/client_raw_test.go
@@ -1,0 +1,550 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blockfetch_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/blinklabs-io/gouroboros/pipeline"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/blinklabs-io/gouroboros/protocol/blockfetch"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+// musashiBlockFixture returns the real Musashi ranking block that
+// ledger/dijkstra's decode test uses, along with its point. Its header body
+// carries the 12-field Leios extension, so the strict Conway decoder cannot
+// represent it, while Musashi peers tag it as Conway (block type 7) on the
+// wire. The fixture is read from the dijkstra package rather than copied so
+// the two tests cannot drift onto different bytes.
+func musashiBlockFixture(t *testing.T) ([]byte, pcommon.Point) {
+	t.Helper()
+	hexData, err := os.ReadFile(filepath.Join(
+		"..", "..", "ledger", "dijkstra", "testdata",
+		"musashi_dijkstra_block.hex",
+	))
+	require.NoError(t, err)
+	raw, err := hex.DecodeString(strings.TrimSpace(string(hexData)))
+	require.NoError(t, err)
+	// A consumer that knows the Dijkstra layout can decode these bytes; that
+	// is precisely what the raw callback exists to allow.
+	blk, err := dijkstra.NewDijkstraBlockFromCbor(raw)
+	require.NoError(t, err)
+	// Guard the premise of every test below: if the generic Conway decoder
+	// ever learns this layout, these tests stop exercising the gap they were
+	// written for and must be revisited rather than silently passing.
+	_, err = ledger.NewBlockFromCbor(
+		ledger.BlockTypeConway,
+		raw,
+		lcommon.VerifyConfig{SkipBodyHashValidation: true},
+	)
+	require.Error(
+		t,
+		err,
+		"fixture decodes as Conway; it no longer covers the raw-callback gap",
+	)
+	return raw, pcommon.NewPoint(blk.SlotNumber(), blk.Hash().Bytes())
+}
+
+// conwayTaggedWrappedBlock wraps raw block bytes the way a Musashi peer does:
+// tagged with the Conway block type.
+func conwayTaggedWrappedBlock(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	wrappedBlockCbor, err := cbor.Encode(blockfetch.WrappedBlock{
+		Type:     ledger.BlockTypeConway,
+		RawBlock: cbor.RawMessage(raw),
+	})
+	require.NoError(t, err)
+	return wrappedBlockCbor
+}
+
+// TestGetBlockRangeRawFuncReceivesUndecodableBlock covers a Conway-tagged
+// Dijkstra-shaped block reaching BlockRawFunc. The generic type decoder
+// cannot represent the wire layout, so decoding it is the raw callback's job;
+// the client must not fail the request before the callback ever runs.
+func TestGetBlockRangeRawFuncReceivesUndecodableBlock(t *testing.T) {
+	raw, point := musashiBlockFixture(t)
+	conversation := append(
+		conversationHandshakeRequestRange,
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: blockfetch.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				blockfetch.NewMsgStartBatch(),
+				blockfetch.NewMsgBlock(conwayTaggedWrappedBlock(t, raw)),
+				blockfetch.NewMsgBatchDone(),
+			},
+		},
+	)
+	type rawBlock struct {
+		blockType uint
+		block     []byte
+	}
+	rawChan := make(chan rawBlock, 1)
+	doneChan := make(chan struct{}, 1)
+	runTest(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			require.NoError(
+				t,
+				oConn.BlockFetch().Client.GetBlockRange(point, point),
+			)
+			select {
+			case got := <-rawChan:
+				require.Equal(t, uint(ledger.BlockTypeConway), got.blockType)
+				require.True(
+					t,
+					bytes.Equal(raw, got.block),
+					"raw callback did not receive the exact wire bytes",
+				)
+			case <-time.After(5 * time.Second):
+				require.Fail(t, "BlockRawFunc was not called within timeout")
+			}
+			select {
+			case <-doneChan:
+			case <-time.After(5 * time.Second):
+				require.Fail(t, "BatchDoneFunc was not called within timeout")
+			}
+		},
+		ouroboros.WithBlockFetchConfig(blockfetch.Config{
+			SkipBlockValidation: true,
+			BlockRawFunc: func(
+				_ blockfetch.CallbackContext,
+				blockType uint,
+				block []byte,
+			) error {
+				rawChan <- rawBlock{blockType: blockType, block: block}
+				return nil
+			},
+			BatchDoneFunc: func(_ blockfetch.CallbackContext) error {
+				doneChan <- struct{}{}
+				return nil
+			},
+		}),
+	)
+}
+
+// TestGetBlockRangeRawFuncRejectsBlockOutsideRange covers the negative case:
+// falling back to raw delivery must not weaken range correlation. A peer that
+// answers with a block outside the requested range is still rejected, and the
+// callback must not see those bytes.
+func TestGetBlockRangeRawFuncRejectsBlockOutsideRange(t *testing.T) {
+	raw, point := musashiBlockFixture(t)
+	// Request a range that the delivered block does not start.
+	requested := pcommon.NewPoint(point.Slot-1, point.Hash)
+	conversation := append(
+		conversationHandshakeRequestRange,
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: blockfetch.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				blockfetch.NewMsgStartBatch(),
+				blockfetch.NewMsgBlock(conwayTaggedWrappedBlock(t, raw)),
+				blockfetch.NewMsgBatchDone(),
+			},
+		},
+		ouroboros_mock.ConversationEntrySleep{Duration: 100 * time.Millisecond},
+		ouroboros_mock.ConversationEntryClose{},
+	)
+	rawCalled := make(chan struct{}, 1)
+	connErr := runTestExpectingError(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			require.NoError(
+				t,
+				oConn.BlockFetch().Client.GetBlockRange(requested, requested),
+			)
+		},
+		ouroboros.WithBlockFetchConfig(blockfetch.Config{
+			SkipBlockValidation: true,
+			BlockRawFunc: func(
+				_ blockfetch.CallbackContext,
+				_ uint,
+				_ []byte,
+			) error {
+				rawCalled <- struct{}{}
+				return nil
+			},
+		}),
+	)
+	require.ErrorContains(t, connErr, "outside requested range")
+	select {
+	case <-rawCalled:
+		require.Fail(t, "BlockRawFunc was called for an out-of-range block")
+	default:
+	}
+}
+
+// TestGetBlockRangeBlockFuncStillFailsUndecodableBlock covers the other half
+// of the contract: a caller that asks for decoded blocks gets unchanged
+// behavior. Without a raw callback there is nothing to deliver the block to,
+// so the decode failure still fails the request.
+func TestGetBlockRangeBlockFuncStillFailsUndecodableBlock(t *testing.T) {
+	raw, point := musashiBlockFixture(t)
+	conversation := append(
+		conversationHandshakeRequestRange,
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: blockfetch.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				blockfetch.NewMsgStartBatch(),
+				blockfetch.NewMsgBlock(conwayTaggedWrappedBlock(t, raw)),
+				blockfetch.NewMsgBatchDone(),
+			},
+		},
+		ouroboros_mock.ConversationEntrySleep{Duration: 100 * time.Millisecond},
+		ouroboros_mock.ConversationEntryClose{},
+	)
+	blockCalled := make(chan struct{}, 1)
+	connErr := runTestExpectingError(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			require.NoError(
+				t,
+				oConn.BlockFetch().Client.GetBlockRange(point, point),
+			)
+		},
+		ouroboros.WithBlockFetchConfig(blockfetch.Config{
+			SkipBlockValidation: true,
+			BlockFunc: func(
+				_ blockfetch.CallbackContext,
+				_ uint,
+				_ ledger.Block,
+			) error {
+				blockCalled <- struct{}{}
+				return nil
+			},
+		}),
+	)
+	require.ErrorContains(t, connErr, "decode Conway block error")
+	select {
+	case <-blockCalled:
+		require.Fail(t, "BlockFunc was called for an undecodable block")
+	default:
+	}
+}
+
+// TestGetBlockUndecodableBlockStillFails covers single-block delivery, which
+// hands the caller a decoded ledger.Block and therefore has no raw fallback
+// available even when a raw callback is configured.
+func TestGetBlockUndecodableBlockStillFails(t *testing.T) {
+	raw, point := musashiBlockFixture(t)
+	conversation := append(
+		conversationHandshakeRequestRange,
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: blockfetch.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				blockfetch.NewMsgStartBatch(),
+				blockfetch.NewMsgBlock(conwayTaggedWrappedBlock(t, raw)),
+				blockfetch.NewMsgBatchDone(),
+			},
+		},
+		ouroboros_mock.ConversationEntrySleep{Duration: 100 * time.Millisecond},
+		ouroboros_mock.ConversationEntryClose{},
+	)
+	connErr := runTestExpectingError(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			_, err := oConn.BlockFetch().Client.GetBlock(point)
+			require.Error(t, err)
+		},
+		ouroboros.WithBlockFetchConfig(blockfetch.Config{
+			SkipBlockValidation: true,
+			BlockRawFunc: func(
+				_ blockfetch.CallbackContext,
+				_ uint,
+				_ []byte,
+			) error {
+				return nil
+			},
+		}),
+	)
+	require.ErrorContains(t, connErr, "decode Conway block error")
+}
+
+// TestGetBlockRangePipelineStillFailsUndecodableBlock covers the remaining
+// consumer. The block pipeline takes precedence over BlockRawFunc and runs its
+// own typed decode, so configuring a raw callback alongside it must not make
+// the client accept a block the pipeline cannot decode either.
+func TestGetBlockRangePipelineStillFailsUndecodableBlock(t *testing.T) {
+	raw, point := musashiBlockFixture(t)
+	conversation := append(
+		conversationHandshakeRequestRange,
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: blockfetch.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				blockfetch.NewMsgStartBatch(),
+				blockfetch.NewMsgBlock(conwayTaggedWrappedBlock(t, raw)),
+				blockfetch.NewMsgBatchDone(),
+			},
+		},
+		ouroboros_mock.ConversationEntrySleep{Duration: 100 * time.Millisecond},
+		ouroboros_mock.ConversationEntryClose{},
+	)
+	blockPipeline := pipeline.NewBlockPipeline(
+		pipeline.WithSkipBodyHashValidation(true),
+		pipeline.WithApplyFunc(func(_ *pipeline.BlockItem) error {
+			return nil
+		}),
+	)
+	require.NoError(t, blockPipeline.Start(t.Context()))
+	defer func() { _ = blockPipeline.Stop() }()
+	rawCalled := make(chan struct{}, 1)
+	connErr := runTestExpectingError(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			require.NoError(
+				t,
+				oConn.BlockFetch().Client.GetBlockRange(point, point),
+			)
+		},
+		ouroboros.WithBlockFetchConfig(blockfetch.Config{
+			SkipBlockValidation: true,
+			Pipeline:            blockPipeline,
+			BlockRawFunc: func(
+				_ blockfetch.CallbackContext,
+				_ uint,
+				_ []byte,
+			) error {
+				rawCalled <- struct{}{}
+				return nil
+			},
+		}),
+	)
+	require.ErrorContains(t, connErr, "decode Conway block error")
+	select {
+	case <-rawCalled:
+		require.Fail(t, "BlockRawFunc was called while a pipeline was set")
+	default:
+	}
+}
+
+// chainedMusashiBlock rewrites the fixture's slot and prev_hash so it follows
+// the given point, producing a second Leios-extended block for range tests.
+// Only the header fields BlockFetch correlates on are changed; the block stays
+// undecodable by the generic Conway decoder, which is the point. Nothing here
+// re-signs the header, so this is only valid with SkipBlockValidation.
+func chainedMusashiBlock(
+	t *testing.T,
+	raw []byte,
+	prev pcommon.Point,
+	slot uint64,
+) ([]byte, pcommon.Point) {
+	t.Helper()
+	var blockElems []cbor.RawMessage
+	_, err := cbor.Decode(raw, &blockElems)
+	require.NoError(t, err)
+	var headerElems []cbor.RawMessage
+	_, err = cbor.Decode(blockElems[0], &headerElems)
+	require.NoError(t, err)
+	var bodyElems []cbor.RawMessage
+	_, err = cbor.Decode(headerElems[0], &bodyElems)
+	require.NoError(t, err)
+	require.Len(t, bodyElems, 12, "fixture should carry the Leios extension")
+	slotCbor, err := cbor.Encode(slot)
+	require.NoError(t, err)
+	prevCbor, err := cbor.Encode(prev.Hash)
+	require.NoError(t, err)
+	bodyElems[1] = slotCbor
+	bodyElems[2] = prevCbor
+	headerCbor, err := cbor.Encode(bodyElems)
+	require.NoError(t, err)
+	headerElems[0] = headerCbor
+	newHeader, err := cbor.Encode(headerElems)
+	require.NoError(t, err)
+	blockElems[0] = newHeader
+	newBlock, err := cbor.Encode(blockElems)
+	require.NoError(t, err)
+	hash := lcommon.Blake2b256Hash(newHeader)
+	return newBlock, pcommon.NewPoint(slot, hash.Bytes())
+}
+
+// TestGetBlockRangeRawFuncMultiBlockContinuity covers the path the raw
+// fallback newly makes reachable: a range of more than one undecodable block,
+// where continuity between them is established from each block's previous
+// hash read out of the header CBOR.
+func TestGetBlockRangeRawFuncMultiBlockContinuity(t *testing.T) {
+	raw, first := musashiBlockFixture(t)
+	second, secondPoint := chainedMusashiBlock(t, raw, first, first.Slot+1)
+	conversation := append(
+		conversationHandshakeRequestRange,
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: blockfetch.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				blockfetch.NewMsgStartBatch(),
+				blockfetch.NewMsgBlock(conwayTaggedWrappedBlock(t, raw)),
+				blockfetch.NewMsgBlock(conwayTaggedWrappedBlock(t, second)),
+				blockfetch.NewMsgBatchDone(),
+			},
+		},
+	)
+	rawChan := make(chan []byte, 2)
+	doneChan := make(chan struct{}, 1)
+	runTest(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			require.NoError(
+				t,
+				oConn.BlockFetch().Client.GetBlockRange(first, secondPoint),
+			)
+			for _, want := range [][]byte{raw, second} {
+				select {
+				case got := <-rawChan:
+					require.True(
+						t,
+						bytes.Equal(want, got),
+						"raw callback received blocks out of order or altered",
+					)
+				case <-time.After(5 * time.Second):
+					require.Fail(t, "BlockRawFunc was not called within timeout")
+				}
+			}
+			select {
+			case <-doneChan:
+			case <-time.After(5 * time.Second):
+				require.Fail(t, "BatchDoneFunc was not called within timeout")
+			}
+		},
+		ouroboros.WithBlockFetchConfig(blockfetch.Config{
+			SkipBlockValidation: true,
+			BlockRawFunc: func(
+				_ blockfetch.CallbackContext,
+				_ uint,
+				block []byte,
+			) error {
+				rawChan <- block
+				return nil
+			},
+			BatchDoneFunc: func(_ blockfetch.CallbackContext) error {
+				doneChan <- struct{}{}
+				return nil
+			},
+		}),
+	)
+}
+
+// TestGetBlockRangeRawFuncRejectsBrokenContinuity is the negative twin of the
+// test above. A second block that does not extend the first is rejected even
+// though both are in the requested range, so raw delivery cannot be used to
+// slip a foreign block into the middle of a batch.
+func TestGetBlockRangeRawFuncRejectsBrokenContinuity(t *testing.T) {
+	raw, first := musashiBlockFixture(t)
+	unrelated := pcommon.NewPoint(first.Slot, make([]byte, 32))
+	second, secondPoint := chainedMusashiBlock(
+		t,
+		raw,
+		unrelated,
+		first.Slot+1,
+	)
+	conversation := append(
+		conversationHandshakeRequestRange,
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: blockfetch.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				blockfetch.NewMsgStartBatch(),
+				blockfetch.NewMsgBlock(conwayTaggedWrappedBlock(t, raw)),
+				blockfetch.NewMsgBlock(conwayTaggedWrappedBlock(t, second)),
+				blockfetch.NewMsgBatchDone(),
+			},
+		},
+		ouroboros_mock.ConversationEntrySleep{Duration: 100 * time.Millisecond},
+		ouroboros_mock.ConversationEntryClose{},
+	)
+	rawChan := make(chan []byte, 2)
+	connErr := runTestExpectingError(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			require.NoError(
+				t,
+				oConn.BlockFetch().Client.GetBlockRange(first, secondPoint),
+			)
+		},
+		ouroboros.WithBlockFetchConfig(blockfetch.Config{
+			SkipBlockValidation: true,
+			BlockRawFunc: func(
+				_ blockfetch.CallbackContext,
+				_ uint,
+				block []byte,
+			) error {
+				rawChan <- block
+				return nil
+			},
+		}),
+	)
+	require.ErrorContains(t, connErr, "does not follow previous range point")
+	require.Len(t, rawChan, 1, "only the first block should be delivered")
+}
+
+// runTestExpectingError drives a mock conversation whose Ouroboros connection
+// is expected to fail, and returns that failure. runTest panics on a
+// connection error, so error-path tests use this instead.
+func runTestExpectingError(
+	t *testing.T,
+	conversation []ouroboros_mock.ConversationEntry,
+	innerFunc testInnerFunc,
+	options ...ouroboros.ConnectionOptionFunc,
+) error {
+	t.Helper()
+	// Scope the leak check to goroutines this helper starts. A caller may
+	// have set up long-lived goroutines of its own (a block pipeline, say)
+	// that it stops after this returns.
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+	mockConn := ouroboros_mock.NewConnection(
+		ouroboros_mock.ProtocolRoleClient,
+		conversation,
+	)
+	opts := []ouroboros.ConnectionOptionFunc{
+		ouroboros.WithConnection(mockConn),
+		ouroboros.WithNetworkMagic(ouroboros_mock.MockNetworkMagic),
+		ouroboros.WithNodeToNode(true),
+	}
+	opts = append(opts, options...)
+	oConn, err := ouroboros.New(opts...)
+	require.NoError(t, err, "unexpected error when creating Ouroboros object")
+	innerFunc(t, oConn)
+	var connErr error
+	select {
+	case connErr = <-oConn.ErrorChan():
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "connection did not report an error within timeout")
+	}
+	_ = oConn.Close()
+	return connErr
+}

--- a/protocol/blockfetch/client_raw_test.go
+++ b/protocol/blockfetch/client_raw_test.go
@@ -352,6 +352,187 @@ func TestGetBlockRangePipelineStillFailsUndecodableBlock(t *testing.T) {
 	}
 }
 
+// tamperedBodyConwayBlock returns a Conway block whose layout decodes cleanly
+// but whose body does not match the body hash its header commits to, along
+// with its point. This is the shape of a peer that keeps a valid header and
+// replaces the body.
+func tamperedBodyConwayBlock(t *testing.T) ([]byte, pcommon.Point) {
+	t.Helper()
+	blk := ledger.ConwayBlock{BlockHeader: &ledger.ConwayBlockHeader{}}
+	blk.BlockHeader.Body.BlockNumber = 12345
+	blk.BlockHeader.Body.Slot = 23456
+	raw, err := cbor.Encode(blk)
+	require.NoError(t, err)
+	// The layout is representable, so the decoder gets far enough to check
+	// the body hash and reject it. That distinction is what the fallback
+	// keys on, so assert it rather than assuming it.
+	_, err = ledger.NewBlockFromCbor(
+		ledger.BlockTypeConway,
+		raw,
+		lcommon.VerifyConfig{SkipBodyHashValidation: false},
+	)
+	var validationErr *lcommon.ValidationError
+	require.ErrorAs(t, err, &validationErr)
+	// ErrorAs above already fails the test on no match; the guard is for
+	// static nil analysis, which cannot see that it assigns the target.
+	if validationErr != nil {
+		require.Equal(
+			t,
+			lcommon.ValidationErrorTypeBodyHash,
+			validationErr.Type,
+		)
+	}
+	decoded, err := ledger.NewBlockFromCbor(
+		ledger.BlockTypeConway,
+		raw,
+		lcommon.VerifyConfig{SkipBodyHashValidation: true},
+	)
+	require.NoError(t, err)
+	return raw, pcommon.NewPoint(
+		decoded.SlotNumber(),
+		decoded.Hash().Bytes(),
+	)
+}
+
+// TestGetBlockRangeRawFuncRejectsValidationFailure covers the security
+// boundary of the raw fallback. A block the decoder understood and rejected
+// must not be handed to the raw callback: a peer could otherwise keep a valid
+// header, replace the body, and have the tampered bytes delivered while
+// header-only range correlation still passed. The fallback exists for layouts
+// the decoder cannot represent, not for blocks it has already refused.
+func TestGetBlockRangeRawFuncRejectsValidationFailure(t *testing.T) {
+	raw, point := tamperedBodyConwayBlock(t)
+	conversation := append(
+		conversationHandshakeRequestRange,
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: blockfetch.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				blockfetch.NewMsgStartBatch(),
+				blockfetch.NewMsgBlock(conwayTaggedWrappedBlock(t, raw)),
+				blockfetch.NewMsgBatchDone(),
+			},
+		},
+		ouroboros_mock.ConversationEntrySleep{Duration: 100 * time.Millisecond},
+		ouroboros_mock.ConversationEntryClose{},
+	)
+	rawCalled := make(chan struct{}, 1)
+	connErr := runTestExpectingError(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			require.NoError(
+				t,
+				oConn.BlockFetch().Client.GetBlockRange(point, point),
+			)
+		},
+		ouroboros.WithBlockFetchConfig(blockfetch.Config{
+			// Validation left enabled, which is the default and what the
+			// hole depended on.
+			BlockRawFunc: func(
+				_ blockfetch.CallbackContext,
+				_ uint,
+				_ []byte,
+			) error {
+				rawCalled <- struct{}{}
+				return nil
+			},
+		}),
+	)
+	require.ErrorContains(t, connErr, "body hash mismatch")
+	select {
+	case <-rawCalled:
+		require.Fail(
+			t,
+			"BlockRawFunc received a block that failed body-hash validation",
+		)
+	default:
+	}
+}
+
+// TestGetBlockRangeRawFuncRejectsNilHeaderBlock covers the other member of
+// the rejected-under-validation class. The nil-header check sits beside the
+// body-hash check behind the same validation gate but returns a plain error
+// rather than a common.ValidationError, so a fallback keyed on the error type
+// would let this one through. Keyed on whether the layout is representable,
+// both are refused.
+func TestGetBlockRangeRawFuncRejectsNilHeaderBlock(t *testing.T) {
+	raw, err := cbor.Encode(ledger.ConwayBlock{})
+	require.NoError(t, err)
+	// Representable with validation off, rejected with it on, and rejected
+	// with a plain error rather than a typed one.
+	_, err = ledger.NewBlockFromCbor(
+		ledger.BlockTypeConway,
+		raw,
+		lcommon.VerifyConfig{SkipBodyHashValidation: true},
+	)
+	require.NoError(t, err)
+	_, err = ledger.NewBlockFromCbor(
+		ledger.BlockTypeConway,
+		raw,
+		lcommon.VerifyConfig{SkipBodyHashValidation: false},
+	)
+	require.Error(t, err)
+	var validationErr *lcommon.ValidationError
+	require.NotErrorAs(
+		t,
+		err,
+		&validationErr,
+		"if this becomes typed, the class this test guards has changed",
+	)
+	conversation := append(
+		conversationHandshakeRequestRange,
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: blockfetch.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				blockfetch.NewMsgStartBatch(),
+				blockfetch.NewMsgBlock(conwayTaggedWrappedBlock(t, raw)),
+				blockfetch.NewMsgBatchDone(),
+			},
+		},
+		ouroboros_mock.ConversationEntrySleep{Duration: 100 * time.Millisecond},
+		ouroboros_mock.ConversationEntryClose{},
+	)
+	rawCalled := make(chan struct{}, 1)
+	connErr := runTestExpectingError(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			point := pcommon.NewPoint(1, make([]byte, 32))
+			require.NoError(
+				t,
+				oConn.BlockFetch().Client.GetBlockRange(point, point),
+			)
+		},
+		ouroboros.WithBlockFetchConfig(blockfetch.Config{
+			BlockRawFunc: func(
+				_ blockfetch.CallbackContext,
+				_ uint,
+				_ []byte,
+			) error {
+				rawCalled <- struct{}{}
+				return nil
+			},
+		}),
+	)
+	require.ErrorContains(t, connErr, "header is nil")
+	// The fallback must have been declined outright, not entered and then
+	// tripped over the null header while extracting the point. Both end in a
+	// failed request, so without this the test would pass either way.
+	require.NotContains(
+		t,
+		connErr.Error(),
+		"raw block header",
+		"the fallback was entered for a block rejected on validation",
+	)
+	select {
+	case <-rawCalled:
+		require.Fail(t, "BlockRawFunc received a block rejected on validation")
+	default:
+	}
+}
+
 // chainedMusashiBlock rewrites the fixture's slot and prev_hash so it follows
 // the given point, producing a second Leios-extended block for range tests.
 // Only the header fields BlockFetch correlates on are changed; the block stays

--- a/protocol/blockfetch/client_raw_test.go
+++ b/protocol/blockfetch/client_raw_test.go
@@ -367,9 +367,11 @@ func chainedMusashiBlock(
 	var blockElems []cbor.RawMessage
 	_, err := cbor.Decode(raw, &blockElems)
 	require.NoError(t, err)
+	require.NotEmpty(t, blockElems, "block should hold a header")
 	var headerElems []cbor.RawMessage
 	_, err = cbor.Decode(blockElems[0], &headerElems)
 	require.NoError(t, err)
+	require.NotEmpty(t, headerElems, "header should hold a body")
 	var bodyElems []cbor.RawMessage
 	_, err = cbor.Decode(headerElems[0], &bodyElems)
 	require.NoError(t, err)

--- a/protocol/blockfetch/rawblock.go
+++ b/protocol/blockfetch/rawblock.go
@@ -19,9 +19,41 @@ import (
 	"fmt"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
 )
+
+// blockLayoutRepresentable reports whether the generic type decoder can read
+// this block at all, independent of any validation verdict.
+//
+// This is the raw fallback's actual precondition, and decoding with
+// validation disabled isolates it. If that succeeds, the decoder understood
+// the block and the original failure was a rejection -- a body-hash mismatch,
+// a nil header, or any other check behind the validation gate. Delivering
+// those bytes anyway would let a peer keep a valid header, replace the body,
+// and have the tampered block reach the raw callback while header-only range
+// correlation still passed, so the fallback must not engage. If it still
+// fails, nothing could be read, which is the case the raw callback exists
+// for: the consumer that asked for raw blocks is the one equipped to decode
+// and validate that layout.
+//
+// Asking the decoder beats matching on error types, which every era would
+// have to keep in sync: the body-hash checks return a typed
+// common.ValidationError but the nil-header checks beside them return a plain
+// error, and a new era adding a third shape would silently widen the
+// fallback.
+//
+// Only reached once a decode has already failed and a raw callback is
+// configured, so the second decode is off the healthy path.
+func blockLayoutRepresentable(blockType uint, raw []byte) bool {
+	_, err := ledger.NewBlockFromCbor(
+		blockType,
+		raw,
+		lcommon.VerifyConfig{SkipBodyHashValidation: true},
+	)
+	return err == nil
+}
 
 // blockHeaderBodyMinFields is the number of leading block-header-body fields
 // this file reads: block_number, slot, prev_hash. Every Shelley-family era

--- a/protocol/blockfetch/rawblock.go
+++ b/protocol/blockfetch/rawblock.go
@@ -1,0 +1,123 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blockfetch
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	pcommon "github.com/blinklabs-io/gouroboros/protocol/common"
+)
+
+// blockHeaderBodyMinFields is the number of leading block-header-body fields
+// this file reads: block_number, slot, prev_hash. Every Shelley-family era
+// starts its header body with those three, whatever era-specific fields
+// follow.
+const blockHeaderBodyMinFields = 3
+
+// rawBlockHeaderInfo holds the header facts BlockFetch needs to correlate a
+// received block with the requested range.
+type rawBlockHeaderInfo struct {
+	point    pcommon.Point
+	prevHash []byte
+}
+
+// rawBlockHeaderInfoFromCbor reads a block's point and previous-block hash
+// straight from its CBOR, without a typed era decode.
+//
+// Every Shelley-family block (Shelley through Dijkstra) is a [header, ...]
+// array whose header is [header_body, signature] and whose header body begins
+// with block_number, slot, prev_hash. The block hash is Blake2b-256 over the
+// header's original CBOR bytes, the same definition the typed headers use --
+// see babbage.BabbageBlockHeader.Hash.
+//
+// This exists so range correlation survives a payload whose full wire layout
+// the generic type decoder cannot represent. It reads only the three fields
+// correlation needs and makes no claim about the rest of the block; decoding
+// that is the raw callback's job. Byron blocks use a different header shape
+// and are not supported here.
+func rawBlockHeaderInfoFromCbor(data []byte) (rawBlockHeaderInfo, error) {
+	var blockElems []cbor.RawMessage
+	if _, err := cbor.Decode(data, &blockElems); err != nil {
+		return rawBlockHeaderInfo{}, fmt.Errorf(
+			"decode raw block: %w",
+			err,
+		)
+	}
+	if len(blockElems) == 0 {
+		return rawBlockHeaderInfo{}, errors.New("raw block has no header")
+	}
+	headerCbor := []byte(blockElems[0])
+	var headerElems []cbor.RawMessage
+	if _, err := cbor.Decode(headerCbor, &headerElems); err != nil {
+		return rawBlockHeaderInfo{}, fmt.Errorf(
+			"decode raw block header: %w",
+			err,
+		)
+	}
+	if len(headerElems) == 0 {
+		return rawBlockHeaderInfo{}, errors.New(
+			"raw block header has no body",
+		)
+	}
+	var bodyElems []cbor.RawMessage
+	if _, err := cbor.Decode(headerElems[0], &bodyElems); err != nil {
+		return rawBlockHeaderInfo{}, fmt.Errorf(
+			"decode raw block header body: %w",
+			err,
+		)
+	}
+	if len(bodyElems) < blockHeaderBodyMinFields {
+		return rawBlockHeaderInfo{}, fmt.Errorf(
+			"raw block header body has %d fields, expected at least %d",
+			len(bodyElems),
+			blockHeaderBodyMinFields,
+		)
+	}
+	var slot uint64
+	if _, err := cbor.Decode(bodyElems[1], &slot); err != nil {
+		return rawBlockHeaderInfo{}, fmt.Errorf(
+			"decode raw block header slot: %w",
+			err,
+		)
+	}
+	prevHash, err := decodeRawPrevHash(bodyElems[2])
+	if err != nil {
+		return rawBlockHeaderInfo{}, err
+	}
+	blockHash := lcommon.Blake2b256Hash(headerCbor)
+	return rawBlockHeaderInfo{
+		point:    pcommon.NewPoint(slot, blockHash.Bytes()),
+		prevHash: prevHash,
+	}, nil
+}
+
+// decodeRawPrevHash decodes a header body's prev_hash field. Origin headers
+// encode it as null, which the typed header decoders turn into the zero hash
+// (see babbage.BabbageBlockHeaderBody.UnmarshalCBOR); mirror that here so the
+// two paths agree.
+func decodeRawPrevHash(data cbor.RawMessage) ([]byte, error) {
+	if len(data) == 1 && data[0] == 0xf6 {
+		var zero lcommon.Blake2b256
+		return zero.Bytes(), nil
+	}
+	var prevHash lcommon.Blake2b256
+	if _, err := cbor.Decode(data, &prevHash); err != nil {
+		return nil, fmt.Errorf("decode raw block header prev hash: %w", err)
+	}
+	return prevHash.Bytes(), nil
+}

--- a/protocol/blockfetch/rawblock_internal_test.go
+++ b/protocol/blockfetch/rawblock_internal_test.go
@@ -59,14 +59,24 @@ func TestRawBlockHeaderInfoMatchesTypedDecode(t *testing.T) {
 	_, err = cbor.Decode(babbageCbor, &babbageBlock)
 	require.NoError(t, err)
 
+	// An encoded zero Blake2b256 is a 32-byte bytestring, not CBOR null, so
+	// the case above does not reach the origin branch. Rewrite prev_hash to
+	// null to cover it.
+	originCbor := withNullPrevHash(t, babbageCbor)
+	var originBlock ledger.BabbageBlock
+	_, err = cbor.Decode(originCbor, &originBlock)
+	require.NoError(t, err)
+
 	testCases := []struct {
 		name  string
 		raw   []byte
 		block ledger.Block
 	}{
-		// Babbage exercises a 10-field header body with an origin (null)
-		// prev_hash.
+		// Babbage exercises a 10-field header body with a present prev_hash.
 		{name: "babbage", raw: babbageCbor, block: &babbageBlock},
+		// The origin case: prev_hash encoded as CBOR null, which the typed
+		// header decoder turns into the zero hash.
+		{name: "babbage origin", raw: originCbor, block: &originBlock},
 		// Musashi exercises a 12-field Leios-extended header body, the shape
 		// that made the raw fallback necessary in the first place.
 		{name: "musashi dijkstra", raw: musashi, block: musashiBlock},
@@ -135,4 +145,32 @@ func TestRawBlockHeaderInfoRejectsMalformed(t *testing.T) {
 			require.Error(t, err)
 		})
 	}
+}
+
+// withNullPrevHash rewrites a block's header-body prev_hash to CBOR null,
+// producing the encoding an origin header uses.
+func withNullPrevHash(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	var blockElems []cbor.RawMessage
+	_, err := cbor.Decode(raw, &blockElems)
+	require.NoError(t, err)
+	require.NotEmpty(t, blockElems)
+	var headerElems []cbor.RawMessage
+	_, err = cbor.Decode(blockElems[0], &headerElems)
+	require.NoError(t, err)
+	require.NotEmpty(t, headerElems)
+	var bodyElems []cbor.RawMessage
+	_, err = cbor.Decode(headerElems[0], &bodyElems)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(bodyElems), blockHeaderBodyMinFields)
+	bodyElems[2] = cbor.RawMessage{0xf6}
+	headerBody, err := cbor.Encode(bodyElems)
+	require.NoError(t, err)
+	headerElems[0] = headerBody
+	header, err := cbor.Encode(headerElems)
+	require.NoError(t, err)
+	blockElems[0] = header
+	out, err := cbor.Encode(blockElems)
+	require.NoError(t, err)
+	return out
 }

--- a/protocol/blockfetch/rawblock_internal_test.go
+++ b/protocol/blockfetch/rawblock_internal_test.go
@@ -1,0 +1,138 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blockfetch
+
+import (
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/stretchr/testify/require"
+)
+
+func readMusashiBlock(t *testing.T) []byte {
+	t.Helper()
+	hexData, err := os.ReadFile(filepath.Join(
+		"..", "..", "ledger", "dijkstra", "testdata",
+		"musashi_dijkstra_block.hex",
+	))
+	require.NoError(t, err)
+	raw, err := hex.DecodeString(strings.TrimSpace(string(hexData)))
+	require.NoError(t, err)
+	return raw
+}
+
+// TestRawBlockHeaderInfoMatchesTypedDecode is the agreement test between the
+// two correlation paths. For any block the typed decoder can handle, reading
+// the header directly must produce exactly the point and previous hash the
+// decoded block reports, or the raw fallback would correlate ranges by a
+// different rule than the normal path.
+func TestRawBlockHeaderInfoMatchesTypedDecode(t *testing.T) {
+	musashi := readMusashiBlock(t)
+	musashiBlock, err := dijkstra.NewDijkstraBlockFromCbor(musashi)
+	require.NoError(t, err)
+
+	babbageBlock := ledger.BabbageBlock{
+		BlockHeader: &ledger.BabbageBlockHeader{},
+	}
+	babbageBlock.BlockHeader.Body.BlockNumber = 12345
+	babbageBlock.BlockHeader.Body.Slot = 23456
+	babbageCbor, err := cbor.Encode(babbageBlock)
+	require.NoError(t, err)
+	_, err = cbor.Decode(babbageCbor, &babbageBlock)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name  string
+		raw   []byte
+		block ledger.Block
+	}{
+		// Babbage exercises a 10-field header body with an origin (null)
+		// prev_hash.
+		{name: "babbage", raw: babbageCbor, block: &babbageBlock},
+		// Musashi exercises a 12-field Leios-extended header body, the shape
+		// that made the raw fallback necessary in the first place.
+		{name: "musashi dijkstra", raw: musashi, block: musashiBlock},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			info, err := rawBlockHeaderInfoFromCbor(tc.raw)
+			require.NoError(t, err)
+			require.Equal(t, tc.block.SlotNumber(), info.point.Slot)
+			require.Equal(t, tc.block.Hash().Bytes(), info.point.Hash)
+			wantPrev := tc.block.PrevHash()
+			require.Equal(t, wantPrev.Bytes(), info.prevHash)
+		})
+	}
+}
+
+// TestRawBlockHeaderInfoRejectsMalformed covers the inputs a hostile or broken
+// peer can send. Each must produce an error rather than a panic or a
+// zero-valued point that would correlate against an unrelated range.
+func TestRawBlockHeaderInfoRejectsMalformed(t *testing.T) {
+	headerBody := func(fields ...any) []byte {
+		t.Helper()
+		encoded, err := cbor.Encode(fields)
+		require.NoError(t, err)
+		return encoded
+	}
+	block := func(t *testing.T, header any) []byte {
+		t.Helper()
+		encoded, err := cbor.Encode([]any{header, []any{}})
+		require.NoError(t, err)
+		return encoded
+	}
+	shortBody := headerBody(uint64(1), uint64(2))
+	badSlot := headerBody("not-a-slot", "not-a-slot", make([]byte, 32))
+
+	testCases := []struct {
+		name string
+		raw  []byte
+	}{
+		{name: "empty", raw: []byte{}},
+		{name: "not an array", raw: []byte{0x01}},
+		{
+			name: "empty block array",
+			raw:  func() []byte { b, _ := cbor.Encode([]any{}); return b }(),
+		},
+		{
+			name: "header not an array",
+			raw:  block(t, uint64(1)),
+		},
+		{
+			name: "header body not an array",
+			raw:  block(t, []any{uint64(1), []byte{}}),
+		},
+		{
+			name: "header body too short",
+			raw:  block(t, []any{cbor.RawMessage(shortBody), []byte{}}),
+		},
+		{
+			name: "slot not an integer",
+			raw:  block(t, []any{cbor.RawMessage(badSlot), []byte{}}),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := rawBlockHeaderInfoFromCbor(tc.raw)
+			require.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2178.

`handleBlock` decoded every block with `ledger.NewBlockFromCbor` and failed
the request on error, so a payload the generic type decoder cannot represent
never reached `BlockRawFunc`. Musashi peers tag Dijkstra-shaped blocks as
Conway; the strict Conway decoder rejects their 12-field Leios-extended
header body, tearing down the connection before a consumer that understands
the layout can decode it.

## Change

When the raw callback is the consumer that would receive the block, a decode
failure now falls back to raw delivery.

The fallback is gated on whether the layout is representable at all, by
decoding once with validation disabled. A block that then decodes was
understood and refused, so the refusal stands and the bytes are not
delivered; one that still fails could not be read, which is the case the raw
callback exists for. Keying on that rather than on the error type covers the
whole rejected-under-validation class: the body-hash checks return a typed
`common.ValidationError`, but the `<era> block header is nil` checks beside
them return a plain error.

Range correlation applies on both paths. The decoded block was its input, so
`rawblock.go` reads slot, prev-hash and block hash straight from the header
CBOR, which is era-agnostic for those three fields across Shelley through
Dijkstra. `recordBlock` takes a point and previous hash rather than a decoded
block so both paths run the identical checks, and a peer cannot inject an
unrelated block into a valid batch by sending one the type decoder rejects.

Every other consumer is unchanged and still fails on an undecodable block:
`GetBlock`, which hands its caller a `ledger.Block`; `BlockFunc`; and the
block pipeline, which takes precedence over `BlockRawFunc` and does its own
typed decode.

## Boundary

gouroboros validates what it can represent. A layout it cannot decode is
handed over intact, with range correlation still enforced; validating that
payload is the raw consumer's responsibility. There is no layout-independent
way to check a body hash for a block that failed to decode, since Conway
computes it over a flat 5-element block and Dijkstra over a `[header, body]`
envelope.

## Tests

The regression test serves the real Musashi block from
`ledger/dijkstra/testdata`, tagged Conway, and asserts it reaches
`BlockRawFunc` as the exact wire bytes. It is read from the dijkstra package
rather than copied so the two tests cannot drift onto different bytes, and it
asserts up front that the block still fails Conway decode, so the test fails
loudly if that ever changes instead of silently covering nothing.

Also covered: a block that fails body-hash validation and one rejected with a
nil header, neither of which may reach the raw callback; the path the
fallback creates, a multi-block range whose continuity is checked from the
extracted prev-hash, with its negative twin where a second block that does
not extend the first is rejected; out-of-range rejection under raw delivery;
unchanged failure for `GetBlock`, `BlockFunc` and the pipeline; and an
agreement test proving the extractor returns the same point and prev-hash as
the typed decoder, including the origin case where prev-hash is CBOR null.

Each new guard was verified to fail with its fix reverted.

## Validation

- `go test -race ./...` passes
- `golangci-lint run ./...` reports 0 issues
- `nilaway` clean
- `go test ./internal/test/conformance/...` passes

Not verified: the issue's last acceptance criterion, confirming Dingo Musashi
from-genesis sync passes the first Dijkstra block. That needs a live Musashi
run, which was not available here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DcqSoDCsANbPVamS3iuYU