### PR TITLE
fix(cbor): guard size arithmetic and zero-value access

### DIFF
--- a/cbor/decode.go
+++ b/cbor/decode.go
@@ -395,11 +395,13 @@ func (d *StreamDecoder) Advance(n int) error {
 	if n < 0 {
 		return errors.New("cannot advance by negative amount")
 	}
-	newPos := d.consumed + d.dec.NumBytesRead() + n
-	if newPos > len(d.data) {
+	curPos := d.consumed + d.dec.NumBytesRead()
+	// Compare before adding: a huge n could otherwise overflow int and
+	// wrap the sum negative, which would pass a post-addition bounds check.
+	if n > len(d.data)-curPos {
 		return errors.New("advance would exceed data bounds")
 	}
-	d.consumed = newPos
+	d.consumed = curPos + n
 	// Reinitialize decoder with remaining data, reusing cached DecMode
 	d.dec = d.decMode.NewDecoder(bytes.NewReader(d.data[d.consumed:]))
 	return nil
@@ -785,6 +787,9 @@ func ArrayHeaderSize(length int) uint32 {
 		return 2 // 0x98 + 1-byte length
 	} else if length < 65536 {
 		return 3 // 0x99 + 2-byte length
+	} else if int64(length) < (1 << 32) {
+		return 5 // 0x9a + 4-byte length (covers up to 2^32-1 elements)
 	}
-	return 5 // 0x9a + 4-byte length (covers up to 2^32 elements)
+	// At or above the 32-bit boundary, CBOR requires the 8-byte length form
+	return 9 // 0x9b + 8-byte length
 }

--- a/cbor/stream_decoder_test.go
+++ b/cbor/stream_decoder_test.go
@@ -16,6 +16,8 @@ package cbor_test
 
 import (
 	"encoding/hex"
+	"math"
+	"math/bits"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -160,6 +162,14 @@ func TestStreamDecoderAdvance(t *testing.T) {
 	err = dec.Advance(1000)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "exceed")
+
+	// A huge advance must not overflow the internal position arithmetic and
+	// wrap negative, which would otherwise bypass the bounds check and
+	// corrupt the decoder's position.
+	err = dec.Advance(math.MaxInt)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "exceed")
+	assert.Equal(t, 2, dec.Position())
 }
 
 func TestStreamDecoderDecodeArrayHeader(t *testing.T) {
@@ -452,10 +462,35 @@ func TestArrayHeaderSize(t *testing.T) {
 		{256, 3},
 		{65535, 3},
 		{65536, 5},
+		// math.MaxInt scales with the platform's int width (2^31-1 on
+		// 32-bit, 2^63-1 on 64-bit), so it stays a valid header-size-9
+		// case everywhere without overflowing a 32-bit int.
+		{math.MaxInt, 9},
 	}
 
 	for _, tt := range tests {
 		size := cbor.ArrayHeaderSize(tt.length)
+		assert.Equal(t, tt.expectSize, size, "length %d", tt.length)
+	}
+
+	// These boundary values don't fit in a 32-bit int at all, so they can
+	// only be constructed and exercised on a 64-bit platform. Build them
+	// as int64 first so the source still compiles on a 32-bit GOARCH.
+	if bits.UintSize < 64 {
+		t.Skip("32-bit int cannot represent the 32-bit CBOR length boundary")
+	}
+	sixtyFourBitOnly := []struct {
+		length     int64
+		expectSize uint32
+	}{
+		{int64(math.MaxUint32) - 1, 5},
+		{int64(math.MaxUint32), 5},
+		// At and above the 32-bit boundary, CBOR requires the 8-byte
+		// length form (9-byte header), not the 4-byte form (5-byte header).
+		{int64(math.MaxUint32) + 1, 9},
+	}
+	for _, tt := range sixtyFourBitOnly {
+		size := cbor.ArrayHeaderSize(int(tt.length))
 		assert.Equal(t, tt.expectSize, size, "length %d", tt.length)
 	}
 }

