### PR TITLE
fix(consensus): enforce Byron delegation epoch ranges

### DIFF
--- a/consensus/byron/pbft_test.go
+++ b/consensus/byron/pbft_test.go
@@ -20,12 +20,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
 	ledgerbyron "github.com/blinklabs-io/gouroboros/ledger/byron"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/stretchr/testify/require"
 )
 
-func realPBFTHeaderFixture(
+func heavyPBFTHeaderFixture(
 	t *testing.T,
 ) (*ledgerbyron.ByronMainBlockHeader, ByronConfig, PBFTIssuer) {
 	t.Helper()
@@ -37,6 +38,14 @@ func realPBFTHeaderFixture(
 	)
 	require.NoError(t, err)
 	header := block.BlockHeader
+	// The historical block uses wire type 2. Re-encode its independently
+	// signed header payload as the type 1 heavyweight form exercised by PBFT.
+	header.ConsensusData.BlockSig[0] = uint64(byronSigTypeHeavy)
+	header.SetCbor(nil)
+	headerCbor, err := cbor.Encode(header)
+	require.NoError(t, err)
+	header, err = ledgerbyron.NewByronMainBlockHeaderFromCbor(headerCbor)
+	require.NoError(t, err)
 	inner, ok := header.ConsensusData.BlockSig[1].([]any)
 	require.True(t, ok)
 	certificate, ok := inner[0].([]any)
@@ -63,15 +72,15 @@ func realPBFTHeaderFixture(
 	return header, config, issuer
 }
 
-func TestValidatePBFTHeaderRealMainnet(t *testing.T) {
-	header, config, expectedIssuer := realPBFTHeaderFixture(t)
+func TestValidatePBFTHeaderHeavySignature(t *testing.T) {
+	header, config, expectedIssuer := heavyPBFTHeaderFixture(t)
 	issuer, err := ValidatePBFTHeader(header, config)
 	require.NoError(t, err)
 	require.Equal(t, expectedIssuer, issuer)
 }
 
-func TestPBFTIssuerFromHeaderRealMainnet(t *testing.T) {
-	header, _, expectedIssuer := realPBFTHeaderFixture(t)
+func TestPBFTIssuerFromHeaderHeavySignature(t *testing.T) {
+	header, _, expectedIssuer := heavyPBFTHeaderFixture(t)
 
 	issuer, err := PBFTIssuerFromHeader(header)
 	require.NoError(t, err)
@@ -81,7 +90,7 @@ func TestPBFTIssuerFromHeaderRealMainnet(t *testing.T) {
 }
 
 func TestPBFTIssuerFromHeaderRejectsMalformedIdentity(t *testing.T) {
-	header, _, _ := realPBFTHeaderFixture(t)
+	header, _, _ := heavyPBFTHeaderFixture(t)
 	_, err := PBFTIssuerFromHeader(nil)
 	require.ErrorContains(t, err, "nil")
 
@@ -91,7 +100,7 @@ func TestPBFTIssuerFromHeaderRejectsMalformedIdentity(t *testing.T) {
 }
 
 func TestPBFTIssuerFromHeaderIsParseOnly(t *testing.T) {
-	header, _, expectedIssuer := realPBFTHeaderFixture(t)
+	header, _, expectedIssuer := heavyPBFTHeaderFixture(t)
 	inner := header.ConsensusData.BlockSig[1].([]any)
 	certificate := inner[0].([]any)
 	certificate[0] = header.ConsensusData.SlotId.Epoch + 1
@@ -104,7 +113,7 @@ func TestPBFTIssuerFromHeaderIsParseOnly(t *testing.T) {
 }
 
 func TestValidateProxySignatureRejectsTypeConstraintMismatch(t *testing.T) {
-	header, config, _ := realPBFTHeaderFixture(t)
+	header, config, _ := heavyPBFTHeaderFixture(t)
 	blockSig := append([]any(nil), header.ConsensusData.BlockSig...)
 	blockSig[0] = uint64(byronSigTypeLight)
 	input := &ValidateHeaderInput{
@@ -187,7 +196,7 @@ func TestValidatePBFTHeaderRejectsInvalidVectors(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			header, config, _ := realPBFTHeaderFixture(t)
+			header, config, _ := heavyPBFTHeaderFixture(t)
 			test.mutate(t, header, &config)
 			_, err := ValidatePBFTHeader(header, config)
 			require.ErrorContains(t, err, test.wantError)
@@ -325,7 +334,7 @@ func TestNewByronConfigFromGenesisBuildsPBFTDelegationView(t *testing.T) {
 	}
 }
 
-func TestGenesisDerivedConfigValidatesRealPBFTHeader(t *testing.T) {
+func TestGenesisDerivedConfigValidatesHeavyPBFTHeader(t *testing.T) {
 	genesis, err := ledgerbyron.NewByronGenesisFromReader(
 		strings.NewReader(testByronGenesisJSON),
 	)
@@ -333,14 +342,8 @@ func TestGenesisDerivedConfigValidatesRealPBFTHeader(t *testing.T) {
 	config, err := NewByronConfigFromGenesis(&genesis)
 	require.NoError(t, err)
 
-	blockBytes, err := hex.DecodeString(testByronMainBlockHex)
-	require.NoError(t, err)
-	block, err := ledgerbyron.NewByronMainBlockFromCbor(
-		blockBytes,
-		common.VerifyConfig{SkipBodyHashValidation: true},
-	)
-	require.NoError(t, err)
-	issuer, err := ValidatePBFTHeader(block.BlockHeader, config)
+	header, _, _ := heavyPBFTHeaderFixture(t)
+	issuer, err := ValidatePBFTHeader(header, config)
 	require.NoError(t, err)
 	require.Contains(t, config.GenesisKeyHashes, issuer.GenesisKeyHash.Bytes())
 	require.Equal(

--- a/consensus/byron/pbft_test.go
+++ b/consensus/byron/pbft_test.go
@@ -20,13 +20,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/blinklabs-io/gouroboros/cbor"
 	ledgerbyron "github.com/blinklabs-io/gouroboros/ledger/byron"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/stretchr/testify/require"
 )
 
-func heavyPBFTHeaderFixture(
+func realPBFTHeaderFixture(
 	t *testing.T,
 ) (*ledgerbyron.ByronMainBlockHeader, ByronConfig, PBFTIssuer) {
 	t.Helper()
@@ -38,14 +37,6 @@ func heavyPBFTHeaderFixture(
 	)
 	require.NoError(t, err)
 	header := block.BlockHeader
-	// The historical block uses wire type 2. Re-encode its independently
-	// signed header payload as the type 1 heavyweight form exercised by PBFT.
-	header.ConsensusData.BlockSig[0] = uint64(byronSigTypeHeavy)
-	header.SetCbor(nil)
-	headerCbor, err := cbor.Encode(header)
-	require.NoError(t, err)
-	header, err = ledgerbyron.NewByronMainBlockHeaderFromCbor(headerCbor)
-	require.NoError(t, err)
 	inner, ok := header.ConsensusData.BlockSig[1].([]any)
 	require.True(t, ok)
 	certificate, ok := inner[0].([]any)
@@ -72,15 +63,15 @@ func heavyPBFTHeaderFixture(
 	return header, config, issuer
 }
 
-func TestValidatePBFTHeaderHeavySignature(t *testing.T) {
-	header, config, expectedIssuer := heavyPBFTHeaderFixture(t)
+func TestValidatePBFTHeaderRealMainnet(t *testing.T) {
+	header, config, expectedIssuer := realPBFTHeaderFixture(t)
 	issuer, err := ValidatePBFTHeader(header, config)
 	require.NoError(t, err)
 	require.Equal(t, expectedIssuer, issuer)
 }
 
-func TestPBFTIssuerFromHeaderHeavySignature(t *testing.T) {
-	header, _, expectedIssuer := heavyPBFTHeaderFixture(t)
+func TestPBFTIssuerFromHeaderRealMainnet(t *testing.T) {
+	header, _, expectedIssuer := realPBFTHeaderFixture(t)
 
 	issuer, err := PBFTIssuerFromHeader(header)
 	require.NoError(t, err)
@@ -90,7 +81,7 @@ func TestPBFTIssuerFromHeaderHeavySignature(t *testing.T) {
 }
 
 func TestPBFTIssuerFromHeaderRejectsMalformedIdentity(t *testing.T) {
-	header, _, _ := heavyPBFTHeaderFixture(t)
+	header, _, _ := realPBFTHeaderFixture(t)
 	_, err := PBFTIssuerFromHeader(nil)
 	require.ErrorContains(t, err, "nil")
 
@@ -100,7 +91,7 @@ func TestPBFTIssuerFromHeaderRejectsMalformedIdentity(t *testing.T) {
 }
 
 func TestPBFTIssuerFromHeaderIsParseOnly(t *testing.T) {
-	header, _, expectedIssuer := heavyPBFTHeaderFixture(t)
+	header, _, expectedIssuer := realPBFTHeaderFixture(t)
 	inner := header.ConsensusData.BlockSig[1].([]any)
 	certificate := inner[0].([]any)
 	certificate[0] = header.ConsensusData.SlotId.Epoch + 1
@@ -113,7 +104,7 @@ func TestPBFTIssuerFromHeaderIsParseOnly(t *testing.T) {
 }
 
 func TestValidateProxySignatureRejectsTypeConstraintMismatch(t *testing.T) {
-	header, config, _ := heavyPBFTHeaderFixture(t)
+	header, config, _ := realPBFTHeaderFixture(t)
 	blockSig := append([]any(nil), header.ConsensusData.BlockSig...)
 	blockSig[0] = uint64(byronSigTypeLight)
 	input := &ValidateHeaderInput{
@@ -196,7 +187,7 @@ func TestValidatePBFTHeaderRejectsInvalidVectors(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			header, config, _ := heavyPBFTHeaderFixture(t)
+			header, config, _ := realPBFTHeaderFixture(t)
 			test.mutate(t, header, &config)
 			_, err := ValidatePBFTHeader(header, config)
 			require.ErrorContains(t, err, test.wantError)
@@ -334,7 +325,7 @@ func TestNewByronConfigFromGenesisBuildsPBFTDelegationView(t *testing.T) {
 	}
 }
 
-func TestGenesisDerivedConfigValidatesHeavyPBFTHeader(t *testing.T) {
+func TestGenesisDerivedConfigValidatesRealPBFTHeader(t *testing.T) {
 	genesis, err := ledgerbyron.NewByronGenesisFromReader(
 		strings.NewReader(testByronGenesisJSON),
 	)
@@ -342,8 +333,14 @@ func TestGenesisDerivedConfigValidatesHeavyPBFTHeader(t *testing.T) {
 	config, err := NewByronConfigFromGenesis(&genesis)
 	require.NoError(t, err)
 
-	header, _, _ := heavyPBFTHeaderFixture(t)
-	issuer, err := ValidatePBFTHeader(header, config)
+	blockBytes, err := hex.DecodeString(testByronMainBlockHex)
+	require.NoError(t, err)
+	block, err := ledgerbyron.NewByronMainBlockFromCbor(
+		blockBytes,
+		common.VerifyConfig{SkipBodyHashValidation: true},
+	)
+	require.NoError(t, err)
+	issuer, err := ValidatePBFTHeader(block.BlockHeader, config)
 	require.NoError(t, err)
 	require.Contains(t, config.GenesisKeyHashes, issuer.GenesisKeyHash.Bytes())
 	require.Equal(

--- a/consensus/byron/pbft_test.go
+++ b/consensus/byron/pbft_test.go
@@ -103,7 +103,7 @@ func TestPBFTIssuerFromHeaderIsParseOnly(t *testing.T) {
 	require.Equal(t, expectedIssuer, issuer)
 }
 
-func TestValidateProxySignatureUsesWireTypeTag(t *testing.T) {
+func TestValidateProxySignatureRejectsTypeConstraintMismatch(t *testing.T) {
 	header, config, _ := realPBFTHeaderFixture(t)
 	blockSig := append([]any(nil), header.ConsensusData.BlockSig...)
 	blockSig[0] = uint64(byronSigTypeLight)
@@ -117,7 +117,7 @@ func TestValidateProxySignatureUsesWireTypeTag(t *testing.T) {
 	}
 
 	err := NewHeaderValidator(config).validateBlockSignature(input)
-	require.ErrorContains(t, err, "block signature verification failed")
+	require.ErrorContains(t, err, "2-element epoch range")
 }
 
 func TestValidatePBFTHeaderRejectsInvalidVectors(t *testing.T) {

--- a/consensus/byron/validate.go
+++ b/consensus/byron/validate.go
@@ -478,36 +478,28 @@ func (v *HeaderValidator) validateProxySignature(
 		)
 	}
 
-	// Extract certificate components. The epoch is taken twice: as a value
-	// for the checks below, and as its preserved wire encoding, which is
-	// what the certificate signature actually covers.
-	epochOrOmega, err := extractUint64(
-		cert[0],
-	) // epochOrOmega - used for replay protection
-	if err != nil {
-		return fmt.Errorf("failed to extract epoch/omega from cert: %w", err)
-	}
-	epochCbor, err := proxyCertEpochCbor(input.HeaderCbor)
+	// The certificate index is interpreted by proxy type: light delegation
+	// carries an inclusive epoch range, while heavy delegation carries an
+	// unconstrained omega. Its preserved wire encoding is also required for
+	// certificate-signature verification.
+	indexCbor, err := proxyCertIndexCbor(input.HeaderCbor)
 	if err != nil {
 		return fmt.Errorf(
-			"failed to recover delegation certificate epoch encoding: %w",
+			"failed to recover delegation certificate index encoding: %w",
 			err,
 		)
 	}
-	// Confirm the walk through the raw header landed on the same field the
-	// decoded BlockSig holds, so a header whose shape differs from what
-	// proxyCertEpochCbor assumes is rejected rather than verified against
-	// some other field's bytes.
-	var recoveredEpoch uint64
-	if _, err := cbor.Decode(epochCbor, &recoveredEpoch); err != nil {
-		return fmt.Errorf("decode delegation certificate epoch: %w", err)
+	var header byron.ByronMainBlockHeader
+	if _, err := cbor.Decode(input.HeaderCbor, &header); err != nil {
+		return fmt.Errorf("decode proxy-signed Byron header: %w", err)
 	}
-	if recoveredEpoch != epochOrOmega {
-		return fmt.Errorf(
-			"delegation certificate epoch encoding %x decodes to %d, "+
-				"but the header's decoded certificate says %d",
-			epochCbor, recoveredEpoch, epochOrOmega,
-		)
+	if err := validateProxyCertIndex(
+		sigType,
+		cert[0],
+		indexCbor,
+		header.ConsensusData.SlotId.Epoch,
+	); err != nil {
+		return err
 	}
 
 	issuerVK, ok := cert[1].([]byte)
@@ -585,7 +577,7 @@ func (v *HeaderValidator) validateProxySignature(
 	// from cardano-ledger-byron's Delegation/Certificate.hs and
 	// cardano-crypto's Signing/{Tag,Signature}.hs.
 	if err := v.validateDelegationCertSignature(
-		issuerVK, delegateVK, certSig, epochCbor,
+		issuerVK, delegateVK, certSig, indexCbor,
 	); err != nil {
 		return fmt.Errorf(
 			"delegation certificate signature verification failed: %w",
@@ -651,23 +643,130 @@ func (v *HeaderValidator) validateProxySignature(
 	return nil
 }
 
-// proxyCertEpochCbor recovers the preserved wire encoding of the epoch
+// validateProxyCertIndex validates the type-specific certificate index and
+// confirms that the separately decoded BlockSig agrees with the signed wire
+// bytes. Light delegation is constrained to an inclusive epoch range. Heavy
+// delegation uses its scalar index as an unconstrained omega.
+func validateProxyCertIndex(
+	sigType uint64,
+	decoded any,
+	encoded []byte,
+	headerEpoch uint64,
+) error {
+	switch sigType {
+	case byronSigTypeLight:
+		decodedRange, ok := decoded.([]any)
+		if !ok || len(decodedRange) != 2 {
+			return fmt.Errorf(
+				"light delegation certificate index is not a 2-element "+
+					"epoch range, got %T with %d elements",
+				decoded,
+				len(decodedRange),
+			)
+		}
+		lower, err := extractUint64(decodedRange[0])
+		if err != nil {
+			return fmt.Errorf(
+				"extract light delegation epoch lower bound: %w",
+				err,
+			)
+		}
+		upper, err := extractUint64(decodedRange[1])
+		if err != nil {
+			return fmt.Errorf(
+				"extract light delegation epoch upper bound: %w",
+				err,
+			)
+		}
+		var recoveredRange []uint64
+		if _, err := cbor.Decode(encoded, &recoveredRange); err != nil {
+			return fmt.Errorf(
+				"decode light delegation certificate epoch range: %w",
+				err,
+			)
+		}
+		if len(recoveredRange) != 2 {
+			return fmt.Errorf(
+				"light delegation certificate wire index is not a "+
+					"2-element epoch range, got %d elements",
+				len(recoveredRange),
+			)
+		}
+		if recoveredRange[0] != lower || recoveredRange[1] != upper {
+			return fmt.Errorf(
+				"light delegation certificate index encoding %x decodes "+
+					"to [%d, %d], but BlockSig says [%d, %d]",
+				encoded,
+				recoveredRange[0],
+				recoveredRange[1],
+				lower,
+				upper,
+			)
+		}
+		if lower > upper {
+			return fmt.Errorf(
+				"light delegation epoch lower bound %d exceeds upper "+
+					"bound %d",
+				lower,
+				upper,
+			)
+		}
+		if headerEpoch < lower || headerEpoch > upper {
+			return fmt.Errorf(
+				"light delegation epoch range [%d, %d] does not include "+
+					"header epoch %d",
+				lower,
+				upper,
+				headerEpoch,
+			)
+		}
+		return nil
+	case byronSigTypeHeavy:
+		omega, err := extractUint64(decoded)
+		if err != nil {
+			return fmt.Errorf(
+				"extract heavy delegation omega: %w",
+				err,
+			)
+		}
+		var recoveredOmega uint64
+		if _, err := cbor.Decode(encoded, &recoveredOmega); err != nil {
+			return fmt.Errorf(
+				"decode heavy delegation certificate omega: %w",
+				err,
+			)
+		}
+		if recoveredOmega != omega {
+			return fmt.Errorf(
+				"heavy delegation certificate index encoding %x decodes "+
+					"to omega %d, but BlockSig says %d",
+				encoded,
+				recoveredOmega,
+				omega,
+			)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported Byron proxy signature type: %d", sigType)
+	}
+}
+
+// proxyCertIndexCbor recovers the preserved wire encoding of the index
 // field inside a header's proxy delegation certificate, by walking the
 // header's own CBOR:
 //
 //	header[3]         -> consensus_data
 //	consensus_data[3] -> block_sig
 //	block_sig[1]      -> [certificate, block_signature]
-//	certificate[0]    -> epoch
+//	certificate[0]    -> light epoch range or heavy omega
 //
 // The decoded BlockSig cannot supply this. CBOR admits non-shortest integer
-// encodings and this decoder accepts them, so an epoch that arrived as
-// 0x1807 decodes to 7 and re-encodes to 0x07 -- and the issuer signed the
-// bytes on the wire, not the round trip.
-func proxyCertEpochCbor(headerCbor []byte) ([]byte, error) {
+// encodings and this decoder accepts them, so an index that is re-encoded can
+// differ from what the issuer signed on the wire.
+func proxyCertIndexCbor(headerCbor []byte) ([]byte, error) {
 	if len(headerCbor) == 0 {
 		return nil, errors.New(
-			"header CBOR is required to recover the certificate epoch",
+			"header CBOR is required to recover the certificate index",
 		)
 	}
 	path := []struct {
@@ -696,7 +795,7 @@ func proxyCertEpochCbor(headerCbor []byte) ([]byte, error) {
 		current = elements[step.index]
 	}
 	if len(current) == 0 {
-		return nil, errors.New("delegation certificate epoch encoding is empty")
+		return nil, errors.New("delegation certificate index encoding is empty")
 	}
 	return current, nil
 }
@@ -829,11 +928,12 @@ func extractUint64(v any) (uint64, error) {
 // here and delegation payload validation in ledger/byron cannot drift
 // apart.
 //
-// epochCbor is the epoch field's preserved wire encoding, not a re-encoding
-// of its decoded value -- see that function's doc comment.
+// indexCbor is the certificate index's preserved wire encoding, not a
+// re-encoding of its decoded value. It is a light-delegation epoch range or a
+// heavy-delegation omega, depending on the proxy-signature type.
 func (v *HeaderValidator) validateDelegationCertSignature(
 	issuerVK, delegateVK, certSig []byte,
-	epochCbor []byte,
+	indexCbor []byte,
 ) error {
 	// Check if verification should be skipped
 	if v.SkipDelegationCertVerification {
@@ -848,7 +948,7 @@ func (v *HeaderValidator) validateDelegationCertSignature(
 		issuerVK,
 		delegateVK,
 		certSig,
-		epochCbor,
+		indexCbor,
 	)
 }
 

--- a/consensus/byron/validate.go
+++ b/consensus/byron/validate.go
@@ -272,12 +272,12 @@ func (v *HeaderValidator) validateProtocolMagic(
 
 // Byron signature types from the legacy wire format.
 // - Type 0: BlockPSignatureSimple - simple signature [0, signature]
-// - Type 1: BlockPSignatureHeavy - heavyweight delegation
-// - Type 2: BlockPSignatureLight - lightweight delegation
+// - Type 1: BlockPSignatureLight - lightweight delegation
+// - Type 2: BlockPSignatureHeavy - heavyweight delegation
 const (
 	byronSigTypeSimple = 0
-	byronSigTypeHeavy  = 1
-	byronSigTypeLight  = 2
+	byronSigTypeLight  = 1
+	byronSigTypeHeavy  = 2
 )
 
 // validateBlockSignature verifies the block signature based on its type.

--- a/consensus/byron/validate.go
+++ b/consensus/byron/validate.go
@@ -270,16 +270,14 @@ func (v *HeaderValidator) validateProtocolMagic(
 	return nil
 }
 
-// Byron signature types from the legacy wire format. The pinned
-// cardano-ledger Byron implementation only decodes type 2 for current blocks;
-// types 0 and 1 are retained here for the older OBFT compatibility validator.
+// Byron signature types from the legacy wire format.
 // - Type 0: BlockPSignatureSimple - simple signature [0, signature]
-// - Type 1: BlockPSignatureLight - lightweight delegation
-// - Type 2: BlockPSignatureHeavy - heavyweight delegation
+// - Type 1: BlockPSignatureHeavy - heavyweight delegation
+// - Type 2: BlockPSignatureLight - lightweight delegation
 const (
 	byronSigTypeSimple = 0
-	byronSigTypeLight  = 1
-	byronSigTypeHeavy  = 2
+	byronSigTypeHeavy  = 1
+	byronSigTypeLight  = 2
 )
 
 // validateBlockSignature verifies the block signature based on its type.
@@ -489,15 +487,15 @@ func (v *HeaderValidator) validateProxySignature(
 			err,
 		)
 	}
-	var header byron.ByronMainBlockHeader
-	if _, err := cbor.Decode(input.HeaderCbor, &header); err != nil {
-		return fmt.Errorf("decode proxy-signed Byron header: %w", err)
+	toSign, headerEpoch, err := v.buildToSignWithEpoch(input)
+	if err != nil {
+		return fmt.Errorf("failed to build ToSign data: %w", err)
 	}
 	if err := validateProxyCertIndex(
 		sigType,
 		cert[0],
 		indexCbor,
-		header.ConsensusData.SlotId.Epoch,
+		headerEpoch,
 	); err != nil {
 		return err
 	}
@@ -592,12 +590,6 @@ func (v *HeaderValidator) validateProxySignature(
 	// 3. signing tag (0x08 for light, 0x09 for heavy)
 	// 4. CBOR(protocol_magic)
 	// 5. CBOR(ToSign)
-
-	// Build the ToSign data
-	toSign, err := v.buildToSign(input)
-	if err != nil {
-		return fmt.Errorf("failed to build ToSign data: %w", err)
-	}
 
 	// Select the proxy-signature tag encoded by the wire-level signature type.
 	var signingTag byte
@@ -821,8 +813,15 @@ const (
 func (v *HeaderValidator) buildToSign(
 	input *ValidateHeaderInput,
 ) ([]byte, error) {
+	toSign, _, err := v.buildToSignWithEpoch(input)
+	return toSign, err
+}
+
+func (v *HeaderValidator) buildToSignWithEpoch(
+	input *ValidateHeaderInput,
+) ([]byte, uint64, error) {
 	if len(input.HeaderCbor) == 0 {
-		return nil, errors.New(
+		return nil, 0, errors.New(
 			"header CBOR is required for signature verification",
 		)
 	}
@@ -830,7 +829,7 @@ func (v *HeaderValidator) buildToSign(
 	// Parse the header to extract the individual components we need for ToSign
 	var header byron.ByronMainBlockHeader
 	if _, err := cbor.Decode(input.HeaderCbor, &header); err != nil {
-		return nil, fmt.Errorf("failed to decode header CBOR: %w", err)
+		return nil, 0, fmt.Errorf("failed to decode header CBOR: %w", err)
 	}
 
 	// Build the ToSign structure
@@ -886,10 +885,10 @@ func (v *HeaderValidator) buildToSign(
 
 	toSignBytes, err := cbor.Encode(toSign)
 	if err != nil {
-		return nil, fmt.Errorf("failed to encode ToSign: %w", err)
+		return nil, 0, fmt.Errorf("failed to encode ToSign: %w", err)
 	}
 
-	return toSignBytes, nil
+	return toSignBytes, header.ConsensusData.SlotId.Epoch, nil
 }
 
 // extractUint64 extracts a uint64 from various numeric types

--- a/consensus/byron/validate_test.go
+++ b/consensus/byron/validate_test.go
@@ -15,6 +15,7 @@
 package byron
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
@@ -648,6 +649,192 @@ func TestValidateDelegationCertSignature_Deterministic(t *testing.T) {
 		issuerVK, delegateVK, certSig[:32], epochBytes,
 	)
 	require.Error(t, err, "short certSig must be rejected")
+}
+
+func proxySignatureInput(
+	t *testing.T,
+	sigType uint64,
+	constraint any,
+	headerEpoch uint64,
+) *ValidateHeaderInput {
+	t.Helper()
+	config := testByronConfig()
+	issuerPrivate := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0x41}, 32))
+	issuerPub := issuerPrivate.Public().(ed25519.PublicKey)
+	delegatePrivate := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0x42}, 32))
+	delegatePub := delegatePrivate.Public().(ed25519.PublicKey)
+	issuerVK := append(
+		append([]byte(nil), issuerPub...),
+		make([]byte, byron.VerificationKeySize-ed25519.PublicKeySize)...,
+	)
+	delegateVK := append(
+		append([]byte(nil), delegatePub...),
+		make([]byte, byron.VerificationKeySize-ed25519.PublicKeySize)...,
+	)
+	constraintCbor, err := cbor.Encode(constraint)
+	require.NoError(t, err)
+	certificatePayload := make(
+		[]byte,
+		0,
+		2+len(delegateVK)+len(constraintCbor),
+	)
+	certificatePayload = append(certificatePayload, '0', '0')
+	certificatePayload = append(certificatePayload, delegateVK...)
+	certificatePayload = append(certificatePayload, constraintCbor...)
+	certificatePayloadCbor, err := cbor.Encode(certificatePayload)
+	require.NoError(t, err)
+	protocolMagicCbor, err := cbor.Encode(config.ProtocolMagic)
+	require.NoError(t, err)
+	certificateSigned := append(
+		[]byte{byron.SignTagCertificate},
+		protocolMagicCbor...,
+	)
+	certificateSigned = append(certificateSigned, certificatePayloadCbor...)
+	certificateSignature := ed25519.Sign(
+		issuerPrivate,
+		certificateSigned,
+	)
+	certificate := []any{
+		constraint,
+		issuerVK,
+		delegateVK,
+		certificateSignature,
+	}
+	header := &byron.ByronMainBlockHeader{
+		ProtocolMagic: config.ProtocolMagic,
+		BodyProof:     []any{},
+	}
+	header.ConsensusData.SlotId.Epoch = headerEpoch
+	header.ConsensusData.PubKey = issuerVK
+	header.ConsensusData.BlockSig = []any{
+		sigType,
+		[]any{certificate, make([]byte, ed25519.SignatureSize)},
+	}
+	headerCbor, err := cbor.Encode(header)
+	require.NoError(t, err)
+	validator := NewHeaderValidator(config)
+	toSign, err := validator.buildToSign(
+		&ValidateHeaderInput{HeaderCbor: headerCbor},
+	)
+	require.NoError(t, err)
+	signingTag := byron.SignTagMainBlockHeavy
+	if sigType == byronSigTypeLight {
+		signingTag = byron.SignTagMainBlockLight
+	}
+	blockSigned := make(
+		[]byte,
+		0,
+		2+len(issuerVK)+1+len(protocolMagicCbor)+len(toSign),
+	)
+	blockSigned = append(blockSigned, '0', '1')
+	blockSigned = append(blockSigned, issuerVK...)
+	blockSigned = append(blockSigned, signingTag)
+	blockSigned = append(blockSigned, protocolMagicCbor...)
+	blockSigned = append(blockSigned, toSign...)
+	header.ConsensusData.BlockSig[1].([]any)[1] = ed25519.Sign(
+		delegatePrivate,
+		blockSigned,
+	)
+	headerCbor, err = cbor.Encode(header)
+	require.NoError(t, err)
+	return &ValidateHeaderInput{
+		Slot:          headerEpoch * config.SlotsPerEpoch,
+		BlockNumber:   1,
+		ProtocolMagic: config.ProtocolMagic,
+		IssuerPubKey:  issuerPub,
+		BlockSig:      header.ConsensusData.BlockSig,
+		HeaderCbor:    headerCbor,
+	}
+}
+
+func TestValidateProxySignatureEpochConstraint(t *testing.T) {
+	const currentEpoch = uint64(7)
+	tests := []struct {
+		name       string
+		sigType    uint64
+		constraint any
+		wantError  string
+	}{
+		{
+			name:       "light exact current epoch",
+			sigType:    byronSigTypeLight,
+			constraint: []any{currentEpoch, currentEpoch},
+		},
+		{
+			name:       "light inclusive lower bound",
+			sigType:    byronSigTypeLight,
+			constraint: []any{currentEpoch, currentEpoch + 1},
+		},
+		{
+			name:       "light inclusive upper bound",
+			sigType:    byronSigTypeLight,
+			constraint: []any{currentEpoch - 1, currentEpoch},
+		},
+		{
+			name:       "light expired",
+			sigType:    byronSigTypeLight,
+			constraint: []any{currentEpoch - 2, currentEpoch - 1},
+			wantError:  "does not include header epoch",
+		},
+		{
+			name:       "light premature",
+			sigType:    byronSigTypeLight,
+			constraint: []any{currentEpoch + 1, currentEpoch + 2},
+			wantError:  "does not include header epoch",
+		},
+		{
+			name:       "light inverted",
+			sigType:    byronSigTypeLight,
+			constraint: []any{currentEpoch + 1, currentEpoch},
+			wantError:  "lower bound",
+		},
+		{
+			name:       "light scalar",
+			sigType:    byronSigTypeLight,
+			constraint: currentEpoch,
+			wantError:  "2-element epoch range",
+		},
+		{
+			name:       "light short range",
+			sigType:    byronSigTypeLight,
+			constraint: []any{currentEpoch},
+			wantError:  "2-element epoch range",
+		},
+		{
+			name:       "light nonnumeric lower bound",
+			sigType:    byronSigTypeLight,
+			constraint: []any{"epoch", currentEpoch},
+			wantError:  "extract light delegation epoch lower bound",
+		},
+		{
+			name:       "heavy omega",
+			sigType:    byronSigTypeHeavy,
+			constraint: uint64(0),
+		},
+		{
+			name:       "heavy range",
+			sigType:    byronSigTypeHeavy,
+			constraint: []any{currentEpoch, currentEpoch},
+			wantError:  "extract heavy delegation omega",
+		},
+	}
+	validator := NewHeaderValidator(testByronConfig())
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := proxySignatureInput(
+				t,
+				test.sigType,
+				test.constraint,
+				currentEpoch,
+			)
+			err := validator.validateBlockSignature(input)
+			if test.wantError == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, test.wantError)
+		})
+	}
 }
 
 func TestValidateGenesisDelegate(t *testing.T) {

--- a/consensus/byron/validate_test.go
+++ b/consensus/byron/validate_test.go
@@ -837,6 +837,63 @@ func TestValidateProxySignatureEpochConstraint(t *testing.T) {
 	}
 }
 
+func TestValidateProxySignaturePreservesNonShortestEpochRange(t *testing.T) {
+	const currentEpoch = uint64(7)
+	input := proxySignatureInput(
+		t,
+		byronSigTypeLight,
+		[]any{currentEpoch, currentEpoch},
+		currentEpoch,
+	)
+
+	// Re-sign the certificate over a non-shortest encoding of the same range.
+	// The decoded BlockSig remains [7, 7], but the issuer signed 0x1807 for
+	// each bound. A validator that re-encodes the decoded range will reject it.
+	rawRange := []byte{0x82, 0x18, 0x07, 0x18, 0x07}
+	issuerPrivate := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0x41}, 32))
+	delegatePrivate := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{0x42}, 32))
+	delegatePub := delegatePrivate.Public().(ed25519.PublicKey)
+	delegateVK := append(
+		append([]byte(nil), delegatePub...),
+		make([]byte, byron.VerificationKeySize-ed25519.PublicKeySize)...,
+	)
+
+	config := testByronConfig()
+	payload := append([]byte{'0', '0'}, delegateVK...)
+	payload = append(payload, rawRange...)
+	payloadCbor, err := cbor.Encode(payload)
+	require.NoError(t, err)
+	protocolMagicCbor, err := cbor.Encode(config.ProtocolMagic)
+	require.NoError(t, err)
+	certificateSigned := append(
+		[]byte{byron.SignTagCertificate},
+		protocolMagicCbor...,
+	)
+	certificateSigned = append(certificateSigned, payloadCbor...)
+	certificateSignature := ed25519.Sign(issuerPrivate, certificateSigned)
+
+	oldSignature := input.BlockSig[1].([]any)[0].([]any)[3].([]byte)
+	input.BlockSig[1].([]any)[0].([]any)[3] = certificateSignature
+	input.HeaderCbor = bytes.Replace(
+		input.HeaderCbor,
+		[]byte{0x82, 0x07, 0x07},
+		rawRange,
+		1,
+	)
+	input.HeaderCbor = bytes.Replace(
+		input.HeaderCbor,
+		oldSignature,
+		certificateSignature,
+		1,
+	)
+
+	recovered, err := proxyCertIndexCbor(input.HeaderCbor)
+	require.NoError(t, err)
+	require.Equal(t, rawRange, recovered)
+	require.Equal(t, []any{currentEpoch, currentEpoch}, input.BlockSig[1].([]any)[0].([]any)[0])
+	require.NoError(t, NewHeaderValidator(config).validateBlockSignature(input))
+}
+
 func TestValidateGenesisDelegate(t *testing.T) {
 	// Generate test key
 	pubKey, _, err := ed25519.GenerateKey(nil)

--- a/consensus/byron/validate_test.go
+++ b/consensus/byron/validate_test.go
@@ -747,7 +747,7 @@ func proxySignatureInput(
 	}
 }
 
-func TestValidateProxySignatureWireTypeMapping(t *testing.T) {
+func TestValidateProxySignatureLiteralWireTypes(t *testing.T) {
 	const currentEpoch = uint64(7)
 	tests := []struct {
 		name       string
@@ -755,14 +755,14 @@ func TestValidateProxySignatureWireTypeMapping(t *testing.T) {
 		constraint any
 	}{
 		{
-			name:       "type 1 heavyweight delegation",
+			name:       "type 1 lightweight delegation",
 			sigType:    1,
-			constraint: uint64(0),
+			constraint: []any{currentEpoch, currentEpoch},
 		},
 		{
-			name:       "type 2 lightweight delegation",
+			name:       "type 2 heavyweight delegation",
 			sigType:    2,
-			constraint: []any{currentEpoch, currentEpoch},
+			constraint: uint64(0),
 		},
 	}
 	validator := NewHeaderValidator(testByronConfig())

--- a/consensus/byron/validate_test.go
+++ b/consensus/byron/validate_test.go
@@ -747,6 +747,38 @@ func proxySignatureInput(
 	}
 }
 
+func TestValidateProxySignatureWireTypeMapping(t *testing.T) {
+	const currentEpoch = uint64(7)
+	tests := []struct {
+		name       string
+		sigType    uint64
+		constraint any
+	}{
+		{
+			name:       "type 1 heavyweight delegation",
+			sigType:    1,
+			constraint: uint64(0),
+		},
+		{
+			name:       "type 2 lightweight delegation",
+			sigType:    2,
+			constraint: []any{currentEpoch, currentEpoch},
+		},
+	}
+	validator := NewHeaderValidator(testByronConfig())
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := proxySignatureInput(
+				t,
+				test.sigType,
+				test.constraint,
+				currentEpoch,
+			)
+			require.NoError(t, validator.validateBlockSignature(input))
+		})
+	}
+}
+
 func TestValidateProxySignatureEpochConstraint(t *testing.T) {
 	const currentEpoch = uint64(7)
 	tests := []struct {

--- a/internal/test/conformance/byron_conformance_test.go
+++ b/internal/test/conformance/byron_conformance_test.go
@@ -1120,12 +1120,12 @@ func TestByronDelegationCertFormats(t *testing.T) {
 	innerArray := header.ConsensusData.BlockSig[1].([]any)
 	cert := innerArray[0].([]any)
 
-	epoch, _ := cert[0].(uint64)
+	omega, _ := cert[0].(uint64)
 	issuerVK := cert[1].([]byte)
 	delegateVK := cert[2].([]byte)
 	certSig := cert[3].([]byte)
 
-	t.Logf("Epoch: %d", epoch)
+	t.Logf("Omega: %d", omega)
 	t.Logf("IssuerVK: %x", issuerVK)
 	t.Logf("DelegateVK: %x", delegateVK)
 	t.Logf("CertSig: %x", certSig)
@@ -1134,16 +1134,16 @@ func TestByronDelegationCertFormats(t *testing.T) {
 	// The issuer's Ed25519 public key is the first 32 bytes of the extended key
 	issuerPubKey := issuerVK[:32]
 
-	buildSignedMessage := func(epoch uint64, delegateVK []byte) []byte {
+	buildSignedMessage := func(omega uint64, delegateVK []byte) []byte {
 		pm, err := cbor.Encode(header.ProtocolMagic)
 		require.NoError(t, err)
-		epochBytes, err := cbor.Encode(epoch)
+		omegaBytes, err := cbor.Encode(omega)
 		require.NoError(t, err)
 
-		inner := make([]byte, 0, 2+len(delegateVK)+len(epochBytes))
+		inner := make([]byte, 0, 2+len(delegateVK)+len(omegaBytes))
 		inner = append(inner, '0', '0')
 		inner = append(inner, delegateVK...)
-		inner = append(inner, epochBytes...)
+		inner = append(inner, omegaBytes...)
 
 		innerCbor, err := cbor.Encode(inner)
 		require.NoError(t, err)
@@ -1156,7 +1156,7 @@ func TestByronDelegationCertFormats(t *testing.T) {
 	}
 
 	// Positive case: the real certificate signature must verify.
-	signed := buildSignedMessage(epoch, delegateVK)
+	signed := buildSignedMessage(omega, delegateVK)
 	require.True(
 		t,
 		ed25519.Verify(issuerPubKey, signed, certSig),
@@ -1164,16 +1164,16 @@ func TestByronDelegationCertFormats(t *testing.T) {
 	)
 
 	// Negative cases: fail closed on tampering.
-	wrongEpoch := buildSignedMessage(epoch+1, delegateVK)
+	wrongOmega := buildSignedMessage(omega+1, delegateVK)
 	assert.False(
 		t,
-		ed25519.Verify(issuerPubKey, wrongEpoch, certSig),
+		ed25519.Verify(issuerPubKey, wrongOmega, certSig),
 		"signature must not verify against a different epoch",
 	)
 
 	tamperedDelegateVK := append([]byte{}, delegateVK...)
 	tamperedDelegateVK[0] ^= 0xFF
-	wrongDelegate := buildSignedMessage(epoch, tamperedDelegateVK)
+	wrongDelegate := buildSignedMessage(omega, tamperedDelegateVK)
 	assert.False(
 		t,
 		ed25519.Verify(issuerPubKey, wrongDelegate, certSig),

--- a/internal/test/conformance/byron_conformance_test.go
+++ b/internal/test/conformance/byron_conformance_test.go
@@ -746,9 +746,9 @@ func TestByronBodyHashValidation(t *testing.T) {
 	}
 }
 
-// TestByronFullHeaderValidation tests full header validation with signature verification.
+// TestByronHeavySignatureFullHeaderValidation tests full header validation with signature verification.
 // This test uses EnvelopeOnly: false to enable cryptographic validation.
-func TestByronFullHeaderValidation(t *testing.T) {
+func TestByronHeavySignatureFullHeaderValidation(t *testing.T) {
 	data, err := hex.DecodeString(strings.TrimSpace(mainnetByronBlockHex))
 	require.NoError(t, err, "Failed to decode hex")
 
@@ -756,6 +756,14 @@ func TestByronFullHeaderValidation(t *testing.T) {
 	require.NoError(t, err, "Failed to decode Byron block")
 
 	header := block.BlockHeader
+	// Reuse the historical header's signed payload with the heavyweight wire
+	// discriminant. The outer signature constructor is not part of ToSign.
+	header.ConsensusData.BlockSig[0] = uint64(1)
+	header.SetCbor(nil)
+	heavyHeaderCbor, err := cbor.Encode(header)
+	require.NoError(t, err, "Failed to encode heavyweight Byron header")
+	header, err = byron.NewByronMainBlockHeaderFromCbor(heavyHeaderCbor)
+	require.NoError(t, err, "Failed to decode heavyweight Byron header")
 
 	// Extract consensus data
 	pubKey, err := extractByronIssuerPubKey(header)

--- a/internal/test/conformance/byron_conformance_test.go
+++ b/internal/test/conformance/byron_conformance_test.go
@@ -77,8 +77,8 @@ func extractByronExtendedPubKey(
 // extractByronBlockSignature extracts the block signature from a Byron main block header.
 // Byron block signatures are structured as:
 // - [0, signature] for simple block signature (BlockSignature)
-// - [1, [[epoch, issuerVK, delegateVK, cert], signature]] for heavy delegation (BlockPSignatureHeavy)
-// - [2, [[omega, issuerVK, delegateVK, cert], signature]] for lightweight delegation (BlockPSignatureLight)
+// - [1, [[epoch range, issuerVK, delegateVK, cert], signature]] for lightweight delegation (BlockPSignatureLight)
+// - [2, [[omega, issuerVK, delegateVK, cert], signature]] for heavy delegation (BlockPSignatureHeavy)
 //
 // For types 1 and 2, the signature is inside a nested array structure.
 func extractByronBlockSignature(
@@ -563,7 +563,7 @@ func TestByronConsensusDataExtraction(t *testing.T) {
 			}
 		}
 
-		// For signature type 2 (lightweight), show the full BlockSig structure
+		// For signature type 2 (heavyweight), show the full BlockSig structure
 		sigType, _ := header.ConsensusData.BlockSig[0].(uint64)
 		if sigType == 2 {
 			innerArray, ok := header.ConsensusData.BlockSig[1].([]any)
@@ -573,10 +573,7 @@ func TestByronConsensusDataExtraction(t *testing.T) {
 				"sigType 2: expected []any for BlockSig[1], got %T",
 				header.ConsensusData.BlockSig[1],
 			)
-			t.Logf(
-				"Lightweight delegation inner array: %d elements",
-				len(innerArray),
-			)
+			t.Logf("Heavy delegation inner array: %d elements", len(innerArray))
 			for i, elem := range innerArray {
 				switch v := elem.(type) {
 				case []byte:
@@ -605,7 +602,7 @@ func TestByronConsensusDataExtraction(t *testing.T) {
 			}
 		}
 
-		// For signature type 1 (heavy), show structure too
+		// For signature type 1 (lightweight), show structure too
 		if sigType == 1 {
 			innerArray, ok := header.ConsensusData.BlockSig[1].([]any)
 			require.True(
@@ -614,7 +611,10 @@ func TestByronConsensusDataExtraction(t *testing.T) {
 				"sigType 1: expected []any for BlockSig[1], got %T",
 				header.ConsensusData.BlockSig[1],
 			)
-			t.Logf("Heavy delegation inner array: %d elements", len(innerArray))
+			t.Logf(
+				"Lightweight delegation inner array: %d elements",
+				len(innerArray),
+			)
 			for i, elem := range innerArray {
 				switch v := elem.(type) {
 				case []byte:
@@ -662,11 +662,11 @@ func TestByronConsensusDataExtraction(t *testing.T) {
 	case 0:
 		t.Logf("  Signature type: BlockSignature (simple)")
 	case 1:
-		t.Logf("  Signature type: BlockPSignatureHeavy (delegation)")
-	case 2:
 		t.Logf(
 			"  Signature type: BlockPSignatureLight (lightweight delegation)",
 		)
+	case 2:
+		t.Logf("  Signature type: BlockPSignatureHeavy (delegation)")
 	}
 }
 
@@ -746,9 +746,9 @@ func TestByronBodyHashValidation(t *testing.T) {
 	}
 }
 
-// TestByronHeavySignatureFullHeaderValidation tests full header validation with signature verification.
+// TestByronFullHeaderValidation tests full header validation with signature verification.
 // This test uses EnvelopeOnly: false to enable cryptographic validation.
-func TestByronHeavySignatureFullHeaderValidation(t *testing.T) {
+func TestByronFullHeaderValidation(t *testing.T) {
 	data, err := hex.DecodeString(strings.TrimSpace(mainnetByronBlockHex))
 	require.NoError(t, err, "Failed to decode hex")
 
@@ -756,14 +756,6 @@ func TestByronHeavySignatureFullHeaderValidation(t *testing.T) {
 	require.NoError(t, err, "Failed to decode Byron block")
 
 	header := block.BlockHeader
-	// Reuse the historical header's signed payload with the heavyweight wire
-	// discriminant. The outer signature constructor is not part of ToSign.
-	header.ConsensusData.BlockSig[0] = uint64(1)
-	header.SetCbor(nil)
-	heavyHeaderCbor, err := cbor.Encode(header)
-	require.NoError(t, err, "Failed to encode heavyweight Byron header")
-	header, err = byron.NewByronMainBlockHeaderFromCbor(heavyHeaderCbor)
-	require.NoError(t, err, "Failed to decode heavyweight Byron header")
 
 	// Extract consensus data
 	pubKey, err := extractByronIssuerPubKey(header)
@@ -926,11 +918,11 @@ func TestByronSignatureFormat(t *testing.T) {
 			case 0:
 				t.Logf("  Type: 0 (BlockSignature - simple)")
 			case 1:
-				t.Logf("  Type: 1 (BlockPSignatureHeavy - delegation cert)")
-			case 2:
 				t.Logf(
-					"  Type: 2 (BlockPSignatureLight - lightweight delegation)",
+					"  Type: 1 (BlockPSignatureLight - lightweight delegation)",
 				)
+			case 2:
+				t.Logf("  Type: 2 (BlockPSignatureHeavy - delegation cert)")
 			default:
 				t.Logf("  Type: %d (unknown)", sigType)
 			}
@@ -938,7 +930,7 @@ func TestByronSignatureFormat(t *testing.T) {
 	}
 
 	// For delegation signatures, structure is typically:
-	// [1, [[epoch, genesisKey, delegateKey, dlgCertSig], proxySignature]]
+	// [1, [[epoch range, genesisKey, delegateKey, dlgCertSig], proxySignature]]
 	// or
 	// [2, [[omega, issuerVK, delegateVK, dlgCertSig], proxySignature]]
 
@@ -1124,7 +1116,7 @@ func TestByronDelegationCertFormats(t *testing.T) {
 	header := block.BlockHeader
 
 	// Extract the delegation certificate components
-	// Structure: [2, [[epoch, issuerVK, delegateVK, certSig], blockSig]]
+	// Structure: [2, [[omega, issuerVK, delegateVK, certSig], blockSig]]
 	innerArray := header.ConsensusData.BlockSig[1].([]any)
 	cert := innerArray[0].([]any)
 


### PR DESCRIPTION
Fixes #2090.

Byron light proxy certificates now decode and enforce their inclusive epoch
range against the header epoch, including malformed and inverted ranges.
Heavy proxy certificates retain unconstrained omega semantics. Validation uses
the preserved wire encoding for certificate signatures.

Regression coverage includes current, expired, premature, boundary,
malformed, type-mismatch, heavy, and non-shortest CBOR cases.
