### PR TITLE
fix(ledger): count a duplicated redeemer's budget once

### DIFF
--- a/ledger/alonzo/rules.go
+++ b/ledger/alonzo/rules.go
@@ -233,8 +233,18 @@ func UtxoValidateExUnitsTooBigUtxo(
 	if !ok {
 		return errors.New("transaction is not expected type")
 	}
+	// Iterate the collapsed view rather than the raw list. The wire format is
+	// a list but the ledger holds a map, so a key appearing more than once
+	// contributes its budget once. Summing the raw list multiplies it by the
+	// number of copies: on Preview, transaction 3ace3bc7f4c5… at slot 12925989
+	// carries the same (mint, 0) redeemer six times at 3322788/843448898, and
+	// summing all six gives 19936728 memory against a 14000000 cap, rejecting
+	// a transaction the network accepted (blinklabs-io/dingo#3875).
+	//
+	// The raw list is still the right thing for the script data hash, which has
+	// to reproduce the bytes as they were signed.
 	var totalSteps, totalMemory int64
-	for _, redeemer := range tmpTx.WitnessSet.WsRedeemers.Redeemers {
+	for _, redeemer := range tmpTx.WitnessSet.WsRedeemers.Iter() {
 		newSteps, ok := common.AddInt64Checked(
 			totalSteps,
 			redeemer.ExUnits.Steps,

--- a/ledger/alonzo/rules_test.go
+++ b/ledger/alonzo/rules_test.go
@@ -1256,6 +1256,39 @@ func TestUtxoValidateExUnitsTooBigUtxo(t *testing.T) {
 			Steps:  5_000,
 		},
 	}
+	// A duplicated key contributes its budget once, as it does in the map the
+	// ledger holds. Preview transaction 3ace3bc7f4c5 at slot 12925989 carries
+	// the same (mint, 0) redeemer six times; summing the raw list rejected a
+	// transaction the network accepted (blinklabs-io/dingo#3875). That block is
+	// Babbage, but the rule is duplicated per era and the Alonzo copy summed
+	// the raw list the same way.
+	t.Run(
+		"duplicate redeemer key counts once",
+		func(t *testing.T) {
+			dup := alonzo.AlonzoRedeemer{
+				Tag:   common.RedeemerTagMint,
+				Index: 0,
+				ExUnits: common.ExUnits{
+					Memory: 3_000_000,
+					Steps:  3_000,
+				},
+			}
+			testTx.WitnessSet.WsRedeemers = alonzo.AlonzoRedeemers{
+				Redeemers: []alonzo.AlonzoRedeemer{dup, dup, dup, dup, dup, dup},
+			}
+			// One copy is inside the 5,000,000 / 5,000 cap and two already
+			// exceed it, so only a collapse to exactly one entry passes: an
+			// over-count of any size, not just all six, fails here.
+			if err := alonzo.UtxoValidateExUnitsTooBigUtxo(
+				testTx, testSlot, testLedgerState, testProtocolParams,
+			); err != nil {
+				t.Errorf(
+					"six copies of one redeemer must count once, got: %v", err,
+				)
+			}
+		},
+	)
+
 	// Ex-units too large
 	t.Run(
 		"ExUnits too large",
@@ -1311,15 +1344,20 @@ func TestUtxoValidateExUnitsTooBigUtxo(t *testing.T) {
 	t.Run(
 		"ExUnits overflow",
 		func(t *testing.T) {
+			// Distinct keys: this case is about addition overflowing, and
+			// two entries sharing a key would collapse to one before the
+			// sum ever happens.
 			testTx.WitnessSet.WsRedeemers = alonzo.AlonzoRedeemers{
 				Redeemers: []alonzo.AlonzoRedeemer{
 					{
+						Index: 0,
 						ExUnits: common.ExUnits{
 							Memory: math.MaxInt64 - 10,
 							Steps:  math.MaxInt64 - 10,
 						},
 					},
 					{
+						Index: 1,
 						ExUnits: common.ExUnits{
 							Memory: 100,
 							Steps:  100,

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -1034,8 +1034,13 @@ func UtxoValidateExUnitsTooBigUtxo(
 	if !ok {
 		return errors.New("transaction is not expected type")
 	}
+	// Iterate the collapsed view rather than the raw list: the wire format is a
+	// list but the ledger holds a map, so a key appearing more than once
+	// contributes its budget once. See the Alonzo rule of the same name; this
+	// is where it bites in practice, since Preview transaction 3ace3bc7f4c5 at
+	// slot 12925989 is a Babbage-era block (blinklabs-io/dingo#3875).
 	var totalSteps, totalMemory int64
-	for _, redeemer := range tmpTx.WitnessSet.WsRedeemers.Redeemers {
+	for _, redeemer := range tmpTx.WitnessSet.WsRedeemers.Iter() {
 		newSteps, ok := common.AddInt64Checked(
 			totalSteps,
 			redeemer.ExUnits.Steps,

--- a/ledger/babbage/rules_test.go
+++ b/ledger/babbage/rules_test.go
@@ -1336,6 +1336,38 @@ func TestUtxoValidateExUnitsTooBigUtxo(t *testing.T) {
 			Steps:  5_000,
 		},
 	}
+	// A duplicated key contributes its budget once, as it does in the map the
+	// ledger holds. Preview transaction 3ace3bc7f4c5 at slot 12925989 is a
+	// Babbage block carrying the same (mint, 0) redeemer six times; summing the
+	// raw list rejected a transaction the network accepted
+	// (blinklabs-io/dingo#3875).
+	t.Run(
+		"duplicate redeemer key counts once",
+		func(t *testing.T) {
+			dup := alonzo.AlonzoRedeemer{
+				Tag:   common.RedeemerTagMint,
+				Index: 0,
+				ExUnits: common.ExUnits{
+					Memory: 3_000_000,
+					Steps:  3_000,
+				},
+			}
+			testTx.WitnessSet.WsRedeemers = alonzo.AlonzoRedeemers{
+				Redeemers: []alonzo.AlonzoRedeemer{dup, dup, dup, dup, dup, dup},
+			}
+			// One copy is inside the 5,000,000 / 5,000 cap and two already
+			// exceed it, so only a collapse to exactly one entry passes: an
+			// over-count of any size, not just all six, fails here.
+			if err := babbage.UtxoValidateExUnitsTooBigUtxo(
+				testTx, testSlot, testLedgerState, testProtocolParams,
+			); err != nil {
+				t.Errorf(
+					"six copies of one redeemer must count once, got: %v", err,
+				)
+			}
+		},
+	)
+
 	// Ex-units too large
 	t.Run(
 		"ExUnits too large",
@@ -1391,15 +1423,20 @@ func TestUtxoValidateExUnitsTooBigUtxo(t *testing.T) {
 	t.Run(
 		"ExUnits overflow",
 		func(t *testing.T) {
+			// Distinct keys: this case is about addition overflowing, and
+			// two entries sharing a key would collapse to one before the
+			// sum ever happens.
 			testTx.WitnessSet.WsRedeemers = alonzo.AlonzoRedeemers{
 				Redeemers: []alonzo.AlonzoRedeemer{
 					{
+						Index: 0,
 						ExUnits: common.ExUnits{
 							Memory: math.MaxInt64 - 10,
 							Steps:  math.MaxInt64 - 10,
 						},
 					},
 					{
+						Index: 1,
 						ExUnits: common.ExUnits{
 							Memory: 100,
 							Steps:  100,


### PR DESCRIPTION
Reported as blinklabs-io/dingo#3875.

The last-wins half of this work is already on `main` via #2200. This PR is now
only the second half: the execution-unit budget of a duplicated redeemer key.

## The defect

`UtxoValidateExUnitsTooBigUtxo` summed `WsRedeemers.Redeemers`, the raw wire
list, so a key appearing more than once contributed its budget once per copy.
cardano-ledger sums over the map:

```haskell
totExUnits tx = foldMap snd $ tx ^. witsTxL . rdmrsTxWitsL . unRedeemersL
```

A duplicated key contributes once there, because `unRedeemersL` is a `Map`.

## How it surfaced

After #2200 landed the last-wins fix, a Preview replay advanced 1231 slots and
stopped again:

```
ExUnits too big: total 5060693388/19936728 steps/memory, maximum 10000000000/14000000
```

Transaction `3ace3bc7f4c5…` at slot 12925989 carries the same `(mint, 0)`
redeemer six times at `[3322788, 843448898]`. `6 x 3322788 = 19936728` is
exactly the reported memory. Collapsed, the transaction is well inside both
limits.

## The change

Alonzo and Babbage now iterate `WsRedeemers.Iter()`, the collapsed view, for the
budget. Conway and Dijkstra already did; all four eras now agree. Slot 12925989
is a Babbage block, so Babbage is where it bites in practice.

Collapsing can only lower a sum, so no transaction that validated before can be
newly rejected by this.

The raw list is deliberately left in use for the script data hash, which has to
reproduce the bytes as they were signed.

## Tests

Both eras get a `duplicate redeemer key counts once` accept case: six copies of
one `(mint, 0)` redeemer at 3,000,000 memory / 3,000 steps against a
5,000,000 / 5,000 cap, so one copy fits and *two* already exceed it. Only a
collapse to exactly one entry passes; an over-count of any size fails, not just
a full six.

Reverting only the era's `rules.go` change fails that era's test, at six copies
(`18000000` memory) and at two (`6000000`).

The existing `ExUnits overflow` case in both suites built two redeemers that
both defaulted to key `(0, 0)`, so it depended on duplicates summing. Its
subject is addition overflowing, not duplicate handling, so the entries now
carry distinct indexes and exercise the same arithmetic.

`go build ./...`, `go test ./... -count=1` (39 packages) and `make lint` (0 issues) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cXreCqyqbGJuDtvgYyqQN
