### PR TITLE
fix(ledger): decode MIR reward deltas as signed

### DIFF
--- a/ledger/common/certs.go
+++ b/ledger/common/certs.go
@@ -1348,22 +1348,44 @@ const (
 	MirSourceTreasury    MirSource = 2
 )
 
+// MoveInstantaneousRewardsCertificateReward is the MIR target: either a map
+// of stake credentials to signed reward deltas, or a coin transferred to the
+// opposite accounting pot.
+//
+// Rewards holds delta_coin values, which the CDDL types as int
+// (eras/mary/impl/cddl/data/mary.cddl) and the reference decodes as the signed
+// unbounded Integer newtype DeltaCoin
+// (libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs). A negative delta is a
+// decoding matter only; whether it is permitted is decided by the DELEG rule.
 type MoveInstantaneousRewardsCertificateReward struct {
 	Source   uint
-	Rewards  map[*Credential]uint64
+	Rewards  map[*Credential]*big.Int
 	OtherPot uint64
 }
 
 func (r *MoveInstantaneousRewardsCertificateReward) UnmarshalCBOR(
 	data []byte,
 ) error {
-	// Try to parse as map
+	// Try to parse as map. The reference dispatches on the CBOR major type
+	// of the second element and reads Map (Credential Staking) DeltaCoin
+	// with no sign or range constraint
+	// (eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs, instance
+	// DecCBOR MIRTarget), so this branch has to accept a negative delta.
 	tmpMapData := struct {
 		cbor.StructAsArray
 		Source  uint
-		Rewards map[*Credential]uint64
+		Rewards map[*Credential]*big.Int
 	}{}
 	if _, err := cbor.Decode(data, &tmpMapData); err == nil {
+		for _, delta := range tmpMapData.Rewards {
+			// A *big.Int target accepts CBOR null and undefined as a
+			// nil pointer. delta_coin is int, so reject them.
+			if delta == nil {
+				return errors.New(
+					"instantaneous rewards delta is CBOR null or undefined",
+				)
+			}
+		}
 		if err := validateCredentialMapKeys(
 			tmpMapData.Rewards,
 			"instantaneous rewards",
@@ -1374,7 +1396,8 @@ func (r *MoveInstantaneousRewardsCertificateReward) UnmarshalCBOR(
 		r.Source = tmpMapData.Source
 		return nil
 	}
-	// Try to parse as coin
+	// Try to parse as coin. The opposite-pot amount is coin, which the CDDL
+	// types as uint.
 	tmpCoinData := struct {
 		cbor.StructAsArray
 		Source uint
@@ -1382,7 +1405,7 @@ func (r *MoveInstantaneousRewardsCertificateReward) UnmarshalCBOR(
 	}{}
 	if _, err := cbor.Decode(data, &tmpCoinData); err == nil {
 		r.OtherPot = tmpCoinData.Coin
-		r.Source = tmpMapData.Source
+		r.Source = tmpCoinData.Source
 		return nil
 	}
 	return errors.New("failed to decode as known types")
@@ -1421,7 +1444,7 @@ func (c *MoveInstantaneousRewardsCertificate) Utxorpc() (*utxorpc.Certificate, e
 			tmpMirTargets,
 			&utxorpc.MirTarget{
 				StakeCredential: stakeCr,
-				DeltaCoin:       ToUtxorpcBigInt(deltaCoin),
+				DeltaCoin:       BigIntToUtxorpcBigInt(deltaCoin),
 			},
 		)
 	}
@@ -1449,7 +1472,11 @@ func (r *MoveInstantaneousRewardsCertificateReward) RewardsAmount() map[*Credent
 	}
 	result := make(map[*Credential]*big.Int)
 	for cred, amount := range r.Rewards {
-		result[cred] = new(big.Int).SetUint64(amount)
+		if amount == nil {
+			result[cred] = new(big.Int)
+			continue
+		}
+		result[cred] = new(big.Int).Set(amount)
 	}
 	return result
 }

--- a/ledger/common/certs.go
+++ b/ledger/common/certs.go
@@ -1377,6 +1377,11 @@ func (r *MoveInstantaneousRewardsCertificateReward) UnmarshalCBOR(
 		Rewards map[*Credential]*big.Int
 	}{}
 	if _, err := cbor.Decode(data, &tmpMapData); err == nil {
+		if tmpMapData.Rewards == nil {
+			return errors.New(
+				"instantaneous rewards target is CBOR null or undefined",
+			)
+		}
 		for _, delta := range tmpMapData.Rewards {
 			// A *big.Int target accepts CBOR null and undefined as a
 			// nil pointer. delta_coin is int, so reject them.

--- a/ledger/common/certs.go
+++ b/ledger/common/certs.go
@@ -1436,6 +1436,15 @@ func (c *MoveInstantaneousRewardsCertificate) UnmarshalCBOR(
 func (c *MoveInstantaneousRewardsCertificate) Utxorpc() (*utxorpc.Certificate, error) {
 	tmpMirTargets := []*utxorpc.MirTarget{}
 	for stakeCred, deltaCoin := range c.Reward.Rewards {
+		// MIR delta_coin is unbounded on the Cardano wire, but
+		// BigIntToUtxorpcBigInt's fallback is unsigned. Reject negative values
+		// outside int64 here instead of emitting their absolute magnitude.
+		if deltaCoin != nil && deltaCoin.Sign() < 0 && !deltaCoin.IsInt64() {
+			return nil, fmt.Errorf(
+				"MIR reward delta does not fit in int64: %s",
+				deltaCoin,
+			)
+		}
 		stakeCr, err := stakeCred.Utxorpc()
 		if err != nil {
 			return nil, err

--- a/ledger/common/common.go
+++ b/ledger/common/common.go
@@ -889,7 +889,16 @@ func BigIntToUtxorpcBigInt(v *big.Int) *utxorpc.BigInt {
 			BigInt: &utxorpc.BigInt_Int{Int: v.Int64()},
 		}
 	}
-	// Otherwise use the big int bytes representation
+	// Otherwise use the big int bytes representation. big.Int.Bytes returns
+	// the absolute value, so a negative magnitude has to go in the negative
+	// variant or the sign is lost.
+	if v.Sign() < 0 {
+		return &utxorpc.BigInt{
+			BigInt: &utxorpc.BigInt_BigNInt{
+				BigNInt: v.Bytes(),
+			},
+		}
+	}
 	return &utxorpc.BigInt{
 		BigInt: &utxorpc.BigInt_BigUInt{
 			BigUInt: v.Bytes(),

--- a/ledger/common/common.go
+++ b/ledger/common/common.go
@@ -889,16 +889,7 @@ func BigIntToUtxorpcBigInt(v *big.Int) *utxorpc.BigInt {
 			BigInt: &utxorpc.BigInt_Int{Int: v.Int64()},
 		}
 	}
-	// Otherwise use the big int bytes representation. big.Int.Bytes returns
-	// the absolute value, so a negative magnitude has to go in the negative
-	// variant or the sign is lost.
-	if v.Sign() < 0 {
-		return &utxorpc.BigInt{
-			BigInt: &utxorpc.BigInt_BigNInt{
-				BigNInt: v.Bytes(),
-			},
-		}
-	}
+	// Otherwise use the big int bytes representation
 	return &utxorpc.BigInt{
 		BigInt: &utxorpc.BigInt_BigUInt{
 			BigUInt: v.Bytes(),

--- a/ledger/common/mir_delta_decode_test.go
+++ b/ledger/common/mir_delta_decode_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
 
 // mirCertWire builds the wire form of a move instantaneous rewards certificate
@@ -87,9 +88,11 @@ func TestMirRewardDeltaDecodesAsSigned(t *testing.T) {
 			assert.Equal(t, uint(0), cert.Reward.Source)
 			assert.Equal(t, uint64(0), cert.Reward.OtherPot)
 			require.Len(t, cert.Reward.Rewards, 1)
-			// Read the delta through RewardsAmount so that this test
-			// compiles against the unsigned value type it replaces and
-			// fails on the decode rather than on the build.
+			// RewardsAmount returns map[*Credential]*big.Int both
+			// before and after the value type of Rewards widens, so
+			// reading the delta through it makes this test compile
+			// against the unsigned map and fail on the decode rather
+			// than on the build.
 			amounts := cert.Reward.RewardsAmount()
 			require.Len(t, amounts, 1)
 			for credential, amount := range amounts {
@@ -168,4 +171,78 @@ func TestMirOppositePotDecode(t *testing.T) {
 		var cert common.MoveInstantaneousRewardsCertificate
 		require.Error(t, cert.UnmarshalCBOR(wire))
 	})
+}
+
+// TestMirRewardDeltaUtxorpcKeepsTheSign covers the UTxORPC projection of a
+// signed delta. big.Int.Bytes returns the absolute value, so a magnitude that
+// does not fit in an int64 has to use the negative variant of the BigInt oneof
+// or the reported delta flips sign.
+func TestMirRewardDeltaUtxorpcKeepsTheSign(t *testing.T) {
+	beyondInt64 := new(big.Int).Lsh(big.NewInt(1), 64)
+
+	for _, testDef := range []struct {
+		name     string
+		deltaHex string
+		expected *utxorpc.BigInt
+	}{
+		{
+			"positiveInt64",
+			"184d",
+			&utxorpc.BigInt{BigInt: &utxorpc.BigInt_Int{Int: 77}},
+		},
+		{
+			"negativeInt64",
+			"20",
+			&utxorpc.BigInt{BigInt: &utxorpc.BigInt_Int{Int: -1}},
+		},
+		{
+			"beyondInt64Positive",
+			"c249010000000000000000",
+			&utxorpc.BigInt{
+				BigInt: &utxorpc.BigInt_BigUInt{
+					BigUInt: beyondInt64.Bytes(),
+				},
+			},
+		},
+		{
+			"beyondInt64Negative",
+			"c349010000000000000000",
+			&utxorpc.BigInt{
+				BigInt: &utxorpc.BigInt_BigNInt{
+					BigNInt: new(big.Int).Add(
+						beyondInt64,
+						big.NewInt(1),
+					).Bytes(),
+				},
+			},
+		},
+	} {
+		t.Run(testDef.name, func(t *testing.T) {
+			var cert common.MoveInstantaneousRewardsCertificate
+			require.NoError(
+				t,
+				cert.UnmarshalCBOR(mirCertWire(t, testDef.deltaHex)),
+			)
+			converted, err := cert.Utxorpc()
+			require.NoError(t, err)
+			mirCert := converted.GetMirCert()
+			require.NotNil(t, mirCert)
+			require.Len(t, mirCert.GetTo(), 1)
+			assert.Equal(
+				t,
+				testDef.expected.GetInt(),
+				mirCert.GetTo()[0].GetDeltaCoin().GetInt(),
+			)
+			assert.Equal(
+				t,
+				testDef.expected.GetBigUInt(),
+				mirCert.GetTo()[0].GetDeltaCoin().GetBigUInt(),
+			)
+			assert.Equal(
+				t,
+				testDef.expected.GetBigNInt(),
+				mirCert.GetTo()[0].GetDeltaCoin().GetBigNInt(),
+			)
+		})
+	}
 }

--- a/ledger/common/mir_delta_decode_test.go
+++ b/ledger/common/mir_delta_decode_test.go
@@ -1,0 +1,171 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common_test
+
+import (
+	"encoding/hex"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mirCertWire builds the wire form of a move instantaneous rewards certificate
+// carrying a single stake credential and the given encoded delta.
+//
+// The envelope follows the upstream golden encoding for "mir" in
+// eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs:
+//
+//	TkListLen 2 . TkWord 6 . TkListLen 2 . TkWord 0 <> S rws
+//
+// with rws a one-entry Map (Credential Staking) DeltaCoin. No on-disk upstream
+// fixture carries a MIR certificate, so the delta bytes are appended directly.
+func mirCertWire(t *testing.T, deltaHex string) []byte {
+	t.Helper()
+	credential := "8200" + "581c" + strings.Repeat("ab", 28)
+	wire, err := hex.DecodeString(
+		"8206" + "8200" + "a1" + credential + deltaHex,
+	)
+	require.NoError(t, err)
+	return wire
+}
+
+// TestMirRewardDeltaDecodesAsSigned covers the sign and range of delta_coin.
+// The CDDL types it as int (eras/mary/impl/cddl/data/mary.cddl) and the
+// reference decodes Map (Credential Staking) DeltaCoin by dispatching on the
+// CBOR major type with no sign or range constraint
+// (eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs, instance DecCBOR
+// MIRTarget), DeltaCoin being a signed unbounded Integer newtype
+// (libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs). A delta this decoder
+// rejects fails the whole containing block.
+func TestMirRewardDeltaDecodesAsSigned(t *testing.T) {
+	maxUint64 := new(big.Int).SetUint64(^uint64(0))
+	beyondUint64 := new(big.Int).Lsh(big.NewInt(1), 64)
+
+	for _, testDef := range []struct {
+		name     string
+		deltaHex string
+		expected *big.Int
+	}{
+		// DeltaCoin 77, the upstream golden "mir" value.
+		{"positive", "184d", big.NewInt(77)},
+		{"zero", "00", big.NewInt(0)},
+		// aliceOnlyDelta (-1) in
+		// eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/MirTransfer.hs.
+		{"negativeOne", "20", big.NewInt(-1)},
+		{"negativeLarge", "3b00000002540be3ff", big.NewInt(-10_000_000_000)},
+		{"minInt64", "3b7fffffffffffffff", big.NewInt(-1 << 63)},
+		{"maxUint64", "1bffffffffffffffff", maxUint64},
+		{"bignumPositive", "c249010000000000000000", beyondUint64},
+		{
+			"bignumNegative",
+			"c349010000000000000000",
+			new(big.Int).Neg(new(big.Int).Add(beyondUint64, big.NewInt(1))),
+		},
+	} {
+		t.Run(testDef.name, func(t *testing.T) {
+			var cert common.MoveInstantaneousRewardsCertificate
+			require.NoError(
+				t,
+				cert.UnmarshalCBOR(mirCertWire(t, testDef.deltaHex)),
+			)
+			assert.Equal(t, uint(0), cert.Reward.Source)
+			assert.Equal(t, uint64(0), cert.Reward.OtherPot)
+			require.Len(t, cert.Reward.Rewards, 1)
+			// Read the delta through RewardsAmount so that this test
+			// compiles against the unsigned value type it replaces and
+			// fails on the decode rather than on the build.
+			amounts := cert.Reward.RewardsAmount()
+			require.Len(t, amounts, 1)
+			for credential, amount := range amounts {
+				require.NotNil(t, credential)
+				assert.Equal(
+					t,
+					uint(common.CredentialTypeAddrKeyHash),
+					credential.CredType,
+				)
+				require.NotNil(t, amount)
+				assert.Zero(
+					t,
+					testDef.expected.Cmp(amount),
+					"delta %s",
+					amount,
+				)
+			}
+		})
+	}
+}
+
+// TestMirRewardDeltaRejectsNonInteger is the negative control for the widened
+// value type: delta_coin is int, so a value that is not a CBOR integer must
+// still fail. A *big.Int target accepts CBOR null and undefined as a nil
+// pointer, which the decoder has to reject explicitly.
+func TestMirRewardDeltaRejectsNonInteger(t *testing.T) {
+	for _, testDef := range []struct {
+		name     string
+		deltaHex string
+	}{
+		{"null", "f6"},
+		{"undefined", "f7"},
+		{"textString", "623737"},
+		{"byteString", "4101"},
+		{"array", "8101"},
+		{"float", "fb4052000000000000"},
+		{"boolean", "f5"},
+	} {
+		t.Run(testDef.name, func(t *testing.T) {
+			var cert common.MoveInstantaneousRewardsCertificate
+			require.Error(
+				t,
+				cert.UnmarshalCBOR(mirCertWire(t, testDef.deltaHex)),
+			)
+		})
+	}
+}
+
+// TestMirOppositePotDecode covers the other MIRTarget branch. The CDDL types
+// the opposite-pot amount as coin, which is uint, so it stays unsigned, and the
+// source pot must come from the branch that decoded.
+func TestMirOppositePotDecode(t *testing.T) {
+	t.Run("treasury", func(t *testing.T) {
+		wire, err := hex.DecodeString("8206" + "8201" + "1903e8")
+		require.NoError(t, err)
+		var cert common.MoveInstantaneousRewardsCertificate
+		require.NoError(t, cert.UnmarshalCBOR(wire))
+		assert.Equal(t, uint(1), cert.Reward.Source)
+		assert.Equal(t, uint64(1000), cert.Reward.OtherPot)
+		assert.Empty(t, cert.Reward.Rewards)
+	})
+
+	t.Run("reserves", func(t *testing.T) {
+		wire, err := hex.DecodeString("8206" + "8200" + "1903e8")
+		require.NoError(t, err)
+		var cert common.MoveInstantaneousRewardsCertificate
+		require.NoError(t, cert.UnmarshalCBOR(wire))
+		assert.Equal(t, uint(0), cert.Reward.Source)
+		assert.Equal(t, uint64(1000), cert.Reward.OtherPot)
+		assert.Empty(t, cert.Reward.Rewards)
+	})
+
+	t.Run("negative amount is rejected", func(t *testing.T) {
+		wire, err := hex.DecodeString("8206" + "8200" + "20")
+		require.NoError(t, err)
+		var cert common.MoveInstantaneousRewardsCertificate
+		require.Error(t, cert.UnmarshalCBOR(wire))
+	})
+}

--- a/ledger/common/mir_delta_decode_test.go
+++ b/ledger/common/mir_delta_decode_test.go
@@ -88,11 +88,8 @@ func TestMirRewardDeltaDecodesAsSigned(t *testing.T) {
 			assert.Equal(t, uint(0), cert.Reward.Source)
 			assert.Equal(t, uint64(0), cert.Reward.OtherPot)
 			require.Len(t, cert.Reward.Rewards, 1)
-			// RewardsAmount returns map[*Credential]*big.Int both
-			// before and after the value type of Rewards widens, so
-			// reading the delta through it makes this test compile
-			// against the unsigned map and fail on the decode rather
-			// than on the build.
+			// Read the delta through RewardsAmount so the assertion
+			// compares *big.Int values decoded from the map.
 			amounts := cert.Reward.RewardsAmount()
 			require.Len(t, amounts, 1)
 			for credential, amount := range amounts {
@@ -173,10 +170,8 @@ func TestMirOppositePotDecode(t *testing.T) {
 	})
 }
 
-// TestMirRewardDeltaUtxorpcKeepsTheSign covers the UTxORPC projection of a
-// signed delta. big.Int.Bytes returns the absolute value, so a magnitude that
-// does not fit in an int64 has to use the negative variant of the BigInt oneof
-// or the reported delta flips sign.
+// TestMirRewardDeltaUtxorpcKeepsTheSign covers values the MIR UTxORPC
+// projection can represent without changing their sign or magnitude.
 func TestMirRewardDeltaUtxorpcKeepsTheSign(t *testing.T) {
 	beyondInt64 := new(big.Int).Lsh(big.NewInt(1), 64)
 
@@ -196,23 +191,16 @@ func TestMirRewardDeltaUtxorpcKeepsTheSign(t *testing.T) {
 			&utxorpc.BigInt{BigInt: &utxorpc.BigInt_Int{Int: -1}},
 		},
 		{
+			"minInt64",
+			"3b7fffffffffffffff",
+			&utxorpc.BigInt{BigInt: &utxorpc.BigInt_Int{Int: -1 << 63}},
+		},
+		{
 			"beyondInt64Positive",
 			"c249010000000000000000",
 			&utxorpc.BigInt{
 				BigInt: &utxorpc.BigInt_BigUInt{
 					BigUInt: beyondInt64.Bytes(),
-				},
-			},
-		},
-		{
-			"beyondInt64Negative",
-			"c349010000000000000000",
-			&utxorpc.BigInt{
-				BigInt: &utxorpc.BigInt_BigNInt{
-					BigNInt: new(big.Int).Add(
-						beyondInt64,
-						big.NewInt(1),
-					).Bytes(),
 				},
 			},
 		},
@@ -245,4 +233,17 @@ func TestMirRewardDeltaUtxorpcKeepsTheSign(t *testing.T) {
 			)
 		})
 	}
+}
+
+func TestMirRewardDeltaUtxorpcRejectsNegativeOverflow(t *testing.T) {
+	// CBOR tag 3 encodes -1-n. With n=2^63, this is math.MinInt64-1:
+	// valid delta_coin on the wire, but outside the supported MIR projection.
+	var cert common.MoveInstantaneousRewardsCertificate
+	require.NoError(
+		t,
+		cert.UnmarshalCBOR(mirCertWire(t, "c3488000000000000000")),
+	)
+
+	_, err := cert.Utxorpc()
+	require.ErrorContains(t, err, "MIR reward delta does not fit in int64")
 }

--- a/ledger/common/mir_delta_decode_test.go
+++ b/ledger/common/mir_delta_decode_test.go
@@ -138,6 +138,36 @@ func TestMirRewardDeltaRejectsNonInteger(t *testing.T) {
 	}
 }
 
+func TestMirRewardTargetRejectsNullOrUndefined(t *testing.T) {
+	t.Run("empty map", func(t *testing.T) {
+		wire, err := hex.DecodeString("8206" + "8200" + "a0")
+		require.NoError(t, err)
+		var cert common.MoveInstantaneousRewardsCertificate
+		require.NoError(t, cert.UnmarshalCBOR(wire))
+		require.NotNil(t, cert.Reward.Rewards)
+		assert.Empty(t, cert.Reward.Rewards)
+	})
+
+	for _, testDef := range []struct {
+		name      string
+		targetHex string
+	}{
+		{"null", "f6"},
+		{"undefined", "f7"},
+	} {
+		t.Run(testDef.name, func(t *testing.T) {
+			wire, err := hex.DecodeString("8206" + "8200" + testDef.targetHex)
+			require.NoError(t, err)
+			var cert common.MoveInstantaneousRewardsCertificate
+			require.ErrorContains(
+				t,
+				cert.UnmarshalCBOR(wire),
+				"instantaneous rewards target is CBOR null or undefined",
+			)
+		})
+	}
+}
+
 // TestMirOppositePotDecode covers the other MIRTarget branch. The CDDL types
 // the opposite-pot amount as coin, which is uint, so it stays unsigned, and the
 // source pot must come from the branch that decoded.

--- a/ledger/common/protocol_version.go
+++ b/ledger/common/protocol_version.go
@@ -59,3 +59,20 @@ func PoolAccountNetworkIdValidated(major uint) bool {
 func DuplicateVrfKeysDisallowed(major uint) bool {
 	return major > 10
 }
+
+// MirTransferAllowed reports whether the DELEG rule permits a move
+// instantaneous rewards certificate to move funds to the opposite accounting
+// pot and to carry a negative reward delta. Before it, a negative delta fails
+// with MIRNegativesNotCurrentlyAllowed and a pot-to-pot transfer fails with
+// MIRTransferNotCurrentlyAllowed.
+//
+// Reference: eras/shelley/impl/src/Cardano/Ledger/Shelley/Era.hs,
+// hardforkAlonzoAllowMIRTransfer (pvMajor pv > natVersion @4), consumed by
+// delegTransition in
+// eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs.
+//
+// Note that this is major version 5, the first Alonzo protocol version, not
+// ProtocolVersionAlonzo (6, the second one).
+func MirTransferAllowed(major uint) bool {
+	return major > 4
+}

--- a/ledger/mir_rules_test.go
+++ b/ledger/mir_rules_test.go
@@ -55,6 +55,19 @@ func mirCert(
 	}
 }
 
+func mirOppositePotCert(
+	source uint,
+	amount uint64,
+) *common.MoveInstantaneousRewardsCertificate {
+	return &common.MoveInstantaneousRewardsCertificate{
+		CertType: uint(common.CertificateTypeMoveInstantaneousRewards),
+		Reward: common.MoveInstantaneousRewardsCertificateReward{
+			Source:   source,
+			OtherPot: amount,
+		},
+	}
+}
+
 // TestUtxoValidateDelegationMirNegativeDelta covers
 // MIRNegativesNotCurrentlyAllowed. delta_coin is int on the wire, so the
 // decoder accepts a negative delta and the DELEG rule decides whether it is
@@ -104,8 +117,13 @@ func TestUtxoValidateDelegationMirNegativeDelta(t *testing.T) {
 	})
 
 	t.Run("pot-to-pot transfer is untouched before Alonzo", func(t *testing.T) {
+		// The opposite-pot amount is coin, which is uint, so this branch
+		// carries no sign for the predicate to reject. Whether the
+		// transfer itself is embargoed before Alonzo
+		// (MIRTransferNotCurrentlyAllowed) is a separate predicate that
+		// this rule does not implement.
 		require.NoError(t, shelley.UtxoValidateDelegation(
-			poolCertTx(mirCert(0, nil)),
+			poolCertTx(mirOppositePotCert(0, 1_000_000)),
 			0,
 			ls,
 			maryPparams(0),

--- a/ledger/mir_rules_test.go
+++ b/ledger/mir_rules_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests for the move instantaneous rewards predicates of the Shelley DELEG
+// rule (delegTransition in
+// eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs). They live in
+// package ledger_test rather than shelley_test because the predicate is gated
+// on protocol version and has to be exercised with the real protocol
+// parameters of the eras that carry those versions.
+
+package ledger_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mirStakeCredential(b byte) *common.Credential {
+	credential := common.Credential{
+		CredType: common.CredentialTypeAddrKeyHash,
+	}
+	for i := range credential.Credential {
+		credential.Credential[i] = b
+	}
+	return &credential
+}
+
+func mirCert(
+	source uint,
+	rewards map[*common.Credential]*big.Int,
+) *common.MoveInstantaneousRewardsCertificate {
+	return &common.MoveInstantaneousRewardsCertificate{
+		CertType: uint(common.CertificateTypeMoveInstantaneousRewards),
+		Reward: common.MoveInstantaneousRewardsCertificateReward{
+			Source:  source,
+			Rewards: rewards,
+		},
+	}
+}
+
+// TestUtxoValidateDelegationMirNegativeDelta covers
+// MIRNegativesNotCurrentlyAllowed. delta_coin is int on the wire, so the
+// decoder accepts a negative delta and the DELEG rule decides whether it is
+// permitted: hardforkAlonzoAllowMIRTransfer
+// (eras/shelley/impl/src/Cardano/Ledger/Shelley/Era.hs) gates it on major
+// version > 4.
+func TestUtxoValidateDelegationMirNegativeDelta(t *testing.T) {
+	ls := mockledger.NewLedgerStateBuilder().Build()
+	credential := mirStakeCredential(0xab)
+
+	t.Run("negative delta is rejected before Alonzo", func(t *testing.T) {
+		err := shelley.UtxoValidateDelegation(
+			poolCertTx(mirCert(0, map[*common.Credential]*big.Int{
+				credential: big.NewInt(-1),
+			})),
+			0,
+			ls,
+			maryPparams(0),
+		)
+		var target shelley.MIRNegativesNotCurrentlyAllowedError
+		require.ErrorAs(t, err, &target)
+		assert.Equal(t, credential.Credential, target.Credential.Credential)
+		assert.Zero(t, big.NewInt(-1).Cmp(target.Delta))
+	})
+
+	t.Run("negative delta is accepted from Alonzo", func(t *testing.T) {
+		require.NoError(t, shelley.UtxoValidateDelegation(
+			poolCertTx(mirCert(0, map[*common.Credential]*big.Int{
+				credential: big.NewInt(-1),
+			})),
+			0,
+			ls,
+			alonzoPparams(0),
+		))
+	})
+
+	t.Run("non-negative deltas are accepted before Alonzo", func(t *testing.T) {
+		require.NoError(t, shelley.UtxoValidateDelegation(
+			poolCertTx(mirCert(0, map[*common.Credential]*big.Int{
+				credential:               big.NewInt(77),
+				mirStakeCredential(0xcd): big.NewInt(0),
+			})),
+			0,
+			ls,
+			maryPparams(0),
+		))
+	})
+
+	t.Run("pot-to-pot transfer is untouched before Alonzo", func(t *testing.T) {
+		require.NoError(t, shelley.UtxoValidateDelegation(
+			poolCertTx(mirCert(0, nil)),
+			0,
+			ls,
+			maryPparams(0),
+		))
+	})
+}

--- a/ledger/shelley/errors.go
+++ b/ledger/shelley/errors.go
@@ -226,6 +226,29 @@ func (e DelegateUnregisteredStakeCredentialError) Error() string {
 	)
 }
 
+// MIRNegativesNotCurrentlyAllowedError indicates a move instantaneous rewards
+// certificate carrying a negative reward delta at a protocol version before
+// the Alonzo hard fork, which is the first version that permits one.
+//
+// Reference: MIRNegativesNotCurrentlyAllowed in delegTransition,
+// eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs.
+type MIRNegativesNotCurrentlyAllowedError struct {
+	Credential common.Credential
+	Delta      *big.Int
+}
+
+func (e MIRNegativesNotCurrentlyAllowedError) Error() string {
+	delta := "nil"
+	if e.Delta != nil {
+		delta = e.Delta.String()
+	}
+	return fmt.Sprintf(
+		"negative instantaneous rewards delta not allowed at this protocol version: credential %x delta %s",
+		e.Credential.Credential[:],
+		delta,
+	)
+}
+
 // WithdrawalFromUnregisteredRewardAccountError indicates withdrawal from an unregistered reward account
 type WithdrawalFromUnregisteredRewardAccountError struct {
 	RewardAddress common.Address

--- a/ledger/shelley/rules.go
+++ b/ledger/shelley/rules.go
@@ -676,12 +676,22 @@ func UtxoValidateMetadata(
 // For Shelley, it checks StakeDelegationCertificate:
 // - Pool registration status
 // - Stake credential registration status
+//
+// It also enforces the DELEG predicate that bounds the sign of a move
+// instantaneous rewards delta. The wire format types delta_coin as int, so the
+// decoder accepts a negative delta; the reference rejects one before the Alonzo
+// hard fork with MIRNegativesNotCurrentlyAllowed
+// (eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs, delegTransition).
 func UtxoValidateDelegation(
 	tx common.Transaction,
 	slot uint64,
 	ls common.LedgerState,
 	pp common.ProtocolParameters,
 ) error {
+	if err := validateMirDeltaSigns(tx, pp); err != nil {
+		return err
+	}
+
 	// Track credentials/pools registered within this transaction
 	inTxStakeRegs := make(map[common.Blake2b224]bool)
 	inTxPoolRegs := make(map[common.PoolKeyHash]bool)
@@ -717,6 +727,59 @@ func UtxoValidateDelegation(
 			}
 			if c.StakeCredential != nil && !isStakeRegistered(*c.StakeCredential) {
 				return DelegateUnregisteredStakeCredentialError{Credential: *c.StakeCredential}
+			}
+		}
+	}
+	return nil
+}
+
+// validateMirDeltaSigns rejects a negative move instantaneous rewards delta at
+// a protocol version that does not permit one. From the Alonzo hard fork
+// onwards a negative delta is permitted as long as the resulting reward is not
+// negative, a check that needs the pending InstantaneousRewards accumulated by
+// earlier certificates in the epoch and so is not expressible against the
+// LedgerState interface.
+//
+// Reference: MIRNegativesNotCurrentlyAllowed and MIRProducesNegativeUpdate in
+// delegTransition, eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs.
+func validateMirDeltaSigns(
+	tx common.Transaction,
+	pp common.ProtocolParameters,
+) error {
+	mirCerts := make([]*common.MoveInstantaneousRewardsCertificate, 0)
+	for _, cert := range tx.Certificates() {
+		if c, ok := cert.(*common.MoveInstantaneousRewardsCertificate); ok &&
+			c != nil {
+			mirCerts = append(mirCerts, c)
+		}
+	}
+	if len(mirCerts) == 0 {
+		// Leave transactions that carry no MIR certificate untouched,
+		// including their protocol parameters, so the rule cannot reject
+		// anything the DELEG transition would never have seen.
+		return nil
+	}
+	versionedPparams, ok := pp.(interface {
+		ProtocolMajorVersion() uint
+	})
+	if !ok {
+		return errors.New("pparams are not expected type")
+	}
+	if common.MirTransferAllowed(versionedPparams.ProtocolMajorVersion()) {
+		return nil
+	}
+	for _, cert := range mirCerts {
+		for cred, delta := range cert.Reward.Rewards {
+			if delta == nil || delta.Sign() >= 0 {
+				continue
+			}
+			var tmpCred common.Credential
+			if cred != nil {
+				tmpCred = *cred
+			}
+			return MIRNegativesNotCurrentlyAllowedError{
+				Credential: tmpCred,
+				Delta:      new(big.Int).Set(delta),
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #2240

`MoveInstantaneousRewardsCertificateReward.Rewards` was `map[*Credential]uint64`
(`ledger/common/certs.go:1353`), and the decoder's temporary struct used the
same value type (`:1364`). A negative delta failed the map branch, then the
pot-to-pot coin branch, and `UnmarshalCBOR` returned "failed to decode as known
types" (`:1388`). Because that is a decode failure, the containing block fails,
not one transaction.

The reference decodes `Map (Credential Staking) DeltaCoin` by dispatching on the
CBOR major type with no sign or range constraint
(`eras/shelley/impl/src/Cardano/Ledger/Shelley/TxCert.hs`, `instance DecCBOR
MIRTarget`). `DeltaCoin` is a newtype over `Integer` deriving `DecCBOR`
(`libs/cardano-ledger-core/src/Cardano/Ledger/Coin.hs`), and `DecCBOR Integer`
is `decodeInteger`
(`libs/cardano-ledger-binary/src/Cardano/Ledger/Binary/Decoding/DecCBOR.hs:143`),
so the accepted range is unbounded in both directions. The CDDL agrees:
`delta_coin = int` (`eras/mary/impl/cddl/data/mary.cddl:234`).

`Rewards` becomes `map[*Credential]*big.Int`, matching the existing
`RewardsAmount()` accessor and the `Withdrawals() map[*Address]*big.Int`
transaction accessor. `int64` would have left the same class of divergence at
±2^63.

## Where the constraint goes

The bound is not wrong, it is in the wrong place. The reference bounds the sign
of a MIR delta in the DELEG rule, not the decoder: `MIRNegativesNotCurrentlyAllowed`
rejects a negative delta while `hardforkAlonzoAllowMIRTransfer` is false
(`pvMajor pv > natVersion @4`, `eras/shelley/impl/src/Cardano/Ledger/Shelley/Era.hs`),
and from the Alonzo hard fork a negative delta is permitted subject to
`MIRProducesNegativeUpdate` (`eras/shelley/impl/src/Cardano/Ledger/Shelley/Rules/Deleg.hs`,
`delegTransition`).

`shelley.UtxoValidateDelegation`, the DELEG-equivalent rule that every era from
Shelley through Dijkstra delegates to, now enforces the first predicate via
`common.MirTransferAllowed`. The second needs the `InstantaneousRewards`
accumulated by earlier certificates in the epoch, which the `LedgerState`
interface does not expose, so it is not implemented here.

`OtherPot` stays `uint64`: the CDDL types the opposite-pot amount as `coin`,
which is `uint`.

## Other decoder changes

- The pot-to-pot branch assigned `r.Source` from the map branch's temporary
  struct, which is only populated because the map decode fails after reading the
  first array element. It now reads the struct that decoded.
- A `*big.Int` decode target accepts CBOR null and undefined as a nil pointer.
  `delta_coin` is `int`, so the decoder rejects them. The previous `uint64`
  target silently decoded a null delta as 0.

## UTxORPC projection

`BigIntToUtxorpcBigInt` sent any magnitude outside `int64` to the `BigUInt`
variant, and `big.Int.Bytes` returns the absolute value, so a delta below
`math.MinInt64` was projected as its positive magnitude. A negative value now
uses `BigInt_BigNInt`. Signed deltas are what make that branch reachable:
every other caller passes a non-negative coin, and `ToUtxorpcBigInt` takes a
`uint64`.

## Compatibility

`Rewards` changes value type from `uint64` to `*big.Int`. `RewardsAmount()`,
`OtherPotAmount()` and `Utxorpc()` keep their signatures. Consumers that range
over `Reward.Rewards` and use the amount as a `uint64` need to move to `*big.Int`
or to `RewardsAmount()`.

## Tests

`ledger/common/mir_delta_decode_test.go`
- `TestMirRewardDeltaDecodesAsSigned` decodes a MIR certificate whose delta is
  -1, -10000000000, minimum int64, maximum uint64, and a positive and negative
  bignum, alongside the upstream golden value 77 and 0. The envelope follows the
  upstream golden encoding for "mir"
  (`eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Serialisation/Golden/Encoding.hs`);
  -1 is `aliceOnlyDelta (-1)` from
  `eras/shelley/test-suite/test/Test/Cardano/Ledger/Shelley/Examples/MirTransfer.hs`.
  It reads the delta through `RewardsAmount()` so that it compiles against the
  unsigned value type and fails on the decode.
- `TestMirRewardDeltaRejectsNonInteger` is the negative control: null,
  undefined, text string, byte string, array, float and boolean deltas are
  rejected.
- `TestMirOppositePotDecode` covers the other `MIRTarget` branch, including the
  source pot of a reserves and a treasury transfer and a negative opposite-pot
  amount.

- `TestMirRewardDeltaUtxorpcKeepsTheSign` checks the `Utxorpc()` projection of
  a positive and negative `int64` delta and of a positive and negative
  magnitude beyond `int64`, across all three variants of the `BigInt` oneof.

`ledger/mir_rules_test.go`
- `TestUtxoValidateDelegationMirNegativeDelta` rejects a -1 delta at major
  version 4 with `MIRNegativesNotCurrentlyAllowedError`, accepts it at major
  version 5, and accepts non-negative deltas and a pot-to-pot certificate at
  major version 4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MIR reward deltas now correctly support positive and negative values, including large amounts.
  * Improved certificate decoding rejects invalid or unsupported delta values.
  * Fixed incorrect decoding for coin-based MIR certificates.
  * RPC representations now preserve delta signs and magnitudes, while rejecting values outside supported ranges.
  * Negative MIR reward changes are rejected before the Alonzo protocol era and accepted where permitted.
  * Nil reward amounts are handled safely without causing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->