### PR TITLE
test(cbor): make array header boundary test 32-bit safe

### DIFF
--- a/cbor/stream_decoder_test.go
+++ b/cbor/stream_decoder_test.go
@@ -462,16 +462,19 @@ func TestArrayHeaderSize(t *testing.T) {
 		{256, 3},
 		{65535, 3},
 		{65536, 5},
-		// math.MaxInt scales with the platform's int width (2^31-1 on
-		// 32-bit, 2^63-1 on 64-bit), so it stays a valid header-size-9
-		// case everywhere without overflowing a 32-bit int.
-		{math.MaxInt, 9},
 	}
 
 	for _, tt := range tests {
 		size := cbor.ArrayHeaderSize(tt.length)
 		assert.Equal(t, tt.expectSize, size, "length %d", tt.length)
 	}
+	maxIntExpected := uint32(9)
+	if bits.UintSize < 64 {
+		// On 32-bit platforms math.MaxInt is below the 32-bit CBOR
+		// length boundary and therefore uses the 4-byte length form.
+		maxIntExpected = 5
+	}
+	assert.Equal(t, maxIntExpected, cbor.ArrayHeaderSize(math.MaxInt), "length %d", math.MaxInt)
 
 	// These boundary values don't fit in a 32-bit int at all, so they can
 	// only be constructed and exercised on a 64-bit platform. Build them


### PR DESCRIPTION
Correct the `math.MaxInt` expectation in `TestArrayHeaderSize` for 32-bit builds.

Keep the 64-bit-only `2^32` boundary cases gated by word size so the test validates the implementation on both architectures.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `TestArrayHeaderSize` so it passes on 32-bit builds, where `math.MaxInt` is below the 32-bit CBOR length boundary and should expect the 4-byte header form (size 5) instead of size 9. Keeps the 64-bit-only `2^32` boundary cases gated by word size so the test still validates the implementation on both architectures.

<sup>Written for commit 0a0d1b230ef587d4ac324ad583c56ce1615e5743. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated array header size coverage to account for platform-specific behavior on 32-bit and 64-bit systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->