### PR TITLE
fix(ledger): preserve pool reward account credential type

### DIFF
--- a/ledger/common/certs.go
+++ b/ledger/common/certs.go
@@ -697,6 +697,33 @@ func (c *PoolRegistrationCertificate) RewardAccountCredential() Credential {
 	return cred
 }
 
+// SetRewardAccountCredential sets the reward-account credential and the
+// network identity needed for canonical CBOR encoding.
+func (c *PoolRegistrationCertificate) SetRewardAccountCredential(
+	credential Credential,
+	networkId uint,
+) error {
+	if c == nil {
+		return errors.New("nil pool registration certificate receiver")
+	}
+	if credential.CredType > CredentialTypeScriptHash {
+		return fmt.Errorf(
+			"invalid reward account credential type: %d",
+			credential.CredType,
+		)
+	}
+	if networkId > AddressNetworkMainnet {
+		return fmt.Errorf("invalid reward account network id: %d", networkId)
+	}
+	c.RewardAccount = AddrKeyHash(credential.Credential)
+	c.rewardAccountCredentialType = credential.CredType
+	c.rewardAccountCredentialKnown = true
+	c.rewardAccountNetworkId = networkId
+	c.rewardAccountNetworkIdKnown = true
+	c.DecodeStoreCbor.SetCbor(nil)
+	return nil
+}
+
 // RewardAccountNetworkId returns the network id encoded in the header byte of
 // the certificate's reward account. The second return value is false when the
 // certificate did not come from a wire reward_account carrying that header, in
@@ -706,9 +733,9 @@ func (c *PoolRegistrationCertificate) RewardAccountNetworkId() (uint, bool) {
 	return c.rewardAccountNetworkId, c.rewardAccountNetworkIdKnown
 }
 
