### PR TITLE
fix(ledger): preserve unknown Byron address attributes

### DIFF
--- a/ledger/byron/address_attributes_test.go
+++ b/ledger/byron/address_attributes_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package byron_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"hash/crc32"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+)
+
+// TestByronTransactionOutputPreservesUnknownAddressAttributes covers the path
+// the divergence actually reaches: a Byron address is decoded from every Byron
+// transaction output, so an attribute key this decoder does not interpret
+// failed the whole containing block.
+func TestByronTransactionOutputPreservesUnknownAddressAttributes(t *testing.T) {
+	// The address root of the mainnet Byron address the block fixture carries
+	root, err := hex.DecodeString(
+		"5d5e698eba3dd9452add99a1af9461beb0ba61b8bece26e7399878dd",
+	)
+	if err != nil {
+		t.Fatalf("bad test hash: %v", err)
+	}
+	// {2: <network magic>, 3: <unknown>}: the attribute map is
+	// Map Word8 LByteString, and every key the updater does not consume is
+	// retained (cardano-ledger
+	// eras/byron/ledger/impl/src/Cardano/Chain/Common/Attributes.hs).
+	attrCbor, err := hex.DecodeString("a202410203450102030405")
+	if err != nil {
+		t.Fatalf("bad test attribute hex: %v", err)
+	}
+	payload, err := cbor.Encode(
+		[]any{root, cbor.RawMessage(attrCbor), uint64(0)},
+	)
+	if err != nil {
+		t.Fatalf("encode payload: %v", err)
+	}
+	addrBytes, err := cbor.Encode(
+		[]any{
+			cbor.Tag{Number: 24, Content: payload},
+			crc32.ChecksumIEEE(payload),
+		},
+	)
+	if err != nil {
+		t.Fatalf("encode address: %v", err)
+	}
+	outputBytes, err := cbor.Encode(
+		[]any{cbor.RawMessage(addrBytes), uint64(1000000)},
+	)
+	if err != nil {
+		t.Fatalf("encode output: %v", err)
+	}
+
+	var output byron.ByronTransactionOutput
+	if _, err := cbor.Decode(outputBytes, &output); err != nil {
+		t.Fatalf("decode Byron transaction output: %v", err)
+	}
+	attrs := output.OutputAddress.ByronAttr()
+	if !bytes.Equal(attrs.Unparsed[3], []byte{0x01, 0x02, 0x03, 0x04, 0x05}) {
+		t.Fatalf("unparsed attribute 3: got %x", attrs.Unparsed[3])
+	}
+	if attrs.Network == nil || *attrs.Network != 2 {
+		t.Fatalf("network magic: got %v", attrs.Network)
+	}
+	roundTrip, err := output.OutputAddress.Bytes()
+	if err != nil {
+		t.Fatalf("re-encode address: %v", err)
+	}
+	if !bytes.Equal(roundTrip, addrBytes) {
+		t.Fatalf("round trip: got %x, want %x", roundTrip, addrBytes)
+	}
+}

