### PR TITLE
fix(ledger): retain retired pools during delegation validation

### DIFF
--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -3349,7 +3349,8 @@ func UtxoValidateDelegation(
 			inTxStakeState[stakeKey(c.StakeCredential)] = false
 
 		case *common.PoolRetirementCertificate:
-			delete(inTxPoolRegs, c.PoolKeyHash)
+			// Retirement leaves the pool active until POOLREAP at the end of
+			// the retirement epoch, so later delegations remain valid.
 
 		case *common.DeregistrationDrepCertificate:
 			delete(inTxDRepRegs, c.DrepCredential.Credential)

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -4315,6 +4315,48 @@ func TestUtxoValidateDelegation_DeregistrationBlocksLaterDelegation(
 	}
 }
 
+func TestUtxoValidateDelegation_PoolRetirementKeepsPoolRegistered(
+	t *testing.T,
+) {
+	poolKeyHash := common.PoolKeyHash{0x04, 0x05, 0x06}
+	stakeKeyHash := common.Blake2b224Hash(
+		[]byte("pool-retirement-delegation-stake"),
+	)
+	stakeCred := common.Credential{
+		CredType:   common.CredentialTypeAddrKeyHash,
+		Credential: stakeKeyHash,
+	}
+	ls := mockledger.NewLedgerStateBuilder().
+		WithStakeCredentialRegistered(stakeKeyHash, true).
+		Build()
+	newTx := func(certs ...common.Certificate) *conway.ConwayTransaction {
+		wrappers := make([]common.CertificateWrapper, len(certs))
+		for i, cert := range certs {
+			wrappers[i] = common.CertificateWrapper{Certificate: cert}
+		}
+		return &conway.ConwayTransaction{
+			Body: conway.ConwayTransactionBody{TxCertificates: wrappers},
+		}
+	}
+	delegation := &common.StakeDelegationCertificate{
+		StakeCredential: &stakeCred,
+		PoolKeyHash:     poolKeyHash,
+	}
+	registration := &common.PoolRegistrationCertificate{Operator: poolKeyHash}
+
+	// RetirePool leaves the pool in psStakePools until POOLREAP.
+	require.NoError(t, conway.UtxoValidateDelegation(
+		newTx(
+			registration,
+			&common.PoolRetirementCertificate{PoolKeyHash: poolKeyHash, Epoch: 5},
+			delegation,
+		),
+		0,
+		ls,
+		&conway.ConwayProtocolParameters{},
+	))
+}
+
 func TestUtxoValidateDelegation_InTxVrfKeyDuplicates(t *testing.T) {
 	pool1 := common.PoolKeyHash{0x01, 0x02, 0x03}
 	pool2 := common.PoolKeyHash{0x04, 0x05, 0x06}

--- a/ledger/pool_rules_test.go
+++ b/ledger/pool_rules_test.go
@@ -612,6 +612,44 @@ func TestUtxoValidatePoolCertificatesRetirementRegistered(t *testing.T) {
 	})
 }
 
+func TestUtxoValidateDelegationPoolRetirementKeepsPoolRegistered(
+	t *testing.T,
+) {
+	pool := poolKeyHash(0x04)
+	stake := common.Credential{
+		CredType:   common.CredentialTypeAddrKeyHash,
+		Credential: common.Blake2b224Hash([]byte("delegation-stake")),
+	}
+	ls := mockledger.NewLedgerStateBuilder().
+		WithStakeCredentialRegistered(stake.Credential, true).
+		Build()
+	pparams := maryPparams(0)
+	registration := poolRegCertWire(
+		t,
+		pool,
+		vrfKeyHash(0x05),
+		0,
+		common.AddressNetworkMainnet,
+	)
+	delegation := &common.StakeDelegationCertificate{
+		CertType:        uint(common.CertificateTypeStakeDelegation),
+		StakeCredential: &stake,
+		PoolKeyHash:     pool,
+	}
+
+	// poolTransition retains a retired pool in psStakePools until POOLREAP.
+	require.NoError(t, shelley.UtxoValidateDelegation(
+		poolCertTx(
+			registration,
+			poolRetirementCert(pool, 5),
+			delegation,
+		),
+		0,
+		ls,
+		pparams,
+	))
+}
+
 // TestUtxoValidatePoolCertificatesRetirementEpoch covers
 // StakePoolRetirementWrongEpochPOOL and the degrading EpochState capability.
 func TestUtxoValidatePoolCertificatesRetirementEpoch(t *testing.T) {

--- a/ledger/shelley/rules.go
+++ b/ledger/shelley/rules.go
@@ -712,8 +712,8 @@ func UtxoValidateDelegation(
 			inTxPoolRegs[c.Operator] = true
 
 		case *common.PoolRetirementCertificate:
-			// Remove from in-tx registrations so subsequent delegations fail
-			delete(inTxPoolRegs, c.PoolKeyHash)
+			// Retirement does not remove the pool from the active pool set.
+			// POOLREAP removes it only after the retirement epoch.
 
 		case *common.StakeDelegationCertificate:
 			if !isPoolRegistered(c.PoolKeyHash) {


### PR DESCRIPTION
## Summary

Retain stake pools in the active registration set after a same-transaction retirement, matching `poolTransition` behavior until POOLREAP.

Add Shelley and Conway regression coverage for registration, retirement, and later delegation in one transaction.

## Validation

- `make test`
- `make lint`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2166 by keeping stake pools in the active registration set after a same-transaction retirement. Previously the retirement removed the pool, so a later delegation in the same transaction was rejected; now it remains valid until `POOLREAP`, matching `poolTransition`. Adds Shelley and Conway regression coverage for registration, retirement, and later delegation in one transaction.

<sup>Written for commit 814988793a20c685c11f656fb80915db3ed4ccad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pool retirement no longer incorrectly prevents delegations to the same pool within the transaction.
  * Retired pools remain eligible for delegation until the pool-reaping process completes, matching their active-state behavior.
  * Improved validation for transactions that register, retire, and delegate to a pool in a single transaction.

* **Tests**
  * Added regression coverage for pool retirement and same-transaction delegation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->