### PR TITLE
fix(ledger): reject untagged duplicate sets

### DIFF
--- a/cbor/tags.go
+++ b/cbor/tags.go
@@ -265,6 +265,17 @@ func (t *SetType[T]) CheckForDuplicates() error {
 	if !t.useTag {
 		return nil
 	}
+	return t.checkForDuplicates()
+}
+
+// CheckForDuplicatesAlways rejects duplicate members regardless of the
+// optional tag-258 wrapper. Conway and later decoders require this for all
+// set encodings.
+func (t *SetType[T]) CheckForDuplicatesAlways() error {
+	return t.checkForDuplicates()
+}
+
+func (t *SetType[T]) checkForDuplicates() error {
 	seen := make(map[string]struct{}, len(t.items))
 	for _, item := range t.items {
 		encoded, err := Encode(item)

--- a/cbor/tags_test.go
+++ b/cbor/tags_test.go
@@ -312,6 +312,7 @@ func TestSetTypeTaggedItemsRetainDuplicates(t *testing.T) {
 
 func TestSetTypeAlwaysRejectsUntaggedDuplicates(t *testing.T) {
 	setType := cbor.NewSetType([]uint64{1, 2, 1}, false)
+	assert.NoError(t, setType.CheckForDuplicates())
 	assert.ErrorContains(t, setType.CheckForDuplicatesAlways(), "duplicate member in set")
 }
 

--- a/cbor/tags_test.go
+++ b/cbor/tags_test.go
@@ -310,6 +310,11 @@ func TestSetTypeTaggedItemsRetainDuplicates(t *testing.T) {
 	assert.ErrorContains(t, setType.CheckForDuplicates(), "duplicate member in set")
 }
 
+func TestSetTypeAlwaysRejectsUntaggedDuplicates(t *testing.T) {
+	setType := cbor.NewSetType([]uint64{1, 2, 1}, false)
+	assert.ErrorContains(t, setType.CheckForDuplicatesAlways(), "duplicate member in set")
+}
+
 func TestSetTypeMarshalCBOR(t *testing.T) {
 	// Create SetType with tag
 	setType := cbor.NewSetType([]uint64{1, 2, 3}, true)

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -566,6 +566,9 @@ func (s *ConwayTransactionInputSet) UnmarshalCBOR(data []byte) error {
 }
 
 func (s *ConwayTransactionInputSet) CheckForDuplicates() error {
+	if !s.useSet {
+		return nil
+	}
 	return s.checkForDuplicates()
 }
 

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -480,17 +480,17 @@ func (w *ConwayTransactionWitnessSet) UnmarshalCBOR(cborData []byte) error {
 	// (cardano-ledger scriptDecoderV9 / decodeMapLikeEnforceNoDuplicates), like
 	// the tx-body sets. Only enforce the fields cardano-ledger enforces in
 	// Conway; enforcing the tolerated fields rejects valid historical blocks at
-	// decode (issue #1853). Untagged array fields are left unchecked so
-	// pre-Conway encodings remain valid.
+	// decode (issue #1853). The checked Plutus script sets reject duplicates in
+	// both tagged and untagged encodings.
 	type duplicateChecker interface {
-		CheckForDuplicates() error
+		CheckForDuplicatesAlways() error
 	}
 	for _, c := range []duplicateChecker{
 		&tmp.WsPlutusV1Scripts,
 		&tmp.WsPlutusV2Scripts,
 		&tmp.WsPlutusV3Scripts,
 	} {
-		if err := c.CheckForDuplicates(); err != nil {
+		if err := c.CheckForDuplicatesAlways(); err != nil {
 			return err
 		}
 	}
@@ -566,9 +566,14 @@ func (s *ConwayTransactionInputSet) UnmarshalCBOR(data []byte) error {
 }
 
 func (s *ConwayTransactionInputSet) CheckForDuplicates() error {
-	if !s.useSet {
-		return nil
-	}
+	return s.checkForDuplicates()
+}
+
+func (s *ConwayTransactionInputSet) CheckForDuplicatesAlways() error {
+	return s.checkForDuplicates()
+}
+
+func (s *ConwayTransactionInputSet) checkForDuplicates() error {
 	seen := make(map[string]struct{}, len(s.items))
 	for _, item := range s.items {
 		encoded, err := cbor.Encode(item)
@@ -656,9 +661,10 @@ func (b *ConwayTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	if err := common.ValidateCertificateSet(tmp.TxCertificates); err != nil {
 		return err
 	}
-	// Reject duplicate members in any tag-258 set field on the transaction body.
+	// Reject duplicate members in every Conway set encoding, including
+	// untagged arrays.
 	type duplicateChecker interface {
-		CheckForDuplicates() error
+		CheckForDuplicatesAlways() error
 	}
 	for _, c := range []duplicateChecker{
 		&tmp.TxInputs,
@@ -666,7 +672,7 @@ func (b *ConwayTransactionBody) UnmarshalCBOR(cborData []byte) error {
 		&tmp.TxRequiredSigners,
 		&tmp.TxReferenceInputs,
 	} {
-		if err := c.CheckForDuplicates(); err != nil {
+		if err := c.CheckForDuplicatesAlways(); err != nil {
 			return err
 		}
 	}

--- a/ledger/conway/conway_test.go
+++ b/ledger/conway/conway_test.go
@@ -127,6 +127,20 @@ func TestConwayRedeemersIter(t *testing.T) {
 	}
 }
 
+func TestConwayTransactionInputSetConditionalDuplicateCheck(t *testing.T) {
+	input := shelley.NewShelleyTransactionInput(
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		0,
+	)
+	encoded, err := cbor.Encode([]shelley.ShelleyTransactionInput{input, input})
+	require.NoError(t, err)
+
+	var inputSet ConwayTransactionInputSet
+	_, err = cbor.Decode(encoded, &inputSet)
+	require.NoError(t, err)
+	require.NoError(t, inputSet.CheckForDuplicates())
+}
+
 func TestConwayTransactionBodyUnmarshalCBORCertificateTypes(t *testing.T) {
 	testCases := []struct {
 		name            string

--- a/ledger/conway/conway_test.go
+++ b/ledger/conway/conway_test.go
@@ -433,7 +433,7 @@ func TestConwayTransactionMarshalRejectsNegativeCurrentTreasuryValue(
 	require.ErrorContains(t, err, "current treasury value")
 }
 
-func TestConwayUntaggedInputSetsRetainDuplicatesForValidation(t *testing.T) {
+func TestConwayRejectsDuplicateUntaggedInputSets(t *testing.T) {
 	input := testConwayShelleyInput()
 	tests := []struct {
 		name  string
@@ -454,14 +454,7 @@ func TestConwayUntaggedInputSetsRetainDuplicatesForValidation(t *testing.T) {
 			require.NoError(t, err)
 
 			var body ConwayTransactionBody
-			require.NoError(t, body.UnmarshalCBOR(bodyCbor))
-			tx := &ConwayTransaction{Body: body}
-			require.Error(t, shelley.UtxoValidateNoDuplicateInputs(
-				tx,
-				0,
-				nil,
-				nil,
-			))
+			require.ErrorContains(t, body.UnmarshalCBOR(bodyCbor), "duplicate member in set")
 		})
 	}
 }

--- a/ledger/dijkstra/dijkstra.go
+++ b/ledger/dijkstra/dijkstra.go
@@ -677,7 +677,7 @@ func (g *DijkstraGuards) UnmarshalCBOR(cborData []byte) error {
 	g.SetCbor(cborData)
 	var credentials cbor.SetType[common.Credential]
 	if _, err := cbor.Decode(cborData, &credentials); err == nil {
-		if err := credentials.CheckForDuplicates(); err != nil {
+		if err := credentials.CheckForDuplicatesAlways(); err != nil {
 			return err
 		}
 		if len(credentials.Items()) == 0 {
@@ -691,7 +691,7 @@ func (g *DijkstraGuards) UnmarshalCBOR(cborData []byte) error {
 	if _, err := cbor.Decode(cborData, &keyHashes); err != nil {
 		return err
 	}
-	if err := keyHashes.CheckForDuplicates(); err != nil {
+	if err := keyHashes.CheckForDuplicatesAlways(); err != nil {
 		return err
 	}
 	if len(keyHashes.Items()) == 0 {
@@ -770,9 +770,10 @@ func (b *DijkstraTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	if err := common.ValidateCertificateSet(tmp.TxCertificates); err != nil {
 		return err
 	}
-	// Reject duplicate members in any tag-258 set field on the transaction body.
+	// Reject duplicate members in every Dijkstra set encoding, including
+	// untagged arrays.
 	type duplicateChecker interface {
-		CheckForDuplicates() error
+		CheckForDuplicatesAlways() error
 	}
 	for _, c := range []duplicateChecker{
 		&tmp.TxInputs,
@@ -780,7 +781,7 @@ func (b *DijkstraTransactionBody) UnmarshalCBOR(cborData []byte) error {
 		&tmp.TxReferenceInputs,
 		&tmp.TxSubTransactions,
 	} {
-		if err := c.CheckForDuplicates(); err != nil {
+		if err := c.CheckForDuplicatesAlways(); err != nil {
 			return err
 		}
 	}
@@ -1082,10 +1083,10 @@ func (b *DijkstraSubTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	if err := common.ValidateCertificateSet(tmp.TxCertificates); err != nil {
 		return err
 	}
-	if err := tmp.TxInputs.CheckForDuplicates(); err != nil {
+	if err := tmp.TxInputs.CheckForDuplicatesAlways(); err != nil {
 		return err
 	}
-	if err := tmp.TxReferenceInputs.CheckForDuplicates(); err != nil {
+	if err := tmp.TxReferenceInputs.CheckForDuplicatesAlways(); err != nil {
 		return err
 	}
 	if err := checkMultiAssetDuplicateKeys(tmp.TxMint); err != nil {
@@ -1295,10 +1296,10 @@ func (w *DijkstraTransactionWitnessSet) UnmarshalCBOR(cborData []byte) error {
 	if _, err := cbor.Decode(cborData, &tmp); err != nil {
 		return err
 	}
-	// Reject duplicate members in any tag-258 witness set field.
-	// Untagged array fields are left unchecked so pre-Dijkstra encodings remain valid.
+	// Reject duplicate members in every Dijkstra witness-set encoding, including
+	// untagged arrays.
 	type duplicateChecker interface {
-		CheckForDuplicates() error
+		CheckForDuplicatesAlways() error
 	}
 	for _, c := range []duplicateChecker{
 		&tmp.VkeyWitnesses,
@@ -1310,7 +1311,7 @@ func (w *DijkstraTransactionWitnessSet) UnmarshalCBOR(cborData []byte) error {
 		&tmp.WsPlutusV3Scripts,
 		&tmp.WsPlutusV4Scripts,
 	} {
-		if err := c.CheckForDuplicates(); err != nil {
+		if err := c.CheckForDuplicatesAlways(); err != nil {
 			return err
 		}
 	}
@@ -1816,7 +1817,7 @@ func decodeInvalidTransactions(raw cbor.RawMessage) ([]uint, error) {
 	if _, err := cbor.Decode(raw, &txIndices); err != nil {
 		return nil, fmt.Errorf("decode Dijkstra invalid transactions: %w", err)
 	}
-	if err := txIndices.CheckForDuplicates(); err != nil {
+	if err := txIndices.CheckForDuplicatesAlways(); err != nil {
 		return nil, fmt.Errorf("decode Dijkstra invalid transactions: %w", err)
 	}
 	items := txIndices.Items()

--- a/ledger/dijkstra/dijkstra.go
+++ b/ledger/dijkstra/dijkstra.go
@@ -785,6 +785,9 @@ func (b *DijkstraTransactionBody) UnmarshalCBOR(cborData []byte) error {
 			return err
 		}
 	}
+	if err := checkDuplicateProposalProcedures(tmp.TxProposalProcedures); err != nil {
+		return err
+	}
 	if err := checkMultiAssetDuplicateKeys(tmp.TxMint); err != nil {
 		return err
 	}
@@ -1089,6 +1092,9 @@ func (b *DijkstraSubTransactionBody) UnmarshalCBOR(cborData []byte) error {
 	if err := tmp.TxReferenceInputs.CheckForDuplicatesAlways(); err != nil {
 		return err
 	}
+	if err := checkDuplicateProposalProcedures(tmp.TxProposalProcedures); err != nil {
+		return err
+	}
 	if err := checkMultiAssetDuplicateKeys(tmp.TxMint); err != nil {
 		return err
 	}
@@ -1104,6 +1110,24 @@ func (b *DijkstraSubTransactionBody) UnmarshalCBOR(cborData []byte) error {
 		return err
 	}
 	b.SetCborReference(cborData)
+	return nil
+}
+
+func checkDuplicateProposalProcedures(
+	proposalProcedures []DijkstraProposalProcedure,
+) error {
+	seen := make(map[string]struct{}, len(proposalProcedures))
+	for _, procedure := range proposalProcedures {
+		encoded, err := cbor.Encode(procedure)
+		if err != nil {
+			return err
+		}
+		key := string(encoded)
+		if _, exists := seen[key]; exists {
+			return errors.New("duplicate member in set")
+		}
+		seen[key] = struct{}{}
+	}
 	return nil
 }
 

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -797,7 +797,7 @@ func TestDijkstraTransactionBodyRejectsDuplicateTaggedInputSets(t *testing.T) {
 	}
 }
 
-func TestDijkstraUntaggedInputSetsRetainDuplicatesForValidation(t *testing.T) {
+func TestDijkstraRejectsDuplicateUntaggedInputSets(t *testing.T) {
 	input := testShelleyInput()
 	for _, tt := range []struct {
 		name  string
@@ -817,14 +817,7 @@ func TestDijkstraUntaggedInputSetsRetainDuplicatesForValidation(t *testing.T) {
 			require.NoError(t, err)
 
 			var body DijkstraTransactionBody
-			require.NoError(t, body.UnmarshalCBOR(bodyCbor))
-			tx := &DijkstraTransaction{Body: body}
-			require.Error(t, shelley.UtxoValidateNoDuplicateInputs(
-				tx,
-				0,
-				nil,
-				nil,
-			))
+			require.ErrorContains(t, body.UnmarshalCBOR(bodyCbor), "duplicate member in set")
 		})
 	}
 }
@@ -914,19 +907,17 @@ func TestDijkstraTransactionBodyRejectsDuplicateKeyHashGuards(t *testing.T) {
 	require.ErrorContains(t, err, "duplicate member in set")
 }
 
-func TestDijkstraWitnessSetAllowsDuplicateUntaggedVkeyWitness(t *testing.T) {
-	// Untagged arrays (no tag 258) are not checked for duplicates so that
-	// pre-Dijkstra encodings decoded via this path remain accepted.
+func TestDijkstraWitnessSetRejectsDuplicateUntaggedVkeyWitness(t *testing.T) {
 	dupCbor := []byte{
 		0xa1, // map(1)
 		0x00, // key: 0  (VkeyWitnesses field)
 		// plain array — no tag 258
 		0x82,                         // array(2)
 		0x82, 0x41, 0x01, 0x41, 0x02, // VkeyWitness{[0x01], [0x02]}
-		0x82, 0x41, 0x01, 0x41, 0x02, // duplicate — must NOT be rejected
+		0x82, 0x41, 0x01, 0x41, 0x02, // duplicate
 	}
 	var ws DijkstraTransactionWitnessSet
-	require.NoError(t, ws.UnmarshalCBOR(dupCbor))
+	require.ErrorContains(t, ws.UnmarshalCBOR(dupCbor), "duplicate member in set")
 }
 
 func TestDijkstraBlockDecodesRedeemerWitnessMap(t *testing.T) {

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -868,6 +868,44 @@ func TestDijkstraTransactionBodyRejectsDuplicateSubTransactionReferenceInputs(
 	require.ErrorContains(t, err, "duplicate member in set")
 }
 
+func TestDijkstraRejectsDuplicateProposalProcedures(t *testing.T) {
+	rewardAccount, err := common.NewAddress(
+		"addr1vx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers66hrl8",
+	)
+	require.NoError(t, err)
+	action, err := common.NewInfoGovAction()
+	require.NoError(t, err)
+	procedure := DijkstraProposalProcedure{
+		PPRewardAccount: rewardAccount,
+		PPGovAction: DijkstraGovAction{
+			Action: action,
+		},
+	}
+	for _, tt := range []struct {
+		name  string
+		field uint
+	}{
+		{name: "transaction body", field: 20},
+		{name: "subtransaction body", field: 20},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			bodyCbor, err := cbor.Encode(map[uint]any{
+				tt.field: []DijkstraProposalProcedure{procedure, procedure},
+			})
+			require.NoError(t, err)
+
+			if tt.name == "transaction body" {
+				var body DijkstraTransactionBody
+				err = body.UnmarshalCBOR(bodyCbor)
+			} else {
+				var body DijkstraSubTransactionBody
+				err = body.UnmarshalCBOR(bodyCbor)
+			}
+			require.ErrorContains(t, err, "duplicate member in set")
+		})
+	}
+}
+
 func testShelleyInput() shelley.ShelleyTransactionInput {
 	var txId common.Blake2b256
 	txId[0] = 1


### PR DESCRIPTION
Reject duplicate members in Conway and Dijkstra set encodings even when the optional tag 258 wrapper is absent.

Preserves pre-Conway permissive decoding and adds regression coverage for untagged transaction, witness, guard, and set values.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects duplicate members in Conway and Dijkstra set encodings even when the optional tag-258 wrapper is absent.

**Bug Fixes**
- Previously only tagged sets were checked; untagged duplicates are now rejected at decode across transaction bodies, witness sets, guards, and invalid-transaction indices.
- Dijkstra transaction and subtransaction bodies also reject duplicate proposal procedures.
- Pre-Conway decoding remains permissive; only Conway and Dijkstra enforce the stricter checks.

<sup>Written for commit 82b6a5fd31204d5bb7c5f11211f384fa83a54066. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate members are now rejected when decoding untagged as well as tagged set encodings.
  * Conway and Dijkstra transaction inputs, collateral, reference inputs, witnesses, credentials, and related sets now consistently fail decoding when duplicates are present.
  * Added an option to always validate set duplicates, including untagged arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->