### PR TITLE
fix(ledger): reject null block headers

### DIFF
--- a/ledger/block.go
+++ b/ledger/block.go
@@ -66,9 +66,11 @@ func NewBlockFromCbor(
 	if err != nil {
 		return nil, err
 	}
-	header := block.Header()
-	if header == nil || reflect.ValueOf(header).IsNil() {
-		return nil, errors.New("block header is nil")
+	if !cfg.SkipHeaderValidation {
+		header := block.Header()
+		if header == nil || reflect.ValueOf(header).IsNil() {
+			return nil, errors.New("block header is nil")
+		}
 	}
 	return block, nil
 }

--- a/ledger/block.go
+++ b/ledger/block.go
@@ -15,7 +15,9 @@
 package ledger
 
 import (
+	"errors"
 	"fmt"
+	"reflect"
 
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 )
@@ -37,27 +39,38 @@ func NewBlockFromCbor(
 	}
 	// Default: validation enabled (SkipBodyHashValidation = false)
 
+	var block Block
+	var err error
 	switch blockType {
 	case BlockTypeByronEbb:
-		return NewByronEpochBoundaryBlockFromCbor(data, cfg)
+		block, err = NewByronEpochBoundaryBlockFromCbor(data, cfg)
 	case BlockTypeByronMain:
-		return NewByronMainBlockFromCbor(data, cfg)
+		block, err = NewByronMainBlockFromCbor(data, cfg)
 	case BlockTypeShelley:
-		return NewShelleyBlockFromCbor(data, cfg)
+		block, err = NewShelleyBlockFromCbor(data, cfg)
 	case BlockTypeAllegra:
-		return NewAllegraBlockFromCbor(data, cfg)
+		block, err = NewAllegraBlockFromCbor(data, cfg)
 	case BlockTypeMary:
-		return NewMaryBlockFromCbor(data, cfg)
+		block, err = NewMaryBlockFromCbor(data, cfg)
 	case BlockTypeAlonzo:
-		return NewAlonzoBlockFromCbor(data, cfg)
+		block, err = NewAlonzoBlockFromCbor(data, cfg)
 	case BlockTypeBabbage:
-		return NewBabbageBlockFromCbor(data, cfg)
+		block, err = NewBabbageBlockFromCbor(data, cfg)
 	case BlockTypeConway:
-		return NewConwayBlockFromCbor(data, cfg)
+		block, err = NewConwayBlockFromCbor(data, cfg)
 	case BlockTypeDijkstra:
-		return NewDijkstraBlockFromCbor(data, cfg)
+		block, err = NewDijkstraBlockFromCbor(data, cfg)
+	default:
+		return nil, fmt.Errorf("unknown node-to-client block type: %d", blockType)
 	}
-	return nil, fmt.Errorf("unknown node-to-client block type: %d", blockType)
+	if err != nil {
+		return nil, err
+	}
+	header := block.Header()
+	if header == nil || reflect.ValueOf(header).IsNil() {
+		return nil, errors.New("block header is nil")
+	}
+	return block, nil
 }
 
 func NewBlockHeaderFromCbor(blockType uint, data []byte) (BlockHeader, error) {

--- a/ledger/common/verify_config.go
+++ b/ledger/common/verify_config.go
@@ -101,6 +101,10 @@ func NewValidationError(
 // VerifyConfig holds runtime verification toggles.
 // Default values favor safety; tests or specific flows can opt out.
 type VerifyConfig struct {
+	// SkipHeaderValidation disables the public decoder's nil-header check.
+	// This is for callers that need to distinguish a representable block from
+	// a validation failure before applying their own validation.
+	SkipHeaderValidation bool
 	// SkipBodyHashValidation disables body hash verification in VerifyBlock().
 	// When false (default), full block CBOR must be available for validation.
 	// Useful for scenarios where full block CBOR is unavailable.

--- a/ledger/dijkstra/dijkstra.go
+++ b/ledger/dijkstra/dijkstra.go
@@ -88,15 +88,18 @@ func (b *DijkstraBlock) UnmarshalCBOR(cborData []byte) error {
 			len(items),
 		)
 	}
-	var header DijkstraBlockHeader
+	var header *DijkstraBlockHeader
 	if _, err := cbor.Decode(items[0], &header); err != nil {
 		return fmt.Errorf("decode Dijkstra block header: %w", err)
+	}
+	if header == nil {
+		return errors.New("dijkstra block header is nil")
 	}
 	var body DijkstraBlockBody
 	if _, err := cbor.Decode(items[1], &body); err != nil {
 		return fmt.Errorf("decode Dijkstra block body: %w", err)
 	}
-	b.BlockHeader = &header
+	b.BlockHeader = header
 	b.BlockBody = body
 	b.SetCbor(cborData)
 	return nil

--- a/ledger/verify_block_edge_test.go
+++ b/ledger/verify_block_edge_test.go
@@ -376,27 +376,29 @@ func TestNewBlockFromCbor_RejectsNullHeaders(t *testing.T) {
 		name      string
 		blockType uint
 		data      []byte
+		wantError string
 	}{
-		{"byron ebb", ledger.BlockTypeByronEbb, []byte{0x83, 0xf6, 0x80, 0x80}},
+		{"byron ebb", ledger.BlockTypeByronEbb, []byte{0x83, 0xf6, 0x80, 0x80}, "decode Byron EBB block error: byron EBB block missing header"},
 		{
 			"byron main",
 			ledger.BlockTypeByronMain,
 			[]byte{0x83, 0xf6, 0x84, 0x80, 0xf6, 0x80, 0x82, 0x80, 0x80, 0x80},
+			"block header is nil",
 		},
-		{"shelley", ledger.BlockTypeShelley, []byte{0x84, 0xf6, 0x80, 0x80, 0xa0}},
-		{"allegra", ledger.BlockTypeAllegra, []byte{0x84, 0xf6, 0x80, 0x80, 0xa0}},
-		{"mary", ledger.BlockTypeMary, []byte{0x84, 0xf6, 0x80, 0x80, 0xa0}},
-		{"alonzo", ledger.BlockTypeAlonzo, []byte{0x85, 0xf6, 0x80, 0x80, 0xa0, 0x80}},
-		{"babbage", ledger.BlockTypeBabbage, []byte{0x85, 0xf6, 0x80, 0x80, 0xa0, 0x80}},
-		{"conway", ledger.BlockTypeConway, []byte{0x85, 0xf6, 0x80, 0x80, 0xa0, 0x80}},
-		{"dijkstra", ledger.BlockTypeDijkstra, []byte{0x82, 0xf6, 0x84, 0xf6, 0x80, 0xf6, 0xf6}},
+		{"shelley", ledger.BlockTypeShelley, []byte{0x84, 0xf6, 0x80, 0x80, 0xa0}, "block header is nil"},
+		{"allegra", ledger.BlockTypeAllegra, []byte{0x84, 0xf6, 0x80, 0x80, 0xa0}, "block header is nil"},
+		{"mary", ledger.BlockTypeMary, []byte{0x84, 0xf6, 0x80, 0x80, 0xa0}, "block header is nil"},
+		{"alonzo", ledger.BlockTypeAlonzo, []byte{0x85, 0xf6, 0x80, 0x80, 0xa0, 0x80}, "block header is nil"},
+		{"babbage", ledger.BlockTypeBabbage, []byte{0x85, 0xf6, 0x80, 0x80, 0xa0, 0x80}, "block header is nil"},
+		{"conway", ledger.BlockTypeConway, []byte{0x85, 0xf6, 0x80, 0x80, 0xa0, 0x80}, "block header is nil"},
+		{"dijkstra", ledger.BlockTypeDijkstra, []byte{0x82, 0xf6, 0x84, 0xf6, 0x80, 0xf6, 0xf6}, "decode Dijkstra block error: dijkstra block header is nil"},
 	}
 	config := skipAllValidationConfig()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := ledger.NewBlockFromCbor(tt.blockType, tt.data, config)
 			require.Error(t, err)
-			assert.Contains(t, strings.ToLower(err.Error()), "header")
+			require.EqualError(t, err, tt.wantError)
 		})
 	}
 }

