### PR TITLE
fix(ledger): gate delegation validation by phase-2 validity

### DIFF
--- a/internal/test/conformance/phase2_invalid_test.go
+++ b/internal/test/conformance/phase2_invalid_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	mockconformance "github.com/blinklabs-io/ouroboros-mock/conformance"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConformanceValidationRulesSkipDelegationForPhase2Invalid(
+	t *testing.T,
+) {
+	credential := common.Credential{
+		CredType:   common.CredentialTypeAddrKeyHash,
+		Credential: common.Blake2b224{0x01},
+	}
+	certificates := []common.CertificateWrapper{{
+		Type: uint(common.CertificateTypeStakeDelegation),
+		Certificate: &common.StakeDelegationCertificate{
+			CertType:        uint(common.CertificateTypeStakeDelegation),
+			StakeCredential: &credential,
+			PoolKeyHash:     common.PoolKeyHash{0x02},
+		},
+	}}
+	state := mockledger.NewLedgerStateBuilder().Build()
+	params := &conway.ConwayProtocolParameters{}
+
+	var delegationRule common.UtxoValidationRuleFunc
+	delegationPointer := reflect.ValueOf(conway.UtxoValidateDelegation).Pointer()
+	for _, rule := range mockconformance.ConformanceValidationRules {
+		if reflect.ValueOf(rule).Pointer() == delegationPointer {
+			delegationRule = rule
+			break
+		}
+	}
+	require.NotNil(t, delegationRule)
+
+	validTx := &conway.ConwayTransaction{
+		Body:      conway.ConwayTransactionBody{TxCertificates: certificates},
+		TxIsValid: true,
+	}
+	invalidTx := &conway.ConwayTransaction{
+		Body:      conway.ConwayTransactionBody{TxCertificates: certificates},
+		TxIsValid: false,
+	}
+
+	err := common.VerifyTransaction(
+		validTx,
+		0,
+		state,
+		params,
+		[]common.UtxoValidationRuleFunc{delegationRule},
+	)
+	var poolError shelley.DelegateToUnregisteredPoolError
+	require.ErrorAs(t, err, &poolError)
+
+	require.NoError(t, common.VerifyTransaction(
+		invalidTx,
+		0,
+		state,
+		params,
+		[]common.UtxoValidationRuleFunc{delegationRule},
+	))
+}

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -3204,13 +3204,20 @@ func UtxoValidateNativeScripts(
 // - Stake credential registration for non-registration delegations
 //
 // The function tracks in-transaction registrations to handle cases where
-// registration and delegation are in the same transaction.
+// registration and delegation are in the same transaction. Delegation state
+// transitions only apply to phase-2-valid transactions; this guard is kept in
+// the rule itself because Dijkstra and the conformance harness register and
+// invoke it directly rather than through Conway's composed rule groups.
 func UtxoValidateDelegation(
 	tx common.Transaction,
 	slot uint64,
 	ls common.LedgerState,
 	pp common.ProtocolParameters,
 ) error {
+	if !tx.IsValid() {
+		return nil
+	}
+
 	// Track credential registration state changes within this transaction.
 	// The bool records both registrations and deregistrations so later
 	// certificates observe the state produced by earlier certificates.

--- a/ledger/conway/rules_test.go
+++ b/ledger/conway/rules_test.go
@@ -4006,6 +4006,7 @@ func TestUtxoValidateDelegation_RejectsDuplicateStakeRegistrations(
 			Body: conway.ConwayTransactionBody{
 				TxCertificates: wrappers,
 			},
+			TxIsValid: true,
 		}
 	}
 
@@ -4255,6 +4256,7 @@ func TestUtxoValidateDelegation_DeregistrationBlocksLaterDelegation(
 			Body: conway.ConwayTransactionBody{
 				TxCertificates: wrappers,
 			},
+			TxIsValid: true,
 		}
 	}
 
@@ -4335,7 +4337,8 @@ func TestUtxoValidateDelegation_PoolRetirementKeepsPoolRegistered(
 			wrappers[i] = common.CertificateWrapper{Certificate: cert}
 		}
 		return &conway.ConwayTransaction{
-			Body: conway.ConwayTransactionBody{TxCertificates: wrappers},
+			Body:      conway.ConwayTransactionBody{TxCertificates: wrappers},
+			TxIsValid: true,
 		}
 	}
 	delegation := &common.StakeDelegationCertificate{
@@ -4390,6 +4393,7 @@ func TestUtxoValidateDelegation_InTxVrfKeyDuplicates(t *testing.T) {
 					}},
 				},
 			},
+			TxIsValid: true,
 		}
 
 		err := conway.UtxoValidateDelegation(tx, 0, ls, pv11Params)
@@ -4422,6 +4426,7 @@ func TestUtxoValidateDelegation_InTxVrfKeyDuplicates(t *testing.T) {
 					}},
 				},
 			},
