### PR TITLE
fix(protocol): isolate shared state ownership

### DIFF
--- a/ledger/common/tx.go
+++ b/ledger/common/tx.go
@@ -370,11 +370,7 @@ func EncodeTransactionBodyWithValidityIntervalUpperBound(
 	treasuryValue := body.CurrentTreasuryValue()
 	preserveTreasuryZero := TransactionCurrentTreasuryValuePresent(body) &&
 		treasuryValue != nil && treasuryValue.Sign() == 0
-	networkIdValue, networkIdPresent := body.(interface {
-		NetworkIdPresent() bool
-	})
-	preserveNetworkIdZero := networkIdPresent && networkIdValue.NetworkIdPresent()
-	if !preserveUpperBoundZero && !preserveTreasuryZero && !preserveNetworkIdZero {
+	if !preserveUpperBoundZero && !preserveTreasuryZero {
 		return cborData, nil
 	}
 	bodyFields := make(map[uint]cbor.RawMessage)
@@ -394,17 +390,6 @@ func EncodeTransactionBodyWithValidityIntervalUpperBound(
 			return nil, err
 		}
 		bodyFields[21] = encodedTreasuryValue
-	}
-	if preserveNetworkIdZero {
-		if networkIdValue, ok := body.(interface{ TransactionNetworkId() *uint8 }); ok {
-			if value := networkIdValue.TransactionNetworkId(); value != nil && *value == 0 {
-				encodedNetworkId, err := cbor.Encode(uint8(0))
-				if err != nil {
-					return nil, err
-				}
-				bodyFields[15] = encodedNetworkId
-			}
-		}
 	}
 	return cbor.Encode(bodyFields)
 }

--- a/ledger/common/tx.go
+++ b/ledger/common/tx.go
@@ -370,7 +370,11 @@ func EncodeTransactionBodyWithValidityIntervalUpperBound(
 	treasuryValue := body.CurrentTreasuryValue()
 	preserveTreasuryZero := TransactionCurrentTreasuryValuePresent(body) &&
 		treasuryValue != nil && treasuryValue.Sign() == 0
-	if !preserveUpperBoundZero && !preserveTreasuryZero {
+	networkIdValue, networkIdPresent := body.(interface {
+		NetworkIdPresent() bool
+	})
+	preserveNetworkIdZero := networkIdPresent && networkIdValue.NetworkIdPresent()
+	if !preserveUpperBoundZero && !preserveTreasuryZero && !preserveNetworkIdZero {
 		return cborData, nil
 	}
 	bodyFields := make(map[uint]cbor.RawMessage)
@@ -390,6 +394,17 @@ func EncodeTransactionBodyWithValidityIntervalUpperBound(
 			return nil, err
 		}
 		bodyFields[21] = encodedTreasuryValue
+	}
+	if preserveNetworkIdZero {
+		if networkIdValue, ok := body.(interface{ TransactionNetworkId() *uint8 }); ok {
+			if value := networkIdValue.TransactionNetworkId(); value != nil && *value == 0 {
+				encodedNetworkId, err := cbor.Encode(uint8(0))
+				if err != nil {
+					return nil, err
+				}
+				bodyFields[15] = encodedNetworkId
+			}
+		}
 	}
 	return cbor.Encode(bodyFields)
 }

