### PR TITLE
fix(alonzo): include datum hash in output ToPlutusData

### DIFF
--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -570,13 +570,21 @@ func (o AlonzoTransactionOutput) ToPlutusData() data.PlutusData {
 			assetDataMap.Pairs...,
 		)
 	}
+	var datumOptionPd data.PlutusData
+	if o.OutputDatumHash != nil {
+		datumOptionPd = data.NewConstr(
+			1,
+			data.NewByteString(o.OutputDatumHash.Bytes()),
+		)
+	} else {
+		datumOptionPd = data.NewConstr(0)
+	}
 	tmpData := data.NewConstr(
 		0,
 		o.OutputAddress.ToPlutusData(),
 		data.NewMap(valueData),
-		// Empty datum option
-		data.NewConstr(0),
-		// Empty script ref
+		datumOptionPd,
+		// Empty script ref (no era support for script refs pre-Babbage)
 		data.NewConstr(1),
 	)
 	return tmpData

--- a/ledger/alonzo/alonzo_test.go
+++ b/ledger/alonzo/alonzo_test.go
@@ -146,9 +146,9 @@ func TestAlonzoTransactionOutputToPlutusDataCoinOnly(t *testing.T) {
 				},
 			},
 		),
-		// TODO: empty datum option
+		// Empty datum option (no OutputDatumHash set)
 		data.NewConstr(0),
-		// TODO: empty script ref
+		// Empty script ref
 		data.NewConstr(1),
 	)
 	tmpData := testTxOut.ToPlutusData()
@@ -258,6 +258,72 @@ func TestAlonzoTransactionOutputToPlutusDataCoinAssets(t *testing.T) {
 		),
 		// Empty datum option
 		data.NewConstr(0),
