### PR TITLE
fix(ledger): gate Dijkstra withdrawal network validation

### DIFF
--- a/ledger/common/validation_rules_mapping_test.go
+++ b/ledger/common/validation_rules_mapping_test.go
@@ -269,7 +269,7 @@ var expectedUtxoValidationRuleValidators = map[string][]common.UtxoValidationRul
 		dijkstra.UtxoValidateOutputTooBigUtxo,             // UtxoValidationRuleOutputTooBig
 		conway.UtxoValidateOutputBootAddrAttrsTooBig,      // UtxoValidationRuleOutputBootAddrAttrsTooBig
 		conway.UtxoValidateWrongNetwork,                   // UtxoValidationRuleWrongNetwork
-		conway.UtxoValidateWrongNetworkWithdrawal,         // UtxoValidationRuleWrongNetworkWithdrawal
+		dijkstra.UtxoValidateWrongNetworkWithdrawal,       // UtxoValidationRuleWrongNetworkWithdrawal
 		dijkstra.UtxoValidateTransactionNetworkId,         // UtxoValidationRuleTransactionNetworkId
 		dijkstra.UtxoValidateMaxTxSizeUtxo,                // UtxoValidationRuleMaxTxSize
 		dijkstra.UtxoValidateExUnitsTooBigUtxo,            // UtxoValidationRuleExUnitsTooBig

--- a/ledger/dijkstra/rules.go
+++ b/ledger/dijkstra/rules.go
@@ -194,7 +194,7 @@ var utxoValidationRuleDescriptors = []common.UtxoValidationRuleDescriptor{
 	},
 	{
 		Id:        common.UtxoValidationRuleWrongNetworkWithdrawal,
-		Validator: conway.UtxoValidateWrongNetworkWithdrawal,
+		Validator: UtxoValidateWrongNetworkWithdrawal,
 	},
 	{
 		Id:        common.UtxoValidationRuleTransactionNetworkId,
@@ -2773,6 +2773,21 @@ func UtxoValidateTransactionNetworkId(
 		}
 	}
 	return nil
+}
+
+// UtxoValidateWrongNetworkWithdrawal validates only phase-2-valid Dijkstra
+// transactions. A phase-2-invalid transaction does not apply its withdrawal
+// effects, so its withdrawal addresses are not checked by the withdrawal rule.
+func UtxoValidateWrongNetworkWithdrawal(
+	tx common.Transaction,
+	slot uint64,
+	ls common.LedgerState,
+	pp common.ProtocolParameters,
+) error {
+	if !tx.IsValid() {
+		return nil
+	}
+	return conway.UtxoValidateWrongNetworkWithdrawal(tx, slot, ls, pp)
 }
 
 func UtxoValidateMaxTxSizeUtxo(

--- a/ledger/dijkstra/rules_test.go
+++ b/ledger/dijkstra/rules_test.go
@@ -652,6 +652,34 @@ func TestUtxoValidateWithdrawalsDijkstraAmountModes(t *testing.T) {
 	}
 }
 
+func TestDijkstraWrongNetworkWithdrawalPhase2Gate(t *testing.T) {
+	tx, _ := testDijkstraWithdrawalTx(t, 1, nil)
+	ls := mockledger.NewLedgerStateBuilder().
+		WithNetworkId(common.AddressNetworkMainnet).
+		Build()
+	pp := &DijkstraProtocolParameters{}
+
+	_, ruleIndex := dijkstraValidationRuleDescriptor(
+		t,
+		common.UtxoValidationRuleWrongNetworkWithdrawal,
+	)
+	validate := func(tx common.Transaction) error {
+		return common.VerifyTransaction(
+			tx,
+			0,
+			ls,
+			pp,
+			UtxoValidationRules[ruleIndex:ruleIndex+1],
+		)
+	}
+
+	var wrongNetworkErr shelley.WrongNetworkWithdrawalError
+	require.ErrorAs(t, validate(tx), &wrongNetworkErr)
+
+	tx.TxIsValid = false
+	require.NoError(t, validate(tx))
+}
+
 func testGuardScriptCredential(script common.PlutusV4Script) common.Credential {
 	return common.Credential{
 		CredType:   common.CredentialTypeScriptHash,


### PR DESCRIPTION
Fixes #2180.

- Gate Dijkstra withdrawal-address network validation on transaction validity.
- Preserve rejection of wrong-network withdrawals on phase-2-valid transactions.
- Add registered-rule regression coverage and update descriptor mapping coverage.

Validation: `make test`, `make lint`, `go build ./...`, the full offline conformance suite, and a race-enabled Dijkstra regression test all pass.