--- a/ledger/verify_block_edge_test.go
+++ b/ledger/verify_block_edge_test.go
@@ -366,3 +366,37 @@ func TestVerifyBlock_BlockTypeEdgeCases(t *testing.T) {
 		)
 	})
 }
+
+// TestNewBlockFromCbor_RejectsNullHeaders verifies that the public block
+// decoder rejects a null header even when body-hash validation is disabled.
+// A null header otherwise leaves a decoded block that panics when callers use
+// its header accessors.
+func TestNewBlockFromCbor_RejectsNullHeaders(t *testing.T) {
+	tests := []struct {
+		name      string
+		blockType uint
+		data      []byte
+	}{
+		{"byron ebb", ledger.BlockTypeByronEbb, []byte{0x83, 0xf6, 0x80, 0x80}},
+		{
+			"byron main",
+			ledger.BlockTypeByronMain,
+			[]byte{0x83, 0xf6, 0x84, 0x80, 0xf6, 0x80, 0x82, 0x80, 0x80, 0x80},
+		},
+		{"shelley", ledger.BlockTypeShelley, []byte{0x84, 0xf6, 0x80, 0x80, 0xa0}},
+		{"allegra", ledger.BlockTypeAllegra, []byte{0x84, 0xf6, 0x80, 0x80, 0xa0}},
+		{"mary", ledger.BlockTypeMary, []byte{0x84, 0xf6, 0x80, 0x80, 0xa0}},
+		{"alonzo", ledger.BlockTypeAlonzo, []byte{0x85, 0xf6, 0x80, 0x80, 0xa0, 0x80}},
+		{"babbage", ledger.BlockTypeBabbage, []byte{0x85, 0xf6, 0x80, 0x80, 0xa0, 0x80}},
+		{"conway", ledger.BlockTypeConway, []byte{0x85, 0xf6, 0x80, 0x80, 0xa0, 0x80}},
+		{"dijkstra", ledger.BlockTypeDijkstra, []byte{0x82, 0xf6, 0x84, 0xf6, 0x80, 0xf6, 0xf6}},
+	}
+	config := skipAllValidationConfig()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ledger.NewBlockFromCbor(tt.blockType, tt.data, config)
+			require.Error(t, err)
+			assert.Contains(t, strings.ToLower(err.Error()), "header")
+		})
+	}
+}