--- a/cbor/value.go
+++ b/cbor/value.go
@@ -357,6 +357,9 @@ type LazyValue struct {
 }
 
 func (l *LazyValue) MarshalCBOR() ([]byte, error) {
+	if l.value == nil {
+		l.value = &Value{}
+	}
 	// Return stored CBOR
 	// This is only a stopgap, since it doesn't allow us to build values from scratch
 	return []byte(l.value.cborData), nil
@@ -389,14 +392,23 @@ func (l *LazyValue) MarshalJSON() ([]byte, error) {
 }
 
 func (l *LazyValue) Decode() (any, error) {
+	if l.value == nil {
+		l.value = &Value{}
+	}
 	err := l.value.UnmarshalCBOR([]byte(l.value.cborData))
 	return l.Value(), err
 }
 
 func (l *LazyValue) Value() any {
+	if l.value == nil {
+		return nil
+	}
 	return l.value.Value()
 }
 
 func (l *LazyValue) Cbor() []byte {
+	if l.value == nil {
+		return nil
+	}
 	return l.value.Cbor()
 }

--- a/cbor/value_test.go
+++ b/cbor/value_test.go
@@ -492,3 +492,33 @@ func TestLazyValueMarshalJSONEmptyCborData(t *testing.T) {
 		}
 	})
 }
+
+// TestLazyValueZeroValueMethods ensures every exported LazyValue method is
+// safe to call on a zero-value (never-unmarshaled) LazyValue, rather than
+// dereferencing a nil internal *Value.
+func TestLazyValueZeroValueMethods(t *testing.T) {
+	t.Run("Value", func(t *testing.T) {
+		var tmpValue cbor.LazyValue
+		require.Nil(t, tmpValue.Value())
+	})
+
+	t.Run("Cbor", func(t *testing.T) {
+		var tmpValue cbor.LazyValue
+		require.Nil(t, tmpValue.Cbor())
+	})
+
+	t.Run("MarshalCBOR", func(t *testing.T) {
+		var tmpValue cbor.LazyValue
+		data, err := tmpValue.MarshalCBOR()
+		require.NoError(t, err)
+		require.Empty(t, data)
+	})
+
+	t.Run("Decode", func(t *testing.T) {
+		var tmpValue cbor.LazyValue
+		// No CBOR was ever stored, so decoding is expected to fail with a
+		// normal error rather than panic.
+		_, err := tmpValue.Decode()
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
Fixes #2094

## Changes

- `StreamDecoder.Advance`: check for integer overflow before completing
  the position addition, so a huge `n` returns a normal error instead of
  wrapping `newPos` negative and bypassing the existing bounds check.
- `ArrayHeaderSize`: return the correct 9-byte header size for lengths at
  or above the 32-bit boundary (previously understated as 5 bytes for any
  length ≥ 65536, including lengths requiring the 8-byte form).
- `LazyValue`: guard `MarshalCBOR`, `Decode`, `Value`, and `Cbor` against a
  nil internal `*Value` on a zero-value `LazyValue`, matching the lazy-init
  pattern already used in `UnmarshalCBOR` and `MarshalJSON`.

## Testing

- Added 32-bit/64-bit boundary and overflow cases to `TestArrayHeaderSize`
  and `TestStreamDecoderAdvance`.
- Added `TestLazyValueZeroValueMethods` covering all four previously
  unguarded methods on a zero-value `LazyValue`.
- Confirmed each new test panics/fails against the pre-fix code and passes
  with the fix.
- `make test` (root module + all example modules), `go vet`, `golangci-lint`,
  and `nilaway` all pass clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three cbor edge cases: `StreamDecoder.Advance` no longer wraps on huge advances, `ArrayHeaderSize` returns the correct 9-byte header for lengths ≥2^32, and all `LazyValue` methods are safe on zero values.

**Changes**
- `StreamDecoder.Advance` now checks the bounds before adding, so a huge `n` returns a normal error instead of wrapping negative and bypassing the check.
- `ArrayHeaderSize` returns 9 for lengths at or above the 32-bit boundary instead of understating as 5.
- `LazyValue` `MarshalCBOR`, `Decode`, `Value`, and `Cbor` guard against a nil internal value, matching the existing lazy-init pattern.
- Added boundary, overflow, and zero-value tests covering all three fixes.

<sup>Written for commit e2bbe8d7d0f9a552ddc59aa82e0ec88b9acfadfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stream decoding from accepting invalid advances caused by integer overflow.
  * Corrected array header sizing for lengths above the 32-bit range.
  * Improved safety when using an uninitialized lazy value, avoiding panics and returning appropriate results or errors.

* **Tests**
  * Added coverage for overflow handling, large array lengths, and zero-value lazy value behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->