### PR TITLE
fix(ledger): measure a transaction the same way for maxTxSize and fees

### DIFF
--- a/ledger/alonzo/rules.go
+++ b/ledger/alonzo/rules.go
@@ -821,19 +821,15 @@ func UtxoValidateMaxTxSizeUtxo(
 	if !ok {
 		return errors.New("pparams are not expected type")
 	}
-	txBytes := tx.Cbor()
-	if len(txBytes) == 0 {
-		var err error
-		txBytes, err = cbor.Encode(tx)
-		if err != nil {
-			return err
-		}
+	txSize, sizeErr := common.TxSize(tx)
+	if sizeErr != nil {
+		return sizeErr
 	}
-	if uint(len(txBytes)) <= tmpPparams.MaxTxSize {
+	if uint(txSize) <= tmpPparams.MaxTxSize {
 		return nil
 	}
 	return shelley.MaxTxSizeUtxoError{
-		TxSize:    uint(len(txBytes)),
+		TxSize:    uint(txSize),
 		MaxTxSize: tmpPparams.MaxTxSize,
 	}
 }

--- a/ledger/babbage/rules.go
+++ b/ledger/babbage/rules.go
@@ -1007,15 +1007,15 @@ func UtxoValidateMaxTxSizeUtxo(
 	if !ok {
 		return errors.New("pparams are not expected type")
 	}
-	txBytes, err := cbor.Encode(tx)
-	if err != nil {
-		return err
+	txSize, sizeErr := common.TxSize(tx)
+	if sizeErr != nil {
+		return sizeErr
 	}
-	if uint(len(txBytes)) <= tmpPparams.MaxTxSize {
+	if uint(txSize) <= tmpPparams.MaxTxSize {
 		return nil
 	}
 	return shelley.MaxTxSizeUtxoError{
-		TxSize:    uint(len(txBytes)),
+		TxSize:    uint(txSize),
 		MaxTxSize: tmpPparams.MaxTxSize,
 	}
 }

--- a/ledger/common/rules.go
+++ b/ledger/common/rules.go
@@ -170,30 +170,27 @@ func VerifyTransaction(
 // when the transaction actually has the 4-component Alonzo-style envelope.
 const txTypeAlonzo = 4
 
-// TxSizeForFee returns the fee-relevant transaction size as defined by the
-// Cardano ledger spec. For Alonzo through Conway the on-wire CBOR contains a
-// 4-element array [body, witnesses, isValid, metadata]; the Haskell
-// toCBORForSizeComputation function encodes only 3 elements, so the fee-
-// relevant size is the full on-wire length minus 1 byte (the IsValid field).
-// Dijkstra block transactions use a 3-element envelope, so no adjustment is
-// applied unless an explicitly 4-component transaction is being sized.
+// TxSize returns the size of a transaction as the Cardano ledger spec defines
+// it — the measure used both for fees and for maxTxSize.
 //
-// When the transaction has no stored CBOR (e.g. programmatically constructed),
-// the function falls back to encoding the transaction to compute its size.
-// TxSize returns the size of a transaction as the chain measures it.
-//
-// A transaction stored in a block from Alonzo onwards is split across four
-// parallel arrays — bodies, witness sets, IsValid flags and auxiliary data —
-// and the IsValid flag is not part of the transaction the chain sized.
-// Reconstructing a standalone transaction re-attaches it as the third element
-// of a four-element array, one byte the original never had, so that byte is
-// subtracted here.
+// For Alonzo through Conway the on-wire CBOR is a 4-element array
+// [body, witnesses, isValid, metadata], while the Haskell
+// toCBORForSizeComputation encodes only 3 elements. The IsValid flag is not
+// part of the transaction the chain sized: a block stores bodies, witness
+// sets, IsValid flags and auxiliary data in four parallel arrays, and
+// reconstructing a standalone transaction re-attaches that byte. So the size
+// is the full on-wire length minus 1. Dijkstra block transactions use a
+// 3-element envelope, so no adjustment applies unless an explicitly
+// 4-component transaction is being sized.
 //
 // Every rule expressed against a transaction's size must use this, not
 // len(tx.Cbor()). The two differ by exactly one byte, which only matters for a
 // transaction sitting exactly on a limit — rare enough to survive a long way
 // into a replay before a single transaction built to fill maxTxSize exposes
 // it.
+//
+// When the transaction has no stored CBOR (e.g. programmatically constructed),
+// the function falls back to encoding the transaction to compute its size.
 func TxSize(tx Transaction) (int, error) {
 	cborData := tx.Cbor()
 	if len(cborData) == 0 {

--- a/ledger/common/rules.go
+++ b/ledger/common/rules.go
@@ -180,7 +180,21 @@ const txTypeAlonzo = 4
 //
 // When the transaction has no stored CBOR (e.g. programmatically constructed),
 // the function falls back to encoding the transaction to compute its size.
-func TxSizeForFee(tx Transaction) (int, error) {
+// TxSize returns the size of a transaction as the chain measures it.
+//
+// A transaction stored in a block from Alonzo onwards is split across four
+// parallel arrays — bodies, witness sets, IsValid flags and auxiliary data —
+// and the IsValid flag is not part of the transaction the chain sized.
+// Reconstructing a standalone transaction re-attaches it as the third element
+// of a four-element array, one byte the original never had, so that byte is
+// subtracted here.
+//
+// Every rule expressed against a transaction's size must use this, not
+// len(tx.Cbor()). The two differ by exactly one byte, which only matters for a
+// transaction sitting exactly on a limit — rare enough to survive a long way
+// into a replay before a single transaction built to fill maxTxSize exposes
+// it.
+func TxSize(tx Transaction) (int, error) {
 	cborData := tx.Cbor()
 	if len(cborData) == 0 {
 		// Fallback: encode the transaction to compute its size.
@@ -189,7 +203,7 @@ func TxSizeForFee(tx Transaction) (int, error) {
 		var err error
 		cborData, err = cbor.Encode(tx)
 		if err != nil {
-			return 0, fmt.Errorf("failed to encode transaction for fee size: %w", err)
+			return 0, fmt.Errorf("failed to encode transaction for size: %w", err)
 		}
 	}
 	fullSize := len(cborData)
@@ -197,16 +211,18 @@ func TxSizeForFee(tx Transaction) (int, error) {
 		dec, err := cbor.NewStreamDecoder(cborData)
 		if err == nil {
 			arrayLen, _, _, decodeErr := dec.DecodeArrayHeader()
-			if decodeErr == nil {
-				if arrayLen == 4 {
-					return fullSize - 1, nil
-				}
-				return fullSize, nil
+			if decodeErr == nil && arrayLen == 4 {
+				return fullSize - 1, nil
 			}
 		}
-		return fullSize, nil
 	}
 	return fullSize, nil
+}
+
+// TxSizeForFee returns the fee-relevant size of a transaction. It is the same
+// measure as TxSize; the name is kept for the fee rules that already call it.
+func TxSizeForFee(tx Transaction) (int, error) {
+	return TxSize(tx)
 }
 
 // CalculateMinFee computes the minimum fee for a transaction given its

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -2673,15 +2673,15 @@ func UtxoValidateMaxTxSizeUtxo(
 	if !ok {
 		return errors.New("pparams are not expected type")
 	}
-	txBytes, err := cbor.Encode(tx)
-	if err != nil {
-		return err
+	txSize, sizeErr := common.TxSize(tx)
+	if sizeErr != nil {
+		return sizeErr
 	}
-	if uint(len(txBytes)) <= tmpPparams.MaxTxSize {
+	if uint(txSize) <= tmpPparams.MaxTxSize {
 		return nil
 	}
 	return shelley.MaxTxSizeUtxoError{
-		TxSize:    uint(len(txBytes)),
+		TxSize:    uint(txSize),
 		MaxTxSize: tmpPparams.MaxTxSize,
 	}
 }

--- a/ledger/dijkstra/rules.go
+++ b/ledger/dijkstra/rules.go
@@ -2785,18 +2785,15 @@ func UtxoValidateMaxTxSizeUtxo(
 	if err != nil {
 		return err
 	}
-	txBytes := tx.Cbor()
-	if len(txBytes) == 0 {
-		txBytes, err = cbor.Encode(tx)
-		if err != nil {
-			return err
-		}
+	txSize, sizeErr := common.TxSize(tx)
+	if sizeErr != nil {
+		return sizeErr
 	}
-	if uint(len(txBytes)) <= tmpPparams.MaxTxSize {
+	if uint(txSize) <= tmpPparams.MaxTxSize {
 		return nil
 	}
 	return shelley.MaxTxSizeUtxoError{
-		TxSize:    uint(len(txBytes)),
+		TxSize:    uint(txSize),
 		MaxTxSize: tmpPparams.MaxTxSize,
 	}
 }

--- a/ledger/mary/rules.go
+++ b/ledger/mary/rules.go
@@ -469,19 +469,15 @@ func UtxoValidateMaxTxSizeUtxo(
 	if !ok {
 		return errors.New("pparams are not expected type")
 	}
-	txBytes := tx.Cbor()
-	if len(txBytes) == 0 {
-		var err error
-		txBytes, err = cbor.Encode(tx)
-		if err != nil {
-			return err
-		}
+	txSize, sizeErr := common.TxSize(tx)
+	if sizeErr != nil {
+		return sizeErr
 	}
-	if uint(len(txBytes)) <= tmpPparams.MaxTxSize {
+	if uint(txSize) <= tmpPparams.MaxTxSize {
 		return nil
 	}
 	return shelley.MaxTxSizeUtxoError{
-		TxSize:    uint(len(txBytes)),
+		TxSize:    uint(txSize),
 		MaxTxSize: tmpPparams.MaxTxSize,
 	}
 }

--- a/ledger/max_tx_size_test.go
+++ b/ledger/max_tx_size_test.go
@@ -20,7 +20,6 @@
 package ledger_test
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/ledger/allegra"
@@ -65,9 +64,17 @@ type maxTxSizeEra struct {
 	newTx    func(cborData []byte) common.Transaction
 	pparams  func(maxTxSize uint) common.ProtocolParameters
 	validate func(common.Transaction, uint64, common.LedgerState, common.ProtocolParameters) error
-	// segmented is true for the eras whose in-block representation carries a
-	// separate IsValid flag — Alonzo onwards.
-	segmented bool
+	// blockTxCarriesIsValid is true for the eras whose in-block representation
+	// keeps IsValid in a separate parallel array, so reconstructing a
+	// standalone transaction re-attaches it as a fourth element.
+	//
+	// Dijkstra is false. Its transactions are three components in a block —
+	// newDijkstraTransactionFromCborComponents rejects a four-component
+	// transaction outright with "dijkstra transactions in blocks cannot
+	// include is_valid" — so nothing is re-attached and nothing is
+	// subtracted. It accepts four components only for a standalone
+	// transaction, which is not what maxTxSize validates.
+	blockTxCarriesIsValid bool
 }
 
 func maxTxSizeEras() []maxTxSizeEra {
@@ -82,8 +89,8 @@ func maxTxSizeEras() []maxTxSizeEra {
 			pparams: func(m uint) common.ProtocolParameters {
 				return &shelley.ShelleyProtocolParameters{MaxTxSize: m}
 			},
-			validate:  shelley.UtxoValidateMaxTxSizeUtxo,
-			segmented: false,
+			validate:              shelley.UtxoValidateMaxTxSizeUtxo,
+			blockTxCarriesIsValid: false,
 		},
 		{
 			name: "allegra",
@@ -95,8 +102,8 @@ func maxTxSizeEras() []maxTxSizeEra {
 			pparams: func(m uint) common.ProtocolParameters {
 				return &allegra.AllegraProtocolParameters{MaxTxSize: m}
 			},
-			validate:  allegra.UtxoValidateMaxTxSizeUtxo,
-			segmented: false,
+			validate:              allegra.UtxoValidateMaxTxSizeUtxo,
+			blockTxCarriesIsValid: false,
 		},
 		{
 			name: "mary",
@@ -108,8 +115,8 @@ func maxTxSizeEras() []maxTxSizeEra {
 			pparams: func(m uint) common.ProtocolParameters {
 				return &mary.MaryProtocolParameters{MaxTxSize: m}
 			},
-			validate:  mary.UtxoValidateMaxTxSizeUtxo,
-			segmented: false,
+			validate:              mary.UtxoValidateMaxTxSizeUtxo,
+			blockTxCarriesIsValid: false,
 		},
 		{
 			name: "alonzo",
@@ -121,8 +128,8 @@ func maxTxSizeEras() []maxTxSizeEra {
 			pparams: func(m uint) common.ProtocolParameters {
 				return &alonzo.AlonzoProtocolParameters{MaxTxSize: m}
 			},
-			validate:  alonzo.UtxoValidateMaxTxSizeUtxo,
-			segmented: true,
+			validate:              alonzo.UtxoValidateMaxTxSizeUtxo,
+			blockTxCarriesIsValid: true,
 		},
 		{
 			name: "babbage",
@@ -134,8 +141,8 @@ func maxTxSizeEras() []maxTxSizeEra {
 			pparams: func(m uint) common.ProtocolParameters {
 				return &babbage.BabbageProtocolParameters{MaxTxSize: m}
 			},
-			validate:  babbage.UtxoValidateMaxTxSizeUtxo,
-			segmented: true,
+			validate:              babbage.UtxoValidateMaxTxSizeUtxo,
+			blockTxCarriesIsValid: true,
 		},
 		{
 			name: "conway",
@@ -147,8 +154,8 @@ func maxTxSizeEras() []maxTxSizeEra {
 			pparams: func(m uint) common.ProtocolParameters {
 				return &conway.ConwayProtocolParameters{MaxTxSize: m}
 			},
-			validate:  conway.UtxoValidateMaxTxSizeUtxo,
-			segmented: true,
+			validate:              conway.UtxoValidateMaxTxSizeUtxo,
+			blockTxCarriesIsValid: true,
 		},
 		{
 			name: "dijkstra",
@@ -162,34 +169,85 @@ func maxTxSizeEras() []maxTxSizeEra {
 				pp.MaxTxSize = m
 				return pp
 			},
-			validate:  dijkstra.UtxoValidateMaxTxSizeUtxo,
-			segmented: true,
+			validate:              dijkstra.UtxoValidateMaxTxSizeUtxo,
+			blockTxCarriesIsValid: false,
 		},
 	}
 }
 
-// TestMaxTxSizeUsesTheOnChainMeasure is the regression for the Preview replay
-// wedge at slot 27745494 (epoch 321, Conway). Transaction
+// TestMaxTxSizeAcceptsATransactionExactlyAtTheLimit is the regression for the
+// Preview replay wedge at slot 27745494 (epoch 321, Conway). Transaction
 // ddd3f6b502c45d7c9f60f75c79148b70c0bae6e238aafafa1d24e9b7ed228d85 is exactly
 // 16384 bytes on chain and reconstructs to 16385 with the IsValid byte
 // re-attached. maxTxSize was 16384, so the node rejected a transaction the
 // chain had accepted and stopped following the chain.
 //
-// The fee rule already subtracted that byte (common.TxSizeForFee); the
-// maxTxSize rule measured raw length. Both must use one measure.
-func TestMaxTxSizeUsesTheOnChainMeasure(t *testing.T) {
+// It covers every era rather than only the ones that carry an IsValid byte.
+//
+// All seven eras changed here — six replaced an inline length computation with
+// common.TxSize, and Allegra delegates to Shelley — so all seven need proof
+// that a transaction exactly on the limit is still accepted. A validation
+// change tested only by its rejections is how a false rejection ships.
+func TestMaxTxSizeAcceptsATransactionExactlyAtTheLimit(t *testing.T) {
 	ls := mockledger.NewLedgerStateBuilder().Build()
 	for _, era := range maxTxSizeEras() {
 		t.Run(era.name, func(t *testing.T) {
-			if !era.segmented {
-				t.Skip("pre-Alonzo transactions carry no IsValid byte")
+			// A transaction is exactly maxTxSize on chain. For an era whose
+			// block keeps IsValid in a parallel array, reconstruction re-adds
+			// one byte; for the others the on-wire bytes are the measure.
+			raw := int(testMaxTxSize)
+			body := unsegmentedTxCbor
+			if era.blockTxCarriesIsValid {
+				raw++
+				body = segmentedTxCbor
 			}
-			tx := era.newTx(segmentedTxCbor(int(testMaxTxSize) + 1))
+			tx := era.newTx(body(raw))
 			err := era.validate(tx, 0, ls, era.pparams(testMaxTxSize))
 			assert.NoError(t, err,
-				"a transaction that is exactly maxTxSize on chain must be "+
-					"accepted; it reconstructs one byte larger")
+				"a transaction exactly at maxTxSize on chain must be accepted")
 		})
+	}
+}
+
+// TestMaxTxSizeAdjustmentFollowsTheEnvelopeNotTheEra pins that the IsValid byte
+// is subtracted because the envelope has four components, not because the era
+// is Alonzo or later.
+//
+// Dijkstra is the case that separates the two rules: it is an Alonzo-or-later
+// era whose block transactions are three components —
+// newDijkstraTransactionFromCborComponents rejects four outright for a block
+// transaction — so an era-driven adjustment would wrongly shorten it.
+func TestMaxTxSizeAdjustmentFollowsTheEnvelopeNotTheEra(t *testing.T) {
+	ls := mockledger.NewLedgerStateBuilder().Build()
+	for _, era := range maxTxSizeEras() {
+		if !isAlonzoOrLater(era.name) {
+			continue
+		}
+		t.Run(era.name, func(t *testing.T) {
+			t.Run("three-component envelope is not adjusted", func(t *testing.T) {
+				tx := era.newTx(unsegmentedTxCbor(int(testMaxTxSize) + 1))
+				err := era.validate(tx, 0, ls, era.pparams(testMaxTxSize))
+				require.Error(t, err,
+					"nothing is re-attached to a three-component envelope, "+
+						"so one byte over the limit is over the limit")
+			})
+			t.Run("four-component envelope is adjusted", func(t *testing.T) {
+				tx := era.newTx(segmentedTxCbor(int(testMaxTxSize) + 1))
+				err := era.validate(tx, 0, ls, era.pparams(testMaxTxSize))
+				assert.NoError(t, err,
+					"the fourth component is the IsValid byte and is not "+
+						"part of the size the chain measured")
+			})
+		})
+	}
+}
+
+func isAlonzoOrLater(name string) bool {
+	switch name {
+	case "alonzo", "babbage", "conway", "dijkstra":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -200,12 +258,12 @@ func TestMaxTxSizeStillRejectsOversize(t *testing.T) {
 	for _, era := range maxTxSizeEras() {
 		t.Run(era.name, func(t *testing.T) {
 			raw := int(testMaxTxSize) + 1
-			if era.segmented {
+			if era.blockTxCarriesIsValid {
 				// One byte past the limit once the IsValid byte is removed.
 				raw = int(testMaxTxSize) + 2
 			}
 			body := unsegmentedTxCbor
-			if era.segmented {
+			if era.blockTxCarriesIsValid {
 				body = segmentedTxCbor
 			}
 			tx := era.newTx(body(raw))
@@ -227,7 +285,7 @@ func TestMaxTxSizeStillRejectsOversize(t *testing.T) {
 func TestMaxTxSizePreAlonzoUnchanged(t *testing.T) {
 	ls := mockledger.NewLedgerStateBuilder().Build()
 	for _, era := range maxTxSizeEras() {
-		if era.segmented {
+		if era.blockTxCarriesIsValid {
 			continue
 		}
 		t.Run(era.name, func(t *testing.T) {
@@ -240,5 +298,3 @@ func TestMaxTxSizePreAlonzoUnchanged(t *testing.T) {
 		})
 	}
 }
-
-var _ = bytes.Repeat

--- a/ledger/max_tx_size_test.go
+++ b/ledger/max_tx_size_test.go
@@ -1,0 +1,244 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests that every era's maxTxSize rule measures a transaction the same way
+// the fee rule does. They live in package ledger_test rather than in each
+// era's own package because the rule is duplicated per era and the point of
+// the test is that all of them agree.
+
+package ledger_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testMaxTxSize uint = 16384
+
+// segmentedTxCbor returns a transaction CBOR blob of exactly size bytes whose
+// first byte is a four-element array header.
+//
+// That is the shape gouroboros reconstructs for an Alonzo-and-later
+// transaction read out of a block: the block stores bodies, witness sets,
+// IsValid flags and auxiliary data in four parallel arrays, and rebuilding a
+// standalone transaction re-attaches the IsValid byte that was never part of
+// the transaction the chain measured.
+func segmentedTxCbor(size int) []byte {
+	b := make([]byte, size)
+	b[0] = 0x84 // array(4)
+	return b
+}
+
+// unsegmentedTxCbor is the pre-Alonzo shape: three elements, no IsValid flag,
+// so nothing is re-attached and nothing may be subtracted.
+func unsegmentedTxCbor(size int) []byte {
+	b := make([]byte, size)
+	b[0] = 0x83 // array(3)
+	return b
+}
+
+type maxTxSizeEra struct {
+	name     string
+	newTx    func(cborData []byte) common.Transaction
+	pparams  func(maxTxSize uint) common.ProtocolParameters
+	validate func(common.Transaction, uint64, common.LedgerState, common.ProtocolParameters) error
+	// segmented is true for the eras whose in-block representation carries a
+	// separate IsValid flag — Alonzo onwards.
+	segmented bool
+}
+
+func maxTxSizeEras() []maxTxSizeEra {
+	return []maxTxSizeEra{
+		{
+			name: "shelley",
+			newTx: func(c []byte) common.Transaction {
+				tx := &shelley.ShelleyTransaction{}
+				tx.SetCbor(c)
+				return tx
+			},
+			pparams: func(m uint) common.ProtocolParameters {
+				return &shelley.ShelleyProtocolParameters{MaxTxSize: m}
+			},
+			validate:  shelley.UtxoValidateMaxTxSizeUtxo,
+			segmented: false,
+		},
+		{
+			name: "allegra",
+			newTx: func(c []byte) common.Transaction {
+				tx := &allegra.AllegraTransaction{}
+				tx.SetCbor(c)
+				return tx
+			},
+			pparams: func(m uint) common.ProtocolParameters {
+				return &allegra.AllegraProtocolParameters{MaxTxSize: m}
+			},
+			validate:  allegra.UtxoValidateMaxTxSizeUtxo,
+			segmented: false,
+		},
+		{
+			name: "mary",
+			newTx: func(c []byte) common.Transaction {
+				tx := &mary.MaryTransaction{}
+				tx.SetCbor(c)
+				return tx
+			},
+			pparams: func(m uint) common.ProtocolParameters {
+				return &mary.MaryProtocolParameters{MaxTxSize: m}
+			},
+			validate:  mary.UtxoValidateMaxTxSizeUtxo,
+			segmented: false,
+		},
+		{
+			name: "alonzo",
+			newTx: func(c []byte) common.Transaction {
+				tx := &alonzo.AlonzoTransaction{}
+				tx.SetCbor(c)
+				return tx
+			},
+			pparams: func(m uint) common.ProtocolParameters {
+				return &alonzo.AlonzoProtocolParameters{MaxTxSize: m}
+			},
+			validate:  alonzo.UtxoValidateMaxTxSizeUtxo,
+			segmented: true,
+		},
+		{
+			name: "babbage",
+			newTx: func(c []byte) common.Transaction {
+				tx := &babbage.BabbageTransaction{}
+				tx.SetCbor(c)
+				return tx
+			},
+			pparams: func(m uint) common.ProtocolParameters {
+				return &babbage.BabbageProtocolParameters{MaxTxSize: m}
+			},
+			validate:  babbage.UtxoValidateMaxTxSizeUtxo,
+			segmented: true,
+		},
+		{
+			name: "conway",
+			newTx: func(c []byte) common.Transaction {
+				tx := &conway.ConwayTransaction{}
+				tx.SetCbor(c)
+				return tx
+			},
+			pparams: func(m uint) common.ProtocolParameters {
+				return &conway.ConwayProtocolParameters{MaxTxSize: m}
+			},
+			validate:  conway.UtxoValidateMaxTxSizeUtxo,
+			segmented: true,
+		},
+		{
+			name: "dijkstra",
+			newTx: func(c []byte) common.Transaction {
+				tx := &dijkstra.DijkstraTransaction{}
+				tx.SetCbor(c)
+				return tx
+			},
+			pparams: func(m uint) common.ProtocolParameters {
+				pp := &dijkstra.DijkstraProtocolParameters{}
+				pp.MaxTxSize = m
+				return pp
+			},
+			validate:  dijkstra.UtxoValidateMaxTxSizeUtxo,
+			segmented: true,
+		},
+	}
+}
+
+// TestMaxTxSizeUsesTheOnChainMeasure is the regression for the Preview replay
+// wedge at slot 27745494 (epoch 321, Conway). Transaction
+// ddd3f6b502c45d7c9f60f75c79148b70c0bae6e238aafafa1d24e9b7ed228d85 is exactly
+// 16384 bytes on chain and reconstructs to 16385 with the IsValid byte
+// re-attached. maxTxSize was 16384, so the node rejected a transaction the
+// chain had accepted and stopped following the chain.
+//
+// The fee rule already subtracted that byte (common.TxSizeForFee); the
+// maxTxSize rule measured raw length. Both must use one measure.
+func TestMaxTxSizeUsesTheOnChainMeasure(t *testing.T) {
+	ls := mockledger.NewLedgerStateBuilder().Build()
+	for _, era := range maxTxSizeEras() {
+		t.Run(era.name, func(t *testing.T) {
+			if !era.segmented {
+				t.Skip("pre-Alonzo transactions carry no IsValid byte")
+			}
+			tx := era.newTx(segmentedTxCbor(int(testMaxTxSize) + 1))
+			err := era.validate(tx, 0, ls, era.pparams(testMaxTxSize))
+			assert.NoError(t, err,
+				"a transaction that is exactly maxTxSize on chain must be "+
+					"accepted; it reconstructs one byte larger")
+		})
+	}
+}
+
+// TestMaxTxSizeStillRejectsOversize is the discrimination check. The fix must
+// move the boundary by exactly the IsValid byte, not disable the rule.
+func TestMaxTxSizeStillRejectsOversize(t *testing.T) {
+	ls := mockledger.NewLedgerStateBuilder().Build()
+	for _, era := range maxTxSizeEras() {
+		t.Run(era.name, func(t *testing.T) {
+			raw := int(testMaxTxSize) + 1
+			if era.segmented {
+				// One byte past the limit once the IsValid byte is removed.
+				raw = int(testMaxTxSize) + 2
+			}
+			body := unsegmentedTxCbor
+			if era.segmented {
+				body = segmentedTxCbor
+			}
+			tx := era.newTx(body(raw))
+			err := era.validate(tx, 0, ls, era.pparams(testMaxTxSize))
+			require.Error(t, err, "a genuinely oversize transaction must fail")
+
+			var sizeErr shelley.MaxTxSizeUtxoError
+			require.ErrorAs(t, err, &sizeErr)
+			assert.Equal(t, testMaxTxSize+1, sizeErr.TxSize,
+				"the reported size must be the on-chain measure, not the "+
+					"reconstructed length")
+		})
+	}
+}
+
+// TestMaxTxSizePreAlonzoUnchanged pins that the adjustment is confined to the
+// eras that actually carry an IsValid flag. A pre-Alonzo transaction one byte
+// over the limit is over the limit.
+func TestMaxTxSizePreAlonzoUnchanged(t *testing.T) {
+	ls := mockledger.NewLedgerStateBuilder().Build()
+	for _, era := range maxTxSizeEras() {
+		if era.segmented {
+			continue
+		}
+		t.Run(era.name, func(t *testing.T) {
+			tx := era.newTx(unsegmentedTxCbor(int(testMaxTxSize) + 1))
+			err := era.validate(tx, 0, ls, era.pparams(testMaxTxSize))
+			require.Error(t, err)
+			var sizeErr shelley.MaxTxSizeUtxoError
+			require.ErrorAs(t, err, &sizeErr)
+			assert.Equal(t, testMaxTxSize+1, sizeErr.TxSize)
+		})
+	}
+}
+
+var _ = bytes.Repeat

--- a/ledger/shelley/rules.go
+++ b/ledger/shelley/rules.go
@@ -465,19 +465,15 @@ func UtxoValidateMaxTxSizeUtxo(
 	if !ok {
 		return errors.New("pparams are not expected type")
 	}
-	txBytes := tx.Cbor()
-	if len(txBytes) == 0 {
-		var err error
-		txBytes, err = cbor.Encode(tx)
-		if err != nil {
-			return err
-		}
+	txSize, sizeErr := common.TxSize(tx)
+	if sizeErr != nil {
+		return sizeErr
 	}
-	if uint(len(txBytes)) <= tmpPparams.MaxTxSize {
+	if uint(txSize) <= tmpPparams.MaxTxSize {
 		return nil
 	}
 	return MaxTxSizeUtxoError{
-		TxSize:    uint(len(txBytes)),
+		TxSize:    uint(txSize),
 		MaxTxSize: tmpPparams.MaxTxSize,
 	}
 }


### PR DESCRIPTION
## Why

Every era's `maxTxSize` rule measured a transaction by the raw length of its
reconstructed CBOR. The fee rules measured it one byte shorter, and the shorter
one is what the chain uses.

An Alonzo-and-later transaction is stored in a block as four parallel arrays —
bodies, witness sets, `IsValid` flags, auxiliary data. The `IsValid` flag is not
part of the transaction the chain sized. Reconstructing a standalone
transaction re-attaches it as the third element of a four-element array, one
byte the original never had. `common.TxSizeForFee` already subtracted it;
`UtxoValidateMaxTxSizeUtxo` did not.

A transaction sitting exactly on `maxTxSize` was therefore rejected as one byte
over — the node rejects a block the chain accepted and stops following the
chain.

## Evidence

A from-genesis Preview replay wedged at slot 27745494 (epoch 321, Conway),
reported as blinklabs-io/dingo#3928:

```
transaction size too large: size 16385, max 16384
```

Transaction `ddd3f6b502c45d7c9f60f75c79148b70c0bae6e238aafafa1d24e9b7ed228d85`,
CBOR fetched from Koios and hash-verified against the decoded bytes:

```
first byte      : 0x84  (four-element array)
raw CBOR length : 16385
length - 1      : 16384
maxTxSize       : 16384
```

Exactly on the limit, which is why it took 321 epochs to surface — it needs a
transaction deliberately built to fill `maxTxSize`.

## The change

`common.TxSize` is now the one measure, and `TxSizeForFee` delegates to it, so
the fee rule and the size rule cannot drift apart again.

**The rule is duplicated seven times.** Allegra delegates to Shelley; the other
six each computed the size themselves and none used the fee measure. All six
now call `common.TxSize`. This is the third time in this replay that fixing one
era left the others behaving as before, so I went through the whole set rather
than only Conway, where the wedge happened.

Babbage and Conway were additionally worse: they called `cbor.Encode(tx)`
unconditionally instead of reading the stored on-wire bytes, discarding the
original encoding before measuring it. They now use the same measure as the
rest.

## Tests

`ledger/max_tx_size_test.go`, in `package ledger_test` rather than in each
era's package, because the point of the test is that all seven eras agree.

- A transaction that is exactly `maxTxSize` on chain is accepted in each
  Alonzo-and-later era. Fails before the change in alonzo, babbage, conway and
  dijkstra; skipped for the three pre-Alonzo eras, which carry no `IsValid`
  byte.
- A genuinely oversize transaction is still rejected, and the size reported in
  the error is the on-chain measure. This is the discrimination that keeps the
  fix from being "move the limit by one" — it must move the boundary by exactly
  the `IsValid` byte, not disable the rule.
- Pre-Alonzo eras are unchanged: one byte over the limit is over the limit.

I also verified the fix against the real transaction directly: `common.TxSize`
returns 16384 for it and `conway.UtxoValidateMaxTxSizeUtxo` accepts it. That
check used a locally fetched CBOR file and is not committed — a 16KB fixture
did not seem worth carrying when the synthetic cases pin the same boundary.

## Validation

`go test ./...` passes. `make lint` reports 0 issues across the module and both
examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cXreCqyqbGJuDtvgYyqQN

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes maxTxSize validation rejecting valid transactions that sit exactly on the chain limit, which wedged a Preview replay at slot 27745494.

An Alonzo-and-later transaction is stored in a block as four parallel arrays, and the `IsValid` flag isn't part of the transaction the chain sized, but reconstructing it as a standalone transaction re-attaches that byte. The maxTxSize rule measured the reconstructed length one byte longer than the fee rule, so an exact-limit transaction was rejected as one byte over. `common.TxSize` is now the single measure for both rules, and `TxSizeForFee` delegates to it; all seven era copies of the maxTxSize rule use it. Babbage and Conway also stopped re-encoding the transaction and now read its stored on-wire bytes.

**Tests**
- Adds `ledger/max_tx_size_test.go` verifying exact-limit transactions are accepted in every Alonzo-and-later era, oversize transactions are rejected with the on-chain size, and pre-Alonzo behavior is unchanged.
- Fixes the Dijkstra row: block transactions there are three components, so nothing is re-attached and nothing may be subtracted — the adjustment follows the envelope shape, not the era.

<sup>Written for commit 512d55f494a74467018eee3d0d6945f393151231. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction size validation across all supported ledger eras.
  * Transactions at the exact maximum size are now accepted consistently with fee calculations.
  * Oversized transactions are rejected using the accurate on-chain size in validation errors.
  * Size calculation failures are now reported instead of being silently handled through alternate encoding behavior.
* **Compatibility**
  * Existing transaction-size functionality remains available for integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
