### PR TITLE
fix(ledger): build genesis delegations with key credentials

### DIFF
--- a/ledger/shelley/genesis.go
+++ b/ledger/shelley/genesis.go
@@ -562,7 +562,7 @@ func (g *ShelleyGenesis) InitialPools() (map[string]common.PoolRegistrationCerti
 		}
 
 		addr, err := common.NewAddressFromParts(
-			common.AddressTypeNoneScript, // Script stake address
+			common.AddressTypeNoneKey,
 			networkId,
 			nil,
 			stakeKey,
@@ -628,7 +628,7 @@ func (g *ShelleyGenesis) PoolById(
 			}
 
 			addr, err := common.NewAddressFromParts(
-				common.AddressTypeNoneScript,
+				common.AddressTypeNoneKey,
 				networkId,
 				nil,
 				stakeKey,

--- a/ledger/shelley/genesis_test.go
+++ b/ledger/shelley/genesis_test.go
@@ -758,8 +758,8 @@ func TestGenesisStaking(t *testing.T) {
 				t.Errorf("Expected testnet address, got network ID %d", delegs[0].NetworkId())
 			}
 
-			if delegs[0].Type() != common.AddressTypeNoneScript {
-				t.Errorf("Expected script stake address type, got %d", delegs[0].Type())
+			if delegs[0].Type() != common.AddressTypeNoneKey {
+				t.Errorf("Expected key stake address type, got %d", delegs[0].Type())
 			}
 
 			// Verify stake key matches
@@ -813,8 +813,8 @@ func TestGenesisStaking(t *testing.T) {
 				t.Errorf("Expected testnet address, got network ID %d", delegators[0].NetworkId())
 			}
 
-			if delegators[0].Type() != common.AddressTypeNoneScript {
-				t.Errorf("Expected script stake address type, got %d", delegators[0].Type())
+			if delegators[0].Type() != common.AddressTypeNoneKey {
+				t.Errorf("Expected key stake address type, got %d", delegators[0].Type())
 			}
 
 			// Verify stake key matches


### PR DESCRIPTION
## Summary

- Build Shelley genesis delegations with key credentials.
- Preserve pool associations through `InitialPools` and `PoolById`.
- Update genesis staking regression coverage for key reward addresses.

Fixes #2082

## Validation

- `make test`
- `make lint`
- `go vet ./...`
- `go test -v ./internal/test/conformance/...`
- `make build` with `-buildvcs=false` (linked-worktree VCS stamping workaround)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the address type used for stake delegator addresses in genesis staking configurations.
  * Updated staking validation to reflect key-based delegator addresses accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->