+		// Empty script ref
+		data.NewConstr(1),
+	)
+	tmpData := testTxOut.ToPlutusData()
+	if !reflect.DeepEqual(tmpData, expectedData) {
+		t.Fatalf(
+			"did not get expected PlutusData\n     got: %#v\n  wanted: %#v",
+			tmpData,
+			expectedData,
+		)
+	}
+}
+
+func TestAlonzoTransactionOutputToPlutusDataWithDatumHash(t *testing.T) {
+	testAddr := "addr_test1vqg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygxrcya6"
+	var testAmount uint64 = 123_456_789
+	testDatumHash := common.NewBlake2b256(
+		test.DecodeHexString(
+			"7354f11eaa78d3ca25ac79edadf4ae3a99db9201527c16f43ae93283ff409a7a",
+		),
+	)
+	testTxOut := AlonzoTransactionOutput{
+		OutputAddress: func() common.Address { foo, _ := common.NewAddress(testAddr); return foo }(),
+		OutputAmount: mary.MaryTransactionOutputValue{
+			Amount: testAmount,
+		},
+		OutputDatumHash: &testDatumHash,
+	}
+	expectedData := data.NewConstr(
+		0,
+		// Address
+		data.NewConstr(
+			0,
+			data.NewConstr(
+				0,
+				data.NewByteString(
+					[]byte{
+						0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+					},
+				),
+			),
+			data.NewConstr(
+				1,
+			),
+		),
+		// Value
+		data.NewMap(
+			[][2]data.PlutusData{
+				{
+					data.NewByteString(nil),
+					data.NewMap(
+						[][2]data.PlutusData{
+							{
+								data.NewByteString(nil),
+								data.NewInteger(big.NewInt(int64(testAmount))),
+							},
+						},
+					),
+				},
+			},
+		),
+		// Datum option: hash present -> constructor 1 wrapping the hash bytes
+		data.NewConstr(
+			1,
+			data.NewByteString(testDatumHash.Bytes()),
+		),
 		// Empty script ref
 		data.NewConstr(1),
 	)

--- a/ledger/common/script/context_test.go
+++ b/ledger/common/script/context_test.go
@@ -29,6 +29,7 @@ import (
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/common/script"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
 	"github.com/blinklabs-io/plutigo/data"
@@ -815,4 +816,82 @@ func TestNewTxInfoFromTransactionUnknownRedeemerTag(t *testing.T) {
 		var unmatchedErr script.UnmatchedRedeemerError
 		require.ErrorAs(t, err, &unmatchedErr)
 	})
+}
+
+// TestTxInfoV3AlonzoResolvedInputDatumHash asserts that a V3 TxInfo built
+// from a resolved input whose Output is an *alonzo.AlonzoTransactionOutput
+// (the legacy pre-Babbage array output encoding, which only supports a
+// datum hash) carries that hash through to the rendered PlutusData at the
+// datum-option position, rather than silently dropping it. This exercises
+// the actual production path (NewTxInfoV3FromTransaction -> expandInputs ->
+// ResolvedInput.ToPlutusData -> AlonzoTransactionOutput.ToPlutusData), so a
+// future change routing V3 output rendering through a different path would
+// be caught here even if the per-type alonzo package tests still passed.
+func TestTxInfoV3AlonzoResolvedInputDatumHash(t *testing.T) {
+	input := shelley.NewShelleyTransactionInput(
+		"6107c3019b9d3f119f1b8755a51d0031d82450cf1126302eacbc0dc32ebf6cdb",
+		1,
+	)
+	addr, err := common.NewAddress(
+		"addr_test1vqg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygxrcya6",
+	)
+	require.NoError(t, err)
+	datumHashBytes, err := hex.DecodeString(
+		"7354f11eaa78d3ca25ac79edadf4ae3a99db9201527c16f43ae93283ff409a7a",
+	)
+	require.NoError(t, err)
+	datumHash := common.NewBlake2b256(datumHashBytes)
+	resolvedInputs := []lcommon.Utxo{
+		{
+			Id: input,
+			Output: alonzo.AlonzoTransactionOutput{
+				OutputAddress: addr,
+				OutputAmount: mary.MaryTransactionOutputValue{
+					Amount: 4_400_000,
+				},
+				OutputDatumHash: &datumHash,
+			},
+		},
+	}
+
+	mockTx := mockledger.NewTransactionBuilder()
+	mockTx.WithInputs(input)
+	var tx common.Transaction = mockTx
+
+	txInfo, err := script.NewTxInfoV3FromTransaction(
+		preprodSlotState,
+		tx,
+		resolvedInputs,
+	)
+	require.NoError(t, err)
+	require.Len(t, txInfo.Inputs, 1)
+
+	expectedOutputPd := data.NewConstr(
+		0,
+		addr.ToPlutusData(),
+		data.NewMap(
+			[][2]data.PlutusData{
+				{
+					data.NewByteString(nil),
+					data.NewMap(
+						[][2]data.PlutusData{
+							{
+								data.NewByteString(nil),
+								data.NewInteger(big.NewInt(4_400_000)),
+							},
+						},
+					),
+				},
+			},
+		),
+		// Datum option: hash present -> constructor 1 wrapping the hash
+		data.NewConstr(1, data.NewByteString(datumHash.Bytes())),
+		// Empty script ref (no era support for script refs pre-Babbage)
+		data.NewConstr(1),
+	)
+	require.Equal(
+		t,
+		expectedOutputPd,
+		txInfo.Inputs[0].Output.ToPlutusData(),
+	)
 }


### PR DESCRIPTION
## Summary
- `AlonzoTransactionOutput.ToPlutusData()` hardcoded an empty datum option (`NoOutputDatum`) regardless of `OutputDatumHash`, while `DatumHash()` on the same type correctly returns it.
- Any Plutus script that inspects a spent or reference input's datum option therefore sees "no datum" for legacy (pre-Babbage, array-encoded) outputs that actually carry a datum hash — causing scripts that branch on datum presence to take the wrong execution path and fail.
- Fixes the datum option to mirror what `BabbageTransactionOutput.ToPlutusData()` already does correctly for the hash-only case: `constructor 1` wrapping the hash bytes when `OutputDatumHash != nil`, `constructor 0` otherwise.

