### PR TITLE
fix(ledger): preserve minPoolCost across Mary upgrade

### DIFF
--- a/ledger/mary/pparams.go
+++ b/ledger/mary/pparams.go
@@ -244,7 +244,7 @@ func UpgradePParams(
 		ProtocolMajor:      prevPParams.ProtocolMajor,
 		ProtocolMinor:      prevPParams.ProtocolMinor,
 		MinUtxoValue:       prevPParams.MinUtxoValue,
-		MinPoolCost:        340000000, // initial MinPoolCost at Mary on mainnet
+		MinPoolCost:        prevPParams.MinPoolCost,
 	}
 }
 

--- a/ledger/mary/pparams_test.go
+++ b/ledger/mary/pparams_test.go
@@ -614,6 +614,7 @@ func TestMaryUpgradePParams(t *testing.T) {
 				ProtocolMajor:      6,
 				ProtocolMinor:      0,
 				MinUtxoValue:       1000000,
+				MinPoolCost:        123456789,
 			},
 			validate: func(t *testing.T, maryParams mary.MaryProtocolParameters) {
 				if maryParams.MinFeeA != 44 {
@@ -692,10 +693,9 @@ func TestMaryUpgradePParams(t *testing.T) {
 						maryParams.MinUtxoValue,
 					)
 				}
-				// MinPoolCost should default to 340 ADA for Shelley upgrade
-				if maryParams.MinPoolCost != 340000000 {
+				if maryParams.MinPoolCost != 123456789 {
 					t.Errorf(
-						"MinPoolCost: got %d, want 340000000",
+						"MinPoolCost: got %d, want 123456789",
 						maryParams.MinPoolCost,
 					)
 				}
@@ -726,9 +726,9 @@ func TestMaryUpgradePParams(t *testing.T) {
 				if maryParams.MinFeeA != 0 {
 					t.Errorf("MinFeeA should be 0, got %d", maryParams.MinFeeA)
 				}
-				if maryParams.MinPoolCost != 340000000 {
+				if maryParams.MinPoolCost != 0 {
 					t.Errorf(
-						"MinPoolCost should be 340000000, got %d",
+						"MinPoolCost should be 0, got %d",
 						maryParams.MinPoolCost,
 					)
 				}
@@ -768,9 +768,9 @@ func TestMaryUpgradePParams(t *testing.T) {
 				if maryParams.Decentralization != nil {
 					t.Error("Decentralization should be nil")
 				}
-				if maryParams.MinPoolCost != 340000000 {
+				if maryParams.MinPoolCost != 0 {
 					t.Errorf(
-						"MinPoolCost should be 340000000, got %d",
+						"MinPoolCost should be 0, got %d",
 						maryParams.MinPoolCost,
 					)
 				}

--- a/ledger/pparams_upgrade_test.go
+++ b/ledger/pparams_upgrade_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProtocolParametersUpgradePreservesMinPoolCost(t *testing.T) {
+	const minPoolCost = uint64(123456789)
+
+	shelleyParams := shelley.ShelleyProtocolParameters{
+		MinPoolCost: minPoolCost,
+	}
+	allegraParams := allegra.UpgradePParams(shelleyParams)
+	maryParams := mary.UpgradePParams(allegraParams)
+	alonzoParams := alonzo.UpgradePParams(maryParams)
+	babbageParams := babbage.UpgradePParams(alonzoParams)
+	conwayParams := conway.UpgradePParams(babbageParams)
+
+	paramsByEra := []struct {
+		name string
+		got  uint64
+	}{
+		{name: "Shelley", got: shelleyParams.MinPoolCost},
+		{name: "Allegra", got: allegraParams.MinPoolCost},
+		{name: "Mary", got: maryParams.MinPoolCost},
+		{name: "Alonzo", got: alonzoParams.MinPoolCost},
+		{name: "Babbage", got: babbageParams.MinPoolCost},
+		{name: "Conway", got: conwayParams.MinPoolCost},
+	}
+	for _, tc := range paramsByEra {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, minPoolCost, tc.got)
+		})
+	}
+}


### PR DESCRIPTION
Resolves #2184.

Shelley carries `minPoolCost`, so the Mary protocol-parameter upgrade now preserves the value instead of replacing it with the historical 340 ADA constant. Regression coverage verifies propagation through Allegra, Mary, Alonzo, Babbage, and Conway.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Protocol parameter upgrades now preserve the configured minimum pool cost when moving from the Shelley era into Mary and later eras.
  - Prevents the minimum pool cost from being unexpectedly reset to a fixed default during upgrades.
  - Added coverage to verify that the configured value remains unchanged across the full sequence of protocol era upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->