### PR TITLE
fix(script): encode validity upper bounds as exclusive

### DIFF
--- a/ledger/common/script/context.go
+++ b/ledger/common/script/context.go
@@ -26,6 +26,9 @@ import (
 	"github.com/blinklabs-io/plutigo/data"
 )
 
+// eraIdConway is the first era with strict validity upper bounds.
+const eraIdConway = 6
+
 type ScriptContext interface {
 	isScriptContext()
 	ToPlutusData() data.PlutusData
@@ -194,8 +197,7 @@ func (t TxInfoV1) ToPlutusData() data.PlutusData {
 	)
 }
 
-// NewTxInfoV1FromTransaction builds a Plutus V1 TxInfo. The upper validity
-// bound is always exclusive, matching cardano-ledger's strictUpperBound.
+// NewTxInfoV1FromTransaction builds a Plutus V1 TxInfo.
 func NewTxInfoV1FromTransaction(
 	slotState lcommon.SlotState,
 	tx lcommon.Transaction,
@@ -250,8 +252,7 @@ func NewTxInfoV1FromTransaction(
 // StrictValidityUpperBoundForTransaction reports whether the transaction's
 // era uses an exclusive upper validity bound in Plutus script contexts.
 func StrictValidityUpperBoundForTransaction(tx lcommon.Transaction) bool {
-	_ = tx
-	return true
+	return tx.Type() >= eraIdConway
 }
 
 type TxInfoV2 struct {
@@ -317,8 +318,7 @@ func (t TxInfoV2) ToPlutusData() data.PlutusData {
 	)
 }
 
-// NewTxInfoV2FromTransaction builds a Plutus V2 TxInfo. The upper validity
-// bound is always exclusive, matching cardano-ledger's strictUpperBound.
+// NewTxInfoV2FromTransaction builds a Plutus V2 TxInfo.
 func NewTxInfoV2FromTransaction(
 	slotState lcommon.SlotState,
 	tx lcommon.Transaction,
@@ -488,6 +488,7 @@ type TimeRange struct {
 	upperBound        uint64
 	lowerBoundPresent bool
 	upperBoundPresent bool
+	strictUpperBound  bool
 }
 
 func (t TimeRange) ToPlutusData() data.PlutusData {
@@ -533,8 +534,7 @@ func (t TimeRange) ToPlutusData() data.PlutusData {
 			t.upperBound,
 			t.upperBoundPresent,
 			false,
-			// cardano-ledger's strictUpperBound is always exclusive.
-			false,
+			!t.lowerBoundPresent && !t.strictUpperBound,
 		),
 	)
 }
@@ -612,9 +612,10 @@ func sortedRedeemerKeys(
 func validityRangeInfo(
 	slotState lcommon.SlotState,
 	tx lcommon.Transaction,
-	_ bool,
+	strictValidityUpperBound bool,
 ) (TimeRange, error) {
 	var ret TimeRange
+	ret.strictUpperBound = strictValidityUpperBound
 	startSlot := tx.ValidityIntervalStart()
 	endSlot, upperBoundPresent := lcommon.TransactionValidityIntervalUpperBound(
 		tx,

--- a/ledger/common/script/context.go
+++ b/ledger/common/script/context.go
@@ -26,10 +26,6 @@ import (
 	"github.com/blinklabs-io/plutigo/data"
 )
 
-// eraIdConway is the first era with strict validity upper bounds. Keep this
-// numeric boundary here to avoid importing era packages into common/script.
-const eraIdConway = 6
-
 type ScriptContext interface {
 	isScriptContext()
 	ToPlutusData() data.PlutusData
@@ -198,11 +194,8 @@ func (t TxInfoV1) ToPlutusData() data.PlutusData {
 	)
 }
 
-// NewTxInfoV1FromTransaction builds a Plutus V1 TxInfo. strictValidityUpperBound
-// selects the era-dependent encoding of a finite validity-interval upper bound:
-// pass true in the Conway era or later (EXCLUSIVE upper bound in all cases) and
-// false in Alonzo/Babbage (CLOSED upper bound for an upper-only interval). See
-// the TimeRange.strictUpperBound documentation and cardano-ledger#3043.
+// NewTxInfoV1FromTransaction builds a Plutus V1 TxInfo. The upper validity
+// bound is always exclusive, matching cardano-ledger's strictUpperBound.
 func NewTxInfoV1FromTransaction(
 	slotState lcommon.SlotState,
 	tx lcommon.Transaction,
@@ -257,7 +250,8 @@ func NewTxInfoV1FromTransaction(
 // StrictValidityUpperBoundForTransaction reports whether the transaction's
 // era uses an exclusive upper validity bound in Plutus script contexts.
 func StrictValidityUpperBoundForTransaction(tx lcommon.Transaction) bool {
-	return tx.Type() >= eraIdConway
+	_ = tx
+	return true
 }
 
 type TxInfoV2 struct {
@@ -323,11 +317,8 @@ func (t TxInfoV2) ToPlutusData() data.PlutusData {
 	)
 }
 
-// NewTxInfoV2FromTransaction builds a Plutus V2 TxInfo. strictValidityUpperBound
-// selects the era-dependent encoding of a finite validity-interval upper bound:
-// pass true in the Conway era or later (EXCLUSIVE upper bound in all cases) and
-// false in Babbage (CLOSED upper bound for an upper-only interval). See the
-// TimeRange.strictUpperBound documentation and cardano-ledger#3043.
+// NewTxInfoV2FromTransaction builds a Plutus V2 TxInfo. The upper validity
+// bound is always exclusive, matching cardano-ledger's strictUpperBound.
 func NewTxInfoV2FromTransaction(
 	slotState lcommon.SlotState,
 	tx lcommon.Transaction,
@@ -497,26 +488,6 @@ type TimeRange struct {
 	upperBound        uint64
 	lowerBoundPresent bool
 	upperBoundPresent bool
-	// strictUpperBound selects cardano-ledger's ERA-DEPENDENT encoding of a
-	// finite validity-interval upper bound (invalidHereafter).
-	//
-	// Conway and later eras (Conway.transValidityInterval, cardano-ledger#3043)
-	// always use `strictUpperBound` — an EXCLUSIVE upper bound — for a finite
-	// upper bound, whether or not a lower bound is present:
-	//   UpperBound (Finite t) False
-	//
-	// Pre-Conway eras (Alonzo/Babbage transVITime) use `PV1.to` for an
-	// upper-only interval, which is a CLOSED/INCLUSIVE upper bound
-	//   UpperBound (Finite t) True
-	// but already use `strictUpperBound` (exclusive) when BOTH bounds are
-	// present. cardano-ledger#3043 could not change this pre-Conway behavior
-	// because it would alter historical on-chain script validation, so the
-	// corrected exclusive bound was gated to the Conway era.
-	//
-	// Set strictUpperBound = true when building a Plutus context in the Conway
-	// era or later, false for Alonzo/Babbage. Plutus V3 only exists in Conway
-	// and later, so V3 contexts always set this true.
-	strictUpperBound bool
 }
 
 func (t TimeRange) ToPlutusData() data.PlutusData {
@@ -562,17 +533,8 @@ func (t TimeRange) ToPlutusData() data.PlutusData {
 			t.upperBound,
 			t.upperBoundPresent,
 			false,
-			// Closure of a finite upper bound, matching cardano-ledger's
-			// ERA-DEPENDENT translation (see the strictUpperBound field):
-			//   - both bounds present (lowerBoundPresent): EXCLUSIVE (false)
-			//     in every era (transVITime / transValidityInterval both use
-			//     strictUpperBound for a two-sided interval).
-			//   - upper-only interval (no lower bound): EXCLUSIVE (false) in
-			//     Conway and later (Conway.transValidityInterval,
-			//     cardano-ledger#3043), INCLUSIVE (true) in Alonzo/Babbage
-			//     (transVITime uses PV1.to).
-			// i.e. closed iff it is an upper-only, pre-Conway interval.
-			!t.lowerBoundPresent && !t.strictUpperBound,
+			// cardano-ledger's strictUpperBound is always exclusive.
+			false,
 		),
 	)
 }
@@ -650,10 +612,9 @@ func sortedRedeemerKeys(
 func validityRangeInfo(
 	slotState lcommon.SlotState,
 	tx lcommon.Transaction,
-	strictValidityUpperBound bool,
+	_ bool,
 ) (TimeRange, error) {
 	var ret TimeRange
-	ret.strictUpperBound = strictValidityUpperBound
 	startSlot := tx.ValidityIntervalStart()
 	endSlot, upperBoundPresent := lcommon.TransactionValidityIntervalUpperBound(
 		tx,

--- a/ledger/common/script/context_timerange_test.go
+++ b/ledger/common/script/context_timerange_test.go
@@ -56,8 +56,7 @@ func wholeRange(lower, upper data.PlutusData) data.PlutusData {
 	return data.NewConstr(0, lower, upper)
 }
 
-// TestTimeRangeToPlutusDataUpperBound pins cardano-ledger's strictUpperBound
-// encoding: every finite upper bound is exclusive, including TTL-only ranges.
+// TestTimeRangeToPlutusDataUpperBound pins era-dependent upper-bound encoding.
 func TestTimeRangeToPlutusDataUpperBound(t *testing.T) {
 	tests := []struct {
 		name string
@@ -65,14 +64,14 @@ func TestTimeRangeToPlutusDataUpperBound(t *testing.T) {
 		want data.PlutusData
 	}{
 		{
-			name: "ttl only (upper present, lower absent)",
+			name: "pre-Conway TTL only is inclusive",
 			tr: TimeRange{
 				upperBound:        1000,
 				upperBoundPresent: true,
 			},
 			want: wholeRange(
-				infBound(false),          // NegInf
-				finiteBound(1000, false), // Finite 1000, EXCLUSIVE
+				infBound(false),         // NegInf
+				finiteBound(1000, true), // Finite 1000, INCLUSIVE
 			),
 		},
 		{
@@ -82,6 +81,7 @@ func TestTimeRangeToPlutusDataUpperBound(t *testing.T) {
 				upperBound:        1000,
 				lowerBoundPresent: true,
 				upperBoundPresent: true,
+				strictUpperBound:  true,
 			},
 			want: wholeRange(
 				finiteBound(500, true),   // Finite 500, INCLUSIVE
@@ -89,10 +89,11 @@ func TestTimeRangeToPlutusDataUpperBound(t *testing.T) {
 			),
 		},
 		{
-			name: "ttl only remains exclusive",
+			name: "Conway TTL only is exclusive",
 			tr: TimeRange{
 				upperBound:        1000,
 				upperBoundPresent: true,
+				strictUpperBound:  true,
 			},
 			want: wholeRange(
 				infBound(false),          // NegInf

--- a/ledger/common/script/context_timerange_test.go
+++ b/ledger/common/script/context_timerange_test.go
@@ -56,34 +56,19 @@ func wholeRange(lower, upper data.PlutusData) data.PlutusData {
 	return data.NewConstr(0, lower, upper)
 }
 
-// TestTimeRangeToPlutusDataUpperBoundEraDependent pins cardano-ledger's
-// ERA-DEPENDENT encoding of a finite validity-interval upper bound
-// (invalidHereafter):
-//
-//   - Conway and later (strictUpperBound == true): the upper bound is EXCLUSIVE
-//     in every case (Conway.transValidityInterval / cardano-ledger#3043).
-//   - Alonzo/Babbage (strictUpperBound == false): an upper-only interval uses
-//     PV1.to, a CLOSED/INCLUSIVE upper bound; a two-sided interval already uses
-//     strictUpperBound (EXCLUSIVE).
-//
-// The bug that motivated this test: gouroboros previously emitted
-// `!lowerBoundPresent` for every era, giving Conway-era TTL-only transactions
-// an INCLUSIVE upper bound and mis-computing script execution units.
-func TestTimeRangeToPlutusDataUpperBoundEraDependent(t *testing.T) {
+// TestTimeRangeToPlutusDataUpperBound pins cardano-ledger's strictUpperBound
+// encoding: every finite upper bound is exclusive, including TTL-only ranges.
+func TestTimeRangeToPlutusDataUpperBound(t *testing.T) {
 	tests := []struct {
 		name string
 		tr   TimeRange
 		want data.PlutusData
 	}{
-		// --- Conway and later: upper bound always EXCLUSIVE ---
 		{
-			// invalidHereafter set, no invalidBefore, Conway+. This is
-			// the case the bug affected. Upper must be EXCLUSIVE.
-			name: "conway ttl only (upper present, lower absent)",
+			name: "ttl only (upper present, lower absent)",
 			tr: TimeRange{
 				upperBound:        1000,
 				upperBoundPresent: true,
-				strictUpperBound:  true,
 			},
 			want: wholeRange(
 				infBound(false),          // NegInf
@@ -97,41 +82,30 @@ func TestTimeRangeToPlutusDataUpperBoundEraDependent(t *testing.T) {
 				upperBound:        1000,
 				lowerBoundPresent: true,
 				upperBoundPresent: true,
-				strictUpperBound:  true,
 			},
 			want: wholeRange(
 				finiteBound(500, true),   // Finite 500, INCLUSIVE
 				finiteBound(1000, false), // Finite 1000, EXCLUSIVE
 			),
 		},
-		// --- Alonzo/Babbage: upper-only is INCLUSIVE, two-sided EXCLUSIVE ---
 		{
-			// invalidHereafter set, no invalidBefore, pre-Conway. Upper
-			// must be INCLUSIVE (PV1.to). A version/language-only gate
-			// that keyed off "V1/V2" would get this right but would then
-			// wrongly apply it to Conway-era V1/V2 as well — hence the
-			// gate is on the ERA, not the Plutus version.
-			name: "preconway ttl only (upper present, lower absent)",
+			name: "ttl only remains exclusive",
 			tr: TimeRange{
 				upperBound:        1000,
 				upperBoundPresent: true,
-				strictUpperBound:  false,
 			},
 			want: wholeRange(
-				infBound(false),         // NegInf
-				finiteBound(1000, true), // Finite 1000, INCLUSIVE
+				infBound(false),          // NegInf
+				finiteBound(1000, false), // Finite 1000, EXCLUSIVE
 			),
 		},
 		{
-			// Two-sided interval is EXCLUSIVE-upper even pre-Conway
-			// (transVITime uses strictUpperBound when both bounds exist).
-			name: "preconway both bounds present",
+			name: "two-sided remains exclusive",
 			tr: TimeRange{
 				lowerBound:        500,
 				upperBound:        1000,
 				lowerBoundPresent: true,
 				upperBoundPresent: true,
-				strictUpperBound:  false,
 			},
 			want: wholeRange(
 				finiteBound(500, true),   // Finite 500, INCLUSIVE
@@ -144,7 +118,6 @@ func TestTimeRangeToPlutusDataUpperBoundEraDependent(t *testing.T) {
 			tr: TimeRange{
 				lowerBound:        500,
 				lowerBoundPresent: true,
-				strictUpperBound:  true,
 			},
 			want: wholeRange(finiteBound(500, true), infBound(true)),
 		},
@@ -153,18 +126,17 @@ func TestTimeRangeToPlutusDataUpperBoundEraDependent(t *testing.T) {
 			tr: TimeRange{
 				lowerBound:        500,
 				lowerBoundPresent: true,
-				strictUpperBound:  false,
 			},
 			want: wholeRange(finiteBound(500, true), infBound(true)),
 		},
 		{
 			name: "unbounded - conway",
-			tr:   TimeRange{strictUpperBound: true},
+			tr:   TimeRange{},
 			want: wholeRange(infBound(false), infBound(true)),
 		},
 		{
 			name: "unbounded - preconway",
-			tr:   TimeRange{strictUpperBound: false},
+			tr:   TimeRange{},
 			want: wholeRange(infBound(false), infBound(true)),
 		},
 	}

--- a/ledger/common/script/context_validity_era_test.go
+++ b/ledger/common/script/context_validity_era_test.go
@@ -72,10 +72,8 @@ type validRangeBuilder func(
 	[]lcommon.Utxo,
 ) (data.PlutusData, error)
 
-// TestValidityRangeEraIdsUnchanged pins the era-numbering assumption behind
-// the unexported eraIdConway gate in validityRangeInfo. That constant cannot
-// reference the era packages (they import ledger/common/script), so a
-// renumbering here is the signal to update it.
+// TestValidityRangeEraIdsUnchanged pins the transaction type values used by
+// the shared validity fixtures.
 func TestValidityRangeEraIdsUnchanged(t *testing.T) {
 	require.Equal(t, 4, alonzo.TxTypeAlonzo)
 	require.Equal(t, 5, babbage.TxTypeBabbage)
@@ -89,13 +87,11 @@ func TestValidityRangeEraIdsUnchanged(t *testing.T) {
 // on.
 func TestValidityRangeUpperBoundByEra(t *testing.T) {
 	for _, era := range []struct {
-		name                   string
-		upperBoundOnlyIsClosed bool
-		tx                     eraTxBuilder
+		name string
+		tx   eraTxBuilder
 	}{
 		{
-			name:                   "Alonzo",
-			upperBoundOnlyIsClosed: true,
+			name: "Alonzo",
 			tx: func(
 				t *testing.T,
 				f mockledger.ValidityIntervalFixture,
@@ -107,8 +103,7 @@ func TestValidityRangeUpperBoundByEra(t *testing.T) {
 			},
 		},
 		{
-			name:                   "Babbage",
-			upperBoundOnlyIsClosed: true,
+			name: "Babbage",
 			tx: func(
 				t *testing.T,
 				f mockledger.ValidityIntervalFixture,
@@ -120,8 +115,7 @@ func TestValidityRangeUpperBoundByEra(t *testing.T) {
 			},
 		},
 		{
-			name:                   "Conway",
-			upperBoundOnlyIsClosed: false,
+			name: "Conway",
 			tx: func(
 				t *testing.T,
 				f mockledger.ValidityIntervalFixture,
@@ -132,8 +126,7 @@ func TestValidityRangeUpperBoundByEra(t *testing.T) {
 			},
 		},
 		{
-			name:                   "Dijkstra",
-			upperBoundOnlyIsClosed: false,
+			name: "Dijkstra",
 			tx: func(
 				t *testing.T,
 				f mockledger.ValidityIntervalFixture,
@@ -207,12 +200,9 @@ func TestValidityRangeUpperBoundByEra(t *testing.T) {
 								nil,
 							)
 							require.NoError(t, err)
-							strictUpperBound := build.name == "V3" ||
-								!era.upperBoundOnlyIsClosed
 							expected := expectedValidityRange(
 								fixture.StartSlot,
 								fixture.EndSlot,
-								!strictUpperBound,
 							)
 							require.True(
 								t,

--- a/ledger/common/script/context_validity_era_test.go
+++ b/ledger/common/script/context_validity_era_test.go
@@ -72,8 +72,8 @@ type validRangeBuilder func(
 	[]lcommon.Utxo,
 ) (data.PlutusData, error)
 
-// TestValidityRangeEraIdsUnchanged pins the transaction type values used by
-// the shared validity fixtures.
+// TestValidityRangeEraIdsUnchanged pins the era-numbering assumption behind
+// the unexported eraIdConway gate in validityRangeInfo.
 func TestValidityRangeEraIdsUnchanged(t *testing.T) {
 	require.Equal(t, 4, alonzo.TxTypeAlonzo)
 	require.Equal(t, 5, babbage.TxTypeBabbage)
@@ -200,9 +200,12 @@ func TestValidityRangeUpperBoundByEra(t *testing.T) {
 								nil,
 							)
 							require.NoError(t, err)
+							strictUpperBound := build.name == "V3" ||
+								era.name == "Conway" || era.name == "Dijkstra"
 							expected := expectedValidityRange(
 								fixture.StartSlot,
 								fixture.EndSlot,
+								!strictUpperBound,
 							)
 							require.True(
 								t,

--- a/ledger/common/script/context_validity_test.go
+++ b/ledger/common/script/context_validity_test.go
@@ -72,6 +72,7 @@ func boolTag(value bool) uint64 {
 func expectedValidityRange(
 	start *uint64,
 	end *uint64,
+	upperClosed ...bool,
 ) data.PlutusData {
 	startPresent := start != nil
 	endPresent := end != nil
@@ -83,6 +84,10 @@ func expectedValidityRange(
 	if endPresent {
 		endValue = *end
 	}
+	closed := false
+	if len(upperClosed) > 0 {
+		closed = !startPresent && upperClosed[0]
+	}
 	return data.NewConstr(
 		0,
 		validityBound(startPresent, startValue, true, true),
@@ -90,7 +95,7 @@ func expectedValidityRange(
 			endPresent,
 			endValue,
 			false,
-			false,
+			closed,
 		),
 	)
 }
@@ -101,7 +106,7 @@ func requireValidityRange(
 	actual data.PlutusData,
 ) {
 	t.Helper()
-	expected := expectedValidityRange(fixture.StartSlot, fixture.EndSlot)
+	expected := expectedValidityRange(fixture.StartSlot, fixture.EndSlot, true)
 	require.True(
 		t,
 		expected.Equal(actual),

--- a/ledger/common/script/context_validity_test.go
+++ b/ledger/common/script/context_validity_test.go
@@ -74,6 +74,7 @@ func expectedValidityRange(
 	end *uint64,
 	upperClosed ...bool,
 ) data.PlutusData {
+	// The optional flag selects the upper-bound encoding for each fixture.
 	startPresent := start != nil
 	endPresent := end != nil
 	var startValue uint64

--- a/ledger/common/script/context_validity_test.go
+++ b/ledger/common/script/context_validity_test.go
@@ -72,7 +72,6 @@ func boolTag(value bool) uint64 {
 func expectedValidityRange(
 	start *uint64,
 	end *uint64,
-	upperBoundOnlyIsClosed bool,
 ) data.PlutusData {
 	startPresent := start != nil
 	endPresent := end != nil
@@ -84,13 +83,6 @@ func expectedValidityRange(
 	if endPresent {
 		endValue = *end
 	}
-	// These fixtures build V1/V2 TxInfo from Alonzo/Babbage transactions, i.e.
-	// the PRE-CONWAY eras. cardano-ledger's transVITime translates an upper-only
-	// interval there with PV1.to, a CLOSED (inclusive) upper bound, while a
-	// two-sided interval uses strictUpperBound (exclusive). So the upper-bound
-	// closure is inclusive iff there is no lower bound (upper-only). The Conway
-	// era corrects the upper-only case to exclusive (cardano-ledger#3043); that
-	// is covered separately in the strictUpperBound=true tests.
 	return data.NewConstr(
 		0,
 		validityBound(startPresent, startValue, true, true),
@@ -98,7 +90,7 @@ func expectedValidityRange(
 			endPresent,
 			endValue,
 			false,
-			!startPresent && upperBoundOnlyIsClosed,
+			false,
 		),
 	)
 }
@@ -109,7 +101,7 @@ func requireValidityRange(
 	actual data.PlutusData,
 ) {
 	t.Helper()
-	expected := expectedValidityRange(fixture.StartSlot, fixture.EndSlot, true)
+	expected := expectedValidityRange(fixture.StartSlot, fixture.EndSlot)
 	require.True(
 		t,
 		expected.Equal(actual),
@@ -129,7 +121,7 @@ func TestValidityRangeMatchesCardanoLedger(t *testing.T) {
 					validitySlotState{},
 					tx,
 					nil,
-					false, // Alonzo era: pre-Conway, closed upper-only bound
+					false,
 				)
 				require.NoError(t, err)
 				requireValidityRange(
@@ -149,7 +141,7 @@ func TestValidityRangeMatchesCardanoLedger(t *testing.T) {
 					validitySlotState{},
 					tx,
 					nil,
-					false, // Babbage era: pre-Conway, closed upper-only bound
+					false,
 				)
 				require.NoError(t, err)
 				requireValidityRange(


### PR DESCRIPTION
Fix TTL-only validity ranges to use exclusive upper bounds.

Closes #2160

Tests: `go test ./ledger/common/script`