## Root cause context
Root-caused against a real, currently-rejected mainnet transaction (`2d295dbffc2898b14ccc9b359a342305006fdcf6ccd7907b444419520a98f351`, withdrawal script `f3c398920fc488cb995db26f09f7e7320b8538b123f300799bf101d5`, redeemer tag 3 index 0) being incorrectly rejected by [blinklabs-io/dingo#3860](https://github.com/blinklabs-io/dingo/issues/3860). The consuming script inspects one of its spent inputs' datum-option field; that input's underlying UTXO uses the legacy 3-tuple array output encoding, which `ledger.NewTransactionOutputFromCbor` correctly resolves to `*alonzo.AlonzoTransactionOutput`. `DatumHash()` on that value returns the correct hash, but `ToPlutusData()` silently dropped it, causing the script to see `NoOutputDatum` and fail.

Two existing tests in `alonzo_test.go` (`TestAlonzoTransactionOutputToPlutusDataCoinOnly`/`...CoinAssets`) carried a `// TODO: empty datum option` comment acknowledging this gap; this PR implements it and adds a dedicated regression test (`TestAlonzoTransactionOutputToPlutusDataWithDatumHash`) covering the hash-present case.

**Scope correction** (per @wolf31o2's review): this only affects the **PlutusV3** context. `TxInfoV1` renders outputs via `WithOptionDatum`, which builds the 3-field `PV1.TxOut` from `DatumHash()` directly, and `TxInfoV2` renders them via `WithZeroAdaAsset`, which already emits `Constr 1 [hash]` from `DatumHash()`. Only `TxInfoV3.ToPlutusData()` reaches `AlonzoTransactionOutput.ToPlutusData()` (via `toPlutusData`'s reflect slice path), so V1/V2 script contexts are unaffected and unchanged by this fix.

Also per that review, and explicitly out of scope for this PR: the value map in both `AlonzoTransactionOutput.ToPlutusData()` and `BabbageTransactionOutput.ToPlutusData()` omits the ada entry entirely when `OutputAmount.Amount == 0`, while cardano-ledger's `transValue`/`transCoinToValue` always include it. Filing that separately rather than folding it into this fix.

## Test plan
- [x] `go test ./ledger/alonzo/... -run TestAlonzo -v` — all pass, including new `TestAlonzoTransactionOutputToPlutusDataWithDatumHash`
- [x] `go test ./ledger/common/script/... -run TestTxInfoV3AlonzoResolvedInputDatumHash -v` — new V3-level integration test passes with the fix; confirmed it fails against the pre-fix code (reverted locally to check)
- [x] `go test -race ./ledger/...` — full ledger suite passes
- [x] `go vet ./ledger/...` — clean
- [x] `gofmt -s -l` on changed files — clean
- [ ] `golangci-lint` — could not run locally (linker toolchain issue in this environment); relying on CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `AlonzoTransactionOutput.ToPlutusData()` so it no longer drops the output datum hash. Previously it always emitted an empty datum option (`NoOutputDatum`), so Plutus scripts inspecting legacy (pre-Babbage, array-encoded) outputs with a datum hash saw "no datum" and could take the wrong execution path. Now it emits `constructor 1` wrapping the hash bytes when `OutputDatumHash` is set, and `constructor 0` otherwise, matching `BabbageTransactionOutput` behavior.

<sup>Written for commit 324f44d309fab309702adb6b7a7f6203f7e76dbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Transaction outputs now correctly preserve datum hashes when converted to Plutus data.
  - Outputs without datum hashes continue to use an empty datum option.

- **Tests**
  - Added coverage for outputs containing datum hashes.
  - Clarified test descriptions for empty datum options and script references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
