### PR TITLE
docs: refresh protocol limits and examples

### DIFF
--- a/protocol/PROTOCOL_LIMITS.md
+++ b/protocol/PROTOCOL_LIMITS.md
@@ -1,222 +1,144 @@
-# Ouroboros Mini-Protocol Limits Implementation
+# Ouroboros mini-protocol limits
 
-## Overview
+This document records the limits and state-transition timeouts implemented by
+the protocol state maps in this repository. Values are source-level defaults;
+an option passed to a client or server can replace the timeout where noted.
+An entry with a zero timeout or pending-message limit has no framework limit.
 
-This document describes the implementation of queue/pipeline/message limits for the Ouroboros mini-protocols as specified in the Ouroboros Network Specification. These limits prevent resource exhaustion and ensure protocol compliance by terminating connections when limits are violated.
+The protocol framework applies a state's `PendingMessageByteLimit` while that
+state is active. A state timeout closes the protocol when its agency does not
+make the expected transition before the timeout expires. These are transport
+and state-machine safeguards, not application-level transaction or block
+validation.
 
-## Reference
+## Chain Sync
 
-All limits are based on the [Ouroboros Network Specification](https://ouroboros-network.cardano.intersectmbo.org/pdfs/network-spec/network-spec.pdf).
+The N2N map (`protocol/chainsync/chainsync.go`) has the following limits:
 
-## Implemented Limits
+| State | Timeout | Pending bytes |
+| --- | ---: | ---: |
+| Idle | 3673 seconds | 462,000 |
+| CanAwait | 10 seconds | 462,000 |
+| Intersect | 10 seconds | 462,000 |
+| MustReply | random in `[135, 269)` seconds | 462,000 |
+| Done | none | 462,000 |
 
-### ChainSync Protocol
+The N2C map has no state timeouts or pending-message byte limits. `MustReply`
+uses a fresh random timeout for each state entry; `MustReplyTimeout` is the
+fixed maximum retained for compatibility and configuration defaults.
 
-**Constants defined in `protocol/chainsync/chainsync.go`:**
-- `MaxPipelineLimit = 100` - Maximum number of pipelined ChainSync requests
-- `MaxRecvQueueSize = 100` - Maximum size of the receive message queue
-- `DefaultPipelineLimit = 50` - Conservative default for pipeline limit
-- `DefaultRecvQueueSize = 50` - Conservative default for receive queue size
-- `MaxPendingMessageBytes = 462000` - NtN mux ingress buffer per spec Table 3.15 (462KB)
+Configuration limits are:
 
-**State timeout constants:**
-- `IdleTimeout = 60s` - Timeout for client to send next request
-- `CanAwaitTimeout = 300s` - Timeout for server to provide next block or await
-- `IntersectTimeout = 5s` - Timeout for server to respond to intersect request
-- `MustReplyTimeout = 300s` - Timeout for server to provide next block
+| Setting | Maximum | Default |
+| --- | ---: | ---: |
+| Pipeline limit | 100 requests | 75 |
+| Receive queue size | 100 messages | 75 |
 
-**Enforcement:**
-- Client-side pipeline tracking with disconnect on violation
-- Configuration validation with panic on invalid values
-- Server-side queue size limits enforced by protocol framework
-- Per-state pending message byte limits enforced with connection teardown on violation
-- State transition timeouts enforced with connection teardown on timeout
+`MaxPendingMessageBytes` is 462,000 bytes. `WithPipelineLimit` and
+`WithRecvQueueSize` reject negative values and values above their maximum.
 
-**Files modified:**
-- `protocol/chainsync/chainsync.go` - Added constants, validation, and documentation
-- `protocol/chainsync/client.go` - Added pipeline count tracking and enforcement
+## Block Fetch
 
-### BlockFetch Protocol
+The base map (`protocol/blockfetch/blockfetch.go`) is:
 
-**Constants defined in `protocol/blockfetch/blockfetch.go`:**
-- `MaxRecvQueueSize = 512` - Maximum size of the receive message queue
-- `DefaultRecvQueueSize = 256` - Default receive queue size
-- `MaxPendingMessageBytes = 5242880` - Maximum pending message bytes (5MB)
+| State | Timeout | Pending bytes |
+| --- | ---: | ---: |
+| Idle | none | 65,535 |
+| Busy | 60 seconds | 2,500,000 |
+| Streaming | 60 seconds | 2,500,000 |
+| Done | none | 0 |
 
-**State timeout constants:**
-- `IdleTimeout = 60s` - Timeout for client to send block range request
-- `BusyTimeout = 5s` - Timeout for server to start batch or respond no blocks
-- `StreamingTimeout = 60s` - Timeout for server to send next block in batch
+Client and server instances copy the map and apply their configured
+`BatchStartTimeout` and `BlockTimeout` to Busy and Streaming. A pipelining
+client raises its Idle pending-message limit to 2,500,000 bytes so a block can
+arrive during the Idle transition.
 
-**Request pipelining constants:**
-- `DefaultMaxInFlightBytes = 9011200` - Bound on the expected size of
-  outstanding pipelined range requests, matching `cardano-node`'s
-  `blockFetchProtocolLimits`: `blockFetchPipeliningMax` (100) times the maximum
-  block body size (88 KiB)
-- `DefaultRequestExpectedBytes = 90112` - Size charged to a request whose
-  caller supplied no estimate (one maximum-size block body), which makes the
-  default bound degrade to 100 outstanding requests
-- `PipelinedIdleMaxPendingMessageBytes` - Idle-state ingress limit for a
-  pipelining client, which must admit a block because the peer's response to
-  the next request can arrive while the state machine is momentarily back in
-  Idle
+| Setting | Maximum | Default |
+| --- | ---: | ---: |
+| Receive queue size | 512 messages | 384 |
+| Expected bytes per unestimated range request | — | 90,112 (88 KiB) |
+| Total expected in-flight request bytes | — | 9,011,200 (100 × 88 KiB) |
 
-**Enforcement:**
-- Configuration validation with panic on invalid values
-- Queue size limits enforced by protocol framework
-- Per-state pending message byte limits enforced with connection teardown on violation
-- State transition timeouts enforced with connection teardown on timeout
-- Outstanding pipelined requests bounded in bytes, blocking the caller of
-  `Client.RequestRange` rather than terminating the connection
+`WithRecvQueueSize` rejects values outside the receive-queue range. The
+in-flight byte bound applies to client request pipelining and blocks the
+request caller when the bound is full; it does not terminate the connection.
 
-**Files modified:**
-- `protocol/blockfetch/blockfetch.go` - Added constants, validation, and documentation
-- `protocol/blockfetch/client.go` - Outstanding request queue and in-flight byte bound
+## Transaction Submission
 
-### TxSubmission Protocol
+The TxSubmission state map has no pending-message byte limits:
 
-**Constants defined in `protocol/txsubmission/txsubmission.go`:**
-- `MaxRequestCount = 65535` - Maximum number of transactions per request (uint16 limit)
-- `MaxAckCount = 65535` - Maximum number of transaction acknowledgments (uint16 limit)
-- `DefaultRequestLimit = 1000` - Reasonable default for transaction requests
-- `DefaultAckLimit = 1000` - Reasonable default for transaction acknowledgments
-- Pending message byte limits: Not enforced (0 = no limit)
+| State | Timeout |
+| --- | ---: |
+| Init | none |
+| Idle | none |
+| TxIdsBlocking | none |
+| TxIdsNonBlocking | 10 seconds |
+| Txs | 10 seconds |
+| Done | none |
 
-**State timeout constants:**
-- `InitTimeout = 30s` - Timeout for client to send init message
-- `IdleTimeout = 300s` - Timeout for server to send tx request when idle
-- `TxIdsBlockingTimeout = 60s` - Timeout for client to reply with tx IDs (blocking)
-- `TxIdsNonblockingTimeout = 30s` - Timeout for client to reply with tx IDs (non-blocking)
-- `TxsTimeout = 120s` - Timeout for client to reply with full transactions
+The protocol accepts at most 65,535 transaction IDs in a request and at most
+65,535 acknowledgements (`uint16` wire fields). Both client and server reject
+counts outside those bounds with `ErrProtocolViolationRequestExceeded`.
+`DefaultRequestLimit` and `DefaultAckLimit` are exported guidance constants
+(1,000); they are not configuration fields and are not applied automatically.
 
-**Enforcement:**
-- Server-side validation with disconnect on excessive request counts
-- Client-side validation with disconnect on excessive received counts
-- State transition timeouts enforced with connection teardown on timeout
+## Handshake
 
-**Files modified:**
-- `protocol/txsubmission/txsubmission.go` - Added constants and documentation
-- `protocol/txsubmission/server.go` - Added request count validation
-- `protocol/txsubmission/client.go` - Added received count validation
+For N2N, `Propose` and `Confirm` each have a 10-second timeout. N2C has no
+state timeouts. Client and server instances copy the N2N map and can override
+the applicable timeout with `WithTimeout`; the N2C map remains timeout-free.
 
-### Handshake Protocol
+## Keep Alive
 
-**State timeout constants:**
-- `ProposeTimeout = 5s` - Timeout for client to propose protocol version
-- `ConfirmTimeout = 5s` - Timeout for server to confirm or refuse version
+| State | Timeout |
+| --- | ---: |
+| Client | 97 seconds |
+| Server | 60 seconds |
+| Done | none |
 
-**Files modified:**
-- `protocol/handshake/handshake.go` - Added timeout constants and StateMap integration
+The keep-alive configuration separately defaults to a 60-second period and a
+10-second response timeout for the keep-alive loop. Those values do not change
+the exported state-map constants above.
 
-### Keepalive Protocol
+## Local mini-protocols
 
-**State timeout constants:**
-- `ClientTimeout = 60s` - Timeout for client to send keepalive request
-- `ServerTimeout = 10s` - Timeout for server to respond to keepalive
+These protocols have no static state-map timeout; the client copies the map and
+applies the configured operation timeout where indicated:
 
-**Files modified:**
-- `protocol/keepalive/keepalive.go` - Added timeout constants and StateMap integration
+| Protocol | State/operation | Default |
+| --- | --- | ---: |
+| Local State Query | Acquiring | 5 seconds |
+| Local State Query | Querying | 180 seconds |
+| Local Tx Monitor | Acquiring | 5 seconds |
+| Local Tx Monitor | Busy queries | 30 seconds |
+| Local Tx Submission | Busy submit | 30 seconds |
+| Peer Sharing | Busy response | 60 seconds |
 
-## Protocol Violation Errors
+The local protocols and Peer Sharing have no additional queue, pipeline, or
+pending-message byte limits in their state maps.
 
-**New error types defined in `protocol/error.go`:**
-- `ErrProtocolViolationQueueExceeded` - Message queue limit exceeded
-- `ErrProtocolViolationPipelineExceeded` - Pipeline limit exceeded  
-- `ErrProtocolViolationRequestExceeded` - Request count limit exceeded
-- `ErrProtocolViolationInvalidMessage` - Invalid message received
+## Leios mini-protocols
 
-These errors cause connection termination as per the network specification.
+| Protocol | State | Default timeout |
+| --- | --- | ---: |
+| Leios Fetch client | Votes, BlockRange | 5 seconds |
+| Leios Notify client | Busy | 60 seconds |
+| Leios Votes client | Busy | 60 seconds |
+| Leios Votes server with a configured request callback | Busy | 60 seconds |
 
-## Other Mini-Protocols
+Leios Fetch `Block` and `BlockTxs` requests are bounded by the caller's
+context, not by a protocol state timeout. Leios Notify and Leios Fetch have no
+queue or pending-message byte limits. Leios Notify allows up to 100 pipelined
+requests and defaults to 10. Leios Votes allows up to 100 pipelined requests,
+defaults to 1, and limits one request to 1,000 votes (the default is also
+1,000). Invalid configured values are rejected by their constructors.
 
-All remaining protocols have appropriate timeout implementations:
+## Enforcement scope
 
-- **LocalStateQuery** - Has AcquireTimeout (5s) and QueryTimeout (180s) for database queries
-- **LocalTxMonitor** - Has AcquireTimeout (5s) and QueryTimeout (30s) for mempool monitoring  
-- **LocalTxSubmission** - Has Timeout (30s) for local transaction submission
-- **PeerSharing** - Has Timeout (5s) for peer discovery requests
-- **LeiosFetch** - Has Timeout (5s) for fetching Leios blocks, block
-  transactions, votes, and block ranges
-- **LeiosNotify** - Has Timeout (60s) for Leios block announcements/offers,
-  block transaction offers, and vote offers
-- **LeiosVotes** - Has Timeout (60s) for Leios vote diffusion
-- **Handshake** - Has ProposeTimeout (5s) and ConfirmTimeout (5s) for protocol negotiation
-- **Keepalive** - Has ClientTimeout (60s) and ServerTimeout (10s) for connection health
+State-map timeouts and pending-message limits are enforced by the protocol
+framework. Message-specific limits and configuration validation are enforced
+by the owning protocol implementation. This document intentionally does not
+claim limits for protocols or states whose current map contains no such entry.
 
-## Validation and Testing
-
-**Test file:** `protocol/limits_test.go`
-- Validates that all limits are properly defined and positive
-- Tests configuration validation and panic behavior  
-- Verifies protocol violation errors are defined
-- Ensures default values are reasonable and within limits
-- Comprehensive timeout validation for all 12 mini-protocols
-- Verifies StateMap entries use correct timeout constants
-
-## Protocol State Timeouts
-
-### Implementation
-
-Each protocol state can define a timeout value that is enforced by the protocol framework. When a state transition takes too long, the connection is automatically terminated to prevent hanging connections and ensure protocol compliance.
-
-### Timeout Values
-
-The timeout values are based on the Ouroboros Network Specification and real-world network conditions:
-
-- **Short timeouts (5-30s)**: For rapid protocol handshakes and responses
-- **Medium timeouts (60-120s)**: For normal message exchanges and client requests  
-- **Long timeouts (300s)**: For waiting on new blocks or mempool queries
-
-### Timeout Behavior
-
-- Timeouts are set when entering a state with `StateMapEntry.Timeout > 0`
-- If no state transition occurs within the timeout period, the protocol terminates
-- Connection teardown includes proper error logging for debugging
-- Terminal states (`AgencyNone`) do not have timeouts
-
-## Behavior Changes
-
-**Before:**
-- No enforced limits on pipeline depth or queue sizes
-- Potential for memory exhaustion from excessive pipelining
-- No disconnect on protocol violations
-- No state transition timeouts
-
-**After:**
-- Strict limits enforced as per network specification
-- Automatic connection termination on limit violations
-- Comprehensive logging of violations before disconnect
-- Configuration validation prevents invalid setups
-- State transition timeouts prevent hanging connections
-
-## Usage Examples
-
-### ChainSync with Custom Limits
-
-```go
-cfg := chainsync.NewConfig(
-    chainsync.WithPipelineLimit(75),        // Max 100
-    chainsync.WithRecvQueueSize(80),        // Max 100
-)
-```
-
-### BlockFetch with Custom Queue Size
-
-```go
-cfg := blockfetch.NewConfig(
-    blockfetch.WithRecvQueueSize(400),      // Max 512
-)
-```
-
-### TxSubmission (limits enforced automatically)
-
-The TxSubmission protocol enforces limits automatically in the client and server message handlers.
-
-## Network Specification Compliance
-
-This implementation ensures compliance with the Ouroboros Network Specification by:
-1. Defining appropriate limits for each mini-protocol
-2. Enforcing limits at both client and server sides
-3. Terminating connections on protocol violations
-4. Preventing resource exhaustion attacks
-5. Maintaining protocol state machine integrity
+The repository's `build-examples` workflow runs `make build` on pull requests;
+that target builds every module under `examples/` against the public API.

--- a/protocol/txsubmission/README.md
+++ b/protocol/txsubmission/README.md
@@ -130,7 +130,6 @@ txsubmission.NewConfig(
     txsubmission.WithRequestTxsFunc(requestTxsCallback),
     txsubmission.WithInitFunc(initCallback),
     txsubmission.WithDoneFunc(doneCallback),
-    txsubmission.WithIdleTimeout(0), // no timeout per spec
 )
 ```
 


### PR DESCRIPTION
Closes #2095

- Align protocol limits and state timeout documentation with current implementations.
- Remove the obsolete TxSubmission configuration option from the README.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #2095.

Rewrites `protocol/PROTOCOL_LIMITS.md` to document the limits and state timeouts that match current source defaults instead of the previous stale values, and removes the obsolete `WithIdleTimeout` option from the `txsubmission` README example.

**Refactors**
- Replaces the prose per-protocol sections with tables of state timeouts, pending-message byte limits, and configuration limits.
- Notes which protocols and states have no framework limit and clarifies enforcement scope.

<sup>Written for commit 4fbdf4026d792eb7a4a4f4ae3e0078e9ae6a7815. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