+			TxIsValid: true,
 		}
 
 		err := conway.UtxoValidateDelegation(tx, 0, ls, pv11Params)
@@ -4449,6 +4454,7 @@ func TestUtxoValidateDelegation_InTxVrfKeyDuplicates(t *testing.T) {
 					}},
 				},
 			},
+			TxIsValid: true,
 		}
 
 		// PV10 doesn't enforce VRF key uniqueness
@@ -4479,6 +4485,7 @@ func TestUtxoValidateDelegation_DRepType(t *testing.T) {
 					}},
 				},
 			},
+			TxIsValid: true,
 		}
 	}
 
@@ -4530,6 +4537,7 @@ func TestUtxoValidateDelegation_DRepType(t *testing.T) {
 							}},
 						},
 					},
+					TxIsValid: true,
 				}
 			},
 		},
@@ -4548,6 +4556,7 @@ func TestUtxoValidateDelegation_DRepType(t *testing.T) {
 							}},
 						},
 					},
+					TxIsValid: true,
 				}
 			},
 		},
@@ -4571,6 +4580,7 @@ func TestUtxoValidateDelegation_DRepType(t *testing.T) {
 							}},
 						},
 					},
+					TxIsValid: true,
 				}
 			},
 		},

--- a/ledger/dijkstra/rules_test.go
+++ b/ledger/dijkstra/rules_test.go
@@ -184,6 +184,52 @@ func TestDijkstraGovernanceValidationRules(t *testing.T) {
 	}
 }
 
+func TestDijkstraPhase2InvalidSkipsDelegation(t *testing.T) {
+	credential := common.Credential{
+		CredType:   common.CredentialTypeAddrKeyHash,
+		Credential: common.Blake2b224{0x01},
+	}
+	certificates := []common.CertificateWrapper{{
+		Type: uint(common.CertificateTypeStakeDelegation),
+		Certificate: &common.StakeDelegationCertificate{
+			CertType:        uint(common.CertificateTypeStakeDelegation),
+			StakeCredential: &credential,
+			PoolKeyHash:     common.PoolKeyHash{0x02},
+		},
+	}}
+	state := mockledger.NewLedgerStateBuilder().Build()
+	params := &DijkstraProtocolParameters{}
+
+	rule, _ := dijkstraValidationRule(
+		t,
+		"ledger/conway.UtxoValidateDelegation",
+	)
+	validTx := &DijkstraTransaction{
+		Body:      DijkstraTransactionBody{TxCertificates: certificates},
+		TxIsValid: true,
+	}
+	invalidTx := &DijkstraTransaction{
+		Body:      DijkstraTransactionBody{TxCertificates: certificates},
+		TxIsValid: false,
+	}
+
+	var poolError shelley.DelegateToUnregisteredPoolError
+	require.ErrorAs(t, rule(validTx, 0, state, params), &poolError)
+	require.NoError(t, rule(invalidTx, 0, state, params))
+
+	// The phase-2-valid gate must not replace the always-run structural check
+	// that rejects an invalid transaction without a phase-2 redeemer.
+	var invalidFlag common.InvalidIsValidFlagError
+	err := common.VerifyTransaction(
+		invalidTx,
+		0,
+		state,
+		params,
+		UtxoValidationRules,
+	)
+	require.ErrorAs(t, err, &invalidFlag)
+}
+
 func TestDijkstraGovernanceValidationEnforcesGuardrails(t *testing.T) {
 	guardrailsHash := common.Blake2b224Hash([]byte("constitution-guardrails"))
 	newTx := func(isValid bool, policyHash []byte) *DijkstraTransaction {


### PR DESCRIPTION
## Summary

- Gate `UtxoValidateDelegation` state transitions on phase-2 validity for direct Dijkstra and conformance consumers.
- Preserve invalid-transaction structural rejection through the existing `IsValid` validation rule.
- Add Dijkstra and conformance regressions; update direct valid-transaction fixtures.

Fixes #2182

## Validation

- Regression failed before the fix and passed after it.
- Focused Conway/Dijkstra tests passed.
- Race-enabled ledger and targeted conformance tests passed.
- `go vet` passed.
- `make format` passed.
- Conformance vectors passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates `UtxoValidateDelegation` state transitions on phase-2 validity so structurally invalid transactions reach the `IsValid` rejection instead of failing delegation checks first. Fixes #2182.

**Bug Fixes**
- Delegation rule now returns early for phase-2-invalid transactions; the existing structural `IsValid` check still rejects them.
- Guard lives in the rule itself because Dijkstra and the conformance harness invoke it directly.

**Tests**
- Added Dijkstra and conformance regressions covering phase-2-invalid delegation.
- Updated direct `UtxoValidateDelegation` fixtures to set `TxIsValid` where required.

<sup>Written for commit f364063d961e7e45bc984d61e9e6b52421a36c85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

