### PR TITLE
fix(ledger): reject duplicate proposal procedures

### DIFF
--- a/cbor/tags.go
+++ b/cbor/tags.go
@@ -276,8 +276,14 @@ func (t *SetType[T]) CheckForDuplicatesAlways() error {
 }
 
 func (t *SetType[T]) checkForDuplicates() error {
-	seen := make(map[string]struct{}, len(t.items))
-	for _, item := range t.items {
+	return CheckForDuplicateCBORMembers(t.items)
+}
+
+// CheckForDuplicateCBORMembers rejects duplicate values compared by their
+// canonical CBOR encoding.
+func CheckForDuplicateCBORMembers[T any](items []T) error {
+	seen := make(map[string]struct{}, len(items))
+	for _, item := range items {
 		encoded, err := Encode(item)
 		if err != nil {
 			return err

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -679,6 +679,9 @@ func (b *ConwayTransactionBody) UnmarshalCBOR(cborData []byte) error {
 			return err
 		}
 	}
+	if err := checkDuplicateProposalProcedures(tmp.TxProposalProcedures); err != nil {
+		return err
+	}
 	if err := checkMultiAssetDuplicateKeys(tmp.TxMint); err != nil {
 		return err
 	}
@@ -726,6 +729,24 @@ func checkMultiAssetDuplicateKeys[T int64 | uint64 | *big.Int](
 		return nil
 	}
 	return assets.CheckForDuplicateKeys()
+}
+
+func checkDuplicateProposalProcedures(
+	proposalProcedures []ConwayProposalProcedure,
+) error {
+	seen := make(map[string]struct{}, len(proposalProcedures))
+	for _, procedure := range proposalProcedures {
+		encoded, err := cbor.Encode(procedure)
+		if err != nil {
+			return err
+		}
+		key := string(encoded)
+		if _, exists := seen[key]; exists {
+			return errors.New("duplicate member in set")
+		}
+		seen[key] = struct{}{}
+	}
+	return nil
 }
 
 func (b *ConwayTransactionBody) Inputs() []common.TransactionInput {

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -734,19 +734,7 @@ func checkMultiAssetDuplicateKeys[T int64 | uint64 | *big.Int](
 func checkDuplicateProposalProcedures(
 	proposalProcedures []ConwayProposalProcedure,
 ) error {
-	seen := make(map[string]struct{}, len(proposalProcedures))
-	for _, procedure := range proposalProcedures {
-		encoded, err := cbor.Encode(procedure)
-		if err != nil {
-			return err
-		}
-		key := string(encoded)
-		if _, exists := seen[key]; exists {
-			return errors.New("duplicate member in set")
-		}
-		seen[key] = struct{}{}
-	}
-	return nil
+	return cbor.CheckForDuplicateCBORMembers(proposalProcedures)
 }
 
 func (b *ConwayTransactionBody) Inputs() []common.TransactionInput {

--- a/ledger/conway/conway_test.go
+++ b/ledger/conway/conway_test.go
@@ -473,6 +473,48 @@ func TestConwayRejectsDuplicateUntaggedInputSets(t *testing.T) {
 	}
 }
 
+func TestConwayProposalProceduresSetSemantics(t *testing.T) {
+	rewardAccount, err := common.NewAddress(
+		"addr1vx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzers66hrl8",
+	)
+	require.NoError(t, err)
+	action := common.InfoGovAction{Type: uint(common.GovActionTypeInfo)}
+	procedure := ConwayProposalProcedure{
+		PPDeposit:       1_000_000,
+		PPRewardAccount: rewardAccount,
+		PPGovAction:     ConwayGovAction{Action: &action},
+	}
+
+	for _, useTag := range []bool{false, true} {
+		t.Run(fmt.Sprintf("duplicate useTag=%t", useTag), func(t *testing.T) {
+			bodyCbor, err := cbor.Encode(map[uint]any{
+				20: cbor.NewSetType(
+					[]ConwayProposalProcedure{procedure, procedure},
+					useTag,
+				),
+			})
+			require.NoError(t, err)
+
+			var body ConwayTransactionBody
+			require.ErrorContains(
+				t,
+				body.UnmarshalCBOR(bodyCbor),
+				"duplicate member in set",
+			)
+		})
+	}
+
+	distinct := procedure
+	distinct.PPDeposit++
+	bodyCbor, err := cbor.Encode(map[uint]any{
+		20: []ConwayProposalProcedure{procedure, distinct},
+	})
+	require.NoError(t, err)
+	var body ConwayTransactionBody
+	require.NoError(t, body.UnmarshalCBOR(bodyCbor))
+	require.Len(t, body.TxProposalProcedures, 2)
+}
+
 func TestConwayTransactionBodyRejectsDuplicateMultiAssetKeys(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Closes #2161

Reject duplicate Conway proposal procedures during transaction-body decoding for both tagged and untagged set encodings. Distinct procedures remain accepted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects duplicate Conway proposal procedures during transaction-body decoding, closing #2161. Duplicate procedures in tagged and untagged set encodings now fail with a duplicate member error, while distinct procedures remain accepted.

- Shares the duplicate-member check via `cbor.CheckForDuplicateCBORMembers`, comparing canonical CBOR encodings.

<sup>Written for commit ea520edbfe8339d1075c60cdd37b57adb93015bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

