### PR TITLE
fix(consensus): preserve leader threshold boundaries

### DIFF
--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -32,7 +32,7 @@ type LeaderElectionResult struct {
 	Proof []byte
 	// Output is the VRF output (nil only on early-return cases like zero stake)
 	Output []byte
-	// Threshold is the leadership threshold that was used
+	// Threshold is the integer comparison threshold ceil(T) that was used
 	Threshold *big.Int
 }
 

--- a/consensus/leader_test.go
+++ b/consensus/leader_test.go
@@ -28,6 +28,18 @@ import (
 // Test seed (exactly 32 bytes)
 var testVRFSeed = []byte("test_vrf_seed_for_consensus!!!!!")
 
+type fixedOutputVRFSigner struct {
+	output []byte
+}
+
+func (s fixedOutputVRFSigner) Prove([]byte) ([]byte, []byte, error) {
+	return make([]byte, 80), append([]byte(nil), s.output...), nil
+}
+
+func (fixedOutputVRFSigner) PublicKey() []byte {
+	return make([]byte, 32)
+}
+
 func TestNewSimpleVRFSigner(t *testing.T) {
 	signer, err := NewSimpleVRFSigner(testVRFSeed)
 	require.NoError(t, err, "NewSimpleVRFSigner failed")
@@ -81,6 +93,100 @@ func TestIsSlotLeader(t *testing.T) {
 	}
 	if result.Eligible && (result.Proof == nil || result.Output == nil) {
 		t.Error("if eligible, proof and output should not be nil")
+	}
+}
+
+func TestIsSlotLeaderWithModeRealThresholdBoundaries(t *testing.T) {
+	vrfOutput := make([]byte, 64)
+	vrfOutput[0] = 0x40
+	vrfOutput[63] = 0x01
+	signer := fixedOutputVRFSigner{output: vrfOutput}
+
+	modes := []struct {
+		name       string
+		mode       ConsensusMode
+		upperBound *big.Int
+		leader     *big.Int
+	}{
+		{
+			name:       "CPraos",
+			mode:       ConsensusModeCPraos,
+			upperBound: twoTo256,
+			leader:     new(big.Int).SetBytes(VrfLeaderValue(vrfOutput)),
+		},
+		{
+			name:       "TPraos",
+			mode:       ConsensusModeTPraos,
+			upperBound: twoTo512,
+			leader:     new(big.Int).SetBytes(vrfOutput),
+		},
+	}
+
+	for _, mode := range modes {
+		t.Run(mode.name, func(t *testing.T) {
+			require.Positive(t, mode.leader.Sign())
+			require.Negative(t, mode.leader.Cmp(mode.upperBound))
+
+			cases := []struct {
+				name              string
+				cutoffNumerator   *big.Int
+				cutoffDenominator *big.Int
+				wantThreshold     *big.Int
+				wantEligible      bool
+			}{
+				{
+					name: "below-fractional-cutoff",
+					cutoffNumerator: new(big.Int).Add(
+						new(big.Int).Mul(mode.leader, big.NewInt(2)),
+						big.NewInt(1),
+					),
+					cutoffDenominator: big.NewInt(2),
+					wantThreshold:     new(big.Int).Add(mode.leader, big.NewInt(1)),
+					wantEligible:      true,
+				},
+				{
+					name:              "equal-integral-cutoff",
+					cutoffNumerator:   new(big.Int).Set(mode.leader),
+					cutoffDenominator: big.NewInt(1),
+					wantThreshold:     new(big.Int).Set(mode.leader),
+					wantEligible:      false,
+				},
+				{
+					name: "above-fractional-cutoff",
+					cutoffNumerator: new(big.Int).Sub(
+						new(big.Int).Mul(mode.leader, big.NewInt(2)),
+						big.NewInt(1),
+					),
+					cutoffDenominator: big.NewInt(2),
+					wantThreshold:     new(big.Int).Set(mode.leader),
+					wantEligible:      false,
+				},
+			}
+
+			for _, tc := range cases {
+				t.Run(tc.name, func(t *testing.T) {
+					// With full stake, the real-valued leadership cutoff is
+					// upperBound*f. Construct f so the fixed leader value is
+					// immediately below, exactly at, or immediately above it.
+					f := new(big.Rat).SetFrac(
+						tc.cutoffNumerator,
+						new(big.Int).Mul(mode.upperBound, tc.cutoffDenominator),
+					)
+					result, err := IsSlotLeaderWithMode(
+						42,
+						make([]byte, 32),
+						1,
+						1,
+						f,
+						signer,
+						mode.mode,
+					)
+					require.NoError(t, err)
+					require.Equal(t, tc.wantThreshold, result.Threshold)
+					require.Equal(t, tc.wantEligible, result.Eligible)
+				})
+			}
+		})
 	}
 }
 

--- a/consensus/threshold.go
+++ b/consensus/threshold.go
@@ -79,9 +79,9 @@ var bigIntOne = big.NewInt(1)
 //   - f is the active slot coefficient (e.g., 0.05 on mainnet)
 //   - σ = poolStake / totalStake (the pool's relative stake)
 //
-// If the VRF leader value (BLAKE2b-256 hash of VRF output with "L" prefix,
-// interpreted as an unsigned integer) is less than T, the pool is eligible
-// to be a slot leader.
+// The returned integer is ceil(T). Comparing an integer VRF leader value to
+// that threshold with "<" is therefore exactly equivalent to comparing it to
+// the real-valued cutoff T, including when T is not an integer.
 //
 // This implementation uses arbitrary precision arithmetic to match
 // Cardano's ledger specification.
@@ -127,7 +127,9 @@ func CertifiedNatThreshold(
 //
 //	T = 2^512 * (1 - (1-f)^σ)
 //
-// Returns an error if the consensus mode is unknown.
+// The returned integer is ceil(T), preserving the real-valued strict
+// comparison when used with an integer VRF leader value. Returns an error if
+// the consensus mode is unknown.
 func CertifiedNatThresholdWithMode(
 	poolStake uint64,
 	totalStake uint64,
@@ -217,7 +219,7 @@ func CertifiedNatThresholdWithMode(
 	// General case: (1-f)^sigma is generically irrational, so compute it
 	// via the range-reduced ln/exp pipeline with a rigorously bounded
 	// error, escalating precision if the resulting interval straddles an
-	// integer boundary closely enough that floor(probability*upperBound)
+	// integer boundary closely enough that ceil(probability*upperBound)
 	// cannot yet be determined unambiguously. This never runs the
 	// pipeline more than once per precision level (see
 	// oneMinusFPowerSigmaBounds), so the common, well-separated-from-any-
@@ -237,7 +239,8 @@ func CertifiedNatThresholdWithMode(
 // precision-escalation loop for the general (non-exact-rational) case:
 // starting at startBits, it repeatedly widens the accuracy target passed
 // to thresholdFromBoundedProbability until either the resulting interval
-// resolves to a single integer floor (the provably correct threshold), or
+// resolves to a single integer ceiling (the provably correct comparison
+// threshold), or
 // targetBits reaches capBits without resolving.
 //
 // Reaching the cap without resolving does NOT fall back to returning the
@@ -464,8 +467,8 @@ func exactOneMinusFPowerSigma(
 
 // exactOneMinusFPowerSigmaThreshold attempts the exact-rational fast path
 // (see exactOneMinusFPowerSigma) and, if successful, returns the exact
-// integer threshold floor(upperBound * (1-(1-f)^sigma)) computed via
-// integer arithmetic alone.
+// integer comparison threshold ceil(upperBound * (1-(1-f)^sigma)) computed
+// via integer arithmetic alone.
 func exactOneMinusFPowerSigmaThreshold(
 	oneMinusF *big.Rat,
 	poolStake, totalStake uint64,
@@ -476,19 +479,31 @@ func exactOneMinusFPowerSigmaThreshold(
 		return nil, false
 	}
 	probabilityExact := new(big.Rat).Sub(bigRatOne, powerExact)
-	threshold := new(big.Int).Mul(upperBound, probabilityExact.Num())
-	threshold.Quo(threshold, probabilityExact.Denom())
+	thresholdNumerator := new(big.Int).Mul(
+		upperBound,
+		probabilityExact.Num(),
+	)
+	threshold := new(big.Int)
+	remainder := new(big.Int)
+	threshold.QuoRem(
+		thresholdNumerator,
+		probabilityExact.Denom(),
+		remainder,
+	)
+	if remainder.Sign() != 0 {
+		threshold.Add(threshold, bigIntOne)
+	}
 	return threshold, true
 }
 
 // thresholdFromBoundedProbability computes rigorous lower/upper bounds on
-// the true integer threshold floor(upperBound*(1-(1-f)^sigma)) at the given
-// targetBits of accuracy (see oneMinusFPowerSigmaBounds), and reports
-// whether they agree (in which case the shared value is provably the
-// correct threshold). If they disagree, the caller should retry at a
-// higher targetBits; the returned threshold in that case is the (not yet
-// proven correct) lower bound. escalateThreshold discards this
-// not-yet-proven value rather than returning it once its own escalation
+// the true integer comparison threshold
+// ceil(upperBound*(1-(1-f)^sigma)) at the given targetBits of accuracy (see
+// oneMinusFPowerSigmaBounds), and reports whether they agree (in which case
+// the shared value is provably the correct threshold). If they disagree, the
+// caller should retry at a higher targetBits; the returned threshold in that
+// case is the (not yet proven correct) lower bound. escalateThreshold discards
+// this not-yet-proven value rather than returning it once its own escalation
 // cap is reached -- see that function's doc comment.
 func thresholdFromBoundedProbability(
 	oneMinusF *big.Rat,
@@ -521,10 +536,19 @@ func thresholdFromBoundedProbability(
 		upperBoundFloat,
 	)
 
-	thresholdLo, _ := thresholdLoFloat.Int(nil)
-	thresholdHi, _ := thresholdHiFloat.Int(nil)
+	thresholdLo := ceilBigFloat(thresholdLoFloat)
+	thresholdHi := ceilBigFloat(thresholdHiFloat)
 
 	return thresholdLo, thresholdLo.Cmp(thresholdHi) == 0
+}
+
+// ceilBigFloat returns the least integer greater than or equal to x.
+func ceilBigFloat(x *big.Float) *big.Int {
+	ret, accuracy := x.Int(nil)
+	if accuracy == big.Below {
+		ret.Add(ret, bigIntOne)
+	}
+	return ret
 }
 
 // oneMinusFPowerSigmaBounds computes conservative lower/upper bounds

--- a/consensus/threshold_boundary_test.go
+++ b/consensus/threshold_boundary_test.go
@@ -48,14 +48,10 @@ import (
 // are extremely close to 1 (e.g. f=(2^2000-1)/2^2000, used by
 // TestCertifiedNatThresholdNearOneDenominatorPrecisionLoss in
 // threshold_test.go): doing so requires refPrec on the order of 2000+
-// mantissa bits, at which point refFindE/refLncf's own accumulated
-// rounding pushes exact-rational cutoffs (like the sigma=1, f=0.5 case
-// below) across their integer boundary in the opposite direction --
-// i.e. this reference implementation has exactly the same class of
-// precision sensitivity that this file's regression tests exist to catch
-// in the *production* code, just triggered at a different threshold. The
-// near-one denominator case is therefore exercised only via the
-// production-only exact-value assertions in threshold_test.go, not here.
+// mantissa bits, at which point refFindE/refLncf's accumulated rounding can
+// cross an integer boundary. Exact-rational cutoffs and the near-one
+// denominator case are therefore exercised by exact-value assertions in
+// threshold_test.go instead of this approximate differential reference.
 const refPrec = 2048
 
 // refSeriesTerms bounds the reference continued-fraction/Taylor loops.
@@ -258,8 +254,9 @@ func refLn(x *big.Float) *big.Float {
 	return new(big.Float).SetPrec(prec).Add(nFloat, refLncf(xPrime))
 }
 
-// refThreshold independently computes floor(upperBound * (1-(1-f)^sigma))
-// using refLn/refExp instead of threshold.go's lnOneMinusFloat/expFloat.
+// refThreshold independently computes the integer comparison threshold
+// ceil(upperBound * (1-(1-f)^sigma)) using refLn/refExp instead of
+// threshold.go's lnOneMinusFloat/expFloat.
 func refThreshold(
 	poolStake, totalStake uint64,
 	f *big.Rat,
@@ -286,7 +283,10 @@ func refThreshold(
 		probability,
 		upperBoundFloat,
 	)
-	threshold, _ := thresholdFloat.Int(nil)
+	threshold, accuracy := thresholdFloat.Int(nil)
+	if accuracy == big.Below {
+		threshold.Add(threshold, big.NewInt(1))
+	}
 	return threshold
 }
 
@@ -362,7 +362,7 @@ func TestCertifiedNatThresholdDifferentialAgainstIndependentReference(
 
 						// The two implementations use entirely different
 						// series/range-reduction strategies, so an exact
-						// floor() match is not guaranteed to the very last
+						// ceiling match is not guaranteed to the very last
 						// ULP in pathological cases -- but any real
 						// approximation bug shows up as a large relative
 						// error, not an off-by-a-few-integers rounding
@@ -385,12 +385,12 @@ func TestCertifiedNatThresholdDifferentialAgainstIndependentReference(
 
 // TestLeaderEligibilityBoundaryAgainstIndependentReference checks
 // certified-nat values immediately below, at, and immediately above the
-// true (independently computed) eligibility cutoff, for both TPraos and
+// independently computed integer comparison threshold, for both TPraos and
 // CPraos modes and several active slot coefficients/stake ratios. The
 // eligibility rule is a strict "<" comparison against the threshold, so:
-//   - cutoff-1 must be eligible (below threshold)
-//   - cutoff itself must NOT be eligible (not below threshold)
-//   - cutoff+1 must NOT be eligible
+//   - threshold-1 must be eligible
+//   - threshold itself must NOT be eligible
+//   - threshold+1 must NOT be eligible
 //
 // This is exactly the boundary the issue asked to be covered: values
 // adjacent to the cutoff, not just broad statistical behavior.
@@ -408,19 +408,6 @@ func TestLeaderEligibilityBoundaryAgainstIndependentReference(t *testing.T) {
 		{"f=0.9,sigma=0.9", big.NewRat(9, 10), 9, 10},
 		{"f=0.99,sigma=0.99", big.NewRat(99, 100), 99, 100},
 		{"f=0.999,tiny-sigma", big.NewRat(999, 1000), 1, 1_000_000},
-		// Exact-rational cutoff: full stake (sigma=1) with f=1/2 makes
-		// (1-f)^sigma = 1-f = 0.5 exactly, so the true cutoff lands
-		// exactly on an integer (2^N/2). This is the case that exposed
-		// the off-by-one flooring bug fixed for
-		// CertifiedNatThresholdWithMode's full-stake handling.
-		{"f=0.5,sigma=1(full-stake-exact)", big.NewRat(1, 2), 1, 1},
-		// Partial-stake exact-rational cutoff (PR #1963 review, blocking
-		// finding 1): f=3/4, sigma=1/2 makes (1-f)^sigma=(1/4)^(1/2)=1/2
-		// exactly, so the true cutoff lands exactly on an integer
-		// (2^(N-1)). Feeding an approximate big.Float into the final
-		// floor() previously produced 2^(N-1)-1 instead, incorrectly
-		// rejecting the valid leader value 2^(N-1)-1.
-		{"f=0.75,sigma=0.5(partial-stake-exact)", big.NewRat(3, 4), 1, 2},
 	}
 
 	modes := []struct {
@@ -464,36 +451,10 @@ func TestLeaderEligibilityBoundaryAgainstIndependentReference(t *testing.T) {
 				// for the (deliberately looser) general accuracy bound
 				// against the same reference.
 				//
-				// cubic-dev-ai review (PR #1963, finding 2) questioned
-				// whether this exact-equality check is brittle: refPrec's own
-				// doc comment above notes that refFindE/refLncf's accumulated
-				// rounding can push an exact-rational cutoff across its
-				// integer boundary, and names this file's own two
-				// exact-rational cases (f=0.5/sigma=1, f=0.75/sigma=0.5) as an
-				// example. That drift, however, is specific to raising refPrec
-				// far past its current value (to the ~2000+ mantissa bits the
-				// near-one-f case in threshold_test.go would require), at
-				// which point refSeriesTerms' fixed 4000-iteration cap stops
-				// being enough to converge to the correspondingly tighter
-				// refEpsilon, leaving a much larger residual than usual. It is
-				// not a property of these two cases at refPrec's *current*
-				// value (2048): measured directly, the continued-fraction/
-				// Taylor residual for (1-f)^sigma (which equals exactly 0.5 in
-				// both cases) is on the order of a 2^-1989 relative error, i.e.
-				// an absolute error against even the largest upperBound in use
-				// here (2^512) of around 2^-1477 -- roughly 1450 bits of
-				// margin below what would be needed to shift floor() by even
-				// one integer. That margin would have to shrink by three
-				// orders of magnitude in bit-count before this check could
-				// plausibly flake, so it is kept as an exact equality (not a
-				// tolerance) for these specific cases. This reasoning is tied
-				// to *this* file's current case list at refPrec's current
-				// value: if refPrec, refSeriesTerms, or this file's case list
-				// changes (e.g. to add a near-one-f case), re-derive
-				// below/at/above from threshold instead of cutoff and loosen
-				// this to a tolerance, following the pattern
-				// TestCertifiedNatThresholdDifferentialAgainstIndependentReference
-				// already uses for exactly that reason.
+				// Exact-rational cutoffs are intentionally excluded from this
+				// approximate reference table because an arbitrarily small
+				// reference residual can change ceil(X) at an integral X. They
+				// are covered by exact arithmetic in threshold_test.go.
 				diff := new(big.Int).Sub(threshold, cutoff)
 				require.True(t, diff.Sign() == 0,
 					"production threshold must equal the reference cutoff "+
@@ -514,28 +475,11 @@ func TestLeaderEligibilityBoundaryAgainstIndependentReference(t *testing.T) {
 				// logic the public API applies after hashing.
 				bits := m.outputLen * 8
 
-				// NOTE: gouroboros' eligibility rule compares the raw VRF
-				// leader value v against floor(X) via a strict "<", which
-				// differs from upstream cardano-node's real-number
-				// semantics (certNat < certNatMax*(1-(1-f)^sigma)) by at
-				// most one integer whenever X itself isn't exactly an
-				// integer: upstream would admit v == floor(X) as eligible
-				// in that case, gouroboros rejects it. This is a genuine,
-				// pre-existing, astronomically-low-probability (~2^-256)
-				// boundary discrepancy, known and accepted, and out of
-				// scope for this PR. Once threshold == cutoff exactly (as
-				// asserted above), the "at"/"above" checks below become
-				// tautological with respect to *this* implementation
-				// (threshold < threshold is trivially false) and so can't
-				// catch that discrepancy either way -- they only confirm
-				// this implementation is internally consistent with its
-				// own (integer) threshold value, not that the threshold
-				// itself matches upstream's real-number cutoff to the
-				// last possible integer. Bit-exact boundary agreement
-				// with cardano-node is unattainable by construction
-				// regardless: upstream's own Fixed E34 internal
-				// precision (~113 bits) is far short of exact real-number
-				// arithmetic.
+				// The comparison threshold is ceil(X), where X is the real
+				// cutoff. For every integer leader value v, v < ceil(X) is
+				// equivalent to v < X. This preserves strict rejection at
+				// integral cutoffs while admitting floor(X) when X is
+				// fractional, matching the reference predicate.
 				require.True(
 					t,
 					checkBelowThreshold(t, bits, m.mode, threshold, below),

--- a/consensus/threshold_test.go
+++ b/consensus/threshold_test.go
@@ -76,6 +76,27 @@ func expRational(x *big.Rat) *big.Rat {
 	return rat
 }
 
+func TestCeilBigFloat(t *testing.T) {
+	testCases := []struct {
+		name string
+		x    *big.Rat
+		want int64
+	}{
+		{name: "negative-fraction", x: big.NewRat(-3, 2), want: -1},
+		{name: "negative-subunit", x: big.NewRat(-1, 2), want: 0},
+		{name: "zero", x: big.NewRat(0, 1), want: 0},
+		{name: "positive-fraction", x: big.NewRat(3, 2), want: 2},
+		{name: "positive-integer", x: big.NewRat(2, 1), want: 2},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			x := new(big.Float).SetPrec(128).SetRat(tc.x)
+			require.Equal(t, big.NewInt(tc.want), ceilBigFloat(x))
+		})
+	}
+}
+
 func TestCertifiedNatThresholdZeroStake(t *testing.T) {
 	activeSlotCoeff := big.NewRat(1, 20) // 0.05
 
@@ -1056,9 +1077,14 @@ func TestThresholdAccuracyFullStake(t *testing.T) {
 				tc.f,
 			)
 
-			// Exact expected value: floor(2^256 * f)
-			expected := new(big.Int).Mul(twoTo256, tc.f.Num())
-			expected.Div(expected, tc.f.Denom())
+			// Exact expected comparison threshold: ceil(2^256 * f).
+			expectedNumerator := new(big.Int).Mul(twoTo256, tc.f.Num())
+			expected := new(big.Int)
+			remainder := new(big.Int)
+			expected.QuoRem(expectedNumerator, tc.f.Denom(), remainder)
+			if remainder.Sign() != 0 {
+				expected.Add(expected, big.NewInt(1))
+			}
 
 			require.True(t, threshold.Sign() > 0,
 				"threshold must be positive")
@@ -1328,7 +1354,7 @@ func TestCertifiedNatThresholdFullStakeExactHalf(t *testing.T) {
 // blocking review finding: f=3/4 with sigma=1/2 (e.g. poolStake=1,
 // totalStake=2) has (1-f)^sigma = (1/4)^(1/2) = 1/2 exactly, so the
 // mathematically exact threshold is precisely 2^(N-1) for an N-bit upper
-// bound. Feeding an *approximate* big.Float into the final floor()
+// bound. Feeding an *approximate* big.Float into the final integer conversion
 // previously produced 2^(N-1)-1 instead -- one integer below the exact
 // cutoff -- which, combined with the strict "<" eligibility comparison,
 // incorrectly rejected the valid leader value 2^(N-1)-1.
@@ -1405,8 +1431,8 @@ func TestCertifiedNatThresholdPartialStakeExactCutoff(t *testing.T) {
 // With sigma=1/2, 1-f = 2^-2000 is a perfect square, so
 // (1-f)^sigma = 2^-1000 exactly, giving an exact mathematical threshold of
 // upperBound*(1-2^-1000) = upperBound - 2^(N-1000). Since N (256 or 512)
-// is far smaller than 1000, that fractional term is far less than 1, so
-// floor(exact threshold) = upperBound-1 for both consensus modes.
+// is far smaller than 1000, that fractional term is far less than 1, so the
+// comparison threshold ceil(exact cutoff) is upperBound for both modes.
 func TestCertifiedNatThresholdNearOneDenominatorPrecisionLoss(t *testing.T) {
 	denomExp := int64(2000)
 	den := new(big.Int).Exp(big.NewInt(2), big.NewInt(denomExp), nil)
@@ -1428,10 +1454,10 @@ func TestCertifiedNatThresholdNearOneDenominatorPrecisionLoss(t *testing.T) {
 			threshold, err := CertifiedNatThresholdWithMode(1, 2, f, c.mode)
 			require.NoError(t, err)
 
-			expected := new(big.Int).Sub(c.upperBound, big.NewInt(1))
+			expected := new(big.Int).Set(c.upperBound)
 			require.Equal(t, 0, threshold.Cmp(expected),
 				"f=(2^2000-1)/2^2000,sigma=1/2 threshold must be "+
-					"exactly upperBound-1: got %s, want %s",
+					"exactly upperBound: got %s, want %s",
 				threshold.String(), expected.String())
 		})
 	}


### PR DESCRIPTION
## Summary

- preserve the strict real-valued leader cutoff with an integer ceiling threshold
- cover below, equal, and above boundaries through the production CPraos and TPraos entry point

## Testing

- `make test`
- `make lint`
- `make format`
- `make golines`
- `GOFLAGS=-buildvcs=false make build`
- focused consensus tests with `-race`

Closes #2093.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the leadership threshold from `floor(X)` to `ceil(X)` so integer leader values compare against the real-valued cutoff exactly, fixing off-by-one rejection when the cutoff is an exact integer.

- Applies the ceiling in the general precision-escalated path and the exact-rational fast path in `consensus/threshold.go`, plus the public `IsSlotLeaderWithMode` entry point for CPraos and TPraos.
- Adds boundary tests covering leader values immediately below, at, and above the cutoff; updates existing tests whose expected threshold shifted by one (e.g., near-one-f, full-stake and partial-stake exact cases).
- Closes #2093.

<sup>Written for commit a11d8d1e2aa9da1a9a6721fb714e82d61059533a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated leader eligibility thresholds to use ceiling-based rounding, improving accuracy at fractional and exact cutoff boundaries.
  - Corrected threshold behavior for both CPraos and TPraos consensus modes, including values exactly at the eligibility limit.

- **Tests**
  - Added coverage for threshold rounding, boundary conditions, and precision across supported consensus modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->