### PR TITLE
fix(kes): enforce strict signature verification

### DIFF
--- a/kes/kes.go
+++ b/kes/kes.go
@@ -23,12 +23,14 @@
 package kes
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/subtle"
 	"errors"
 	"fmt"
 	"math"
 
+	"filippo.io/edwards25519"
 	"golang.org/x/crypto/blake2b"
 )
 
@@ -157,7 +159,43 @@ func (s Sum0KesSig) Verify(
 	pubKey ed25519.PublicKey,
 	msg []byte,
 ) bool {
-	return ed25519.Verify(pubKey, msg, s)
+	return verifyEd25519Strict(pubKey, msg, s)
+}
+
+// verifyEd25519Strict applies the strict verification criteria used by
+// Cardano's KES implementation. In addition to the signature equation, both
+// encoded points must be canonical and non-small-order, and S must be a
+// canonical scalar.
+func verifyEd25519Strict(pubKey, msg, sig []byte) bool {
+	if len(pubKey) != ed25519.PublicKeySize ||
+		len(sig) != ed25519.SignatureSize {
+		return false
+	}
+
+	publicPoint, err := new(edwards25519.Point).SetBytes(pubKey)
+	if err != nil ||
+		!bytes.Equal(publicPoint.Bytes(), pubKey) ||
+		isSmallOrder(publicPoint) {
+		return false
+	}
+
+	rPoint, err := new(edwards25519.Point).SetBytes(sig[:32])
+	if err != nil ||
+		!bytes.Equal(rPoint.Bytes(), sig[:32]) ||
+		isSmallOrder(rPoint) {
+		return false
+	}
+
+	if _, err := new(edwards25519.Scalar).SetCanonicalBytes(sig[32:]); err != nil {
+		return false
+	}
+
+	return ed25519.Verify(pubKey, msg, sig)
+}
+
+func isSmallOrder(point *edwards25519.Point) bool {
+	return new(edwards25519.Point).MultByCofactor(point).
+		Equal(edwards25519.NewIdentityPoint()) == 1
 }
 
 // HashPair computes the Blake2b-256 hash of two public keys concatenated

--- a/kes/kes_test.go
+++ b/kes/kes_test.go
@@ -17,14 +17,87 @@ package kes
 
 import (
 	"bytes"
+	"crypto/ed25519"
+	"crypto/sha512"
 	"testing"
 
+	"filippo.io/edwards25519"
 	"github.com/stretchr/testify/require"
 )
 
 // Test seed (exactly 32 bytes)
 // Note: "lenght" typo is intentional - matches canonical test vectors from input-output-hk/kes
 var testSeed = []byte("test string of 32 byte of lenght")
