### PR TITLE
fix(ledger): drop the Dijkstra decode-time transaction size limit

### DIFF
--- a/ledger/dijkstra/dijkstra.go
+++ b/ledger/dijkstra/dijkstra.go
@@ -49,11 +49,6 @@ const (
 	BlockHeaderTypeDijkstra = 7
 
 	TxTypeDijkstra = 7
-
-	// MaxTxSize is the decode-time Dijkstra transaction CBOR limit. It
-	// mirrors the current Cardano max_tx_size until protocol parameters are
-	// available for validation.
-	MaxTxSize = 16 * 1024
 )
 
 var EraDijkstra = common.Era{
@@ -1749,35 +1744,24 @@ func NewDijkstraTransactionFromCborComponents(
 	data []byte,
 	txArray []cbor.RawMessage,
 ) (*DijkstraTransaction, error) {
-	if err := validateDijkstraTransactionCborSize(data); err != nil {
-		return nil, err
-	}
 	return newDijkstraTransactionFromCborComponents(data, txArray, true)
 }
 
+// newDijkstraTransactionFromCbor applies no transaction size limit. The
+// reference decoder does not either (decodeDijkstraTopTx in
+// eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs), and no transaction
+// decoder in any era does. max_tx_size is a protocol parameter enforced by the
+// UTxO rule UtxoValidateMaxTxSizeUtxo, which is registered for Dijkstra in
+// rules.go.
 func newDijkstraTransactionFromCbor(
 	data []byte,
 	allowIsValid bool,
 ) (*DijkstraTransaction, error) {
-	if err := validateDijkstraTransactionCborSize(data); err != nil {
-		return nil, err
-	}
 	var txArray []cbor.RawMessage
 	if _, err := cbor.Decode(data, &txArray); err != nil {
 		return nil, err
 	}
 	return newDijkstraTransactionFromCborComponents(data, txArray, allowIsValid)
-}
-
-func validateDijkstraTransactionCborSize(data []byte) error {
-	if len(data) <= MaxTxSize {
-		return nil
-	}
-	return fmt.Errorf(
-		"newDijkstraTransactionFromCbor: transaction size %d exceeds MaxTxSize %d",
-		len(data),
-		MaxTxSize,
-	)
 }
 
 func newDijkstraTransactionFromCborComponents(

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -310,11 +310,53 @@ func TestDijkstraTransactionAllowsOnlyTrueIsValidForMempool(t *testing.T) {
 	require.ErrorContains(t, err, "is_valid=false")
 }
 
-func TestDijkstraTransactionRejectsOversizedCbor(t *testing.T) {
-	txCbor := make([]byte, MaxTxSize+1)
+// oversizedTxParts builds a well-formed Dijkstra transaction whose CBOR exceeds
+// the current Cardano max_tx_size of 16384 bytes. The bulk is carried by
+// direct_deposits (body key 25), a Dijkstra-only key, so the result is also a
+// Dijkstra era candidate for DetermineTransactionType.
+func oversizedTxParts(entries int) []any {
+	deposits := make(map[cbor.ByteString]uint64, entries)
+	for i := range entries {
+		credential := bytes.Repeat([]byte{0x00}, common.Blake2b224Size)
+		credential[0] = byte(i)
+		credential[1] = byte(i >> 8)
+		credential[2] = byte(i >> 16)
+		deposits[cbor.NewByteString(credential)] = uint64(i + 1)
+	}
+	body := minimalTxBody()
+	body[25] = deposits
+	return []any{body, minimalWitnessSet(), nil}
+}
 
-	_, err := NewDijkstraTransactionFromCbor(txCbor)
-	require.ErrorContains(t, err, "MaxTxSize")
+// TestDijkstraTransactionDecodesOversizedCbor pins that the decoder applies no
+// transaction size limit. The reference decoder does not either
+// (decodeDijkstraTopTx in eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs),
+// and no transaction decoder in any era does; max_tx_size is a protocol
+// parameter enforced by UtxoValidateMaxTxSizeUtxo. A decode failure would fail
+// the containing block rather than the one transaction.
+func TestDijkstraTransactionDecodesOversizedCbor(t *testing.T) {
+	txCbor, err := cbor.Encode(oversizedTxParts(600))
+	require.NoError(t, err)
+	require.Greater(t, len(txCbor), 16*1024)
+
+	tx, err := NewDijkstraTransactionFromCbor(txCbor)
+	require.NoError(t, err)
+	require.Equal(t, TxTypeDijkstra, tx.Type())
+	require.Equal(t, txCbor, tx.Cbor())
+	require.Len(t, tx.Body.TxDirectDeposits, 600)
+}
+
+// TestDijkstraTransactionRejectsOversizedMalformedCbor is the negative control
+// for the removed size check: an oversized payload that is not a Dijkstra
+// transaction is still rejected, on its shape rather than on its length.
+func TestDijkstraTransactionRejectsOversizedMalformedCbor(t *testing.T) {
+	txCbor, err := cbor.Encode(bytes.Repeat([]byte{0x00}, 32*1024))
+	require.NoError(t, err)
+	require.Greater(t, len(txCbor), 16*1024)
+
+	_, err = NewDijkstraTransactionFromCbor(txCbor)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "MaxTxSize")
 }
 
 func TestDijkstraBlockBodyRejectsWrongComponentCount(t *testing.T) {

--- a/ledger/dijkstra_tx_size_test.go
+++ b/ledger/dijkstra_tx_size_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// oversizedDijkstraTxCbor builds a well-formed Dijkstra transaction whose CBOR
+// exceeds the current Cardano max_tx_size of 16384 bytes. The bulk is carried
+// by direct_deposits (body key 25), which is a Dijkstra-only body key, so the
+// transaction is unambiguously a Dijkstra era candidate.
+func oversizedDijkstraTxCbor(t *testing.T) []byte {
+	t.Helper()
+	const entries = 600
+	deposits := make(map[cbor.ByteString]uint64, entries)
+	for i := range entries {
+		credential := bytes.Repeat([]byte{0x00}, common.Blake2b224Size)
+		credential[0] = byte(i)
+		credential[1] = byte(i >> 8)
+		credential[2] = byte(i >> 16)
+		deposits[cbor.NewByteString(credential)] = uint64(i + 1)
+	}
+	txCbor, err := cbor.Encode([]any{
+		map[uint]any{
+			0:  []any{},
+			1:  []any{},
+			2:  uint64(0),
+			25: deposits,
+		},
+		map[uint]any{},
+		nil,
+	})
+	require.NoError(t, err)
+	require.Greater(t, len(txCbor), 16*1024)
+	return txCbor
+}
+
+// TestDetermineTransactionTypeOversizedDijkstra covers the era classification
+// consequence of a decode-time size limit. looksLikeDijkstraTransaction
+// consulted the same constant the decoder did, so an oversized Dijkstra
+// transaction was not reported as oversized: the Dijkstra candidate was
+// dropped and DetermineTransactionType fell through to the earlier eras.
+func TestDetermineTransactionTypeOversizedDijkstra(t *testing.T) {
+	txType, err := ledger.DetermineTransactionType(oversizedDijkstraTxCbor(t))
+	require.NoError(t, err)
+	assert.Equal(t, uint(ledger.TxTypeDijkstra), txType)
+}
+
+// TestOversizedDijkstraTransactionFailsTheSizeRule pins where the bound lives.
+// max_tx_size is a protocol parameter, so an oversized transaction is rejected
+// by UtxoValidateMaxTxSizeUtxo against the value in force, not by the decoder
+// against a hardcoded constant.
+func TestOversizedDijkstraTransactionFailsTheSizeRule(t *testing.T) {
+	txCbor := oversizedDijkstraTxCbor(t)
+	tx, err := dijkstra.NewDijkstraTransactionFromCbor(txCbor)
+	require.NoError(t, err)
+	ls := mockledger.NewLedgerStateBuilder().Build()
+
+	t.Run("rejected at the current max_tx_size", func(t *testing.T) {
+		pparams := &dijkstra.DijkstraProtocolParameters{}
+		pparams.MaxTxSize = 16384
+		err := dijkstra.UtxoValidateMaxTxSizeUtxo(tx, 0, ls, pparams)
+		var sizeErr shelley.MaxTxSizeUtxoError
+		require.ErrorAs(t, err, &sizeErr)
+		assert.Equal(t, uint(len(txCbor)), sizeErr.TxSize)
+		assert.Equal(t, uint(16384), sizeErr.MaxTxSize)
+	})
+
+	t.Run("accepted when max_tx_size permits it", func(t *testing.T) {
+		pparams := &dijkstra.DijkstraProtocolParameters{}
+		pparams.MaxTxSize = uint(len(txCbor))
+		require.NoError(
+			t,
+			dijkstra.UtxoValidateMaxTxSizeUtxo(tx, 0, ls, pparams),
+		)
+	})
+}

--- a/ledger/tx.go
+++ b/ledger/tx.go
@@ -210,12 +210,14 @@ func decodeTxComponents(
 	return txArray, txBody, nil
 }
 
+// looksLikeDijkstraTransaction applies no transaction size limit. A limit here
+// would not report an oversized Dijkstra transaction, it would drop the
+// candidate and let DetermineTransactionType classify it as an earlier era or
+// as unknown. max_tx_size is a protocol parameter enforced by the UTxO rule
+// dijkstra.UtxoValidateMaxTxSizeUtxo.
 func looksLikeDijkstraTransaction(
 	data []byte,
 ) (bool, []cbor.RawMessage, map[uint]cbor.RawMessage, error) {
-	if len(data) > dijkstraera.MaxTxSize {
-		return false, nil, nil, nil
-	}
 	txArray, txBody, err := decodeTxComponents(data)
 	if err != nil {
 		return false, nil, nil, err

--- a/ledger/tx.go
+++ b/ledger/tx.go
@@ -193,9 +193,53 @@ func DetermineTransactionType(data []byte) (uint, error) {
 func decodeTxComponents(
 	data []byte,
 ) ([]cbor.RawMessage, map[uint]cbor.RawMessage, error) {
-	var txArray []cbor.RawMessage
-	if _, err := cbor.Decode(data, &txArray); err != nil {
+	componentCount, headerSize, indefinite := cbor.ArrayInfo(data)
+	if componentCount < 0 {
+		return nil, nil, errors.New("invalid transaction array header")
+	}
+	if !indefinite && componentCount != 3 && componentCount != 4 {
+		return nil, nil, fmt.Errorf(
+			"invalid transaction component count %d",
+			componentCount,
+		)
+	}
+
+	decoder, err := cbor.NewStreamDecoder(data)
+	if err != nil {
 		return nil, nil, err
+	}
+	if err := decoder.Advance(int(headerSize)); err != nil {
+		return nil, nil, err
+	}
+	capacity := componentCount
+	if indefinite {
+		capacity = 4
+	}
+	txArray := make([]cbor.RawMessage, 0, capacity)
+	for indefinite || len(txArray) < componentCount {
+		position := decoder.Position()
+		if position >= len(data) {
+			return nil, nil, errors.New("unterminated transaction array")
+		}
+		if indefinite && data[position] == 0xff {
+			if err := decoder.Advance(1); err != nil {
+				return nil, nil, err
+			}
+			break
+		}
+		if len(txArray) == 4 {
+			return nil, nil, errors.New(
+				"invalid transaction component count: more than 4",
+			)
+		}
+		offset, length, err := decoder.Skip()
+		if err != nil {
+			return nil, nil, err
+		}
+		txArray = append(
+			txArray,
+			cbor.RawMessage(data[offset:offset+length]),
+		)
 	}
 	if len(txArray) != 3 && len(txArray) != 4 {
 		return nil, nil, fmt.Errorf(

--- a/ledger/tx_internal_test.go
+++ b/ledger/tx_internal_test.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeTxComponentsBoundsTopLevelArray(t *testing.T) {
+	t.Run("oversized declared count", func(t *testing.T) {
+		// A definite array claiming one million components must be rejected
+		// from its header, before a decoder allocates a RawMessage slice or
+		// attempts to read the absent items.
+		data := []byte{0x9a, 0x00, 0x0f, 0x42, 0x40}
+		_, _, err := decodeTxComponents(data)
+		require.EqualError(
+			t,
+			err,
+			"invalid transaction component count 1000000",
+		)
+	})
+
+	t.Run("indefinite fifth component", func(t *testing.T) {
+		// The fifth item begins a malformed indefinite text string. The
+		// component bound must reject it without asking the decoder to consume
+		// that item or scan for a closing break.
+		data := []byte{0x9f, 0xa0, 0xa0, 0xf6, 0xf6, 0x7f}
+		_, _, err := decodeTxComponents(data)
+		require.EqualError(
+			t,
+			err,
+			"invalid transaction component count: more than 4",
+		)
+	})
+}


### PR DESCRIPTION
Fixes #2241

`NewDijkstraTransactionFromCbor`, `newDijkstraTransactionFromCbor` and
`NewDijkstraTransactionFromCborComponents` rejected CBOR over a hardcoded 16 KiB
before decoding any field (`ledger/dijkstra/dijkstra.go:1742-1770`), through
`validateDijkstraTransactionCborSize` (`:1772-1780`) and the constant `MaxTxSize`
(`:56`). Because that is a decode failure, an oversized transaction fails the
whole containing block rather than one transaction.

The reference applies no size limit: `decodeDijkstraTopTx`
(`eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Tx.hs:137-157`) reads the body,
witnesses, optional `isPhase2Valid` and auxiliary data with no length check, and
no transaction decoder in any era has one.

## Where the constraint goes

The bound is not wrong, it is in the wrong place. `max_tx_size` is a protocol
parameter, and the UTxO rule that enforces it is already registered for
Dijkstra: `UtxoValidationRuleMaxTxSize` maps to
`dijkstra.UtxoValidateMaxTxSizeUtxo` (`ledger/dijkstra/rules.go:204`,
`:2793`), which compares `common.TxSize(tx)` against
`DijkstraProtocolParameters.MaxTxSize` and returns
`shelley.MaxTxSizeUtxoError`. It is covered for Dijkstra by the existing
`ledger/max_tx_size_test.go`. So the constraint is not dropped, only its
duplicate at decode time, along with the `MaxTxSize` constant that had no other
user.

## Era classification

`looksLikeDijkstraTransaction` consulted the same constant
(`ledger/tx.go:216`), and returned `false` with a nil error rather than an
error. An oversized Dijkstra transaction was therefore not reported as
oversized: the Dijkstra candidate was dropped and `DetermineTransactionType`
fell through to the earlier eras, returning an earlier era or
"unknown transaction type". That guard is removed too.

## Compatibility

The exported constant `dijkstra.MaxTxSize` is removed. It was documented as the
decode-time limit "until protocol parameters are available for validation", and
the only two readers were the decoder and the era heuristic. Callers that need
the value in force should read `MaxTxSize` from the protocol parameters.

## Tests

`ledger/dijkstra/dijkstra_test.go`
- `TestDijkstraTransactionDecodesOversizedCbor` decodes a well-formed 19537-byte
  Dijkstra transaction whose bulk is `direct_deposits` (body key 25), and checks
  the stored CBOR and the decoded deposit count.
- `TestDijkstraTransactionRejectsOversizedMalformedCbor` is the negative
  control: an oversized payload that is not a Dijkstra transaction is still
  rejected, on its shape rather than on its length.
- `TestDijkstraTransactionRejectsOversizedCbor`, which pinned the removed
  behaviour, is replaced by the two above.

`ledger/dijkstra_tx_size_test.go`
- `TestDetermineTransactionTypeOversizedDijkstra` classifies the same
  oversized transaction as `TxTypeDijkstra`.
- `TestOversizedDijkstraTransactionFailsTheSizeRule` runs it through
  `dijkstra.UtxoValidateMaxTxSizeUtxo`: rejected with `MaxTxSizeUtxoError` at a
  `max_tx_size` of 16384, with the reported and permitted sizes checked, and
  accepted when `max_tx_size` permits it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the hardcoded 16 KiB decode-time size limit for Dijkstra transactions so oversized transactions are rejected by the UTxO size rule against the protocol's `max_tx_size` parameter instead of failing the entire block. Also bounds transaction component decoding in `decodeTxComponents` so malformed CBOR headers (inflated component counts, more than four components) are rejected before any allocation.

Era classification now identifies oversized Dijkstra transactions as Dijkstra rather than falling through to earlier eras or "unknown".

**Breaking changes**
- Removed the exported constant `dijkstra.MaxTxSize`; read `MaxTxSize` from protocol parameters instead.

**Tests**
- Added decoder, era classification, UTxO size rule, and component decoding bounds tests for oversized and malformed transactions.

<sup>Written for commit 6f8b90b6501da8794dd1288072afb2773b790cfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->