### PR TITLE
fix(ledger): include Conway execution costs in fees

### DIFF
--- a/ledger/conway/ref_scripts.go
+++ b/ledger/conway/ref_scripts.go
@@ -148,19 +148,22 @@ func CalculateExecutionUnitsFee(
 	if witnesses == nil || witnesses.Redeemers() == nil {
 		return 0, nil
 	}
+	if witnesses.Redeemers().Len() == 0 {
+		return 0, nil
+	}
+	if prices.MemPrice == nil || prices.MemPrice.Rat == nil {
+		return 0, errors.New("invalid execution memory price")
+	}
+	if prices.StepPrice == nil || prices.StepPrice.Rat == nil {
+		return 0, errors.New("invalid execution step price")
+	}
+	if prices.MemPrice.Sign() < 0 || prices.StepPrice.Sign() < 0 {
+		return 0, errors.New("execution prices must not be negative")
+	}
 	total := new(big.Rat)
 	hasRedeemer := false
 	for _, redeemer := range witnesses.Redeemers().Iter() {
 		hasRedeemer = true
-		if prices.MemPrice == nil || prices.MemPrice.Rat == nil {
-			return 0, errors.New("invalid execution memory price")
-		}
-		if prices.StepPrice == nil || prices.StepPrice.Rat == nil {
-			return 0, errors.New("invalid execution step price")
-		}
-		if prices.MemPrice.Sign() < 0 || prices.StepPrice.Sign() < 0 {
-			return 0, errors.New("execution prices must not be negative")
-		}
 		if redeemer.ExUnits.Memory < 0 || redeemer.ExUnits.Steps < 0 {
 			return 0, errors.New("execution units must not be negative")
 		}

--- a/ledger/conway/ref_scripts.go
+++ b/ledger/conway/ref_scripts.go
@@ -148,22 +148,21 @@ func CalculateExecutionUnitsFee(
 	if witnesses == nil || witnesses.Redeemers() == nil {
 		return 0, nil
 	}
-	if witnesses.Redeemers().Len() == 0 {
-		return 0, nil
-	}
-	if prices.MemPrice == nil || prices.MemPrice.Rat == nil {
-		return 0, errors.New("invalid execution memory price")
-	}
-	if prices.StepPrice == nil || prices.StepPrice.Rat == nil {
-		return 0, errors.New("invalid execution step price")
-	}
-	if prices.MemPrice.Sign() < 0 || prices.StepPrice.Sign() < 0 {
-		return 0, errors.New("execution prices must not be negative")
-	}
 	total := new(big.Rat)
-	hasRedeemer := false
+	pricesValidated := false
 	for _, redeemer := range witnesses.Redeemers().Iter() {
-		hasRedeemer = true
+		if !pricesValidated {
+			if prices.MemPrice == nil || prices.MemPrice.Rat == nil {
+				return 0, errors.New("invalid execution memory price")
+			}
+			if prices.StepPrice == nil || prices.StepPrice.Rat == nil {
+				return 0, errors.New("invalid execution step price")
+			}
+			if prices.MemPrice.Sign() < 0 || prices.StepPrice.Sign() < 0 {
+				return 0, errors.New("execution prices must not be negative")
+			}
+			pricesValidated = true
+		}
 		if redeemer.ExUnits.Memory < 0 || redeemer.ExUnits.Steps < 0 {
 			return 0, errors.New("execution units must not be negative")
 		}
@@ -177,13 +176,6 @@ func CalculateExecutionUnitsFee(
 		)
 		total.Add(total, memoryFee)
 		total.Add(total, stepsFee)
-	}
-	if !hasRedeemer {
-		return 0, nil
-	}
-
-	if total.Sign() < 0 {
-		return 0, errors.New("execution fee must not be negative")
 	}
 	fee := new(big.Int).Quo(total.Num(), total.Denom())
 	if new(big.Int).Mod(total.Num(), total.Denom()).Sign() != 0 {

--- a/ledger/conway/ref_scripts.go
+++ b/ledger/conway/ref_scripts.go
@@ -137,6 +137,61 @@ func CalculateRefScriptFee(
 	return fee.Uint64(), nil
 }
 
+// CalculateExecutionUnitsFee calculates the fee for all redeemer execution
+// unit budgets. The rational total is rounded up once, after all redeemers
+// have been accumulated, as required by the Conway ledger specification.
+func CalculateExecutionUnitsFee(
+	tx common.Transaction,
+	prices common.ExUnitPrice,
+) (uint64, error) {
+	witnesses := tx.Witnesses()
+	if witnesses == nil || witnesses.Redeemers() == nil {
+		return 0, nil
+	}
+	total := new(big.Rat)
+	hasRedeemer := false
+	for _, redeemer := range witnesses.Redeemers().Iter() {
+		hasRedeemer = true
+		if prices.MemPrice == nil || prices.MemPrice.Rat == nil {
+			return 0, errors.New("invalid execution memory price")
+		}
+		if prices.StepPrice == nil || prices.StepPrice.Rat == nil {
+			return 0, errors.New("invalid execution step price")
+		}
+		if prices.MemPrice.Sign() < 0 || prices.StepPrice.Sign() < 0 {
+			return 0, errors.New("execution prices must not be negative")
+		}
+		if redeemer.ExUnits.Memory < 0 || redeemer.ExUnits.Steps < 0 {
+			return 0, errors.New("execution units must not be negative")
+		}
+		memoryFee := new(big.Rat).Mul(
+			new(big.Rat).SetInt64(redeemer.ExUnits.Memory),
+			prices.MemPrice.Rat,
+		)
+		stepsFee := new(big.Rat).Mul(
+			new(big.Rat).SetInt64(redeemer.ExUnits.Steps),
+			prices.StepPrice.Rat,
+		)
+		total.Add(total, memoryFee)
+		total.Add(total, stepsFee)
+	}
+	if !hasRedeemer {
+		return 0, nil
+	}
+
+	if total.Sign() < 0 {
+		return 0, errors.New("execution fee must not be negative")
+	}
+	fee := new(big.Int).Quo(total.Num(), total.Denom())
+	if new(big.Int).Mod(total.Num(), total.Denom()).Sign() != 0 {
+		fee.Add(fee, big.NewInt(1))
+	}
+	if !fee.IsUint64() {
+		return 0, fmt.Errorf("execution fee overflow: %s", fee)
+	}
+	return fee.Uint64(), nil
+}
+
 // MinFeeTxWithRefScriptSize adds the Conway tiered reference-script fee to
 // the size-based transaction fee. Callers that already resolved the UTxO set
 // can use this function without repeating the lookup.

--- a/ledger/conway/ref_scripts_test.go
+++ b/ledger/conway/ref_scripts_test.go
@@ -348,6 +348,12 @@ func TestMinFeeTxIncludesExecutionAndReferenceScriptCosts(t *testing.T) {
 					}: {
 						ExUnits: common.ExUnits{Memory: 3, Steps: 4},
 					},
+					{
+						Tag:   common.RedeemerTagSpend,
+						Index: 1,
+					}: {
+						ExUnits: common.ExUnits{Memory: 1, Steps: 1},
+					},
 				},
 			},
 		},
@@ -367,7 +373,7 @@ func TestMinFeeTxIncludesExecutionAndReferenceScriptCosts(t *testing.T) {
 	require.NoError(t, err)
 	executionFee, err := conway.CalculateExecutionUnitsFee(tx, pp.ExecutionCosts)
 	require.NoError(t, err)
-	require.Equal(t, uint64(5), executionFee)
+	require.Equal(t, uint64(6), executionFee)
 	minFee, err := conway.MinFeeTx(tx, pp)
 	require.NoError(t, err)
 	require.Equal(t, byteFee+executionFee, minFee)

--- a/ledger/conway/ref_scripts_test.go
+++ b/ledger/conway/ref_scripts_test.go
@@ -337,6 +337,46 @@ func TestConwayRefScriptFeeAndLimitUseSameConsumedSet(t *testing.T) {
 	require.Zero(t, publishingFee)
 }
 
+func TestMinFeeTxIncludesExecutionAndReferenceScriptCosts(t *testing.T) {
+	tx := &conway.ConwayTransaction{
+		WitnessSet: conway.ConwayTransactionWitnessSet{
+			WsRedeemers: conway.ConwayRedeemers{
+				Redeemers: map[common.RedeemerKey]common.RedeemerValue{
+					{
+						Tag:   common.RedeemerTagSpend,
+						Index: 0,
+					}: {
+						ExUnits: common.ExUnits{Memory: 3, Steps: 4},
+					},
+				},
+			},
+		},
+	}
+	tx.SetCbor([]byte{0x84, 0xa0, 0xa0, 0xf5, 0xf6})
+	pp := &conway.ConwayProtocolParameters{
+		MinFeeA: 2,
+		MinFeeB: 3,
+		ExecutionCosts: common.ExUnitPrice{
+			MemPrice:  &cbor.Rat{Rat: big.NewRat(1, 2)},
+			StepPrice: &cbor.Rat{Rat: big.NewRat(2, 3)},
+		},
+		MinFeeRefScriptCostPerByte: &cbor.Rat{Rat: big.NewRat(1, 1)},
+	}
+
+	byteFee, err := common.CalculateMinFee(4, pp.MinFeeA, pp.MinFeeB)
+	require.NoError(t, err)
+	executionFee, err := conway.CalculateExecutionUnitsFee(tx, pp.ExecutionCosts)
+	require.NoError(t, err)
+	require.Equal(t, uint64(5), executionFee)
+	minFee, err := conway.MinFeeTx(tx, pp)
+	require.NoError(t, err)
+	require.Equal(t, byteFee+executionFee, minFee)
+
+	combinedFee, err := conway.MinFeeTxWithRefScriptSize(tx, pp, 2)
+	require.NoError(t, err)
+	require.Equal(t, minFee+2, combinedFee)
+}
+
 func TestCalculateRefScriptFeeFloorsFractionalTotal(t *testing.T) {
 	fee, err := conway.CalculateRefScriptFee(
 		51_201,

--- a/ledger/conway/rules.go
+++ b/ledger/conway/rules.go
@@ -2789,7 +2789,14 @@ func MinFeeTx(
 	if err != nil {
 		return 0, err
 	}
-	return minFee, nil
+	executionFee, err := CalculateExecutionUnitsFee(tx, tmpPparams.ExecutionCosts)
+	if err != nil {
+		return 0, err
+	}
+	if minFee > math.MaxUint64-executionFee {
+		return 0, errors.New("minimum transaction fee overflow")
+	}
+	return minFee + executionFee, nil
 }
 
 // MinCoinTxOut calculates the minimum coin for a transaction output based on protocol parameters.


### PR DESCRIPTION
Fixes #2086

Conway minimum fees now include the execution-unit cost for every redeemer, rounded up once after summing rational prices. The existing resolved-UTxO path adds consumed reference-script costs to this corrected base fee, while transactions without redeemers retain the byte-fee behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2086 by including Conway execution-unit costs in the minimum transaction fee.

`MinFeeTx` now adds a fee for every redeemer's execution budget, rounding up once after accumulating rational prices. Execution prices and units are validated during fee calculation, and overflow returns an error instead of wrapping. The resolved-UTxO path (`MinFeeTxWithRefScriptSize`) adds reference-script costs on top of this corrected base. Transactions without redeemers keep the existing byte-fee behavior.

<sup>Written for commit 07d09d1c00c37ff9c49b417064aaf90284e073fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction minimum-fee calculations now include execution-unit costs for script-based transactions.
  * Added validation and overflow handling for execution-unit fee calculations.
  * Transactions without redeemers or witnesses correctly incur no execution-unit fee.

* **Bug Fixes**
  * Minimum-fee calculations now return errors instead of silently producing incorrect results when fee totals overflow.

* **Tests**
  * Added coverage for combined transaction, execution-unit, and reference-script fees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->