-// SetCbor invalidates the decoded reward-account network only when replacing
-// the cached bytes. Clearing the cache before mutating fields must preserve
-// that consensus-relevant metadata.
+// SetCbor invalidates decoded reward-account metadata only when replacing the
+// cached bytes. Clearing the cache before mutating fields must preserve that
+// consensus-relevant metadata.
 func (c *PoolRegistrationCertificate) SetCbor(cborData []byte) {
 	c.DecodeStoreCbor.SetCbor(cborData)
 	if cborData != nil {
@@ -1177,6 +1204,10 @@ func (c PoolRegistrationCertificate) MarshalCBOR() ([]byte, error) {
 	if err := ValidatePoolMargin(c.Margin); err != nil {
 		return nil, fmt.Errorf("invalid pool registration margin: %w", err)
 	}
+	rewardAccount, err := c.rewardAccountBytes()
+	if err != nil {
+		return nil, err
+	}
 	if c.LeiosKey == nil {
 		return cbor.Encode([]any{
 			c.CertType,
@@ -1185,7 +1216,7 @@ func (c PoolRegistrationCertificate) MarshalCBOR() ([]byte, error) {
 			c.Pledge,
 			c.Cost,
 			c.Margin,
-			c.RewardAccount,
+			rewardAccount,
 			c.PoolOwners,
 			c.Relays,
 			c.PoolMetadata,
@@ -1199,11 +1230,42 @@ func (c PoolRegistrationCertificate) MarshalCBOR() ([]byte, error) {
 		c.Pledge,
 		c.Cost,
 		c.Margin,
-		c.RewardAccount,
+		rewardAccount,
 		c.PoolOwners,
 		c.Relays,
 		c.PoolMetadata,
 	})
+}
+
+func (c PoolRegistrationCertificate) rewardAccountBytes() ([]byte, error) {
+	if !c.rewardAccountNetworkIdKnown || !c.rewardAccountCredentialKnown {
+		return nil, errors.New(
+			"pool reward account metadata is required for CBOR encoding",
+		)
+	}
+	if c.rewardAccountNetworkId > AddressNetworkMainnet {
+		return nil, fmt.Errorf(
+			"invalid reward account network id: %d",
+			c.rewardAccountNetworkId,
+		)
+	}
+	if c.rewardAccountCredentialType > CredentialTypeScriptHash {
+		return nil, fmt.Errorf(
+			"invalid reward account credential type: %d",
+			c.rewardAccountCredentialType,
+		)
+	}
+	header := byte(0xE0)
+	if c.rewardAccountNetworkId == AddressNetworkMainnet {
+		header |= 0x01
+	}
+	if c.rewardAccountCredentialType == CredentialTypeScriptHash {
+		header |= 0x10
+	}
+	ret := make([]byte, Blake2b224Size+1)
+	ret[0] = header
+	copy(ret[1:], c.RewardAccount[:])
+	return ret, nil
 }
 
 func (c *PoolRegistrationCertificate) Utxorpc() (*utxorpc.Certificate, error) {

--- a/ledger/common/certs.go
+++ b/ledger/common/certs.go
@@ -675,10 +675,26 @@ type PoolRegistrationCertificate struct {
 	// byte of the wire reward_account, which RewardAccount itself does not
 	// retain. rewardAccountNetworkIdKnown is false when the certificate was
 	// not decoded from a CBOR reward account carrying a header byte (a
-	// programmatically constructed certificate, one built from JSON, or the
-	// legacy 28-byte encoding).
-	rewardAccountNetworkId      uint
-	rewardAccountNetworkIdKnown bool
+	// programmatically constructed certificate or one built from JSON/genesis).
+	rewardAccountNetworkId       uint
+	rewardAccountNetworkIdKnown  bool
+	rewardAccountCredentialType  uint
+	rewardAccountCredentialKnown bool
+}
+
+// RewardAccountCredential returns the credential carried by the pool's
+// reward account. Programmatically constructed and JSON/genesis certificates
+// have no wire header and retain the historical key-hash default.
+func (c *PoolRegistrationCertificate) RewardAccountCredential() Credential {
+	cred := Credential{CredType: CredentialTypeAddrKeyHash}
+	if c == nil {
+		return cred
+	}
+	cred.Credential = CredentialHash(c.RewardAccount)
+	if c.rewardAccountCredentialKnown {
+		cred.CredType = c.rewardAccountCredentialType
+	}
+	return cred
 }
 
 // RewardAccountNetworkId returns the network id encoded in the header byte of
@@ -698,6 +714,8 @@ func (c *PoolRegistrationCertificate) SetCbor(cborData []byte) {
 	if cborData != nil {
 		c.rewardAccountNetworkId = 0
 		c.rewardAccountNetworkIdKnown = false
+		c.rewardAccountCredentialType = CredentialTypeAddrKeyHash
+		c.rewardAccountCredentialKnown = false
 	}
 }
 
@@ -1104,7 +1122,9 @@ func (c *PoolRegistrationCertificate) UnmarshalCBOR(cborData []byte) error {
 		c.Pledge = tmp.Pledge
 		c.Cost = tmp.Cost
 		c.Margin = tmp.Margin
-		c.RewardAccount = tmp.RewardAccount.credential
+		c.RewardAccount = AddrKeyHash(tmp.RewardAccount.credential.Credential)
+		c.rewardAccountCredentialType = tmp.RewardAccount.credential.CredType
+		c.rewardAccountCredentialKnown = true
 		c.rewardAccountNetworkId = tmp.RewardAccount.networkId
 		c.rewardAccountNetworkIdKnown = tmp.RewardAccount.networkIdKnown
 		c.PoolOwners = tmp.PoolOwners
@@ -1127,7 +1147,9 @@ func (c *PoolRegistrationCertificate) UnmarshalCBOR(cborData []byte) error {
 		c.Pledge = tmp.Pledge
 		c.Cost = tmp.Cost
 		c.Margin = tmp.Margin
-		c.RewardAccount = tmp.RewardAccount.credential
+		c.RewardAccount = AddrKeyHash(tmp.RewardAccount.credential.Credential)
+		c.rewardAccountCredentialType = tmp.RewardAccount.credential.CredType
+		c.rewardAccountCredentialKnown = true
 		c.rewardAccountNetworkId = tmp.RewardAccount.networkId
 		c.rewardAccountNetworkIdKnown = tmp.RewardAccount.networkIdKnown
 		c.PoolOwners = tmp.PoolOwners

--- a/ledger/common/certs.go
+++ b/ledger/common/certs.go
@@ -739,11 +739,15 @@ func (c *PoolRegistrationCertificate) RewardAccountNetworkId() (uint, bool) {
 func (c *PoolRegistrationCertificate) SetCbor(cborData []byte) {
 	c.DecodeStoreCbor.SetCbor(cborData)
 	if cborData != nil {
-		c.rewardAccountNetworkId = 0
-		c.rewardAccountNetworkIdKnown = false
-		c.rewardAccountCredentialType = CredentialTypeAddrKeyHash
-		c.rewardAccountCredentialKnown = false
+		c.clearRewardAccountMetadata()
 	}
+}
+
+func (c *PoolRegistrationCertificate) clearRewardAccountMetadata() {
+	c.rewardAccountNetworkId = 0
+	c.rewardAccountNetworkIdKnown = false
+	c.rewardAccountCredentialType = CredentialTypeAddrKeyHash
+	c.rewardAccountCredentialKnown = false
 }
 
 // ErrPoolMarginOutsideUnitInterval identifies a stake-pool margin outside the
@@ -1083,6 +1087,12 @@ func (p *PoolRegistrationCertificate) UnmarshalJSON(data []byte) error {
 		}
 		p.PoolOwners = owners
 	}
+
+	// JSON reward accounts do not carry the wire header needed to recover
+	// credential type or network identity. The decoded-CBOR cache is likewise
+	// stale after JSON replaces certificate fields.
+	p.DecodeStoreCbor.SetCbor(nil)
+	p.clearRewardAccountMetadata()
 
 	return nil
 }

--- a/ledger/common/certs_test.go
+++ b/ledger/common/certs_test.go
@@ -338,6 +338,7 @@ func TestPoolRegistrationCertificateRewardAccountDecode(t *testing.T) {
 		{
 			name:          "legacy credential",
 			rewardAccount: credential,
+			wantErr:       "invalid reward account length",
 		},
 		{
 			name: "reward address",
@@ -422,6 +423,11 @@ func TestPoolRegistrationCertificateRewardAccountDecode(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, AddrKeyHash(credential), decoded.RewardAccount)
+			if test.rewardAccount[0]&0x10 != 0 {
+				assert.Equal(t, CredentialTypeScriptHash, decoded.RewardAccountCredential().CredType)
+			} else {
+				assert.Equal(t, CredentialTypeAddrKeyHash, decoded.RewardAccountCredential().CredType)
+			}
 			assert.Equal(t, encoded, decoded.Cbor())
 		})
 	}

--- a/ledger/common/certs_test.go
+++ b/ledger/common/certs_test.go
@@ -242,6 +242,13 @@ func TestPoolRegistrationCertificateLeiosKey(t *testing.T) {
 		Relays:       []PoolRelay{},
 		PoolMetadata: nil,
 	}
+	require.NoError(t, base.SetRewardAccountCredential(
+		Credential{
+			CredType:   CredentialTypeAddrKeyHash,
+			Credential: CredentialHash(base.RewardAccount),
+		},
+		AddressNetworkTestnet,
+	))
 
 	t.Run("legacy certificate remains 10 fields", func(t *testing.T) {
 		encoded, err := cbor.Encode(base)
@@ -293,6 +300,8 @@ func TestPoolRegistrationCertificateLeiosKey(t *testing.T) {
 	})
 
 	t.Run("Dijkstra certificate accepts explicit null key", func(t *testing.T) {
+		rewardAccount, err := base.rewardAccountBytes()
+		require.NoError(t, err)
 		encoded, err := cbor.Encode([]any{
 			base.CertType,
 			base.Operator,
@@ -301,7 +310,7 @@ func TestPoolRegistrationCertificateLeiosKey(t *testing.T) {
 			base.Pledge,
 			base.Cost,
 			base.Margin,
-			base.RewardAccount,
+			rewardAccount,
 			base.PoolOwners,
 			base.Relays,
 			base.PoolMetadata,
@@ -423,11 +432,23 @@ func TestPoolRegistrationCertificateRewardAccountDecode(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, AddrKeyHash(credential), decoded.RewardAccount)
+			provider, ok := any(&decoded).(interface {
+				RewardAccountCredential() Credential
+			})
+			require.True(
+				t,
+				ok,
+				"decoded pool registration must preserve reward credential type",
+			)
+			wantType := uint(CredentialTypeAddrKeyHash)
 			if test.rewardAccount[0]&0x10 != 0 {
-				assert.Equal(t, CredentialTypeScriptHash, decoded.RewardAccountCredential().CredType)
-			} else {
-				assert.Equal(t, CredentialTypeAddrKeyHash, decoded.RewardAccountCredential().CredType)
+				wantType = uint(CredentialTypeScriptHash)
 			}
+			assert.Equal(
+				t,
+				wantType,
+				provider.RewardAccountCredential().CredType,
+			)
 			assert.Equal(t, encoded, decoded.Cbor())
 		})
 	}

--- a/ledger/common/pool_margin_test.go
+++ b/ledger/common/pool_margin_test.go
@@ -49,6 +49,10 @@ func testPoolRegistrationCertificate(
 		RewardAccount: NewBlake2b224(
 			bytes.Repeat([]byte{0x03}, Blake2b224Size),
 		),
+		rewardAccountNetworkId:       AddressNetworkTestnet,
+		rewardAccountNetworkIdKnown:  true,
+		rewardAccountCredentialType:  CredentialTypeAddrKeyHash,
+		rewardAccountCredentialKnown: true,
 		PoolOwners: []AddrKeyHash{
 			NewBlake2b224(bytes.Repeat([]byte{0x04}, Blake2b224Size)),
 		},
@@ -69,6 +73,8 @@ func testPoolRegistrationWire(
 ) []byte {
 	t.Helper()
 	cert := testPoolRegistrationCertificate(NewGenesisRat(0, 1))
+	rewardAccount, err := cert.rewardAccountBytes()
+	require.NoError(t, err)
 	fields := []any{
 		cert.CertType,
 		cert.Operator,
@@ -76,7 +82,7 @@ func testPoolRegistrationWire(
 		cert.Pledge,
 		cert.Cost,
 		margin,
-		cert.RewardAccount,
+		rewardAccount,
 		cert.PoolOwners,
 		cert.Relays,
 		cert.PoolMetadata,

--- a/ledger/common/pool_reward_account_test.go
+++ b/ledger/common/pool_reward_account_test.go
@@ -84,26 +84,90 @@ func TestPoolRegistrationRewardAccountNetworkId(t *testing.T) {
 
 	t.Run("legacy 28-byte encoding is rejected", func(t *testing.T) {
 		cert := &PoolRegistrationCertificate{}
-		require.ErrorContains(t, cert.UnmarshalCBOR(encode(t, credential)), "invalid reward account length")
+		require.ErrorContains(
+			t,
+			cert.UnmarshalCBOR(encode(t, credential)),
+			"invalid reward account length",
+		)
 	})
 
 	t.Run("constructed certificate has no network id", func(t *testing.T) {
 		cert := &PoolRegistrationCertificate{
 			RewardAccount: NewBlake2b224(credential),
+			Margin:        NewGenesisRat(0, 1),
 		}
 		_, known := cert.RewardAccountNetworkId()
 		assert.False(t, known)
+		assert.Equal(
+			t,
+			uint(CredentialTypeAddrKeyHash),
+			cert.RewardAccountCredential().CredType,
+		)
+		_, err := cert.MarshalCBOR()
+		require.ErrorContains(t, err, "reward account metadata is required")
 	})
 
-	t.Run("decoding preserves the wire bytes", func(t *testing.T) {
-		rewardAccount := append([]byte{0xe1}, credential...)
-		wire := encode(t, rewardAccount)
-		cert := &PoolRegistrationCertificate{}
-		require.NoError(t, cert.UnmarshalCBOR(wire))
-		remarshaled, err := cert.MarshalCBOR()
-		require.NoError(t, err)
-		assert.Equal(t, wire, remarshaled)
-	})
+	t.Run(
+		"constructed certificate can set canonical identity",
+		func(t *testing.T) {
+			cert := &PoolRegistrationCertificate{}
+			err := cert.SetRewardAccountCredential(
+				Credential{
+					CredType:   CredentialTypeScriptHash,
+					Credential: NewBlake2b224(credential),
+				},
+				AddressNetworkMainnet,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, AddrKeyHash(credential), cert.RewardAccount)
+			assert.Equal(
+				t,
+				uint(CredentialTypeScriptHash),
+				cert.RewardAccountCredential().CredType,
+			)
+			gotNetwork, known := cert.RewardAccountNetworkId()
+			require.True(t, known)
+			assert.Equal(t, uint(AddressNetworkMainnet), gotNetwork)
+			encodedReward, err := cert.rewardAccountBytes()
+			require.NoError(t, err)
+			assert.Equal(t, append([]byte{0xf1}, credential...), encodedReward)
+		},
+	)
+
+	t.Run(
+		"constructed certificate rejects invalid identity",
+		func(t *testing.T) {
+			cert := &PoolRegistrationCertificate{}
+			err := cert.SetRewardAccountCredential(
+				Credential{CredType: CredentialTypeScriptHash + 1},
+				AddressNetworkMainnet,
+			)
+			require.ErrorContains(
+				t,
+				err,
+				"invalid reward account credential type",
+			)
+			err = cert.SetRewardAccountCredential(
+				Credential{CredType: CredentialTypeAddrKeyHash},
+				AddressNetworkMainnet+1,
+			)
+			require.ErrorContains(t, err, "invalid reward account network id")
+		},
+	)
+
+	t.Run(
+		"decoding preserves canonical identity after cache clear",
+		func(t *testing.T) {
+			rewardAccount := append([]byte{0xf1}, credential...)
+			wire := encode(t, rewardAccount)
+			cert := &PoolRegistrationCertificate{}
+			require.NoError(t, cert.UnmarshalCBOR(wire))
+			cert.SetCbor(nil)
+			remarshaled, err := cert.MarshalCBOR()
+			require.NoError(t, err)
+			assert.Equal(t, wire, remarshaled)
+		},
+	)
 }
 
 // TestPoolMetadataHashLengthIsFixed proves a pool registration whose metadata

--- a/ledger/common/pool_reward_account_test.go
+++ b/ledger/common/pool_reward_account_test.go
@@ -82,17 +82,9 @@ func TestPoolRegistrationRewardAccountNetworkId(t *testing.T) {
 		assert.Equal(t, uint(1), got)
 	})
 
-	t.Run("legacy 28-byte encoding has no network id", func(t *testing.T) {
+	t.Run("legacy 28-byte encoding is rejected", func(t *testing.T) {
 		cert := &PoolRegistrationCertificate{}
-		require.NoError(t, cert.UnmarshalCBOR(encode(t, credential)))
-		assert.Equal(
-			t,
-			AddrKeyHash(NewBlake2b224(credential)),
-			cert.RewardAccount,
-		)
-		got, known := cert.RewardAccountNetworkId()
-		assert.False(t, known)
-		assert.Equal(t, uint(0), got)
+		require.ErrorContains(t, cert.UnmarshalCBOR(encode(t, credential)), "invalid reward account length")
 	})
 
 	t.Run("constructed certificate has no network id", func(t *testing.T) {

--- a/ledger/common/pool_reward_account_test.go
+++ b/ledger/common/pool_reward_account_test.go
@@ -16,6 +16,8 @@ package common
 
 import (
 	"bytes"
+	"encoding/hex"
+	"encoding/json"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -168,6 +170,51 @@ func TestPoolRegistrationRewardAccountNetworkId(t *testing.T) {
 			assert.Equal(t, wire, remarshaled)
 		},
 	)
+
+	t.Run("JSON replacement clears decoded identity", func(t *testing.T) {
+		rewardAccount := append([]byte{0xf1}, credential...)
+		cert := &PoolRegistrationCertificate{}
+		require.NoError(t, cert.UnmarshalCBOR(encode(t, rewardAccount)))
+		assert.Equal(
+			t,
+			uint(CredentialTypeScriptHash),
+			cert.RewardAccountCredential().CredType,
+		)
+
+		replacementCredential := bytes.Repeat(
+			[]byte{0x08},
+			Blake2b224Size,
+		)
+		jsonData, err := json.Marshal(map[string]any{
+			"margin": map[string]any{
+				"numerator":   0,
+				"denominator": 1,
+			},
+			"rewardAccount": map[string]any{
+				"credential": map[string]any{
+					"key hash": hex.EncodeToString(replacementCredential),
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(jsonData, cert))
+
+		assert.Nil(t, cert.Cbor())
+		assert.Equal(
+			t,
+			AddrKeyHash(replacementCredential),
+			cert.RewardAccount,
+		)
+		assert.Equal(
+			t,
+			uint(CredentialTypeAddrKeyHash),
+			cert.RewardAccountCredential().CredType,
+		)
+		_, known := cert.RewardAccountNetworkId()
+		assert.False(t, known)
+		_, err = cert.MarshalCBOR()
+		require.ErrorContains(t, err, "reward account metadata is required")
+	})
 }
 
 // TestPoolMetadataHashLengthIsFixed proves a pool registration whose metadata

--- a/ledger/common/strict_decode.go
+++ b/ledger/common/strict_decode.go
@@ -25,14 +25,12 @@ import (
 // rewardAccountCBOR isolates reward addresses from the Blake2b224 decoder.
 // The ledger wire value is a one-byte address header followed by a 28-byte
 // credential, while the exported certificate field retains only the
-// credential. Accept the repository's legacy 28-byte encoding as well so
-// existing constructed values round-trip.
+// credential. Keep the credential kind as well as its hash so decoding does
+// not erase the distinction between key and script reward accounts.
 type rewardAccountCBOR struct {
-	credential AddrKeyHash
+	credential Credential
 	// networkId holds the low nibble of the address header byte, and
 	// networkIdKnown records whether a header byte was present at all. The
-	// legacy 28-byte encoding carries no header, so no network id can be
-	// recovered from it.
 	networkId      uint
 	networkIdKnown bool
 }
@@ -214,15 +212,13 @@ func (r *rewardAccountCBOR) UnmarshalCBOR(cborData []byte) error {
 	if err != nil {
 		return fmt.Errorf("decode reward account: %w", err)
 	}
-	if decodedLength != Blake2b224Size && decodedLength != Blake2b224Size+1 {
+	if decodedLength != Blake2b224Size+1 {
 		return fmt.Errorf(
-			"invalid reward account length: expected 28 or 29 bytes, got %d",
+			"invalid reward account length: expected 29 bytes, got %d",
 			decodedLength,
 		)
 	}
-	credentialOffset := 0
-	if decodedLength == Blake2b224Size+1 {
-		credentialOffset = 1
+	{
 		// headerIsAccountAddress in Cardano.Ledger.Address:
 		// header .&. 0b11101110 == 0b11100000. Bits 7-5 are the account
 		// address prefix, bit 4 is the script flag and is free, bits 3-1
@@ -235,11 +231,12 @@ func (r *rewardAccountCBOR) UnmarshalCBOR(cborData []byte) error {
 			)
 		}
 	}
-	copy(
-		r.credential[:],
-		decoded[credentialOffset:credentialOffset+Blake2b224Size],
-	)
-	if credentialOffset == 1 {
+	r.credential.CredType = CredentialTypeAddrKeyHash
+	if decoded[0]&0x10 != 0 {
+		r.credential.CredType = CredentialTypeScriptHash
+	}
+	copy(r.credential.Credential[:], decoded[1:])
+	{
 		// Bit 0 of a reward address header byte is the network id,
 		// which the header check above has already constrained to 0 or
 		// 1. See Cardano.Ledger.Address (aaNetworkId), read by

--- a/ledger/conway/conway_test.go
+++ b/ledger/conway/conway_test.go
@@ -218,7 +218,7 @@ func TestConwayTransactionBodyUnmarshalCBORCertificateTypes(t *testing.T) {
 }
 
 func TestConwayTransactionBodyUnmarshalCBORCertificateTagRange(t *testing.T) {
-	certificates := conwayCertificateFixturesByType()
+	certificates := conwayCertificateFixturesByType(t)
 	for certType := common.CertificateTypeStakeRegistration; certType <= common.CertificateTypeUpdateDrep; certType++ {
 		certType := certType
 		t.Run(fmt.Sprintf("type %d", certType), func(t *testing.T) {
@@ -245,10 +245,21 @@ func TestConwayTransactionBodyUnmarshalCBORCertificateTagRange(t *testing.T) {
 	}
 }
 
-func conwayCertificateFixturesByType() map[common.CertificateType]any {
+func conwayCertificateFixturesByType(
+	t *testing.T,
+) map[common.CertificateType]any {
+	t.Helper()
 	credential := common.Credential{
 		CredType: common.CredentialTypeAddrKeyHash,
 	}
+	poolRegistration := &common.PoolRegistrationCertificate{
+		CertType: uint(common.CertificateTypePoolRegistration),
+		Margin:   cbor.Rat{Rat: big.NewRat(0, 1)},
+	}
+	require.NoError(t, poolRegistration.SetRewardAccountCredential(
+		credential,
+		common.AddressNetworkTestnet,
+	))
 	return map[common.CertificateType]any{
 		common.CertificateTypeStakeRegistration: &common.StakeRegistrationCertificate{
 			CertType: uint(common.CertificateTypeStakeRegistration),
@@ -260,10 +271,7 @@ func conwayCertificateFixturesByType() map[common.CertificateType]any {
 			CertType:        uint(common.CertificateTypeStakeDelegation),
 			StakeCredential: &credential,
 		},
-		common.CertificateTypePoolRegistration: &common.PoolRegistrationCertificate{
-			CertType: uint(common.CertificateTypePoolRegistration),
-			Margin:   cbor.Rat{Rat: big.NewRat(0, 1)},
-		},
+		common.CertificateTypePoolRegistration: poolRegistration,
 		common.CertificateTypePoolRetirement: &common.PoolRetirementCertificate{
 			CertType: uint(common.CertificateTypePoolRetirement),
 		},
@@ -468,7 +476,11 @@ func TestConwayRejectsDuplicateUntaggedInputSets(t *testing.T) {
 			require.NoError(t, err)
 
 			var body ConwayTransactionBody
-			require.ErrorContains(t, body.UnmarshalCBOR(bodyCbor), "duplicate member in set")
+			require.ErrorContains(
+				t,
+				body.UnmarshalCBOR(bodyCbor),
+				"duplicate member in set",
+			)
 		})
 	}
 }

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -57,7 +57,7 @@ func TestDijkstraTransactionBodiesUnmarshalCBORCertificateTypes(t *testing.T) {
 			},
 		},
 	}
-	certificates := certificateFixturesByType()
+	certificates := certificateFixturesByType(t)
 	testCases := make([]struct {
 		name     string
 		certType common.CertificateType
@@ -124,10 +124,19 @@ func TestDijkstraTransactionBodiesRejectNegativeCurrentTreasuryValue(
 	})
 }
 
-func certificateFixturesByType() map[common.CertificateType]any {
+func certificateFixturesByType(t *testing.T) map[common.CertificateType]any {
+	t.Helper()
 	credential := common.Credential{
 		CredType: common.CredentialTypeAddrKeyHash,
 	}
+	poolRegistration := &common.PoolRegistrationCertificate{
+		CertType: uint(common.CertificateTypePoolRegistration),
+		Margin:   cbor.Rat{Rat: big.NewRat(0, 1)},
+	}
+	require.NoError(t, poolRegistration.SetRewardAccountCredential(
+		credential,
+		common.AddressNetworkTestnet,
+	))
 	return map[common.CertificateType]any{
 		common.CertificateTypeStakeRegistration: &common.StakeRegistrationCertificate{
 			CertType: uint(common.CertificateTypeStakeRegistration),
@@ -139,10 +148,7 @@ func certificateFixturesByType() map[common.CertificateType]any {
 			CertType:        uint(common.CertificateTypeStakeDelegation),
 			StakeCredential: &credential,
 		},
-		common.CertificateTypePoolRegistration: &common.PoolRegistrationCertificate{
-			CertType: uint(common.CertificateTypePoolRegistration),
-			Margin:   cbor.Rat{Rat: big.NewRat(0, 1)},
-		},
+		common.CertificateTypePoolRegistration: poolRegistration,
 		common.CertificateTypePoolRetirement: &common.PoolRetirementCertificate{
 			CertType: uint(common.CertificateTypePoolRetirement),
 		},
@@ -817,7 +823,11 @@ func TestDijkstraRejectsDuplicateUntaggedInputSets(t *testing.T) {
 			require.NoError(t, err)
 
 			var body DijkstraTransactionBody
-			require.ErrorContains(t, body.UnmarshalCBOR(bodyCbor), "duplicate member in set")
+			require.ErrorContains(
+				t,
+				body.UnmarshalCBOR(bodyCbor),
+				"duplicate member in set",
+			)
 		})
 	}
 }
@@ -955,7 +965,11 @@ func TestDijkstraWitnessSetRejectsDuplicateUntaggedVkeyWitness(t *testing.T) {
 		0x82, 0x41, 0x01, 0x41, 0x02, // duplicate
 	}
 	var ws DijkstraTransactionWitnessSet
-	require.ErrorContains(t, ws.UnmarshalCBOR(dupCbor), "duplicate member in set")
+	require.ErrorContains(
+		t,
+		ws.UnmarshalCBOR(dupCbor),
+		"duplicate member in set",
+	)
 }
 
 func TestDijkstraBlockDecodesRedeemerWitnessMap(t *testing.T) {


### PR DESCRIPTION
Fixes #2197.

Pool registration reward_account decoding now requires the canonical 29-byte reward address and preserves key/script credential type alongside the existing hash and network metadata. Legacy 28-byte wire values and invalid headers are rejected.

Adds regression coverage for canonical key/script forms and malformed lengths/headers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2197 by making pool reward account decoding and encoding require the canonical 29-byte address and preserve the key/script credential type, instead of reducing reward accounts to a key hash and accepting legacy 28-byte wire values.

- Pool registration certificates built programmatically or from JSON must now call `SetRewardAccountCredential` before CBOR encoding; otherwise `MarshalCBOR` fails.
- Rejects legacy 28-byte wire values and invalid headers, and adds regression coverage for canonical key/script forms and malformed lengths/headers.

<sup>Written for commit 69994673ee4ce6e6d5bf286566c67a2fe8223ab2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

