### PR TITLE
fix(localstatequery): unwrap DRep state replies

### DIFF
--- a/protocol/localstatequery/client.go
+++ b/protocol/localstatequery/client.go
@@ -1177,11 +1177,15 @@ func (c *Client) GetDRepState(
 		QueryTypeShelleyDRepState,
 		credSet,
 	)
-	var result DRepStateResult
-	if err := c.runQuery(query, &result); err != nil {
+	// The result is wrapped in a single-element array.
+	var wrappedResult []DRepStateResult
+	if err := c.runQuery(query, &wrappedResult); err != nil {
 		return nil, err
 	}
-	return &result, nil
+	if len(wrappedResult) == 0 {
+		return nil, errors.New("empty result from DRep state query")
+	}
+	return &wrappedResult[0], nil
 }
 
 // GetDRepStakeDistr returns the stake distribution across DReps (CIP-1694).

--- a/protocol/localstatequery/client_test.go
+++ b/protocol/localstatequery/client_test.go
@@ -356,6 +356,34 @@ func TestGetConstitution(t *testing.T) {
 	)
 }
 
+func TestGetDRepStateEmptyWrapper(t *testing.T) {
+	cborData, err := cbor.Encode([]any{})
+	require.NoError(t, err, "unexpected error encoding empty DRep state wrapper")
+
+	conversation := append(
+		conversationConwayEra,
+		ouroboros_mock.ConversationEntryInput{
+			ProtocolId:  localstatequery.ProtocolId,
+			MessageType: localstatequery.MessageTypeQuery,
+		},
+		ouroboros_mock.ConversationEntryOutput{
+			ProtocolId: localstatequery.ProtocolId,
+			IsResponse: true,
+			Messages: []protocol.Message{
+				localstatequery.NewMsgResult(cborData),
+			},
+		},
+	)
+	runTest(
+		t,
+		conversation,
+		func(t *testing.T, oConn *ouroboros.Connection) {
+			_, err := oConn.LocalStateQuery().Client.GetDRepState(nil)
+			require.EqualError(t, err, "empty result from DRep state query")
+		},
+	)
+}
+
 func TestGetConstitutionPreConway(t *testing.T) {
 	// Test that GetConstitution returns an error on pre-Conway eras
 	runTest(
@@ -856,7 +884,7 @@ func TestGetDRepState(t *testing.T) {
 			Deposit: 500000000,
 		},
 	}
-	cborData, err := cbor.Encode(expectedResult)
+	cborData, err := cbor.Encode([]any{expectedResult})
 	require.NoError(t, err, "unexpected error encoding DRepStateResult")
 
 	conversation := append(
@@ -898,7 +926,7 @@ func TestGetDRepState(t *testing.T) {
 func TestGetDRepStateEmpty(t *testing.T) {
 	// Test with empty result
 	expectedResult := localstatequery.DRepStateResult{}
-	cborData, err := cbor.Encode(expectedResult)
+	cborData, err := cbor.Encode([]any{expectedResult})
 	require.NoError(t, err, "unexpected error encoding empty DRepStateResult")
 
 	conversation := append(


### PR DESCRIPTION
Fixes #2169.

Decode the Conway DRep state query reply as its single-element CBOR array wrapper and reject an empty wrapper. Update protocol tests to use the wire shape and cover the empty-wrapper error.

Validation: go test ./protocol/localstatequery; go test -race ./protocol/localstatequery -run TestGetDRepState -count=1; go vet ./protocol/localstatequery; git diff --check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2169 by decoding Conway DRep state query replies as their single-element CBOR array wrapper instead of a bare `DRepStateResult`, and returns an error when the wrapper is empty.

**Bug Fixes**
- Rejects empty wrappers from the DRep state query with an `"empty result from DRep state query"` error.
- Updates protocol tests to encode replies with the wrapper and adds coverage for the empty-wrapper case.

<sup>Written for commit 1c6532cd4b6661494d8dc430f45d34330dfbea02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