--- a/ledger/common/address.go
+++ b/ledger/common/address.go
@@ -952,6 +952,7 @@ type byronAddressPayload struct {
 }
 
 type ByronAddressAttributes struct {
+	cbor.DecodeStoreCbor
 	Payload []byte
 	Network *uint32
 	// Unparsed holds the attribute keys this decoder does not interpret,
@@ -975,6 +976,7 @@ func (a *ByronAddressAttributes) UnmarshalCBOR(data []byte) error {
 	if _, err := cbor.Decode(data, &tmpData); err != nil {
 		return err
 	}
+	a.SetCbor(data)
 	a.Payload = nil
 	a.Network = nil
 	a.Unparsed = nil
@@ -1011,7 +1013,10 @@ func (a *ByronAddressAttributes) UnmarshalCBOR(data []byte) error {
 	return nil
 }
 
-func (a *ByronAddressAttributes) MarshalCBOR() ([]byte, error) {
+func (a ByronAddressAttributes) MarshalCBOR() ([]byte, error) {
+	if data := a.Cbor(); data != nil {
+		return data, nil
+	}
 	tmpData := make(map[uint8][]byte, len(a.Unparsed)+2)
 	for key, value := range a.Unparsed {
 		if key == byronAddressAttrDerivationPath ||

--- a/ledger/common/address.go
+++ b/ledger/common/address.go
@@ -1014,11 +1014,7 @@ func (a *ByronAddressAttributes) UnmarshalCBOR(data []byte) error {
 }
 
 func (a ByronAddressAttributes) MarshalCBOR() ([]byte, error) {
-	if data := a.Cbor(); data != nil {
-		return data, nil
-	}
-	tmpData := make(map[uint8][]byte, len(a.Unparsed)+2)
-	for key, value := range a.Unparsed {
+	for key := range a.Unparsed {
 		if key == byronAddressAttrDerivationPath ||
 			key == byronAddressAttrNetworkMagic {
 			return nil, fmt.Errorf(
@@ -1026,6 +1022,12 @@ func (a ByronAddressAttributes) MarshalCBOR() ([]byte, error) {
 				key,
 			)
 		}
+	}
+	if data := a.Cbor(); data != nil {
+		return data, nil
+	}
+	tmpData := make(map[uint8][]byte, len(a.Unparsed)+2)
+	for key, value := range a.Unparsed {
 		tmpData[key] = value
 	}
 	if len(a.Payload) > 0 {

--- a/ledger/common/address.go
+++ b/ledger/common/address.go
@@ -52,6 +52,12 @@ const (
 
 	AddressTypeScriptBit = 0x01
 
+	// Byron address attribute keys, from the EncCBOR and DecCBOR instances
+	// for Attributes AddrAttributes (cardano-ledger
+	// eras/byron/ledger/impl/src/Cardano/Chain/Common/AddrAttributes.hs)
+	byronAddressAttrDerivationPath = 1
+	byronAddressAttrNetworkMagic   = 2
+
 	ByronAddressTypePubkey = 0
 	ByronAddressTypeScript = 1
 	ByronAddressTypeRedeem = 2
@@ -948,38 +954,84 @@ type byronAddressPayload struct {
 type ByronAddressAttributes struct {
 	Payload []byte
 	Network *uint32
+	// Unparsed holds the attribute keys this decoder does not interpret,
+	// mapped to their raw values. The reference updater returns Nothing for
+	// every key other than 1 and 2
+	// (cardano-ledger
+	// eras/byron/ledger/impl/src/Cardano/Chain/Common/AddrAttributes.hs:121-143),
+	// and decCBORAttributes retains those keys in attrRemain, which
+	// encCBORAttributes writes back
+	// (.../Common/Attributes.hs:213-234). The attribute map is hashed into the
+	// Byron address root, so an unknown key that is dropped rather than
+	// carried through changes the address it belongs to.
+	Unparsed map[uint8][]byte
 }
 
 func (a *ByronAddressAttributes) UnmarshalCBOR(data []byte) error {
-	var tmpData struct {
-		Payload    []byte `cbor:"1,keyasint,omitempty"`
-		NetworkRaw []byte `cbor:"2,keyasint,omitempty"`
-	}
+	// decCBORAttributes decodes the whole map as Map Word8 LByteString before
+	// interpreting any key, so an unrecognised key is data rather than an
+	// error.
+	var tmpData map[uint8][]byte
 	if _, err := cbor.Decode(data, &tmpData); err != nil {
 		return err
 	}
-	a.Payload = tmpData.Payload
-	if len(tmpData.NetworkRaw) > 0 {
-		var tmpNetwork uint32
-		if _, err := cbor.Decode(tmpData.NetworkRaw, &tmpNetwork); err != nil {
-			return err
+	a.Payload = nil
+	a.Network = nil
+	a.Unparsed = nil
+	for key, value := range tmpData {
+		switch key {
+		case byronAddressAttrDerivationPath:
+			// The reference runs decodeFull over this value, which cannot
+			// succeed on an empty one, and an empty value would also be
+			// dropped by MarshalCBOR and so break the round trip.
+			if len(value) == 0 {
+				return errors.New(
+					"invalid Byron address attributes: empty derivation path",
+				)
+			}
+			a.Payload = value
+		case byronAddressAttrNetworkMagic:
+			if len(value) == 0 {
+				return errors.New(
+					"invalid Byron address attributes: empty network magic",
+				)
+			}
+			var tmpNetwork uint32
+			if _, err := cbor.Decode(value, &tmpNetwork); err != nil {
+				return err
+			}
+			a.Network = &tmpNetwork
+		default:
+			if a.Unparsed == nil {
+				a.Unparsed = make(map[uint8][]byte)
+			}
+			a.Unparsed[key] = value
 		}
-		a.Network = &tmpNetwork
 	}
 	return nil
 }
 
 func (a *ByronAddressAttributes) MarshalCBOR() ([]byte, error) {
-	tmpData := make(map[int]any)
+	tmpData := make(map[uint8][]byte, len(a.Unparsed)+2)
+	for key, value := range a.Unparsed {
+		if key == byronAddressAttrDerivationPath ||
+			key == byronAddressAttrNetworkMagic {
+			return nil, fmt.Errorf(
+				"byron address attribute %d is both parsed and unparsed",
+				key,
+			)
+		}
+		tmpData[key] = value
+	}
 	if len(a.Payload) > 0 {
-		tmpData[1] = a.Payload
+		tmpData[byronAddressAttrDerivationPath] = a.Payload
 	}
 	if a.Network != nil {
 		networkRaw, err := cbor.Encode(a.Network)
 		if err != nil {
 			return nil, err
 		}
-		tmpData[2] = networkRaw
+		tmpData[byronAddressAttrNetworkMagic] = networkRaw
 	}
 	return cbor.Encode(tmpData)
 }

--- a/ledger/common/byron_address_attributes_test.go
+++ b/ledger/common/byron_address_attributes_test.go
@@ -249,6 +249,28 @@ func TestByronAddressAttributesEncodeAsValue(t *testing.T) {
 	}
 }
 
+func TestByronAddressPreservesNonCanonicalAttributeEncoding(t *testing.T) {
+	// The attribute map uses a non-canonical map-length encoding and an
+	// indefinite-length byte string. Both forms are accepted by the Byron
+	// decoder and are part of the bytes hashed into the address root.
+	attrCbor, err := hex.DecodeString("b802035f41c041deff014a1c010203040506070809")
+	if err != nil {
+		t.Fatalf("bad test attribute hex: %v", err)
+	}
+	addrBytes := buildByronAddress(t, attrCbor)
+	var addr common.Address
+	if _, err := cbor.Decode(addrBytes, &addr); err != nil {
+		t.Fatalf("decode Byron address: %v", err)
+	}
+	roundTrip, err := addr.Bytes()
+	if err != nil {
+		t.Fatalf("re-encode Byron address: %v", err)
+	}
+	if !bytes.Equal(roundTrip, addrBytes) {
+		t.Fatalf("round trip: got %x, want %x", roundTrip, addrBytes)
+	}
+}
+
 // TestByronAddressAttributesRejectShadowedKey covers the case
 // encCBORAttributes panics on: a key that is both interpreted and carried as
 // unparsed.

--- a/ledger/common/byron_address_attributes_test.go
+++ b/ledger/common/byron_address_attributes_test.go
@@ -283,3 +283,18 @@ func TestByronAddressAttributesRejectShadowedKey(t *testing.T) {
 		t.Fatal("expected a shadowed attribute key to be rejected")
 	}
 }
+
+func TestDecodedByronAddressAttributesRejectShadowedKey(t *testing.T) {
+	attrCbor, err := hex.DecodeString("a202410203420102")
+	if err != nil {
+		t.Fatalf("bad test attribute hex: %v", err)
+	}
+	var attrs common.ByronAddressAttributes
+	if _, err := cbor.Decode(attrCbor, &attrs); err != nil {
+		t.Fatalf("decode attributes: %v", err)
+	}
+	attrs.Unparsed[1] = []byte{0x41, 0x01}
+	if _, err := attrs.MarshalCBOR(); err == nil {
+		t.Fatal("expected a shadowed attribute key to be rejected")
+	}
+}

--- a/ledger/common/byron_address_attributes_test.go
+++ b/ledger/common/byron_address_attributes_test.go
@@ -1,0 +1,263 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"hash/crc32"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+// byronAddressHash is the 28 byte root of the mainnet Byron address
+// 82d818582483581c5d5e698eba3dd9452add99a1af9461beb0ba61b8bece26e7399878dd
+// a1024102001a36d41aba, which is the address the Byron block fixture and
+// TestAddressFromBytes use.
+const byronAddressHash = "5d5e698eba3dd9452add99a1af9461beb0ba61b8bece26e7399878dd"
+
+// buildByronAddress assembles the wire form of a Byron address:
+// [ #6.24(bytes .cbor ([ address_root, addr_attributes, addr_type ])), crc ],
+// with the attribute map supplied as raw CBOR so an attribute key this
+// decoder does not interpret can be placed in it.
+func buildByronAddress(t *testing.T, attrCbor []byte) []byte {
+	t.Helper()
+	root, err := hex.DecodeString(byronAddressHash)
+	if err != nil {
+		t.Fatalf("bad test hash: %v", err)
+	}
+	payload, err := cbor.Encode(
+		[]any{root, cbor.RawMessage(attrCbor), uint64(0)},
+	)
+	if err != nil {
+		t.Fatalf("encode payload: %v", err)
+	}
+	addr, err := cbor.Encode(
+		[]any{
+			cbor.Tag{Number: 24, Content: payload},
+			crc32.ChecksumIEEE(payload),
+		},
+	)
+	if err != nil {
+		t.Fatalf("encode address: %v", err)
+	}
+	return addr
+}
+
+// TestByronAddressPreservesUnknownAttributes covers the forward compatibility
+// decCBORAttributes is built for: every key the updater does not consume is
+// retained in attrRemain and written back by encCBORAttributes
+// (cardano-ledger eras/byron/ledger/impl/src/Cardano/Chain/Common/Attributes.hs).
+// The attribute map is hashed into the address root, so the re-encoding has to
+// be byte for byte.
+func TestByronAddressPreservesUnknownAttributes(t *testing.T) {
+	tests := []struct {
+		name         string
+		attrHex      string
+		wantUnparsed map[uint8][]byte
+		wantPayload  []byte
+		wantNetwork  *uint32
+	}{
+		{
+			name:         "no attributes",
+			attrHex:      "a0",
+			wantUnparsed: nil,
+		},
+		{
+			name:         "unknown key alone",
+			attrHex:      "a10342c0de",
+			wantUnparsed: map[uint8][]byte{3: {0xc0, 0xde}},
+		},
+		{
+			name:    "unknown key alongside a derivation path",
+			attrHex: "a2014a1c0102030405060708090342c0de",
+			wantPayload: []byte{
+				0x1c, 0x01, 0x02, 0x03, 0x04,
+				0x05, 0x06, 0x07, 0x08, 0x09,
+			},
+			wantUnparsed: map[uint8][]byte{3: {0xc0, 0xde}},
+		},
+		{
+			name:         "unknown key alongside a network magic",
+			attrHex:      "a2024102034100",
+			wantNetwork:  func() *uint32 { v := uint32(2); return &v }(),
+			wantUnparsed: map[uint8][]byte{3: {0x00}},
+		},
+		{
+			name:    "several unknown keys",
+			attrHex: "a3034201020542030407420506",
+			wantUnparsed: map[uint8][]byte{
+				3: {0x01, 0x02},
+				5: {0x03, 0x04},
+				7: {0x05, 0x06},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attrCbor, err := hex.DecodeString(tt.attrHex)
+			if err != nil {
+				t.Fatalf("bad test attribute hex: %v", err)
+			}
+			addrBytes := buildByronAddress(t, attrCbor)
+
+			var addr common.Address
+			if _, err := cbor.Decode(addrBytes, &addr); err != nil {
+				t.Fatalf("decode Byron address: %v", err)
+			}
+			attrs := addr.ByronAttr()
+			if len(attrs.Unparsed) != len(tt.wantUnparsed) {
+				t.Fatalf(
+					"unparsed attributes: got %v, want %v",
+					attrs.Unparsed,
+					tt.wantUnparsed,
+				)
+			}
+			for key, want := range tt.wantUnparsed {
+				if !bytes.Equal(attrs.Unparsed[key], want) {
+					t.Fatalf(
+						"unparsed attribute %d: got %x, want %x",
+						key,
+						attrs.Unparsed[key],
+						want,
+					)
+				}
+			}
+			if !bytes.Equal(attrs.Payload, tt.wantPayload) {
+				t.Fatalf(
+					"derivation path: got %x, want %x",
+					attrs.Payload,
+					tt.wantPayload,
+				)
+			}
+			switch {
+			case tt.wantNetwork == nil && attrs.Network != nil:
+				t.Fatalf("unexpected network magic %d", *attrs.Network)
+			case tt.wantNetwork != nil && attrs.Network == nil:
+				t.Fatal("missing network magic")
+			case tt.wantNetwork != nil && *attrs.Network != *tt.wantNetwork:
+				t.Fatalf(
+					"network magic: got %d, want %d",
+					*attrs.Network,
+					*tt.wantNetwork,
+				)
+			}
+
+			// The address root is a hash over the attribute map, so the
+			// re-encoding has to reproduce the input exactly.
+			roundTrip, err := addr.Bytes()
+			if err != nil {
+				t.Fatalf("re-encode Byron address: %v", err)
+			}
+			if !bytes.Equal(roundTrip, addrBytes) {
+				t.Fatalf(
+					"round trip: got %x, want %x",
+					roundTrip,
+					addrBytes,
+				)
+			}
+
+			// And the base58 form has to survive a parse
+			reparsed, err := common.NewAddress(addr.String())
+			if err != nil {
+				t.Fatalf("reparse Byron address: %v", err)
+			}
+			reparsedBytes, err := reparsed.Bytes()
+			if err != nil {
+				t.Fatalf("re-encode reparsed address: %v", err)
+			}
+			if !bytes.Equal(reparsedBytes, addrBytes) {
+				t.Fatalf(
+					"base58 round trip: got %x, want %x",
+					reparsedBytes,
+					addrBytes,
+				)
+			}
+		})
+	}
+}
+
+// TestByronAddressAttributesRejectMalformedValues is the negative control: the
+// attribute map is Map Word8 LByteString, and key 2 is decoded as a Word32, so
+// neither a non-bytestring value nor a bad network magic is accepted.
+func TestByronAddressAttributesRejectMalformedValues(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		attrHex string
+	}{
+		// value for an unknown key is a text string, not a byte string
+		{"unknown key with text value", "a10363616263"},
+		// derivation path value is empty, which decodeFull cannot accept
+		{"derivation path with empty value", "a10140"},
+		// network magic value is not a valid CBOR uint32
+		{"network magic with bad value", "a10243616263"},
+		// network magic value is empty
+		{"network magic with empty value", "a10240"},
+		// duplicate attribute key
+		{"duplicate key", "a20342010203420304"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			attrCbor, err := hex.DecodeString(tc.attrHex)
+			if err != nil {
+				t.Fatalf("bad test attribute hex: %v", err)
+			}
+			addrBytes := buildByronAddress(t, attrCbor)
+			var addr common.Address
+			if _, err := cbor.Decode(addrBytes, &addr); err == nil {
+				t.Fatal("expected malformed attributes to be rejected")
+			}
+		})
+	}
+}
+
+// TestByronAddressAttributesEncodeAsValue pins the encoding of a
+// ByronAddressAttributes value rather than a pointer. The Byron address root
+// is a hash over the CBOR of the attribute map, and a consumer recomputing it
+// from ByronAttr() encodes the value it is handed, so the unparsed keys have
+// to be present there too.
+func TestByronAddressAttributesEncodeAsValue(t *testing.T) {
+	// {2: <network magic 2>, 3: <unknown>}
+	attrCbor, err := hex.DecodeString("a202410203420102")
+	if err != nil {
+		t.Fatalf("bad test attribute hex: %v", err)
+	}
+	addrBytes := buildByronAddress(t, attrCbor)
+	var addr common.Address
+	if _, err := cbor.Decode(addrBytes, &addr); err != nil {
+		t.Fatalf("decode Byron address: %v", err)
+	}
+	encoded, err := cbor.Encode(addr.ByronAttr())
+	if err != nil {
+		t.Fatalf("encode attributes: %v", err)
+	}
+	if !bytes.Equal(encoded, attrCbor) {
+		t.Fatalf("attribute encoding: got %x, want %x", encoded, attrCbor)
+	}
+}
+
+// TestByronAddressAttributesRejectShadowedKey covers the case
+// encCBORAttributes panics on: a key that is both interpreted and carried as
+// unparsed.
+func TestByronAddressAttributesRejectShadowedKey(t *testing.T) {
+	attrs := common.ByronAddressAttributes{
+		Payload:  []byte{0x41, 0x00},
+		Unparsed: map[uint8][]byte{1: {0x41, 0x01}},
+	}
+	if _, err := attrs.MarshalCBOR(); err == nil {
+		t.Fatal("expected a shadowed attribute key to be rejected")
+	}
+}


### PR DESCRIPTION
`ByronAddressAttributes.UnmarshalCBOR` decoded the attribute map into a struct
declaring only keys 1 and 2 (`ledger/common/address.go:948-971`), and the
shared decode mode sets `ExtraReturnErrors: ExtraDecErrorUnknownField`
(`cbor/decode.go:51`), so any other key failed with
`cbor: found unknown field`. A Byron address is decoded from every Byron
transaction output (`ledger/byron/byron.go:840`, `:856`) and from every
Shelley-era bootstrap output, so that failed the whole containing block.

## Reference decoder

`DecCBOR (Attributes AddrAttributes)` handles keys 1 and 2 and returns
`Nothing` from the updater for every other key
(`eras/byron/ledger/impl/src/Cardano/Chain/Common/AddrAttributes.hs:121-143`).
`decCBORAttributes` decodes the whole map as `Map Word8 LByteString` before
interpreting anything, and retains every key the updater did not consume in
`attrRemain` (`.../Common/Attributes.hs:213-234`). `encCBORAttributes` folds the
interpreted keys back into that map, so an unparsed key is written out again.
The note in that module states the intent: the old version "can serialize and
deserialize data received from the new version in a lossless way".

## Where the constraint goes

Nowhere. The reference has no rule rejecting an unknown attribute key.

## What re-encoding has to preserve

The attribute map is hashed into the address, so a dropped key changes the
address rather than only its encoding. `Address.Bytes()` encodes
`[address_root, attributes, addr_type]` and takes a CRC over it, and
`NewByronAddressRedeem` hashes `[type, [type, pubkey], attributes]` through
SHA3-256 and Blake2b-224 to derive the root that a bootstrap or redeem witness
is matched against. Both re-encode the attributes rather than replaying stored
bytes.

Preserved is therefore the whole attribute map, byte for byte:

- Unparsed values are held as their raw `LByteString` contents and written back
  unchanged.
- Key 1 keeps holding the raw derivation path value, and key 2 keeps being
  re-encoded from the decoded `uint32`, both as before. An empty value for key
  1 is now rejected: the reference runs `decodeFull` over it, which cannot
  succeed on an empty input, and an empty value would otherwise be dropped by
  `MarshalCBOR` and break the round trip.
- Key order comes from `cbor.Encode`, which sorts deterministically
  (`cbor/encode.go:40`), matching the ordering of the reference's
  `Map Word8 LByteString`.

`MarshalCBOR` rejects an `Unparsed` entry for key 1 or 2, which is the case
`encCBORAttributes` panics on.

## Compatibility

`ByronAddressAttributes` gains an exported `Unparsed map[uint8][]byte` field.
No signature changes. A consumer that recomputes a Byron address root from
`Address.ByronAttr()` picks the unparsed keys up automatically, including when
it encodes the value rather than a pointer.

## Tests

`ledger/common/byron_address_attributes_test.go`
- `TestByronAddressPreservesUnknownAttributes` builds a Byron address around
  the address root of the mainnet address the block fixture carries, with an
  unknown key alone, alongside a derivation path, alongside a network magic,
  and with three unknown keys, then checks the decoded fields, a byte-for-byte
  round trip through `Bytes()`, and a round trip through the base58 form.
- `TestByronAddressAttributesEncodeAsValue` pins the encoding of a
  `ByronAddressAttributes` value, which is the shape a consumer recomputing an
  address root uses.
- `TestByronAddressAttributesRejectMalformedValues` is the negative control: a
  non-bytestring value, a network magic that is not a `uint32`, an empty
  network magic, an empty derivation path, and a duplicate attribute key.
- `TestByronAddressAttributesRejectShadowedKey` covers a key that is both
  interpreted and carried as unparsed.

`ledger/byron/address_attributes_test.go`
- `TestByronTransactionOutputPreservesUnknownAddressAttributes` decodes a Byron
  transaction output whose address carries attribute key 3 alongside a network
  magic, and checks the round trip.

No fixture in the repository carries a Byron address with an unknown attribute
key. The addresses are constructed around the address root of an existing
mainnet fixture, with the attribute map shaped as the `Map Word8 LByteString`
that `decCBORAttributes` decodes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2243. Byron addresses with unknown attribute keys no longer fail decoding: previously any key other than 1 or 2 caused `cbor: found unknown field` and failed the containing block. Decoded attribute maps now replay their original bytes byte-for-byte, so even non-canonical encodings round-trip exactly, and `ByronAddressAttributes.Unparsed` exposes unknown keys for consumers recomputing an address root. Empty derivation paths and empty or malformed network magic values are rejected, and `MarshalCBOR` rejects a key that is both parsed and unparsed.

<sup>Written for commit 5834de3725b99f8dc328f5c492787b12a9d78683. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

