### PR TITLE
fix(crypto): apply strict Ed25519 rules outside Byron

### DIFF
--- a/consensus/byron/validate.go
+++ b/consensus/byron/validate.go
@@ -337,6 +337,13 @@ func (v *HeaderValidator) validateSimpleSignature(
 		}
 		// Permissive fallback (opt-in only): verify directly against HeaderCbor
 		// WARNING: This is less secure and should only be used for testing
+		// Byron signatures are verified permissively on purpose. The reference is
+		// Cardano.Crypto.Signing.Signature.verifySignatureRaw, which calls CC.verify in
+		// cardano-crypto-wallet, whose bundled ed25519-donna ed25519_sign_open checks
+		// only the high bits of S and performs no small-order test on A or R. It
+		// accepts proofs libsodium rejects, and Byron blocks are immutable history, so
+		// routing these through internal/ed25519strict would reject chain the node
+		// accepts. Do not "fix" these to match the non-Byron boundaries.
 		valid := ed25519.Verify(
 			input.IssuerPubKey,
 			input.HeaderCbor,

--- a/consensus/byron/validate.go
+++ b/consensus/byron/validate.go
@@ -367,7 +367,10 @@ func (v *HeaderValidator) validateSimpleSignature(
 		return fmt.Errorf("failed to domain-separate ToSign: %w", err)
 	}
 
-	// Verify Ed25519 signature on the domain-separated ToSign.
+	// Byron verification stays permissive at this primary path. Its
+	// ed25519-donna reference accepts small-order public and R points, and
+	// tightening immutable Byron history to the non-Byron criteria would break
+	// sync from genesis. Do not route this through internal/ed25519strict.
 	valid := ed25519.Verify(
 		input.IssuerPubKey,
 		signed,
@@ -645,6 +648,10 @@ func (v *HeaderValidator) validateProxySignature(
 	// Use the Ed25519 portion of the delegate's extended key (first 32 bytes)
 	delegatePubKey := delegateVK[:32]
 
+	// Byron verification stays permissive at this delegated block-signature
+	// path. Its ed25519-donna reference accepts small-order public and R points,
+	// and tightening immutable Byron history to the non-Byron criteria would
+	// break sync from genesis. Do not route this through internal/ed25519strict.
 	valid := ed25519.Verify(delegatePubKey, signedBuf, blockSig)
 	if !valid {
 		return fmt.Errorf(

--- a/consensus/byron/validate_test.go
+++ b/consensus/byron/validate_test.go
@@ -53,6 +53,60 @@ func testByronConfig() ByronConfig {
 	}
 }
 
+func testByronIdentityPair() (ed25519.PublicKey, []byte) {
+	publicKey := make(ed25519.PublicKey, ed25519.PublicKeySize)
+	publicKey[0] = 0x01
+	signature := make([]byte, ed25519.SignatureSize)
+	signature[0] = 0x01
+	return publicKey, signature
+}
+
+func testByronHeaderCbor(t *testing.T) []byte {
+	t.Helper()
+	header := &byron.ByronMainBlockHeader{
+		ProtocolMagic: testByronProtocolMagicMainnet,
+	}
+	headerCbor, err := cbor.Encode(header)
+	require.NoError(t, err)
+	return headerCbor
+}
+
+func testByronProxyInput(
+	t *testing.T,
+	delegatePublicKey, blockSignature []byte,
+) *ValidateHeaderInput {
+	t.Helper()
+	issuerVK := make([]byte, byron.VerificationKeySize)
+	issuerVK[0] = 0x02
+	delegateVK := make([]byte, byron.VerificationKeySize)
+	copy(delegateVK, delegatePublicKey)
+	certSignature := make([]byte, ed25519.SignatureSize)
+
+	header := &byron.ByronMainBlockHeader{
+		ProtocolMagic: testByronProtocolMagicMainnet,
+	}
+	header.ConsensusData.BlockSig = []any{
+		uint64(byronSigTypeHeavy),
+		[]any{
+			[]any{uint64(7), issuerVK, delegateVK, certSignature},
+			blockSignature,
+		},
+	}
+	headerCbor, err := cbor.Encode(header)
+	require.NoError(t, err)
+
+	// Real callers populate BlockSig and HeaderCbor from the same decoded
+	// header. Round-trip here because proxyCertEpochCbor walks the raw bytes.
+	var decoded byron.ByronMainBlockHeader
+	_, err = cbor.Decode(headerCbor, &decoded)
+	require.NoError(t, err)
+
+	return &ValidateHeaderInput{
+		HeaderCbor: headerCbor,
+		BlockSig:   decoded.ConsensusData.BlockSig,
+	}
+}
+
 func TestNewHeaderValidator(t *testing.T) {
 	config := testByronConfig()
 	validator := NewHeaderValidator(config)
@@ -445,6 +499,78 @@ func TestValidateSimpleSignatureRequiresMainBlockDomain(t *testing.T) {
 	// The raw ToSign signature must not verify in the main-block domain.
 	input.BlockSignature = ed25519.Sign(privKey, toSign)
 	assert.Error(t, validator.validateSimpleSignature(input))
+}
+
+// TestValidateSimpleSignatureStaysPermissive pins the primary,
+// domain-separated Byron signature path. Byron's ed25519-donna reference
+// accepts the identity public key and R point; changing this call to strict
+// verification would reject immutable chain history.
+func TestValidateSimpleSignatureStaysPermissive(t *testing.T) {
+	publicKey, signature := testByronIdentityPair()
+	validator := NewHeaderValidator(testByronConfig())
+	require.False(t, validator.AllowSignatureFallback)
+	input := &ValidateHeaderInput{
+		IssuerPubKey:   publicKey,
+		BlockSignature: signature,
+		HeaderCbor:     testByronHeaderCbor(t),
+	}
+
+	require.NoError(t, validator.validateSimpleSignature(input))
+}
+
+func TestValidateSimpleSignatureRejectsGarbage(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	validator := NewHeaderValidator(testByronConfig())
+	input := &ValidateHeaderInput{
+		IssuerPubKey: publicKey,
+		BlockSignature: ed25519.Sign(
+			privateKey,
+			[]byte("not the domain-separated header"),
+		),
+		HeaderCbor: testByronHeaderCbor(t),
+	}
+
+	require.ErrorContains(
+		t,
+		validator.validateSimpleSignature(input),
+		"block signature verification failed",
+	)
+}
+
+// TestValidateProxySignatureStaysPermissive pins the delegate block-signature
+// half of Byron proxy signatures. Byron's ed25519-donna reference accepts the
+// identity public key and R point; changing this call to strict verification
+// would reject immutable chain history.
+func TestValidateProxySignatureStaysPermissive(t *testing.T) {
+	publicKey, signature := testByronIdentityPair()
+	validator := NewHeaderValidator(testByronConfig())
+	validator.SkipDelegationCertVerification = true
+
+	require.NoError(
+		t,
+		validator.validateProxySignature(
+			testByronProxyInput(t, publicKey, signature),
+			byronSigTypeHeavy,
+		),
+	)
+}
+
+func TestValidateProxySignatureRejectsGarbage(t *testing.T) {
+	publicKey, privateKey, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	validator := NewHeaderValidator(testByronConfig())
+	validator.SkipDelegationCertVerification = true
+
+	err = validator.validateProxySignature(
+		testByronProxyInput(
+			t,
+			publicKey,
+			ed25519.Sign(privateKey, []byte("not the delegated header")),
+		),
+		byronSigTypeHeavy,
+	)
+	require.ErrorContains(t, err, "block signature verification failed")
 }
 
 func TestValidateSimpleSignatureReferenceVector(t *testing.T) {

--- a/consensus/validate.go
+++ b/consensus/validate.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/blinklabs-io/gouroboros/internal/ed25519strict"
 	"github.com/blinklabs-io/gouroboros/kes"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/vrf"
@@ -574,7 +575,7 @@ func (v *HeaderValidator) validateOpCertSignature(
 	)
 
 	// Verify Ed25519 signature
-	valid := ed25519.Verify(
+	valid := ed25519strict.Verify(
 		input.IssuerVkey,
 		opCertBody,
 		input.OpCertSignature,

--- a/internal/ed25519strict/verify.go
+++ b/internal/ed25519strict/verify.go
@@ -1,0 +1,75 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ed25519strict provides the Ed25519 verification criteria used by the
+// Cardano node for every signature outside the Byron era.
+//
+// The node reaches libsodium's crypto_sign_ed25519_verify_detached through
+// cardano-crypto-class's Ed25519DSIGN, which rejects non-canonical point and
+// scalar encodings and small-order public and R points. crypto/ed25519.Verify
+// applies none of those checks: it accepts the edwards25519 identity public key
+// with an all-zero signature for any message, because the verification equation
+// [S]B == R + [h]A reduces to identity == identity. Accepting a proof the node
+// rejects is a consensus divergence, so every boundary whose reference is
+// Ed25519DSIGN must verify through Verify below.
+//
+// Byron is deliberately not covered. Byron signatures are verified by
+// cardano-crypto-wallet's bundled ed25519-donna, whose ed25519_sign_open checks
+// only the high bits of S and performs no small-order test, so it accepts
+// proofs libsodium rejects. Byron blocks are immutable history; applying these
+// criteria to them would reject chain the node accepts.
+package ed25519strict
+
+import (
+	"bytes"
+	"crypto/ed25519"
+
+	"filippo.io/edwards25519"
+)
+
+// Verify reports whether sig is a valid signature of msg by pubKey under the
+// strict criteria described in the package comment.
+func Verify(pubKey, msg, sig []byte) bool {
+	if len(pubKey) != ed25519.PublicKeySize ||
+		len(sig) != ed25519.SignatureSize {
+		return false
+	}
+
+	publicPoint, err := new(edwards25519.Point).SetBytes(pubKey)
+	if err != nil ||
+		!bytes.Equal(publicPoint.Bytes(), pubKey) ||
+		IsSmallOrder(publicPoint) {
+		return false
+	}
+
+	rPoint, err := new(edwards25519.Point).SetBytes(sig[:32])
+	if err != nil ||
+		!bytes.Equal(rPoint.Bytes(), sig[:32]) ||
+		IsSmallOrder(rPoint) {
+		return false
+	}
+
+	if _, err := new(edwards25519.Scalar).SetCanonicalBytes(sig[32:]); err != nil {
+		return false
+	}
+
+	return ed25519.Verify(pubKey, msg, sig)
+}
+
+// IsSmallOrder reports whether point lies in the small-order subgroup, which
+// libsodium refuses for both the public key and R.
+func IsSmallOrder(point *edwards25519.Point) bool {
+	return new(edwards25519.Point).MultByCofactor(point).
+		Equal(edwards25519.NewIdentityPoint()) == 1
+}

--- a/internal/ed25519strict/verify.go
+++ b/internal/ed25519strict/verify.go
@@ -16,13 +16,13 @@
 // Cardano node for every signature outside the Byron era.
 //
 // The node reaches libsodium's crypto_sign_ed25519_verify_detached through
-// cardano-crypto-class's Ed25519DSIGN, which rejects non-canonical point and
-// scalar encodings and small-order public and R points. crypto/ed25519.Verify
-// applies none of those checks: it accepts the edwards25519 identity public key
-// with an all-zero signature for any message, because the verification equation
-// [S]B == R + [h]A reduces to identity == identity. Accepting a proof the node
-// rejects is a consensus divergence, so every boundary whose reference is
-// Ed25519DSIGN must verify through Verify below.
+// cardano-crypto-class's Ed25519DSIGN, which rejects small-order public and R
+// points. crypto/ed25519.Verify applies no small-order checks: it accepts the
+// edwards25519 identity public key with an all-zero signature for any message,
+// because the verification equation [S]B == R + [h]A reduces to identity ==
+// identity. Accepting a proof the node rejects is a consensus divergence, so
+// every boundary whose reference is Ed25519DSIGN must verify through Verify
+// below.
 //
 // Byron is deliberately not covered. Byron signatures are verified by
 // cardano-crypto-wallet's bundled ed25519-donna, whose ed25519_sign_open checks

--- a/internal/ed25519strict/verify_test.go
+++ b/internal/ed25519strict/verify_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ed25519strict_test
+
+import (
+	"crypto/ed25519"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/internal/ed25519strict"
+)
+
+// IdentityPublicKey and IdentitySignature are the edwards25519 identity point
+// and an all-zero scalar. crypto/ed25519.Verify accepts this pair for any
+// message; libsodium's crypto_sign_ed25519_verify_detached rejects it.
+var (
+	identityPublicKey = append([]byte{0x01}, make([]byte, 31)...)
+	identitySignature = append(
+		append([]byte{0x01}, make([]byte, 31)...),
+		make([]byte, 32)...,
+	)
+)
+
+func TestVerifyRejectsIdentityKey(t *testing.T) {
+	for _, msg := range []string{"", "a", "arbitrary transaction body hash"} {
+		if !ed25519.Verify(identityPublicKey, []byte(msg), identitySignature) {
+			t.Fatalf(
+				"crypto/ed25519 no longer accepts the identity pair for %q; this test no longer discriminates",
+				msg,
+			)
+		}
+		if ed25519strict.Verify(identityPublicKey, []byte(msg), identitySignature) {
+			t.Errorf("strict verification accepted the identity pair for %q", msg)
+		}
+	}
+}
+
+func TestVerifyAcceptsHonestSignature(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg := []byte("a message this key actually signed")
+	sig := ed25519.Sign(priv, msg)
+	if !ed25519strict.Verify(pub, msg, sig) {
+		t.Error("strict verification rejected an honest signature")
+	}
+	if ed25519strict.Verify(pub, []byte("a different message"), sig) {
+		t.Error("strict verification accepted a signature over a different message")
+	}
+}
+
+func TestVerifyRejectsMalformedSizes(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg := []byte("message")
+	sig := ed25519.Sign(priv, msg)
+	if ed25519strict.Verify(pub[:31], msg, sig) {
+		t.Error("accepted a short public key")
+	}
+	if ed25519strict.Verify(pub, msg, sig[:63]) {
+		t.Error("accepted a short signature")
+	}
+}
+
+// TestVerifyRejectsNonCanonicalScalar covers the third criterion: S must be a
+// canonical scalar.
+//
+// crypto/ed25519 already rejects an unreduced S, so this passes with or without
+// the criteria added here -- it documents the boundary rather than guarding it.
+// The identity-key cases above are the discriminating ones.
+func TestVerifyRejectsNonCanonicalScalar(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg := []byte("message")
+	sig := ed25519.Sign(priv, msg)
+	tampered := make([]byte, len(sig))
+	copy(tampered, sig)
+	tampered[63] |= 0xe0
+	if ed25519strict.Verify(pub, msg, tampered) {
+		t.Error("accepted a non-canonical S")
+	}
+}

--- a/kes/kes.go
+++ b/kes/kes.go
@@ -23,14 +23,13 @@
 package kes
 
 import (
-	"bytes"
 	"crypto/ed25519"
 	"crypto/subtle"
 	"errors"
 	"fmt"
 	"math"
 
-	"filippo.io/edwards25519"
+	"github.com/blinklabs-io/gouroboros/internal/ed25519strict"
 	"golang.org/x/crypto/blake2b"
 )
 
@@ -163,39 +162,10 @@ func (s Sum0KesSig) Verify(
 }
 
 // verifyEd25519Strict applies the strict verification criteria used by
-// Cardano's KES implementation. In addition to the signature equation, both
-// encoded points must be canonical and non-small-order, and S must be a
-// canonical scalar.
+// Cardano's KES implementation. The criteria are shared with every non-Byron
+// signature boundary; see internal/ed25519strict.
 func verifyEd25519Strict(pubKey, msg, sig []byte) bool {
-	if len(pubKey) != ed25519.PublicKeySize ||
-		len(sig) != ed25519.SignatureSize {
-		return false
-	}
-
-	publicPoint, err := new(edwards25519.Point).SetBytes(pubKey)
-	if err != nil ||
-		!bytes.Equal(publicPoint.Bytes(), pubKey) ||
-		isSmallOrder(publicPoint) {
-		return false
-	}
-
-	rPoint, err := new(edwards25519.Point).SetBytes(sig[:32])
-	if err != nil ||
-		!bytes.Equal(rPoint.Bytes(), sig[:32]) ||
-		isSmallOrder(rPoint) {
-		return false
-	}
-
-	if _, err := new(edwards25519.Scalar).SetCanonicalBytes(sig[32:]); err != nil {
-		return false
-	}
-
-	return ed25519.Verify(pubKey, msg, sig)
-}
-
-func isSmallOrder(point *edwards25519.Point) bool {
-	return new(edwards25519.Point).MultByCofactor(point).
-		Equal(edwards25519.NewIdentityPoint()) == 1
+	return ed25519strict.Verify(pubKey, msg, sig)
 }
 
 // HashPair computes the Blake2b-256 hash of two public keys concatenated

--- a/ledger/byron/sign.go
+++ b/ledger/byron/sign.go
@@ -95,6 +95,13 @@ func verifyEd25519(verificationKey, signed, sig []byte) bool {
 		len(sig) != ed25519.SignatureSize {
 		return false
 	}
+	// Byron signatures are verified permissively on purpose. The reference is
+	// Cardano.Crypto.Signing.Signature.verifySignatureRaw, which calls CC.verify in
+	// cardano-crypto-wallet, whose bundled ed25519-donna ed25519_sign_open checks
+	// only the high bits of S and performs no small-order test on A or R. It
+	// accepts proofs libsodium rejects, and Byron blocks are immutable history, so
+	// routing these through internal/ed25519strict would reject chain the node
+	// accepts. Do not "fix" these to match the non-Byron boundaries.
 	return ed25519.Verify(verificationKey[:32], signed, sig)
 }
 

--- a/ledger/byron/sign_permissive_test.go
+++ b/ledger/byron/sign_permissive_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package byron
+
+import (
+	"crypto/ed25519"
+	"testing"
+)
+
+// TestVerifyEd25519StaysPermissive is the guard against a well-meaning sweep.
+//
+// Byron's reference is Cardano.Crypto.Signing.Signature.verifySignatureRaw ->
+// CC.verify in cardano-crypto-wallet, whose bundled ed25519-donna
+// ed25519_sign_open checks only the high bits of S and performs no small-order
+// test. It accepts the edwards25519 identity pair. Byron blocks are immutable,
+// so tightening this boundary to match the non-Byron ones would reject chain
+// the node accepts and break sync from genesis.
+func TestVerifyEd25519StaysPermissive(t *testing.T) {
+	// A Byron extended verification key is the 32-byte Ed25519 key followed by
+	// a 32-byte chain code; only the first half is verified against.
+	verificationKey := make([]byte, VerificationKeySize)
+	verificationKey[0] = 0x01
+	signature := append(
+		append([]byte{0x01}, make([]byte, 31)...),
+		make([]byte, 32)...,
+	)
+	if !verifyEd25519(
+		verificationKey,
+		[]byte("any Byron payload"),
+		signature,
+	) {
+		t.Error(
+			"Byron verification rejected the identity pair; ed25519-donna accepts it, " +
+				"so this boundary must not use the strict criteria",
+		)
+	}
+}
+
+func TestVerifyEd25519AcceptsHonestSignature(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	verificationKey := make([]byte, VerificationKeySize)
+	copy(verificationKey, pub)
+	msg := []byte("a Byron payload this key actually signed")
+	sig := ed25519.Sign(priv, msg)
+	if !verifyEd25519(verificationKey, msg, sig) {
+		t.Error("rejected an honest Byron signature")
+	}
+	if verifyEd25519(verificationKey, []byte("a different payload"), sig) {
+		t.Error("accepted a Byron signature over a different payload")
+	}
+}

--- a/ledger/common/verify.go
+++ b/ledger/common/verify.go
@@ -19,6 +19,8 @@ import (
 	"crypto/sha3"
 	"errors"
 	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/internal/ed25519strict"
 )
 
 // VerifyVKeySignature verifies an ed25519 signature against the provided public key and message.
@@ -29,7 +31,7 @@ func VerifyVKeySignature(pubKey, sig, msg []byte) error {
 	if len(sig) != ed25519.SignatureSize {
 		return fmt.Errorf("invalid signature size: %d", len(sig))
 	}
-	if !ed25519.Verify(ed25519.PublicKey(pubKey), msg, sig) {
+	if !ed25519strict.Verify(pubKey, msg, sig) {
 		return errors.New("signature verification failed")
 	}
 	return nil
@@ -217,11 +219,10 @@ func ValidateBootstrapWitnesses(tx Transaction) error {
 				nil,
 			)
 		}
-		if !ed25519.Verify(
-			ed25519.PublicKey(bw.PublicKey),
-			msg,
-			bw.Signature,
-		) {
+		// Cardano.Ledger.Keys.Bootstrap.verifyBootstrapWit routes through the
+		// same verifySignedDSIGN as an ordinary vkey witness, not through the
+		// Byron primitive, despite the witness being Byron-shaped.
+		if !ed25519strict.Verify(bw.PublicKey, msg, bw.Signature) {
 			return NewValidationError(
 				ValidationErrorTypeTransaction,
 				"invalid bootstrap signature",

--- a/ledger/common/verify_strict_test.go
+++ b/ledger/common/verify_strict_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common_test
+
+import (
+	"crypto/ed25519"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+var (
+	identityPublicKey = append([]byte{0x01}, make([]byte, 31)...)
+	identitySignature = append(
+		append([]byte{0x01}, make([]byte, 31)...),
+		make([]byte, 32)...,
+	)
+)
+
+// TestVerifyVKeySignatureRejectsIdentityKey pins the transaction-witness
+// boundary. Cardano.Ledger.Keys.Internal.verifySignedDSIGN reaches libsodium,
+// which rejects this pair, so accepting it here is a consensus divergence.
+func TestVerifyVKeySignatureRejectsIdentityKey(t *testing.T) {
+	msg := []byte("arbitrary transaction body hash")
+	if !ed25519.Verify(identityPublicKey, msg, identitySignature) {
+		t.Fatal("crypto/ed25519 no longer accepts the identity pair; this test no longer discriminates")
+	}
+	if err := common.VerifyVKeySignature(
+		identityPublicKey, identitySignature, msg,
+	); err == nil {
+		t.Error("VerifyVKeySignature accepted the identity key and an all-zero signature")
+	}
+}
+
+func TestVerifyVKeySignatureAcceptsHonestSignature(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg := []byte("a message this key actually signed")
+	sig := ed25519.Sign(priv, msg)
+	if err := common.VerifyVKeySignature(pub, sig, msg); err != nil {
+		t.Errorf("rejected an honest signature: %v", err)
+	}
+	if err := common.VerifyVKeySignature(
+		pub, sig, []byte("a different message"),
+	); err == nil {
+		t.Error("accepted a signature over a different message")
+	}
+}

--- a/ledger/verify_opcert.go
+++ b/ledger/verify_opcert.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/blinklabs-io/gouroboros/internal/ed25519strict"
 	"github.com/blinklabs-io/gouroboros/kes"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 )
@@ -92,8 +93,7 @@ func VerifyOpCertSignature(opCert *OpCert, coldVkey []byte) error {
 	)
 
 	// Verify signature using cold verification key
-	pubKey := ed25519.PublicKey(coldVkey)
-	if !ed25519.Verify(pubKey, signable, opCert.ColdSignature) {
+	if !ed25519strict.Verify(coldVkey, signable, opCert.ColdSignature) {
 		return &OpCertError{
 			Field:   "cold_signature",
 			Message: "signature verification failed",

--- a/ledger/verify_opcert_strict_test.go
+++ b/ledger/verify_opcert_strict_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger_test
+
+import (
+	"crypto/ed25519"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// TestVerifyOpCertSignatureRejectsIdentityColdKey pins the operational
+// certificate boundary, whose reference is the same Ed25519DSIGN as a
+// transaction witness.
+func TestVerifyOpCertSignatureRejectsIdentityColdKey(t *testing.T) {
+	coldVkey := append([]byte{0x01}, make([]byte, 31)...)
+	opCert := &ledger.OpCert{
+		KesVkey:     make([]byte, 32),
+		IssueNumber: 1,
+		KesPeriod:   2,
+		ColdSignature: append(
+			append([]byte{0x01}, make([]byte, 31)...),
+			make([]byte, 32)...,
+		),
+	}
+	signable := common.OpCertSignableBytes(
+		opCert.KesVkey, opCert.IssueNumber, opCert.KesPeriod,
+	)
+	if !ed25519.Verify(coldVkey, signable, opCert.ColdSignature) {
+		t.Fatal("crypto/ed25519 no longer accepts the identity pair; this test no longer discriminates")
+	}
+	if err := ledger.VerifyOpCertSignature(opCert, coldVkey); err == nil {
+		t.Error("VerifyOpCertSignature accepted an identity cold key and an all-zero signature")
+	}
+}
+
+func TestVerifyOpCertSignatureAcceptsHonestSignature(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kesVkey := make([]byte, 32)
+	kesVkey[0] = 0x07
+	signable := common.OpCertSignableBytes(kesVkey, 3, 4)
+	opCert := &ledger.OpCert{
+		KesVkey:       kesVkey,
+		IssueNumber:   3,
+		KesPeriod:     4,
+		ColdSignature: ed25519.Sign(priv, signable),
+	}
+	if err := ledger.VerifyOpCertSignature(opCert, pub); err != nil {
+		t.Errorf("rejected an honest opcert signature: %v", err)
+	}
+	opCert.IssueNumber = 4
+	if err := ledger.VerifyOpCertSignature(opCert, pub); err == nil {
+		t.Error("accepted an opcert signature after changing the signed body")
+	}
+}

--- a/protocol/common/authentication.go
+++ b/protocol/common/authentication.go
@@ -16,7 +16,6 @@ package common
 
 import (
 	"bytes"
-	"crypto/ed25519"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -27,6 +26,7 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/internal/ed25519strict"
 	"golang.org/x/crypto/blake2b"
 )
 
@@ -271,8 +271,7 @@ func (m *MessageAuthenticator) verifyOperationalCertificate(
 	}
 
 	// Verify signature using cold verification key
-	pubKey := ed25519.PublicKey(coldVerificationKey)
-	if !ed25519.Verify(pubKey, certCbor, opcert.ColdSignature) {
+	if !ed25519strict.Verify(coldVerificationKey, certCbor, opcert.ColdSignature) {
 		return errors.New("cold signature verification failed")
 	}
 


### PR DESCRIPTION
Fixes #2234

## Defect

#2206 added `verifyEd25519Strict` (`kes/kes.go`), which rejects non-canonical and small-order public and R points and non-canonical S. It was unexported and confined to `kes`, so every other Ed25519 verifier still called `crypto/ed25519.Verify`, which applies neither check.

`crypto/ed25519.Verify` accepts the edwards25519 identity public key `0100…00` with an all-zero signature for an arbitrary message: `[S]B == R + [h]A` reduces to `identity == identity` when `A = R = identity` and `S = 0`. libsodium's `crypto_sign_ed25519_verify_detached` rejects the same pair.

## The boundaries are not uniform

Five verifiers reach libsodium in the reference and are changed here:

| call site | reference |
|---|---|
| `ledger/common/verify.go` `VerifyVKeySignature` | `Cardano.Ledger.Keys.Internal.verifySignedDSIGN` -> `Ed25519DSIGN` -> `cardano-crypto-class` |
| `ledger/common/verify.go` `ValidateBootstrapWitnesses` | `Cardano.Ledger.Keys.Bootstrap.verifyBootstrapWit` calls that same `verifySignedDSIGN`, not the Byron primitive, despite the witness being Byron-shaped |
| `ledger/verify_opcert.go` `VerifyOpCertSignature` | opcert cold signature, same DSIGN |
| `consensus/validate.go` | the same cold signature over `OpCertSignableBytes`, on the header path |
| `protocol/common/authentication.go` | the same cold signature, on the handshake path |

Four Byron verifiers are deliberately left permissive: `consensus/byron/validate.go` (three) and `ledger/byron/sign.go`. Their reference is `Cardano.Crypto.Signing.Signature.verifySignatureRaw` -> `CC.verify` in `cardano-crypto-wallet`, whose bundled ed25519-donna `ed25519_sign_open` is

```c
if ((RS[63] & 224) || !ge25519_unpack_negative_vartime(&A, pk))
        return -1;
```

— only the high bits of S, no small-order test on `A` or `R`. It accepts the identity pair. Byron blocks are immutable, so tightening these would reject chain the node accepts. Both files carry a comment saying so.

## Change

The criteria move to `internal/ed25519strict`, with the reasoning and the Byron exclusion in the package comment. `kes.verifyEd25519Strict` now delegates there rather than keeping a private copy.

## Tests

- `internal/ed25519strict` — the identity pair is rejected for three messages while `crypto/ed25519.Verify` accepts it, an honest signature verifies and fails against an altered message, and malformed sizes are rejected.
- `ledger/common` — `VerifyVKeySignature` rejects the identity pair and accepts an honest witness.
- `ledger` — `VerifyOpCertSignature` rejects an identity cold key and accepts an honest certificate, failing once the signed body changes.
- `ledger/byron` — `verifyEd25519` **accepts** the identity pair, guarding the Byron boundary against a later sweep, and still rejects a signature over a different payload.

The three rejection tests fail without the criteria. `kes`'s own `TestVerifySignedKESRejectsNonStrictEd25519Leaves` also fails, which is what pins the delegation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2234 by applying strict Ed25519 verification to every signature boundary outside Byron; Byron keeps its permissive checks deliberately. Previously only the KES verifier was strict, while the others used `crypto/ed25519.Verify`, which accepts an identity public key with an all-zero signature for any message.

**Changes**
- Moves the criteria into `internal/ed25519strict`; `kes` now delegates to it.
- Routes vkey and bootstrap witness checks plus the three opcert checks (ledger, consensus header, handshake) through the strict verifier.

**Byron boundary**
- Byron's reference, `cardano-crypto-wallet`'s ed25519-donna, accepts the identity pair, and Byron blocks are immutable history, so tightening would reject accepted chain.
- Every permissive call site carries a warning comment and a pinning test against a future sweep.

<sup>Written for commit fd3d3b965274f514916a21a4120eec782b91d5ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Strengthened Ed25519 signature validation for operational certificates, transaction witnesses, bootstrap witnesses, and KES verification.
  * Strict verification now rejects non-canonical keys, signatures, and small-order points while continuing to accept valid signatures.
  * Byron signature verification remains permissive for compatibility with the Cardano reference implementation.

* **Tests**
  * Added coverage for valid signatures, altered messages, malformed inputs, and identity-key edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->