### PR TITLE
fix(ledger): preserve invalid transaction script requirements

### DIFF
--- a/ledger/common/reference_native_script_test.go
+++ b/ledger/common/reference_native_script_test.go
@@ -313,6 +313,87 @@ func TestReferenceProvidedNativeScriptsAreValidated(t *testing.T) {
 	}
 }
 
+// UTXOW witness requirements apply before phase-2 validity is interpreted.
+// An invalid transaction may therefore use a native script carried by a
+// reference input, but it may not omit the required script entirely.
+func TestInvalidTransactionsRetainReferenceScriptRequirements(t *testing.T) {
+	vkey := bytes.Repeat([]byte{0x64}, 32)
+	nativeScript := testPubkeyNativeScript(t, vkey)
+	unusedScript := testPubkeyNativeScript(t, bytes.Repeat([]byte{0x65}, 32))
+	scriptAddr := testScriptPaymentAddress(t, nativeScript.Hash())
+	keyAddr := testKeyPaymentAddress(t, vkey)
+
+	spendInput := shelley.NewShelleyTransactionInput(
+		"6666666666666666666666666666666666666666666666666666666666666666",
+		0,
+	)
+	refInput := shelley.NewShelleyTransactionInput(
+		"7777777777777777777777777777777777777777777777777777777777777777",
+		0,
+	)
+
+	eras := []struct {
+		name  string
+		rules []common.UtxoValidationRuleFunc
+	}{
+		{name: "Babbage", rules: babbage.UtxoValidationRules},
+		{name: "Conway", rules: conway.UtxoValidationRules},
+		{name: "Dijkstra", rules: dijkstra.UtxoValidationRules},
+	}
+	tests := []struct {
+		name      string
+		reference common.Script
+		wantError bool
+	}{
+		{
+			name:      "matching reference script satisfies the spend",
+			reference: nativeScript,
+		},
+		{
+			name:      "unrelated reference script does not satisfy the spend",
+			reference: unusedScript,
+			wantError: true,
+		},
+	}
+
+	for _, era := range eras {
+		t.Run(era.name, func(t *testing.T) {
+			rules := selectRules(
+				t,
+				era.rules,
+				".UtxoValidateScriptWitnesses",
+				".UtxoValidateNativeScripts",
+			)
+			for _, test := range tests {
+				t.Run(test.name, func(t *testing.T) {
+					tx := mockledger.NewTransactionBuilder()
+					tx.WithValid(false)
+					tx.WithInputs(spendInput)
+					tx.WithReferenceInputs(refInput)
+					tx.WithWitnesses(
+						mockledger.NewMockTransactionWitnessSet().WithVkeyWitnesses(
+							common.VkeyWitness{Vkey: vkey},
+						),
+					)
+					ls := testLedgerState(map[string]common.TransactionOutput{
+						spendInput.String(): testOutput(scriptAddr, nil),
+						refInput.String():   testOutput(keyAddr, test.reference),
+					})
+
+					err := common.VerifyTransaction(tx, 0, ls, nil, rules)
+					if !test.wantError {
+						require.NoError(t, err)
+						return
+					}
+					var missing common.MissingScriptWitnessesError
+					require.ErrorAs(t, err, &missing)
+					require.Equal(t, common.ScriptHash(nativeScript.Hash()), missing.ScriptHash)
+				})
+			}
+		})
+	}
+}
+
 // The native-script rule reads an empty script view when an input cannot be
 // resolved, so it evaluates the witness set alone and contributes no
 // reference-provided script. That is safe only because a transaction with an

--- a/ledger/common/rules.go
+++ b/ledger/common/rules.go
@@ -1061,9 +1061,6 @@ func ValidateScriptWitnesses(tx Transaction, ls LedgerState) error {
 		// tightening it as a side effect.
 		return nil
 	}
-	if !tx.IsValid() {
-		return nil
-	}
 	requirements, err := collectTransactionScriptRequirements(tx, ls)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #2176.

- Preserve UTXOW script requirements when `IsValid=false`, including scripts supplied by reference inputs.
- Keep invalid-transaction state transitions and phase-2 validation behavior unchanged.
- Add Babbage, Conway, and Dijkstra regression coverage for matching and unrelated reference scripts.

Validation: `make test`, `make lint`, and 315/315 conformance vectors pass offline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Script witness requirements are now enforced consistently for transactions marked invalid.
  - Transactions using reference scripts must provide the correct script; unrelated or missing scripts now produce an appropriate validation error.
  - Validation now checks script witnesses, redeemers, and extraneous scripts regardless of phase-2 validity status.
  - Behavior is consistent across Babbage, Conway, and Dijkstra eras.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->