### PR TITLE
fix(ledger): order withdrawals by credential (#2187)

### DIFF
--- a/ledger/common/script/context.go
+++ b/ledger/common/script/context.go
@@ -709,7 +709,7 @@ func withdrawalsInfo(
 			},
 		)
 	}
-	sorted := sortWithdrawalAddresses(withdrawals)
+	sorted := SortWithdrawalAddresses(withdrawals)
 	ret = ret[:0]
 	for _, addr := range sorted {
 		ret = append(ret, KeyValuePair[*lcommon.Address, *big.Int]{

--- a/ledger/common/script/context_test.go
+++ b/ledger/common/script/context_test.go
@@ -15,6 +15,7 @@
 package script_test
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -34,6 +35,63 @@ import (
 	"github.com/blinklabs-io/plutigo/data"
 	"github.com/stretchr/testify/require"
 )
+
+func TestTxInfoWithdrawalOrderFollowsCredentialOrder(t *testing.T) {
+	hash := bytes.Repeat([]byte{0x42}, common.AddressHashSize)
+	scriptAddress, err := common.NewAddressFromParts(
+		common.AddressTypeNoneScript,
+		common.AddressNetworkTestnet,
+		nil,
+		hash,
+	)
+	require.NoError(t, err)
+	keyAddress, err := common.NewAddressFromParts(
+		common.AddressTypeNoneKey,
+		common.AddressNetworkTestnet,
+		nil,
+		hash,
+	)
+	require.NoError(t, err)
+	tx := mockledger.NewTransactionBuilder().WithWithdrawals(
+		map[*common.Address]uint64{
+			&scriptAddress: 1,
+			&keyAddress:    2,
+		},
+	)
+
+	assertOrder := func(
+		t *testing.T,
+		withdrawals script.KeyValuePairs[*common.Address, *big.Int],
+	) {
+		require.Len(t, withdrawals, 2)
+		require.Same(t, &scriptAddress, withdrawals[0].Key)
+		require.Same(t, &keyAddress, withdrawals[1].Key)
+	}
+
+	t.Run("Plutus V1", func(t *testing.T) {
+		txInfo, err := script.NewTxInfoV1FromTransaction(
+			mockSlotState{}, tx, nil, false,
+		)
+		require.NoError(t, err)
+		require.Len(t, txInfo.Withdrawals, 2)
+		require.Same(t, &scriptAddress, txInfo.Withdrawals[0].T1)
+		require.Same(t, &keyAddress, txInfo.Withdrawals[1].T1)
+	})
+	t.Run("Plutus V2", func(t *testing.T) {
+		txInfo, err := script.NewTxInfoV2FromTransaction(
+			mockSlotState{}, tx, nil, false,
+		)
+		require.NoError(t, err)
+		assertOrder(t, txInfo.Withdrawals)
+	})
+	t.Run("Plutus V3", func(t *testing.T) {
+		txInfo, err := script.NewTxInfoV3FromTransaction(
+			mockSlotState{}, tx, nil,
+		)
+		require.NoError(t, err)
+		assertOrder(t, txInfo.Withdrawals)
+	})
+}
 
 func buildTxInfoV1(
 	slotState lcommon.SlotState,

--- a/ledger/common/script/purpose.go
+++ b/ledger/common/script/purpose.go
@@ -485,6 +485,9 @@ func BuildScriptPurpose(
 			return nil, UnmatchedRedeemerError{RedeemerKey: redeemerKey}
 		}
 		addr := sortedAddrs[redeemerKey.Index]
+		if addr == nil {
+			return nil, UnmatchedRedeemerError{RedeemerKey: redeemerKey}
+		}
 		return ScriptPurposeRewarding{
 			StakeCredential: lcommon.Credential{
 				CredType:   lcommon.CredentialTypeScriptHash,

--- a/ledger/common/script/purpose.go
+++ b/ledger/common/script/purpose.go
@@ -480,7 +480,7 @@ func BuildScriptPurpose(
 			Certificate: certificates[redeemerKey.Index],
 		}, nil
 	case lcommon.RedeemerTagReward:
-		sortedAddrs := sortWithdrawalAddresses(withdrawals)
+		sortedAddrs := SortWithdrawalAddresses(withdrawals)
 		if uint64(redeemerKey.Index) >= uint64(len(sortedAddrs)) {
 			return nil, UnmatchedRedeemerError{RedeemerKey: redeemerKey}
 		}
@@ -546,9 +546,9 @@ func BuildScriptPurpose(
 	}
 }
 
-// sortWithdrawalAddresses matches cardano-ledger's Ord instance for reward
+// SortWithdrawalAddresses matches cardano-ledger's Ord instance for reward
 // accounts: network first, then credential type, then credential hash.
-func sortWithdrawalAddresses(
+func SortWithdrawalAddresses(
 	withdrawals map[*lcommon.Address]*big.Int,
 ) []*lcommon.Address {
 	sorted := make([]*lcommon.Address, 0, len(withdrawals))
@@ -556,6 +556,12 @@ func sortWithdrawalAddresses(
 		sorted = append(sorted, addr)
 	}
 	slices.SortFunc(sorted, func(a, b *lcommon.Address) int {
+		if a == nil {
+			return -1
+		}
+		if b == nil {
+			return 1
+		}
 		aCred, aErr := a.RewardAccountCredential()
 		bCred, bErr := b.RewardAccountCredential()
 		if aErr != nil || bErr != nil {

--- a/ledger/dijkstra/plutus_v4.go
+++ b/ledger/dijkstra/plutus_v4.go
@@ -1140,31 +1140,15 @@ func dijkstraPurposeV4(
 func dijkstraWithdrawalsV4(
 	withdrawals map[*common.Address]*big.Int,
 ) (data.PlutusData, error) {
-	type entry struct {
-		credential common.Credential
-		amount     *big.Int
-	}
-	entries := make([]entry, 0, len(withdrawals))
-	for address, amount := range withdrawals {
+	sortedAddresses := script.SortWithdrawalAddresses(withdrawals)
+	pairs := make([][2]data.PlutusData, len(sortedAddresses))
+	for idx, address := range sortedAddresses {
 		credential, err := address.RewardAccountCredential()
 		if err != nil {
 			return nil, err
 		}
-		entries = append(entries, entry{credential: credential, amount: amount})
-	}
-	slices.SortFunc(entries, func(a, b entry) int {
-		if a.credential.CredType != b.credential.CredType {
-			return int(a.credential.CredType) - int(b.credential.CredType)
-		}
-		return bytes.Compare(
-			a.credential.Credential.Bytes(),
-			b.credential.Credential.Bytes(),
-		)
-	})
-	pairs := make([][2]data.PlutusData, len(entries))
-	for idx, item := range entries {
 		pairs[idx] = [2]data.PlutusData{
-			item.credential.ToPlutusData(), data.NewInteger(item.amount),
+			credential.ToPlutusData(), data.NewInteger(withdrawals[address]),
 		}
 	}
 	return data.NewMap(pairs), nil

--- a/ledger/dijkstra/plutus_v4_test.go
+++ b/ledger/dijkstra/plutus_v4_test.go
@@ -113,6 +113,72 @@ func dijkstraV4TestLevel(
 	return levels[0]
 }
 
+func TestDijkstraWithdrawalsV4FollowCredentialOrder(t *testing.T) {
+	hash := bytes.Repeat([]byte{0x42}, common.AddressHashSize)
+	scriptAddress, err := common.NewAddressFromParts(
+		common.AddressTypeNoneScript,
+		common.AddressNetworkTestnet,
+		nil,
+		hash,
+	)
+	require.NoError(t, err)
+	keyAddress, err := common.NewAddressFromParts(
+		common.AddressTypeNoneKey,
+		common.AddressNetworkTestnet,
+		nil,
+		hash,
+	)
+	require.NoError(t, err)
+	withdrawals := map[*common.Address]*big.Int{
+		&scriptAddress: big.NewInt(1),
+		&keyAddress:    big.NewInt(2),
+	}
+
+	withdrawalsData, err := dijkstraWithdrawalsV4(withdrawals)
+	require.NoError(t, err)
+	withdrawalMap := requireDijkstraV4Map(t, withdrawalsData, 2)
+	first := requireDijkstraV4Constr(t, withdrawalMap.Pairs[0][0], 1, 1)
+	requireDijkstraV4Bytes(t, first.Fields[0], hash)
+	requireDijkstraV4Integer(t, withdrawalMap.Pairs[0][1], 1)
+	second := requireDijkstraV4Constr(t, withdrawalMap.Pairs[1][0], 0, 1)
+	requireDijkstraV4Bytes(t, second.Fields[0], hash)
+	requireDijkstraV4Integer(t, withdrawalMap.Pairs[1][1], 2)
+}
+
+func TestDijkstraRewardPurposeUsesCredentialOrder(t *testing.T) {
+	hash := bytes.Repeat([]byte{0x42}, common.AddressHashSize)
+	scriptAddress, err := common.NewAddressFromParts(
+		common.AddressTypeNoneScript,
+		common.AddressNetworkTestnet,
+		nil,
+		hash,
+	)
+	require.NoError(t, err)
+	keyAddress, err := common.NewAddressFromParts(
+		common.AddressTypeNoneKey,
+		common.AddressNetworkTestnet,
+		nil,
+		hash,
+	)
+	require.NoError(t, err)
+	tx := &DijkstraTransaction{
+		Body: DijkstraTransactionBody{
+			TxWithdrawals: map[*common.Address]uint64{
+				&scriptAddress: 1,
+				&keyAddress:    2,
+			},
+		},
+		TxIsValid: true,
+	}
+	level := dijkstraV4TestLevel(t, tx)
+	purposes := dijkstraRequiredScriptPurposes(level)
+	require.Len(t, purposes, 1)
+	require.Equal(t, common.RedeemerKey{
+		Tag:   common.RedeemerTagReward,
+		Index: 0,
+	}, purposes[0].key)
+}
+
 func TestDijkstraTxInfoV4ReleasedSchema(t *testing.T) {
 	var policy common.Blake2b224
 	copy(policy[:], bytes.Repeat([]byte{0x31}, len(policy)))

--- a/ledger/dijkstra/rules.go
+++ b/ledger/dijkstra/rules.go
@@ -22,7 +22,6 @@ import (
 	"math"
 	"math/big"
 	"slices"
-	"strings"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
@@ -1209,24 +1208,7 @@ func dijkstraRequiredScriptPurposes(
 		)
 	}
 
-	withdrawals := make([]*common.Address, 0, len(level.tx.Withdrawals()))
-	for address := range level.tx.Withdrawals() {
-		withdrawals = append(withdrawals, address)
-	}
-	slices.SortFunc(withdrawals, func(a, b *common.Address) int {
-		if a == nil {
-			return -1
-		}
-		if b == nil {
-			return 1
-		}
-		aBytes, aErr := a.Bytes()
-		bBytes, bErr := b.Bytes()
-		if aErr != nil || bErr != nil {
-			return strings.Compare(a.String(), b.String())
-		}
-		return bytes.Compare(aBytes, bBytes)
-	})
+	withdrawals := script.SortWithdrawalAddresses(level.tx.Withdrawals())
 	for idx, address := range withdrawals {
 		if address == nil ||
 			address.Type()&common.AddressTypeScriptBit == 0 {


### PR DESCRIPTION
Fixes #2187

Cardano ledger orders withdrawal reward accounts by `(network, Credential)`,
with script credentials before key credentials. Address-byte ordering reverses
that credential-type distinction.

- Share credential-based withdrawal ordering across TxInfo and redeemer-purpose consumers.
- Apply the ordering to Dijkstra V4 withdrawal TxInfo and reward redeemer indices.
- Add mixed key-hash/script-hash regression coverage for Plutus V1–V3 and Dijkstra V4.

Validation:

- `GOWORK=off go test -race -count=1 ./...` — pass
- `GOWORK=off go test -race -count=1 -v ./internal/test/conformance/...` — 315/315 vectors passed
- `GOWORK=off go vet ./...` — pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured withdrawal entries consistently follow credential order across transaction information and Plutus script versions.
  - Preserved deterministic ordering for reward withdrawals, including cases with both script and key credentials.
  - Standardized handling of nil and non-nil withdrawal addresses.

- **Tests**
  - Added coverage validating withdrawal ordering across Plutus V1–V4 and reward purpose indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->