### PR TITLE
fix(blockfetch): report shutdown completion

### DIFF
--- a/protocol/blockfetch/client.go
+++ b/protocol/blockfetch/client.go
@@ -919,6 +919,15 @@ func (c *Client) resolve(req *rangeRequest, err error) error {
 				c.callbackContextFor(req),
 				err,
 			)
+		} else if !req.pipelined && err != nil &&
+			req.delivery == deliveryCallback &&
+			c.config.BatchDoneFunc != nil {
+			// GetBlockRange returns after MsgStartBatch, so an error that
+			// resolves the request later cannot reach its caller. Report the
+			// terminal outcome through the existing batch callback instead.
+			callbackErr = c.config.BatchDoneFunc(
+				c.callbackContextFor(req),
+			)
 		}
 	})
 	return callbackErr

--- a/protocol/blockfetch/client.go
+++ b/protocol/blockfetch/client.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -92,6 +93,9 @@ type rangeRequest struct {
 	// resolveOnce ensures a request is resolved exactly once, whichever of
 	// the response path and the shutdown path reaches it first.
 	resolveOnce sync.Once
+	// batchDoneReported prevents resolve from invoking BatchDoneFunc again
+	// after handleBatchDone has already reported it.
+	batchDoneReported atomic.Bool
 }
 
 // RangeRequest describes a single block range request queued through
@@ -920,8 +924,10 @@ func (c *Client) resolve(req *rangeRequest, err error) error {
 				err,
 			)
 		} else if !req.pipelined && err != nil &&
+			req.started &&
 			req.delivery == deliveryCallback &&
-			c.config.BatchDoneFunc != nil {
+			c.config.BatchDoneFunc != nil &&
+			!req.batchDoneReported.Load() {
 			// GetBlockRange returns after MsgStartBatch, so an error that
 			// resolves the request later cannot reach its caller. Report the
 			// terminal outcome through the existing batch callback instead.
@@ -1383,6 +1389,10 @@ func (c *Client) handleBatchDone() error {
 				req.end.Hash,
 			),
 		)
+	}
+	if !req.pipelined && req.delivery == deliveryCallback &&
+		c.config.BatchDoneFunc != nil {
+		req.batchDoneReported.Store(true)
 	}
 	c.removeLocked(req)
 	c.queueMutex.Unlock()

--- a/protocol/blockfetch/client_queue_internal_test.go
+++ b/protocol/blockfetch/client_queue_internal_test.go
@@ -805,6 +805,32 @@ func TestOldProtocolShutdownDoesNotFailRestartedRequests(t *testing.T) {
 	require.Zero(t, c.inFlightBytes)
 }
 
+func TestNonPipelinedShutdownCallsBatchDone(t *testing.T) {
+	completions := make(chan uint64, 1)
+	c := newQueueTestClient(&Config{
+		BatchDoneFunc: func(ctx CallbackContext) error {
+			completions <- ctx.RequestId
+			return nil
+		},
+	})
+	req := c.appendTestRequest(1)
+	req.pipelined = false
+
+	c.failOutstanding(protocol.ErrProtocolShuttingDown)
+
+	select {
+	case id := <-completions:
+		require.Equal(t, req.id, id)
+	case <-time.After(time.Second):
+		t.Fatal("non-pipelined shutdown did not report batch completion")
+	}
+	select {
+	case id := <-completions:
+		t.Fatalf("non-pipelined shutdown reported completion twice for request %d", id)
+	default:
+	}
+}
+
 // idleLimitObservationWindow bounds both halves of the Idle-state ingress
 // limit pair below: the non-pipelining client must report the oversized
 // message within it, and the pipelining client must not.

--- a/protocol/blockfetch/client_queue_internal_test.go
+++ b/protocol/blockfetch/client_queue_internal_test.go
@@ -806,7 +806,7 @@ func TestOldProtocolShutdownDoesNotFailRestartedRequests(t *testing.T) {
 }
 
 func TestNonPipelinedShutdownCallsBatchDone(t *testing.T) {
-	completions := make(chan uint64, 1)
+	completions := make(chan uint64, 2)
 	c := newQueueTestClient(&Config{
 		BatchDoneFunc: func(ctx CallbackContext) error {
 			completions <- ctx.RequestId
@@ -815,6 +815,7 @@ func TestNonPipelinedShutdownCallsBatchDone(t *testing.T) {
 	})
 	req := c.appendTestRequest(1)
 	req.pipelined = false
+	req.started = true
 
 	c.failOutstanding(protocol.ErrProtocolShuttingDown)
 
@@ -827,6 +828,50 @@ func TestNonPipelinedShutdownCallsBatchDone(t *testing.T) {
 	select {
 	case id := <-completions:
 		t.Fatalf("non-pipelined shutdown reported completion twice for request %d", id)
+	default:
+	}
+}
+
+func TestNonPipelinedNoBlocksDoesNotCallBatchDone(t *testing.T) {
+	completions := make(chan uint64, 1)
+	c := newQueueTestClient(&Config{
+		BatchDoneFunc: func(ctx CallbackContext) error {
+			completions <- ctx.RequestId
+			return nil
+		},
+	})
+	req := c.appendTestRequest(1)
+	req.pipelined = false
+
+	require.NoError(t, c.handleNoBlocks())
+	select {
+	case id := <-completions:
+		t.Fatalf("no-blocks response reported completion for request %d", id)
+	default:
+	}
+}
+
+func TestNonPipelinedBatchDoneErrorCallsBatchDoneOnce(t *testing.T) {
+	callbackErr := errors.New("batch callback failed")
+	completions := make(chan uint64, 2)
+	c := newQueueTestClient(&Config{
+		BatchDoneFunc: func(ctx CallbackContext) error {
+			completions <- ctx.RequestId
+			return callbackErr
+		},
+	})
+	req := c.appendTestRequest(1)
+	req.pipelined = false
+	req.started = true
+	req.end = pcommon.NewPoint(1, []byte("end"))
+	req.lastPoint = req.end
+	req.hasLastPoint = true
+
+	require.ErrorIs(t, c.handleBatchDone(), callbackErr)
+	require.Equal(t, req.id, <-completions)
+	select {
+	case id := <-completions:
+		t.Fatalf("batch completion reported twice for request %d", id)
 	default:
 	}
 }


### PR DESCRIPTION
A non-pipelined `GetBlockRange` returns after `MsgStartBatch`. If shutdown terminates the range before `MsgBatchDone`, report completion through `BatchDoneFunc` exactly once. Requests rejected before `MsgStartBatch` retain their existing error-return behavior.

Adds focused coverage for shutdown completion, pre-start `MsgNoBlocks`, and callback errors.

Closes #2179