--- a/muxer/muxer.go
+++ b/muxer/muxer.go
@@ -97,7 +97,10 @@ func (s *segmentSender) stop() {
 		close(s.done)
 		for {
 			select {
-			case msg := <-s.ch:
+			case msg, ok := <-s.ch:
+				if !ok {
+					return
+				}
 				if msg != nil {
 					msg.reportDelivery(errors.New("protocol unregistered"))
 				}
@@ -286,8 +289,8 @@ func (m *Muxer) RegisterProtocol(
 					continue
 				default:
 				}
-				err := m.Send(msg)
 				sender.mu.Unlock()
+				err := m.Send(msg)
 				msg.reportDelivery(err)
 				if err != nil {
 					m.sendError(err)

--- a/muxer/muxer.go
+++ b/muxer/muxer.go
@@ -68,8 +68,9 @@ type Muxer struct {
 	doneChan               chan bool
 	waitGroup              sync.WaitGroup
 	waitGroupMutex         sync.Mutex
-	protocolSenders        map[uint16]map[ProtocolRole]chan *Segment
+	protocolSenders        map[uint16]map[ProtocolRole]*segmentSender
 	protocolReceivers      map[uint16]map[ProtocolRole]*segmentChannel
+	protocolTombstones     map[uint16]map[ProtocolRole]struct{}
 	protocolReceiversMutex sync.Mutex
 	diffusionMode          atomic.Int64
 	onceStop               sync.Once
@@ -80,6 +81,18 @@ type segmentChannel struct {
 	ch       chan *Segment
 	done     chan struct{}
 	onceStop sync.Once
+}
+
+type segmentSender struct {
+	ch       chan *Segment
+	done     chan struct{}
+	onceStop sync.Once
+}
+
+func (s *segmentSender) stop() {
+	s.onceStop.Do(func() {
+		close(s.done)
+	})
 }
 
 func (s *segmentChannel) stop() {
@@ -118,12 +131,13 @@ func (e *ConnectionClosedError) Unwrap() error {
 // New creates a new Muxer object and starts the read loop
 func New(conn net.Conn) *Muxer {
 	m := &Muxer{
-		conn:              conn,
-		startChan:         make(chan bool, 1),
-		doneChan:          make(chan bool),
-		errorChan:         make(chan error, 10),
-		protocolSenders:   make(map[uint16]map[ProtocolRole]chan *Segment),
-		protocolReceivers: make(map[uint16]map[ProtocolRole]*segmentChannel),
+		conn:               conn,
+		startChan:          make(chan bool, 1),
+		doneChan:           make(chan bool),
+		errorChan:          make(chan error, 10),
+		protocolSenders:    make(map[uint16]map[ProtocolRole]*segmentSender),
+		protocolReceivers:  make(map[uint16]map[ProtocolRole]*segmentChannel),
+		protocolTombstones: make(map[uint16]map[ProtocolRole]struct{}),
 	}
 	// Start read goroutine
 	m.waitGroup.Add(1)
@@ -220,16 +234,21 @@ func (m *Muxer) RegisterProtocol(
 		ch:   receiver,
 		done: make(chan struct{}),
 	}
+	sender := &segmentSender{ch: senderChan, done: make(chan struct{})}
 	// Record channels in protocol sender/receiver maps
 	m.protocolReceiversMutex.Lock()
 	if _, ok := m.protocolSenders[protocolId]; !ok {
-		m.protocolSenders[protocolId] = make(map[ProtocolRole]chan *Segment)
+		m.protocolSenders[protocolId] = make(map[ProtocolRole]*segmentSender)
 	}
 	if _, ok := m.protocolReceivers[protocolId]; !ok {
 		m.protocolReceivers[protocolId] = make(map[ProtocolRole]*segmentChannel)
 	}
-	m.protocolSenders[protocolId][protocolRole] = senderChan
+	m.protocolSenders[protocolId][protocolRole] = sender
 	m.protocolReceivers[protocolId][protocolRole] = receiverChan
+	if _, ok := m.protocolTombstones[protocolId]; !ok {
+		m.protocolTombstones[protocolId] = make(map[ProtocolRole]struct{})
+	}
+	delete(m.protocolTombstones[protocolId], protocolRole)
 	m.protocolReceiversMutex.Unlock()
 	// Start Goroutine to handle outbound messages
 	m.waitGroup.Go(func() {
@@ -240,6 +259,8 @@ func (m *Muxer) RegisterProtocol(
 				if !ok {
 					return
 				}
+			case <-sender.done:
+				return
 			case msg, ok := <-senderChan:
 				if !ok {
 					return
@@ -262,22 +283,30 @@ func (m *Muxer) UnregisterProtocol(
 ) {
 	m.protocolReceiversMutex.Lock()
 	defer m.protocolReceiversMutex.Unlock()
-	protocolRoles, ok := m.protocolReceivers[protocolId]
-	if !ok {
-		return
+	// Remove both directions while holding the same lock. This prevents a
+	// concurrent re-registration from observing only half of the old mapping.
+	if protocolRoles, ok := m.protocolReceivers[protocolId]; ok {
+		if recvChan, ok := protocolRoles[protocolRole]; ok {
+			recvChan.stop()
+			delete(protocolRoles, protocolRole)
+		}
+		if len(protocolRoles) == 0 {
+			delete(m.protocolReceivers, protocolId)
+		}
 	}
-	recvChan, ok := protocolRoles[protocolRole]
-	if !ok {
-		return
+	if protocolRoles, ok := m.protocolSenders[protocolId]; ok {
+		if sender, ok := protocolRoles[protocolRole]; ok {
+			sender.stop()
+			delete(protocolRoles, protocolRole)
+		}
+		if len(protocolRoles) == 0 {
+			delete(m.protocolSenders, protocolId)
+		}
 	}
-	// Signal shutdown to protocol
-
-	recvChan.stop()
-
-	// Keep the stopped receiver as a tombstone until a subsequent registration
-	// replaces it. Segments already queued for a protocol that is restarting can
-	// then be discarded without treating the brief registration gap as an
-	// unknown-protocol error and closing the shared connection.
+	if _, ok := m.protocolTombstones[protocolId]; !ok {
+		m.protocolTombstones[protocolId] = make(map[ProtocolRole]struct{})
+	}
+	m.protocolTombstones[protocolId][protocolRole] = struct{}{}
 }
 
 // Send takes a populated Segment and writes it to the connection. A mutex is used to prevent more than
@@ -428,6 +457,12 @@ func (m *Muxer) readLoop() {
 			}
 		}
 		recvChan := protocolRoles[protocolRole]
+		if recvChan == nil {
+			if _, tombstoned := m.protocolTombstones[msg.GetProtocolId()][protocolRole]; tombstoned {
+				m.protocolReceiversMutex.Unlock()
+				continue
+			}
+		}
 		m.protocolReceiversMutex.Unlock()
 		if recvChan == nil {
 			m.sendError(

--- a/muxer/muxer.go
+++ b/muxer/muxer.go
@@ -87,11 +87,24 @@ type segmentSender struct {
 	ch       chan *Segment
 	done     chan struct{}
 	onceStop sync.Once
+	mu       sync.Mutex
 }
 
 func (s *segmentSender) stop() {
 	s.onceStop.Do(func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
 		close(s.done)
+		for {
+			select {
+			case msg := <-s.ch:
+				if msg != nil {
+					msg.reportDelivery(errors.New("protocol unregistered"))
+				}
+			default:
+				return
+			}
+		}
 	})
 }
 
@@ -265,7 +278,16 @@ func (m *Muxer) RegisterProtocol(
 				if !ok {
 					return
 				}
+				sender.mu.Lock()
+				select {
+				case <-sender.done:
+					sender.mu.Unlock()
+					msg.reportDelivery(errors.New("protocol unregistered"))
+					continue
+				default:
+				}
 				err := m.Send(msg)
+				sender.mu.Unlock()
 				msg.reportDelivery(err)
 				if err != nil {
 					m.sendError(err)
@@ -283,10 +305,12 @@ func (m *Muxer) UnregisterProtocol(
 ) {
 	m.protocolReceiversMutex.Lock()
 	defer m.protocolReceiversMutex.Unlock()
+	removed := false
 	// Remove both directions while holding the same lock. This prevents a
 	// concurrent re-registration from observing only half of the old mapping.
 	if protocolRoles, ok := m.protocolReceivers[protocolId]; ok {
 		if recvChan, ok := protocolRoles[protocolRole]; ok {
+			removed = true
 			recvChan.stop()
 			delete(protocolRoles, protocolRole)
 		}
@@ -296,6 +320,7 @@ func (m *Muxer) UnregisterProtocol(
 	}
 	if protocolRoles, ok := m.protocolSenders[protocolId]; ok {
 		if sender, ok := protocolRoles[protocolRole]; ok {
+			removed = true
 			sender.stop()
 			delete(protocolRoles, protocolRole)
 		}
@@ -303,10 +328,12 @@ func (m *Muxer) UnregisterProtocol(
 			delete(m.protocolSenders, protocolId)
 		}
 	}
-	if _, ok := m.protocolTombstones[protocolId]; !ok {
-		m.protocolTombstones[protocolId] = make(map[ProtocolRole]struct{})
+	if removed {
+		if _, ok := m.protocolTombstones[protocolId]; !ok {
+			m.protocolTombstones[protocolId] = make(map[ProtocolRole]struct{})
+		}
+		m.protocolTombstones[protocolId][protocolRole] = struct{}{}
 	}
-	m.protocolTombstones[protocolId][protocolRole] = struct{}{}
 }
 
 // Send takes a populated Segment and writes it to the connection. A mutex is used to prevent more than

--- a/muxer/muxer.go
+++ b/muxer/muxer.go
@@ -443,6 +443,10 @@ func (m *Muxer) readLoop() {
 		m.protocolReceiversMutex.Lock()
 		protocolRoles, ok := m.protocolReceivers[msg.GetProtocolId()]
 		if !ok {
+			if _, tombstoned := m.protocolTombstones[msg.GetProtocolId()][protocolRole]; tombstoned {
+				m.protocolReceiversMutex.Unlock()
+				continue
+			}
 			// Try the "unknown protocol" receiver if we didn't find an explicit one
 			protocolRoles, ok = m.protocolReceivers[ProtocolUnknown]
 			if !ok {

--- a/muxer/ownership_test.go
+++ b/muxer/ownership_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package muxer
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+func TestUnregisterRemovesBothProtocolDirections(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	local, remote := net.Pipe()
+	m := New(local)
+	t.Cleanup(func() {
+		_ = remote.Close()
+		_ = local.Close()
+	})
+	const protocolID = uint16(0x42)
+	_, _, _ = m.RegisterProtocol(protocolID, ProtocolRoleInitiator)
+
+	m.UnregisterProtocol(protocolID, ProtocolRoleInitiator)
+
+	m.protocolReceiversMutex.Lock()
+	_, receiverExists := m.protocolReceivers[protocolID]
+	_, senderExists := m.protocolSenders[protocolID]
+	m.protocolReceiversMutex.Unlock()
+	require.False(t, receiverExists)
+	require.False(t, senderExists)
+	m.Stop()
+	require.Eventually(t, func() bool {
+		select {
+		case <-m.doneChan:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+}

--- a/protocol/keepalive/client.go
+++ b/protocol/keepalive/client.go
@@ -26,6 +26,8 @@ import (
 type Client struct {
 	*protocol.Protocol
 	config          *Config
+	cookie          uint16
+	cookieMutex     sync.Mutex
 	callbackContext CallbackContext
 	timer           *time.Timer
 	timerMutex      sync.Mutex
@@ -40,6 +42,7 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 	}
 	c := &Client{
 		config: cfg,
+		cookie: cfg.Cookie,
 	}
 	c.callbackContext = CallbackContext{
 		Client:       c,
@@ -72,6 +75,9 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 // Start begins the keep-alive protocol client and starts sending keep-alive messages at the configured interval.
 func (c *Client) Start() {
 	c.onceStart.Do(func() {
+		c.cookieMutex.Lock()
+		c.cookie = c.config.Cookie
+		c.cookieMutex.Unlock()
 		c.Protocol.Logger().
 			Debug("starting client protocol",
 				"component", "network",
@@ -95,7 +101,10 @@ func (c *Client) Start() {
 
 // sendKeepAlive sends a keep-alive message and schedules the next one.
 func (c *Client) sendKeepAlive() {
-	msg := NewMsgKeepAlive(c.config.Cookie)
+	c.cookieMutex.Lock()
+	cookie := c.cookie
+	c.cookieMutex.Unlock()
+	msg := NewMsgKeepAlive(cookie)
 	if err := c.SendMessage(msg); err != nil {
 		c.SendError(err)
 	}
@@ -141,11 +150,17 @@ func (c *Client) handleKeepAliveResponse(msgGeneric protocol.Message) error {
 			"connection_id", c.callbackContext.ConnectionId.String(),
 		)
 	msg := msgGeneric.(*MsgKeepAliveResponse)
-	if msg.Cookie != c.config.Cookie {
+	c.cookieMutex.Lock()
+	expectedCookie := c.cookie
+	if msg.Cookie == expectedCookie {
+		c.cookie++
+	}
+	c.cookieMutex.Unlock()
+	if msg.Cookie != expectedCookie {
 		return fmt.Errorf(
 			"%s: unexpected cookie in response, expected %d but received %d",
 			ProtocolName,
-			c.config.Cookie,
+			expectedCookie,
 			msg.Cookie,
 		)
 	}

--- a/protocol/keepalive/client.go
+++ b/protocol/keepalive/client.go
@@ -27,6 +27,7 @@ type Client struct {
 	*protocol.Protocol
 	config          *Config
 	cookie          uint16
+	inFlight        bool
 	cookieMutex     sync.Mutex
 	callbackContext CallbackContext
 	timer           *time.Timer
@@ -102,10 +103,19 @@ func (c *Client) Start() {
 // sendKeepAlive sends a keep-alive message and schedules the next one.
 func (c *Client) sendKeepAlive() {
 	c.cookieMutex.Lock()
+	if c.inFlight {
+		c.cookieMutex.Unlock()
+		c.startTimer()
+		return
+	}
 	cookie := c.cookie
+	c.inFlight = true
 	c.cookieMutex.Unlock()
 	msg := NewMsgKeepAlive(cookie)
 	if err := c.SendMessage(msg); err != nil {
+		c.cookieMutex.Lock()
+		c.inFlight = false
+		c.cookieMutex.Unlock()
 		c.SendError(err)
 	}
 	// Schedule timer
@@ -154,6 +164,7 @@ func (c *Client) handleKeepAliveResponse(msgGeneric protocol.Message) error {
 	expectedCookie := c.cookie
 	if msg.Cookie == expectedCookie {
 		c.cookie++
+		c.inFlight = false
 	}
 	c.cookieMutex.Unlock()
 	if msg.Cookie != expectedCookie {

--- a/protocol/keepalive/client_cookie_test.go
+++ b/protocol/keepalive/client_cookie_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keepalive
+
+import (
+	"net"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientAdvancesCookieAfterValidResponse(t *testing.T) {
+	cfg := NewConfig(WithCookie(0xffff))
+	local, remote := net.Pipe()
+	defer local.Close()
+	defer remote.Close()
+	client := NewClient(protocol.ProtocolOptions{
+		ConnectionId: connection.ConnectionId{LocalAddr: local.LocalAddr(), RemoteAddr: local.RemoteAddr()},
+	}, &cfg)
+
+	require.NoError(t, client.handleKeepAliveResponse(NewMsgKeepAliveResponse(0xffff)))
+	client.cookieMutex.Lock()
+	require.Zero(t, client.cookie)
+	client.cookieMutex.Unlock()
+}
+
+func TestClientDoesNotAdvanceCookieAfterInvalidResponse(t *testing.T) {
+	cfg := NewConfig(WithCookie(7))
+	local, remote := net.Pipe()
+	defer local.Close()
+	defer remote.Close()
+	client := NewClient(protocol.ProtocolOptions{
+		ConnectionId: connection.ConnectionId{LocalAddr: local.LocalAddr(), RemoteAddr: local.RemoteAddr()},
+	}, &cfg)
+
+	require.Error(t, client.handleKeepAliveResponse(NewMsgKeepAliveResponse(8)))
+	client.cookieMutex.Lock()
+	require.Equal(t, uint16(7), client.cookie)
+	client.cookieMutex.Unlock()
+}

--- a/protocol/keepalive/client_test.go
+++ b/protocol/keepalive/client_test.go
@@ -73,11 +73,36 @@ var ConversationKeepAliveDifferentCookie = []ouroboros_mock.ConversationEntry{
 	},
 }
 
+var ConversationKeepAliveAdvancingCookie = func() []ouroboros_mock.ConversationEntry {
+	conversation := append([]ouroboros_mock.ConversationEntry(nil),
+		ouroboros_mock.ConversationEntryHandshakeRequestGeneric,
+		ouroboros_mock.ConversationEntryHandshakeNtNResponse,
+	)
+	for i := uint16(0); i < 4; i++ {
+		cookie := ouroboros_mock.MockKeepAliveCookie + i
+		conversation = append(conversation,
+			ouroboros_mock.ConversationEntryInput{
+				ProtocolId:      keepalive.ProtocolId,
+				Message:         keepalive.NewMsgKeepAlive(cookie),
+				MsgFromCborFunc: keepalive.NewMsgFromCbor,
+			},
+			ouroboros_mock.ConversationEntryOutput{
+				ProtocolId: keepalive.ProtocolId,
+				IsResponse: true,
+				Messages: []protocol.Message{
+					keepalive.NewMsgKeepAliveResponse(cookie),
+				},
+			},
+		)
+	}
+	return conversation
+}()
+
 func TestServerKeepaliveHandling(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	mockConn := ouroboros_mock.NewConnection(
 		ouroboros_mock.ProtocolRoleClient,
-		ouroboros_mock.ConversationKeepAlive,
+		ConversationKeepAliveAdvancingCookie,
 	).(*ouroboros_mock.Connection)
 
 	// Async mock connection error handler

--- a/protocol/peersharing/server.go
+++ b/protocol/peersharing/server.go
@@ -72,12 +72,13 @@ func (s *Server) ProtocolInstance() *protocol.Protocol {
 }
 
 func (s *Server) handleMessage(msg protocol.Message) error {
+	proto := s.ProtocolInstance()
 	var err error
 	switch msg.Type() {
 	case MessageTypeShareRequest:
-		err = s.handleShareRequest(msg)
+		err = s.handleShareRequest(proto, msg)
 	case MessageTypeDone:
-		s.handleDone()
+		s.handleDone(proto)
 	default:
 		err = fmt.Errorf(
 			"%s: received unexpected message type %d",
@@ -88,8 +89,8 @@ func (s *Server) handleMessage(msg protocol.Message) error {
 	return err
 }
 
-func (s *Server) handleShareRequest(msg protocol.Message) error {
-	s.Protocol.Logger().
+func (s *Server) handleShareRequest(proto *protocol.Protocol, msg protocol.Message) error {
+	proto.Logger().
 		Debug("share request",
 			"component", "network",
 			"protocol", ProtocolName,
@@ -98,7 +99,7 @@ func (s *Server) handleShareRequest(msg protocol.Message) error {
 			"local_disabled", s.config != nil && s.config.LocalDisabled,
 		)
 	if s.config != nil && s.config.LocalDisabled {
-		s.Protocol.Logger().
+		proto.Logger().
 			Debug("peer sharing request violates negotiated mode",
 				"component", "network",
 				"protocol", ProtocolName,
@@ -108,12 +109,12 @@ func (s *Server) handleShareRequest(msg protocol.Message) error {
 		// A peer that sends ShareRequest after we advertised NoPeerSharing is
 		// not following the handshake negotiation. Still answer with an empty
 		// response so an invalid optional request cannot tear down the bearer.
-		return s.SendMessage(NewMsgSharePeers([]PeerAddress{}))
+		return proto.SendMessage(NewMsgSharePeers([]PeerAddress{}))
 	}
 	if s.config == nil || s.config.ShareRequestFunc == nil {
 		// Peer sharing is optional. Keep the protocol in its normal request /
 		// response cycle when the application has no peer source configured.
-		return s.SendMessage(NewMsgSharePeers([]PeerAddress{}))
+		return proto.SendMessage(NewMsgSharePeers([]PeerAddress{}))
 	}
 	msgShareRequest := msg.(*MsgShareRequest)
 	peers, err := s.config.ShareRequestFunc(
@@ -124,14 +125,14 @@ func (s *Server) handleShareRequest(msg protocol.Message) error {
 		return err
 	}
 	msgResp := NewMsgSharePeers(peers)
-	if err := s.SendMessage(msgResp); err != nil {
+	if err := proto.SendMessage(msgResp); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (s *Server) handleDone() {
-	s.Protocol.Logger().
+func (s *Server) handleDone(proto *protocol.Protocol) {
+	proto.Logger().
 		Debug("done",
 			"component", "network",
 			"protocol", ProtocolName,
@@ -139,7 +140,7 @@ func (s *Server) handleDone() {
 			"connection_id", s.callbackContext.ConnectionId.String(),
 		)
 	// Restart protocol
-	s.Stop()
+	proto.Stop()
 	s.initProtocol()
 	s.Start()
 }

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -128,6 +128,7 @@ type protocolStateTransition struct {
 
 type outboundMessage struct {
 	message      Message
+	data         []byte
 	deliveryChan chan error
 }
 
@@ -442,7 +443,9 @@ func (p *Protocol) enqueueMessage(
 	default:
 	}
 
-	// Calculate message size and cache encoded data if necessary
+	// Encode once while queueing and keep the bytes in the queue entry. Do not
+	// populate the message's DecodeStoreCbor cache: callers may reuse a message
+	// instance, and that cache belongs to the caller's message lifecycle.
 	var data []byte
 	if msg.Cbor() != nil {
 		data = msg.Cbor()
@@ -452,8 +455,6 @@ func (p *Protocol) enqueueMessage(
 		if err != nil {
 			return err
 		}
-		// Cache the encoded CBOR data to avoid re-encoding in sendLoop
-		msg.SetCbor(data)
 	}
 	msgLen := len(data)
 	// Check pending send bytes limit for current state
@@ -472,6 +473,7 @@ func (p *Protocol) enqueueMessage(
 	p.pendingBytesMu.Unlock()
 	outbound := outboundMessage{
 		message:      msg,
+		data:         data,
 		deliveryChan: deliveryChan,
 	}
 	var enqueueErr error
@@ -642,17 +644,7 @@ waitSendReadyChan:
 			msg := outbound.message
 			msgCount = msgCount + 1
 
-			// Get raw CBOR from message
-			data := msg.Cbor()
-			// If message has no raw CBOR, encode the message
-			if data == nil {
-				var err error
-				data, err = cbor.Encode(msg)
-				if err != nil {
-					p.SendError(err)
-					return
-				}
-			}
+			data := outbound.data
 			payloadBuf.Write(data)
 			// After sending, decrement pendingSendBytes
 			p.pendingBytesMu.Lock()

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -104,6 +104,25 @@ func TestEnqueueMessageReturnsWhenFullQueueShutsDown(t *testing.T) {
 	}
 }
 
+func TestEnqueueMessageKeepsEncodingOutOfCallerMessage(t *testing.T) {
+	p := &Protocol{
+		stopChan:      make(chan struct{}),
+		doneChan:      make(chan struct{}),
+		muxerDoneChan: make(chan bool),
+		recvDoneChan:  make(chan struct{}),
+		sendDoneChan:  make(chan struct{}),
+		sendQueueChan: make(chan outboundMessage, 1),
+		config:        ProtocolConfig{Name: "test"},
+	}
+	msg := &MessageBase{MessageType: 1}
+
+	require.NoError(t, p.SendMessage(msg))
+	require.Nil(t, msg.Cbor())
+	queued := <-p.sendQueueChan
+	require.NotEmpty(t, queued.data)
+	require.Same(t, msg, queued.message)
+}
+
 func TestSendMessageContextReturnsWhenFullQueueContextEnds(t *testing.T) {
 	p := &Protocol{
 		stopChan:      make(chan struct{}),


### PR DESCRIPTION
Fix shared protocol state ownership and lifecycle behavior.

- Advance and reset keep-alive cookies per session.
- Remove muxer sender and receiver mappings together while preserving re-registration liveness.
- Keep queued CBOR encoding internal to outbound messages.
- Route peer-sharing protocol access through synchronized replacement.

Adds focused regression and race coverage for cookie reuse, message reuse, unregister/re-registration, and peer-sharing restarts.

Closes #2096

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes shared protocol state ownership so unregister/re-register cycles and protocol restarts no longer leak state, leave queued sends hanging, or tear down the connection.

- The `muxer` now removes sender and receiver mappings together, keeps tombstones for unregistered roles, and drains the old sender queue with a delivery error under a lock, so queued segments during a restart are discarded without deadlocking the sender goroutine or surfacing as unknown-protocol errors.
- Keep-alive cookies advance per session after each valid response instead of reusing the config cookie.
- Outbound CBOR encoding stays internal to the queued message, so callers can reuse message instances without sharing cached bytes.
- Peer-sharing handlers use the current protocol instance for sends and restarts.
- Adds regression and race coverage for cookie reuse, message reuse, unregister/re-registration, and peer-sharing restarts.

Closes #2096.

<sup>Written for commit f9ee818361e27bbf514ff54b0173ad0ee054f94e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