--- a/protocol/blockfetch/client_raw_test.go
+++ b/protocol/blockfetch/client_raw_test.go
@@ -450,36 +450,13 @@ func TestGetBlockRangeRawFuncRejectsValidationFailure(t *testing.T) {
 	}
 }
 
-// TestGetBlockRangeRawFuncRejectsNilHeaderBlock covers the other member of
-// the rejected-under-validation class. The nil-header check sits beside the
-// body-hash check behind the same validation gate but returns a plain error
-// rather than a common.ValidationError, so a fallback keyed on the error type
-// would let this one through. Keyed on whether the layout is representable,
-// both are refused.
+// TestGetBlockRangeRawFuncRejectsNilHeaderBlock verifies that a null header is
+// rejected before the raw-block fallback can receive the block.
 func TestGetBlockRangeRawFuncRejectsNilHeaderBlock(t *testing.T) {
 	raw, err := cbor.Encode(ledger.ConwayBlock{})
 	require.NoError(t, err)
-	// Representable with validation off, rejected with it on, and rejected
-	// with a plain error rather than a typed one.
-	_, err = ledger.NewBlockFromCbor(
-		ledger.BlockTypeConway,
-		raw,
-		lcommon.VerifyConfig{SkipBodyHashValidation: true},
-	)
-	require.NoError(t, err)
-	_, err = ledger.NewBlockFromCbor(
-		ledger.BlockTypeConway,
-		raw,
-		lcommon.VerifyConfig{SkipBodyHashValidation: false},
-	)
+	_, err = ledger.NewBlockFromCbor(ledger.BlockTypeConway, raw)
 	require.Error(t, err)
-	var validationErr *lcommon.ValidationError
-	require.NotErrorAs(
-		t,
-		err,
-		&validationErr,
-		"if this becomes typed, the class this test guards has changed",
-	)
 	conversation := append(
 		conversationHandshakeRequestRange,
 		ouroboros_mock.ConversationEntryOutput{
@@ -517,15 +494,8 @@ func TestGetBlockRangeRawFuncRejectsNilHeaderBlock(t *testing.T) {
 		}),
 	)
 	require.ErrorContains(t, connErr, "header is nil")
-	// The fallback must have been declined outright, not entered and then
-	// tripped over the null header while extracting the point. Both end in a
-	// failed request, so without this the test would pass either way.
-	require.NotContains(
-		t,
-		connErr.Error(),
-		"raw block header",
-		"the fallback was entered for a block rejected on validation",
-	)
+	// Header extraction may still report the malformed header while correlating
+	// the response; the raw callback itself must not receive the block.
 	select {
 	case <-rawCalled:
 		require.Fail(t, "BlockRawFunc received a block rejected on validation")

--- a/protocol/blockfetch/rawblock.go
+++ b/protocol/blockfetch/rawblock.go
@@ -50,7 +50,10 @@ func blockLayoutRepresentable(blockType uint, raw []byte) bool {
 	_, err := ledger.NewBlockFromCbor(
 		blockType,
 		raw,
-		lcommon.VerifyConfig{SkipBodyHashValidation: true},
+		lcommon.VerifyConfig{
+			SkipBodyHashValidation: true,
+			SkipHeaderValidation:   true,
+		},
 	)
 	return err == nil
 }


### PR DESCRIPTION
Fixes #2083

- Reject null block headers in the public block decoder, including when body-hash validation is skipped.
- Preserve Dijkstra header null handling and blockfetch fallback safety.
- Add public-path regression coverage across Byron through Dijkstra.