+
+var ed25519GeneratorEncoding = []byte{
+	0x58, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+	0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+	0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+	0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+}
+
+func makeKESProof(
+	t *testing.T,
+	depth uint64,
+	leafPublicKey ed25519.PublicKey,
+	leafSignature []byte,
+) ([]byte, ed25519.PublicKey) {
+	t.Helper()
+	require.Len(t, leafPublicKey, ed25519.PublicKeySize)
+	require.Len(t, leafSignature, ed25519.SignatureSize)
+
+	proof := append([]byte(nil), leafSignature...)
+	root := append(ed25519.PublicKey(nil), leafPublicKey...)
+	for level := range depth {
+		right := make(ed25519.PublicKey, ed25519.PublicKeySize)
+		right[0] = byte(level + 2)
+		proof = append(proof, root...)
+		proof = append(proof, right...)
+		root = HashPair(root, right)
+	}
+	require.Len(t, proof, SignatureSize(depth))
+	return proof, root
+}
+
+func universalIdentitySignature(rEncoding []byte) []byte {
+	sig := make([]byte, ed25519.SignatureSize)
+	copy(sig[:32], rEncoding)
+	// S=1 makes [S]B equal the generator R. With an identity public key,
+	// the challenge term is always the identity, regardless of the message.
+	sig[32] = 1
+	return sig
+}
+
+func smallOrderRSignature(
+	t *testing.T,
+	msg []byte,
+) (ed25519.PublicKey, []byte) {
+	t.Helper()
+	seed := make([]byte, ed25519.SeedSize)
+	seed[0] = 42
+	expanded := sha512.Sum512(seed)
+	privateScalar, err := new(edwards25519.Scalar).
+		SetBytesWithClamping(expanded[:32])
+	require.NoError(t, err)
+	publicKey := ed25519.PublicKey(
+		new(edwards25519.Point).ScalarBaseMult(privateScalar).Bytes(),
+	)
+
+	rEncoding := make([]byte, 32)
+	rEncoding[0] = 1
+	h := sha512.New()
+	_, _ = h.Write(rEncoding)
+	_, _ = h.Write(publicKey)
+	_, _ = h.Write(msg)
+	challenge, err := new(edwards25519.Scalar).SetUniformBytes(h.Sum(nil))
+	require.NoError(t, err)
+	s := new(edwards25519.Scalar).Multiply(challenge, privateScalar)
+
+	sig := make([]byte, ed25519.SignatureSize)
+	copy(sig[:32], rEncoding)
+	copy(sig[32:], s.Bytes())
+	return publicKey, sig
+}
 
 func TestKeyGen(t *testing.T) {
 	sk, pk, err := KeyGen(CardanoKesDepth, testSeed)
@@ -142,6 +215,139 @@ func TestVerifySignedKES(t *testing.T) {
 		VerifySignedKES(pk, 0, message, sig),
 		"VerifySignedKES failed",
 	)
+
+	wrongMessage := append([]byte(nil), message...)
+	wrongMessage[0] ^= 0xff
+	require.False(
+		t,
+		VerifySignedKES(pk, 0, wrongMessage, sig),
+		"signature verified for the wrong message",
+	)
+	wrongRoot := append([]byte(nil), pk...)
+	wrongRoot[0] ^= 0xff
+	require.False(
+		t,
+		VerifySignedKES(wrongRoot, 0, message, sig),
+		"signature verified for the wrong root",
+	)
+	require.False(
+		t,
+		VerifySignedKES(pk, 1, message, sig),
+		"signature verified for the wrong period",
+	)
+}
+
+func TestSum0KesSigVerifyRejectsMalformedInputs(t *testing.T) {
+	publicKey, _, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	signature := Sum0KesSig(make([]byte, ed25519.SignatureSize))
+
+	require.NotPanics(t, func() {
+		require.False(t, signature.Verify(0, publicKey[:31], nil))
+	})
+	require.False(
+		t,
+		Sum0KesSig(signature[:63]).Verify(0, publicKey, nil),
+		"short leaf signature accepted",
+	)
+}
+
+func TestVerifySignedKESRejectsNonStrictEd25519Leaves(t *testing.T) {
+	message := []byte("header body")
+	identity := make(ed25519.PublicKey, ed25519.PublicKeySize)
+	identity[0] = 1
+	nonCanonicalIdentity := ed25519.PublicKey{
+		0xee, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f,
+	}
+	nonCanonicalIdentityR := append([]byte(nil), nonCanonicalIdentity...)
+	groupOrder := []byte{
+		0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58,
+		0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde, 0x14,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10,
+	}
+
+	nonCanonicalScalar := make([]byte, ed25519.SignatureSize)
+	copy(nonCanonicalScalar[:32], ed25519GeneratorEncoding)
+	copy(nonCanonicalScalar[32:], groupOrder)
+	smallOrderRPublicKey, smallOrderR := smallOrderRSignature(t, message)
+	nonCanonicalR := make([]byte, ed25519.SignatureSize)
+	copy(nonCanonicalR[:32], nonCanonicalIdentityR)
+	malformedPoint := make(ed25519.PublicKey, ed25519.PublicKeySize)
+	for i := range malformedPoint {
+		malformedPoint[i] = 0xff
+	}
+
+	tests := []struct {
+		name                   string
+		leafPublicKey          ed25519.PublicKey
+		leafSignature          []byte
+		standardLibraryAccepts bool
+	}{
+		{
+			name:                   "small-order public key",
+			leafPublicKey:          identity,
+			leafSignature:          universalIdentitySignature(ed25519GeneratorEncoding),
+			standardLibraryAccepts: true,
+		},
+		{
+			name:                   "non-canonical public key",
+			leafPublicKey:          nonCanonicalIdentity,
+			leafSignature:          universalIdentitySignature(ed25519GeneratorEncoding),
+			standardLibraryAccepts: true,
+		},
+		{
+			name:                   "small-order R",
+			leafPublicKey:          smallOrderRPublicKey,
+			leafSignature:          smallOrderR,
+			standardLibraryAccepts: true,
+		},
+		{
+			name:          "non-canonical R",
+			leafPublicKey: identity,
+			leafSignature: nonCanonicalR,
+		},
+		{
+			name:          "non-canonical scalar",
+			leafPublicKey: identity,
+			leafSignature: nonCanonicalScalar,
+		},
+		{
+			name:          "malformed public key",
+			leafPublicKey: malformedPoint,
+			leafSignature: universalIdentitySignature(ed25519GeneratorEncoding),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.standardLibraryAccepts {
+				require.True(
+					t,
+					ed25519.Verify(
+						test.leafPublicKey,
+						message,
+						test.leafSignature,
+					),
+					"test vector does not exercise stricter verification",
+				)
+			}
+			proof, root := makeKESProof(
+				t,
+				CardanoKesDepth,
+				test.leafPublicKey,
+				test.leafSignature,
+			)
+			require.False(
+				t,
+				VerifySignedKES(root, 0, message, proof),
+				"non-strict Ed25519 leaf accepted",
+			)
+		})
+	}
 }
 
 func TestUpdateErasesSpentKey(t *testing.T) {

--- a/ledger/verify_kes_test.go
+++ b/ledger/verify_kes_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"crypto/ed25519"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/kes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyKesComponentsRejectsSmallOrderLeaf(t *testing.T) {
+	identity := make(ed25519.PublicKey, ed25519.PublicKeySize)
+	identity[0] = 1
+	generator := []byte{
+		0x58, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+		0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+		0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+		0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
+	}
+	leafSignature := make([]byte, ed25519.SignatureSize)
+	copy(leafSignature[:32], generator)
+	leafSignature[32] = 1
+
+	proof := append([]byte(nil), leafSignature...)
+	root := identity
+	for level := range uint64(kes.CardanoKesDepth) {
+		right := make(ed25519.PublicKey, ed25519.PublicKeySize)
+		right[0] = byte(level + 2)
+		proof = append(proof, root...)
+		proof = append(proof, right...)
+		root = kes.HashPair(root, right)
+	}
+	require.Len(t, proof, kes.CardanoKesSignatureSize)
+
+	valid, err := VerifyKesComponents(
+		[]byte("header body"),
+		proof,
+		root,
+		0,
+		0,
+		1,
+	)
+	require.NoError(t, err)
+	require.False(t, valid, "consensus boundary accepted a small-order leaf")
+}


### PR DESCRIPTION
Closes #2204.

- require canonical, non-small-order Ed25519 points at SumKES leaves
- reject non-canonical scalars and malformed leaf inputs
- cover accepted standard-library edge cases through the 448-byte consensus path
- preserve reference vectors and add wrong-message, wrong-root, and wrong-period controls


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces strict Ed25519 signature verification at SumKES leaves so malformed signatures no longer verify, matching Cardano's KES implementation.

**Bug Fixes**
- Replaces `ed25519.Verify` with `verifyEd25519Strict`, which validates canonical encodings and rejects small-order points before the signature equation check.
- Adds regression tests for malformed public keys, R points, and scalars in `kes`, plus a consensus-boundary test in `ledger`.

<sup>Written for commit df7c16b18fbbc7ce659ad0ea5447764b8c300227. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

