### PR TITLE
fix(ledger): resolve duplicate redeemers last-wins

### DIFF
--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -720,31 +720,31 @@ func (r AlonzoRedeemers) MarshalCBOR() ([]byte, error) {
 	return cbor.Encode(r.Redeemers)
 }
 
+// Iter projects the list-form encoding into the map held by cardano-ledger.
+// Duplicate keys therefore resolve to their last value and are yielded once.
 func (r AlonzoRedeemers) Iter() iter.Seq2[common.RedeemerKey, common.RedeemerValue] {
 	return func(yield func(common.RedeemerKey, common.RedeemerValue) bool) {
-		// Sort redeemers
-		sorted := make([]AlonzoRedeemer, len(r.Redeemers))
-		copy(sorted, r.Redeemers)
-		slices.SortFunc(
-			sorted,
-			func(a, b AlonzoRedeemer) int {
-				return common.CompareRedeemerKeys(
-					common.RedeemerKey{Tag: a.Tag, Index: a.Index},
-					common.RedeemerKey{Tag: b.Tag, Index: b.Index},
-				)
-			},
+		byKey := make(
+			map[common.RedeemerKey]common.RedeemerValue,
+			len(r.Redeemers),
 		)
-		// Yield keys
-		for _, redeemer := range sorted {
-			tmpKey := common.RedeemerKey{
+		for _, redeemer := range r.Redeemers {
+			key := common.RedeemerKey{
 				Tag:   redeemer.Tag,
 				Index: redeemer.Index,
 			}
-			tmpVal := common.RedeemerValue{
+			byKey[key] = common.RedeemerValue{
 				Data:    redeemer.Data,
 				ExUnits: redeemer.ExUnits,
 			}
-			if !yield(tmpKey, tmpVal) {
+		}
+		keys := make([]common.RedeemerKey, 0, len(byKey))
+		for key := range byKey {
+			keys = append(keys, key)
+		}
+		slices.SortFunc(keys, common.CompareRedeemerKeys)
+		for _, key := range keys {
+			if !yield(key, byKey[key]) {
 				return
 			}
 		}
@@ -765,7 +765,9 @@ func (r AlonzoRedeemers) Value(
 	index uint,
 	tag common.RedeemerTag,
 ) common.RedeemerValue {
-	for _, redeemer := range r.Redeemers {
+	// Walk backward so duplicate keys resolve like Map.fromList: last wins.
+	for i := len(r.Redeemers) - 1; i >= 0; i-- {
+		redeemer := r.Redeemers[i]
 		if redeemer.Tag == tag && uint(redeemer.Index) == index {
 			return common.RedeemerValue{
 				Data:    redeemer.Data,

--- a/ledger/alonzo/duplicate_redeemer_test.go
+++ b/ledger/alonzo/duplicate_redeemer_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alonzo_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+func decodeRedeemers(t *testing.T, raw string) alonzo.AlonzoRedeemers {
+	t.Helper()
+	b, err := hex.DecodeString(raw)
+	if err != nil {
+		t.Fatalf("decode fixture hex: %v", err)
+	}
+	var ret alonzo.AlonzoRedeemers
+	if err := ret.UnmarshalCBOR(b); err != nil {
+		t.Fatalf("decode redeemers: %v", err)
+	}
+	return ret
+}
+
+// TestAlonzoRedeemersDuplicateKeyLastWins reproduces the redeemer-list shape
+// from the Preview transaction that wedged a Dingo replay at slot 12924758
+// (blinklabs-io/dingo#3875). It carries six (mint, 0) entries with data
+// 1, 1, 2, 2, 3, 3; execution-unit values are minimized because they do not
+// affect key resolution.
+func TestAlonzoRedeemersDuplicateKeyLastWins(t *testing.T) {
+	const raw = "8684010001820101840100018201018401000282010184010002820101" +
+		"8401000382010184010003820101"
+	r := decodeRedeemers(t, raw)
+	if len(r.Redeemers) != 6 {
+		t.Fatalf("fixture redeemer count = %d, want 6", len(r.Redeemers))
+	}
+
+	got := r.Value(0, common.RedeemerTagMint)
+	if got.Data.Data == nil {
+		t.Fatal("Value did not resolve (mint, 0)")
+	}
+	if gotData := hex.EncodeToString(got.Data.Cbor()); gotData != "03" {
+		t.Errorf("Value data = %s, want last entry 03", gotData)
+	}
+
+	count := 0
+	for key, value := range r.Iter() {
+		count++
+		if key.Tag != common.RedeemerTagMint || key.Index != 0 {
+			t.Errorf("Iter key = (%d, %d), want (%d, 0)", key.Tag, key.Index, common.RedeemerTagMint)
+		}
+		if gotData := hex.EncodeToString(value.Data.Cbor()); gotData != "03" {
+			t.Errorf("Iter data = %s, want last entry 03", gotData)
+		}
+	}
+	if count != 1 {
+		t.Errorf("Iter count = %d, want one value for duplicated key", count)
+	}
+}
+
+// TestAlonzoRedeemersDuplicateKeyPreservesDistinctKeys is a control proving
+// that collapsing one duplicate does not discard or reorder distinct keys.
+func TestAlonzoRedeemersDuplicateKeyPreservesDistinctKeys(t *testing.T) {
+	// [(mint, 0, 1), (spend, 2, 4), (mint, 0, 3)]
+	const raw = "83840100018201018400020482020384010003820405"
+	r := decodeRedeemers(t, raw)
+
+	type observed struct {
+		key  common.RedeemerKey
+		data string
+	}
+	var got []observed
+	for key, value := range r.Iter() {
+		got = append(got, observed{
+			key:  key,
+			data: hex.EncodeToString(value.Data.Cbor()),
+		})
+	}
+	want := []observed{
+		{key: common.RedeemerKey{Tag: common.RedeemerTagSpend, Index: 2}, data: "04"},
+		{key: common.RedeemerKey{Tag: common.RedeemerTagMint, Index: 0}, data: "03"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("Iter count = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Iter[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
Supersedes #2198 and addresses the duplicate-redeemer failure in blinklabs-io/dingo#3875.

Alonzo and Babbage encode redeemers as lists, while cardano-ledger resolves them through a map. This change:

- resolves duplicate keys to the last list entry;
- yields each resolved key once, preventing repeated script evaluation and execution-unit accounting;
- covers the Preview duplicate-key shape plus a distinct-key control.

Validated with a focused fail-before/pass-after regression, affected-package tests, a focused race test, and `go vet`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate redeemer handling in Alonzo so replay no longer fails on transactions with repeated keys. Duplicate keys now resolve to the last list entry and are yielded once, matching cardano-ledger's map-based behavior. This resolves the Preview replay failure in blinklabs-io/dingo#3875.

- `Iter()` now collapses duplicate keys to their last value before yielding sorted keys.
- `Value()` walks redeemers backward so the last entry wins.
- Adds a regression test using the Preview transaction shape from #3875 plus a distinct-key control.

<sup>Written for commit 3bfdb4aebc482cfad592e2abc5c70bd15318ba1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

