### PR TITLE
fix(script): deduplicate sorted transaction inputs

### DIFF
--- a/ledger/common/script/context.go
+++ b/ledger/common/script/context.go
@@ -577,10 +577,9 @@ func (t TimeRange) ToPlutusData() data.PlutusData {
 	)
 }
 
-// SortInputs returns a sorted copy of the given inputs, ordered by
-// (TxId, Index) in ascending byte order. This matches the canonical
-// ordering required by the Cardano ledger spec for redeemer index
-// mapping.
+// SortInputs returns a sorted, deduplicated copy of the given inputs, ordered
+// by (TxId, Index) in ascending byte order. This matches the canonical
+// ordering required by the Cardano ledger spec for redeemer index mapping.
 func SortInputs(inputs []lcommon.TransactionInput) []lcommon.TransactionInput {
 	ret := make([]lcommon.TransactionInput, len(inputs))
 	copy(ret, inputs)
@@ -601,7 +600,19 @@ func SortInputs(inputs []lcommon.TransactionInput) []lcommon.TransactionInput {
 			return 0
 		},
 	)
-	return ret
+	if len(ret) < 2 {
+		return ret
+	}
+	unique := 1
+	for _, input := range ret[1:] {
+		previous := ret[unique-1]
+		if input.Id() == previous.Id() && input.Index() == previous.Index() {
+			continue
+		}
+		ret[unique] = input
+		unique++
+	}
+	return ret[:unique]
 }
 
 func expandInputs(

--- a/ledger/common/script/context_sort_test.go
+++ b/ledger/common/script/context_sort_test.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package script_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/common/script"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSortInputsDeduplicatesAndPreservesInputSlice(t *testing.T) {
+	first := shelley.NewShelleyTransactionInput(
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		1,
+	)
+	duplicate := shelley.NewShelleyTransactionInput(
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		1,
+	)
+	second := shelley.NewShelleyTransactionInput(
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		2,
+	)
+	third := shelley.NewShelleyTransactionInput(
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		3,
+	)
+	inputs := []common.TransactionInput{first, duplicate, third, second}
+
+	sorted := script.SortInputs(inputs)
+
+	require.Equal(
+		t,
+		[]common.TransactionInput{second, third, first},
+		sorted,
+	)
+	require.Equal(
+		t,
+		[]common.TransactionInput{first, duplicate, third, second},
+		inputs,
+	)
+}

--- a/ledger/common/script/redeemers_test.go
+++ b/ledger/common/script/redeemers_test.go
@@ -382,6 +382,64 @@ func TestValidateRequiredRedeemersMixedInputsBothRedeemed(t *testing.T) {
 	require.NoError(t, script.ValidateRequiredRedeemers(tx, ls))
 }
 
+// TestValidateRequiredRedeemersDeduplicatesInputs ensures duplicate TxIn
+// values do not shift the spend redeemer index of a later input. The
+// duplicate-input phase-1 rule is intentionally bypassed here so this test
+// exercises the derived sorted-input view used by this helper.
+func TestValidateRequiredRedeemersDeduplicatesInputs(t *testing.T) {
+	v1 := common.PlutusV1Script{0x01}
+	first := shelley.NewShelleyTransactionInput(
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		0,
+	)
+	second := shelley.NewShelleyTransactionInput(
+		"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		0,
+	)
+	utxoFirst := common.Utxo{
+		Id: first,
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAddress: scriptAddress(t, v1),
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
+		},
+	}
+	utxoSecond := common.Utxo{
+		Id: second,
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAddress: scriptAddress(t, v1),
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
+		},
+	}
+
+	tx := &conway.ConwayTransaction{
+		Body: conway.ConwayTransactionBody{
+			TxInputs: conway.NewConwayTransactionInputSet(
+				[]shelley.ShelleyTransactionInput{first, first, second},
+			),
+		},
+		WitnessSet: conway.ConwayTransactionWitnessSet{
+			WsPlutusV1Scripts: cbor.NewSetType(
+				[]common.PlutusV1Script{v1},
+				false,
+			),
+			WsRedeemers: conway.ConwayRedeemers{
+				Redeemers: map[common.RedeemerKey]common.RedeemerValue{
+					{Tag: common.RedeemerTagSpend, Index: 0}: {
+						ExUnits: common.ExUnits{Steps: 1, Memory: 1},
+					},
+					{Tag: common.RedeemerTagSpend, Index: 1}: {
+						ExUnits: common.ExUnits{Steps: 1, Memory: 1},
+					},
+				},
+			},
+		},
+		TxIsValid: true,
+	}
+
+	ls := ledgerStateWithUtxos(utxoFirst, utxoSecond)
+	require.NoError(t, script.ValidateRequiredRedeemers(tx, ls))
+}
+
 // TestValidateRequiredRedeemersSkipsNonScriptAddress ensures a key-address
 // input is never treated as requiring a redeemer.
 func TestValidateRequiredRedeemersSkipsNonScriptAddress(t *testing.T) {


### PR DESCRIPTION
Fixes #2177.

`SortInputs` now deduplicates transaction inputs after canonical raw `TxId`/index ordering, preserving the original input slice and transaction serialization. Added direct ordering coverage and a required-redeemer index regression test.

Validation:
- Focused tests and race tests for `ledger/common/script`, `ledger/conway`, and `ledger/dijkstra`
- `go vet`, `gofmt`, and `git diff --check`
- Offline conformance: 315/315 vectors
