### PR TITLE
fix(ledger): widen operational certificate counter and KES period

### DIFF
--- a/consensus/block.go
+++ b/consensus/block.go
@@ -40,8 +40,8 @@ type BlockBuilder struct {
 // OperationalCert represents an operational certificate for block production.
 type OperationalCert struct {
 	HotVkey        []byte // KES verification key (32 bytes)
-	SequenceNumber uint32 // Monotonically increasing counter
-	KesPeriod      uint32 // Starting KES period for this cert
+	SequenceNumber uint64 // Monotonically increasing counter
+	KesPeriod      uint64 // Starting KES period for this cert
 	Signature      []byte // Cold key signature (64 bytes)
 }
 
@@ -131,8 +131,8 @@ type HeaderBody struct {
 	BlockBodySize        uint64
 	BlockBodyHash        []byte // 32 bytes
 	OpCertHotVkey        []byte // 32 bytes
-	OpCertSequenceNumber uint32
-	OpCertKesPeriod      uint32
+	OpCertSequenceNumber uint64
+	OpCertKesPeriod      uint64
 	OpCertSignature      []byte // 64 bytes
 	ProtoMajor           uint64
 	ProtoMinor           uint64

--- a/consensus/block_test.go
+++ b/consensus/block_test.go
@@ -859,8 +859,8 @@ func TestBuildHeaderTPraosRoundTripsWithHeaderValidator(t *testing.T) {
 	coldPrivateKey := ed25519.NewKeyFromSeed(coldSeed)
 	coldPublicKey := coldPrivateKey.Public().(ed25519.PublicKey)
 
-	opCertSeqNum := uint32(1)
-	opCertKesPeriod := uint32(0)
+	opCertSeqNum := uint64(1)
+	opCertKesPeriod := uint64(0)
 	opCertBody := common.OpCertSignableBytes(
 		kesSigner.PublicKey(),
 		uint64(opCertSeqNum),

--- a/consensus/validate.go
+++ b/consensus/validate.go
@@ -87,8 +87,8 @@ type ValidateHeaderInput struct {
 
 	// OpCert fields
 	OpCertHotVkey        []byte
-	OpCertSequenceNumber uint32
-	OpCertKesPeriod      uint32
+	OpCertSequenceNumber uint64
+	OpCertKesPeriod      uint64
 	OpCertSignature      []byte
 
 	// Previous header for chain validation
@@ -456,7 +456,7 @@ func (v *HeaderValidator) validateKESPeriod(input *ValidateHeaderInput) error {
 	}
 
 	currentKESPeriod := input.Slot / v.slotsPerKESPeriod
-	opCertKESPeriod := uint64(input.OpCertKesPeriod)
+	opCertKESPeriod := input.OpCertKesPeriod
 
 	// OpCert cannot be from the future
 	if currentKESPeriod < opCertKESPeriod {
@@ -510,7 +510,7 @@ func (v *HeaderValidator) validateKESSignature(
 
 	// Calculate evolution period
 	currentKESPeriod := input.Slot / v.slotsPerKESPeriod
-	opCertKESPeriod := uint64(input.OpCertKesPeriod)
+	opCertKESPeriod := input.OpCertKesPeriod
 	// Guard against underflow if OpCert KES period is in the future
 	if currentKESPeriod < opCertKESPeriod {
 		return fmt.Errorf(
@@ -569,8 +569,8 @@ func (v *HeaderValidator) validateOpCertSignature(
 	// (hot_vkey || sequence_number || kes_period), not a CBOR encoding.
 	opCertBody := common.OpCertSignableBytes(
 		input.OpCertHotVkey,
-		uint64(input.OpCertSequenceNumber),
-		uint64(input.OpCertKesPeriod),
+		input.OpCertSequenceNumber,
+		input.OpCertKesPeriod,
 	)
 
 	// Verify Ed25519 signature

--- a/consensus/validate_test.go
+++ b/consensus/validate_test.go
@@ -495,8 +495,8 @@ func TestValidateHeaderFull(t *testing.T) {
 
 	// Create OpCert signature: cold key signs the raw OCertSignable
 	// representation (hot_vkey || sequence_number || kes_period).
-	opCertSeqNum := uint32(0)
-	opCertKesPeriod := uint32(0)
+	opCertSeqNum := uint64(0)
+	opCertKesPeriod := uint64(0)
 	opCertBody := common.OpCertSignableBytes(
 		kesPk,
 		uint64(opCertSeqNum),
@@ -607,8 +607,8 @@ func TestValidateOpCertSignature(t *testing.T) {
 
 	// Create valid OpCert signature over the raw OCertSignable representation
 	// (hot_vkey || sequence_number || kes_period).
-	opCertSeqNum := uint32(5)
-	opCertKesPeriod := uint32(10)
+	opCertSeqNum := uint64(5)
+	opCertKesPeriod := uint64(10)
 	opCertBody := common.OpCertSignableBytes(
 		kesPk,
 		uint64(opCertSeqNum),
@@ -981,8 +981,8 @@ func TestValidateHeaderFullTPraosValid(t *testing.T) {
 	kesSig, err := kes.Sign(kesSk, 0, message)
 	require.NoError(t, err)
 
-	opCertSeqNum := uint32(0)
-	opCertKesPeriod := uint32(0)
+	opCertSeqNum := uint64(0)
+	opCertKesPeriod := uint64(0)
 	opCertBody := common.OpCertSignableBytes(
 		kesPk,
 		uint64(opCertSeqNum),

--- a/internal/test/conformance/opcert_width_conformance_test.go
+++ b/internal/test/conformance/opcert_width_conformance_test.go
@@ -1,0 +1,352 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package conformance
+
+import (
+	"path"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/blinklabs-io/ouroboros-mock/fixtures"
+)
+
+// goldenHeaderDir is the CardanoNodeToNodeVersion2 golden directory in the
+// embedded upstream fixtures. Each Header_* golden is
+// [era_id, #6.24(bytes .cbor header)].
+const goldenHeaderDir = "upstream/ouroboros-consensus/ouroboros-consensus-cardano/golden/cardano/CardanoNodeToNodeVersion2"
+
+// tPraosOCertOffset is the index of the operational certificate sequence
+// number in the flat Shelley-family (TPraos) header body array; the KES period
+// is the element after it. Shelley through Alonzo share the shape.
+const tPraosOCertOffset = 10
+
+// cPraosOCertIndex is the index of the nested operational certificate array in
+// the Babbage-family (CPraos) header body array. Within that array the
+// sequence number is element 1 and the KES period element 2.
+const cPraosOCertIndex = 8
+
+// readGoldenHeader returns the era id and header CBOR carried by an upstream
+// Header_* golden.
+func readGoldenHeader(t *testing.T, name string) (uint, []byte) {
+	t.Helper()
+	raw, err := fixtures.EmbeddedFixtures().
+		ReadFile(path.Join(goldenHeaderDir, name))
+	if err != nil {
+		t.Fatalf("read golden %s: %v", name, err)
+	}
+	var envelope struct {
+		cbor.StructAsArray
+		EraId  uint
+		Header cbor.Tag
+	}
+	if _, err := cbor.Decode(raw, &envelope); err != nil {
+		t.Fatalf("decode golden envelope %s: %v", name, err)
+	}
+	headerCbor, ok := envelope.Header.Content.([]byte)
+	if !ok {
+		t.Fatalf(
+			"golden %s header tag content is %T, want []byte",
+			name,
+			envelope.Header.Content,
+		)
+	}
+	return envelope.EraId, headerCbor
+}
+
+// setOCertFields rewrites the operational certificate sequence number and KES
+// period in a header, leaving every other byte of the header untouched.
+func setOCertFields(
+	t *testing.T,
+	headerCbor []byte,
+	tpraos bool,
+	sequenceNumber uint64,
+	kesPeriod uint64,
+) []byte {
+	t.Helper()
+	var header []cbor.RawMessage
+	if _, err := cbor.Decode(headerCbor, &header); err != nil {
+		t.Fatalf("decode header array: %v", err)
+	}
+	if len(header) != 2 {
+		t.Fatalf("header array has %d elements, want 2", len(header))
+	}
+	var body []cbor.RawMessage
+	if _, err := cbor.Decode(header[0], &body); err != nil {
+		t.Fatalf("decode header body array: %v", err)
+	}
+	encode := func(v uint64) cbor.RawMessage {
+		encoded, err := cbor.Encode(v)
+		if err != nil {
+			t.Fatalf("encode %d: %v", v, err)
+		}
+		return encoded
+	}
+	if tpraos {
+		if len(body) <= tPraosOCertOffset+1 {
+			t.Fatalf("TPraos header body has %d elements", len(body))
+		}
+		body[tPraosOCertOffset] = encode(sequenceNumber)
+		body[tPraosOCertOffset+1] = encode(kesPeriod)
+	} else {
+		if len(body) <= cPraosOCertIndex {
+			t.Fatalf("CPraos header body has %d elements", len(body))
+		}
+		var ocert []cbor.RawMessage
+		if _, err := cbor.Decode(body[cPraosOCertIndex], &ocert); err != nil {
+			t.Fatalf("decode operational certificate array: %v", err)
+		}
+		if len(ocert) != 4 {
+			t.Fatalf(
+				"operational certificate array has %d elements, want 4",
+				len(ocert),
+			)
+		}
+		ocert[1] = encode(sequenceNumber)
+		ocert[2] = encode(kesPeriod)
+		encodedOCert, err := cbor.Encode(ocert)
+		if err != nil {
+			t.Fatalf("encode operational certificate array: %v", err)
+		}
+		body[cPraosOCertIndex] = encodedOCert
+	}
+	encodedBody, err := cbor.Encode(body)
+	if err != nil {
+		t.Fatalf("encode header body array: %v", err)
+	}
+	header[0] = encodedBody
+	encodedHeader, err := cbor.Encode(header)
+	if err != nil {
+		t.Fatalf("encode header array: %v", err)
+	}
+	return encodedHeader
+}
+
+// headerOCertFields returns the decoded operational certificate sequence
+// number and KES period for any Shelley-family header.
+func headerOCertFields(
+	t *testing.T,
+	header common.BlockHeader,
+) (uint64, uint64) {
+	t.Helper()
+	switch h := header.(type) {
+	case *shelley.ShelleyBlockHeader:
+		return h.Body.OpCertSequenceNumber, h.Body.OpCertKesPeriod
+	case *allegra.AllegraBlockHeader:
+		return h.Body.OpCertSequenceNumber, h.Body.OpCertKesPeriod
+	case *mary.MaryBlockHeader:
+		return h.Body.OpCertSequenceNumber, h.Body.OpCertKesPeriod
+	case *alonzo.AlonzoBlockHeader:
+		return h.Body.OpCertSequenceNumber, h.Body.OpCertKesPeriod
+	case *dijkstra.DijkstraBlockHeader:
+		return h.Body.OpCert.SequenceNumber, h.Body.OpCert.KesPeriod
+	case *conway.ConwayBlockHeader:
+		return h.Body.OpCert.SequenceNumber, h.Body.OpCert.KesPeriod
+	case *babbage.BabbageBlockHeader:
+		return h.Body.OpCert.SequenceNumber, h.Body.OpCert.KesPeriod
+	default:
+		t.Fatalf("unexpected header type %T", header)
+		return 0, 0
+	}
+}
+
+// TestGoldenHeaderOCertCounterAndKesPeriodWidth pins the operational
+// certificate sequence number and KES period at their reference widths.
+//
+// cardano-ledger decodes the counter as Word64 and the period as a Word
+// newtype with plain decCBOR and no bound (decodeOCertFields,
+// libs/cardano-protocol/src/Cardano/Protocol/TPraos/OCert.hs), and the CDDL
+// declares sequence_number = uint .size 8 and kes_period = uint .size 8. A
+// header carrying a counter or period at or above 2^32 therefore decodes; the
+// counter is bounded against ledger state by the OCERT rule and the period by
+// the KES expiry check, not by the wire type.
+func TestGoldenHeaderOCertCounterAndKesPeriodWidth(t *testing.T) {
+	const (
+		wideSequenceNumber = uint64(1) << 32
+		wideKesPeriod      = uint64(1)<<32 + 7
+	)
+	for _, testDef := range []struct {
+		name   string
+		golden string
+		tpraos bool
+	}{
+		{name: "Shelley", golden: "Header_Shelley", tpraos: true},
+		{name: "Allegra", golden: "Header_Allegra", tpraos: true},
+		{name: "Mary", golden: "Header_Mary", tpraos: true},
+		{name: "Alonzo", golden: "Header_Alonzo", tpraos: true},
+		{name: "Babbage", golden: "Header_Babbage"},
+		{name: "Conway", golden: "Header_Conway"},
+		{name: "Dijkstra", golden: "Header_Dijkstra"},
+	} {
+		t.Run(testDef.name, func(t *testing.T) {
+			eraId, headerCbor := readGoldenHeader(t, testDef.golden)
+			blockType, ok := ledger.BlockHeaderToBlockTypeMap[eraId]
+			if !ok {
+				t.Fatalf("no block type for era id %d", eraId)
+			}
+			if _, err := ledger.NewBlockHeaderFromCbor(blockType, headerCbor); err != nil {
+				t.Fatalf("unmodified golden failed to decode: %v", err)
+			}
+			modified := setOCertFields(
+				t,
+				headerCbor,
+				testDef.tpraos,
+				wideSequenceNumber,
+				wideKesPeriod,
+			)
+			header, err := ledger.NewBlockHeaderFromCbor(blockType, modified)
+			if err != nil {
+				t.Fatalf(
+					"header with sequence number %d and KES period %d failed to decode: %v",
+					wideSequenceNumber,
+					wideKesPeriod,
+					err,
+				)
+			}
+			sequenceNumber, kesPeriod := headerOCertFields(t, header)
+			if sequenceNumber != wideSequenceNumber {
+				t.Errorf(
+					"decoded sequence number %d, want %d",
+					sequenceNumber,
+					wideSequenceNumber,
+				)
+			}
+			if kesPeriod != wideKesPeriod {
+				t.Errorf(
+					"decoded KES period %d, want %d",
+					kesPeriod,
+					wideKesPeriod,
+				)
+			}
+			// The bound the decoder does not carry is the KES expiry
+			// check against the block's own slot, which still rejects
+			// this certificate.
+			if _, err := ledger.ValidateKesPeriod(
+				kesPeriod,
+				header.SlotNumber(),
+				129600,
+				62,
+			); err == nil {
+				t.Error(
+					"KES period validation accepted a certificate from the future",
+				)
+			}
+		})
+	}
+}
+
+// TestGoldenHeaderOCertFieldsRejectNonIntegers keeps the negative controls the
+// widened fields still owe: the operational certificate counter and KES period
+// are unsigned integers, so a negative value and a byte string are still
+// rejected at decode.
+func TestGoldenHeaderOCertFieldsRejectNonIntegers(t *testing.T) {
+	for _, testDef := range []struct {
+		name   string
+		golden string
+		tpraos bool
+	}{
+		{name: "Shelley", golden: "Header_Shelley", tpraos: true},
+		{name: "Babbage", golden: "Header_Babbage"},
+	} {
+		t.Run(testDef.name, func(t *testing.T) {
+			eraId, headerCbor := readGoldenHeader(t, testDef.golden)
+			blockType := ledger.BlockHeaderToBlockTypeMap[eraId]
+			for _, badCase := range []struct {
+				name  string
+				value cbor.RawMessage
+			}{
+				// -1
+				{name: "negative", value: cbor.RawMessage{0x20}},
+				// h'00'
+				{name: "bytes", value: cbor.RawMessage{0x41, 0x00}},
+				// 2^64
+				{
+					name: "bignum",
+					value: cbor.RawMessage{
+						0xc2, 0x49, 0x01, 0x00, 0x00,
+						0x00, 0x00, 0x00, 0x00, 0x00,
+						0x00,
+					},
+				},
+			} {
+				t.Run(badCase.name, func(t *testing.T) {
+					modified := setOCertRaw(
+						t,
+						headerCbor,
+						testDef.tpraos,
+						badCase.value,
+					)
+					if _, err := ledger.NewBlockHeaderFromCbor(blockType, modified); err == nil {
+						t.Errorf(
+							"header with a %s sequence number decoded",
+							badCase.name,
+						)
+					}
+				})
+			}
+		})
+	}
+}
+
+// setOCertRaw replaces the operational certificate sequence number with
+// arbitrary CBOR.
+func setOCertRaw(
+	t *testing.T,
+	headerCbor []byte,
+	tpraos bool,
+	value cbor.RawMessage,
+) []byte {
+	t.Helper()
+	var header []cbor.RawMessage
+	if _, err := cbor.Decode(headerCbor, &header); err != nil {
+		t.Fatalf("decode header array: %v", err)
+	}
+	var body []cbor.RawMessage
+	if _, err := cbor.Decode(header[0], &body); err != nil {
+		t.Fatalf("decode header body array: %v", err)
+	}
+	if tpraos {
+		body[tPraosOCertOffset] = value
+	} else {
+		var ocert []cbor.RawMessage
+		if _, err := cbor.Decode(body[cPraosOCertIndex], &ocert); err != nil {
+			t.Fatalf("decode operational certificate array: %v", err)
+		}
+		ocert[1] = value
+		encodedOCert, err := cbor.Encode(ocert)
+		if err != nil {
+			t.Fatalf("encode operational certificate array: %v", err)
+		}
+		body[cPraosOCertIndex] = encodedOCert
+	}
+	encodedBody, err := cbor.Encode(body)
+	if err != nil {
+		t.Fatalf("encode header body array: %v", err)
+	}
+	header[0] = encodedBody
+	encodedHeader, err := cbor.Encode(header)
+	if err != nil {
+		t.Fatalf("encode header array: %v", err)
+	}
+	return encodedHeader
+}

--- a/internal/test/conformance/opcert_width_conformance_test.go
+++ b/internal/test/conformance/opcert_width_conformance_test.go
@@ -75,13 +75,39 @@ func readGoldenHeader(t *testing.T, name string) (uint, []byte) {
 }
 
 // setOCertFields rewrites the operational certificate sequence number and KES
-// period in a header, leaving every other byte of the header untouched.
+// period while retaining the raw CBOR for every other header field.
 func setOCertFields(
 	t *testing.T,
 	headerCbor []byte,
 	tpraos bool,
 	sequenceNumber uint64,
 	kesPeriod uint64,
+) []byte {
+	t.Helper()
+	encode := func(v uint64) cbor.RawMessage {
+		encoded, err := cbor.Encode(v)
+		if err != nil {
+			t.Fatalf("encode %d: %v", v, err)
+		}
+		return encoded
+	}
+	return setOCertRawFields(
+		t,
+		headerCbor,
+		tpraos,
+		encode(sequenceNumber),
+		encode(kesPeriod),
+	)
+}
+
+// setOCertRawFields replaces the operational certificate sequence number or
+// KES period when its replacement is non-nil. Other header fields are retained.
+func setOCertRawFields(
+	t *testing.T,
+	headerCbor []byte,
+	tpraos bool,
+	sequenceNumber cbor.RawMessage,
+	kesPeriod cbor.RawMessage,
 ) []byte {
 	t.Helper()
 	var header []cbor.RawMessage
@@ -95,19 +121,16 @@ func setOCertFields(
 	if _, err := cbor.Decode(header[0], &body); err != nil {
 		t.Fatalf("decode header body array: %v", err)
 	}
-	encode := func(v uint64) cbor.RawMessage {
-		encoded, err := cbor.Encode(v)
-		if err != nil {
-			t.Fatalf("encode %d: %v", v, err)
-		}
-		return encoded
-	}
 	if tpraos {
 		if len(body) <= tPraosOCertOffset+1 {
 			t.Fatalf("TPraos header body has %d elements", len(body))
 		}
-		body[tPraosOCertOffset] = encode(sequenceNumber)
-		body[tPraosOCertOffset+1] = encode(kesPeriod)
+		if sequenceNumber != nil {
+			body[tPraosOCertOffset] = sequenceNumber
+		}
+		if kesPeriod != nil {
+			body[tPraosOCertOffset+1] = kesPeriod
+		}
 	} else {
 		if len(body) <= cPraosOCertIndex {
 			t.Fatalf("CPraos header body has %d elements", len(body))
@@ -122,8 +145,12 @@ func setOCertFields(
 				len(ocert),
 			)
 		}
-		ocert[1] = encode(sequenceNumber)
-		ocert[2] = encode(kesPeriod)
+		if sequenceNumber != nil {
+			ocert[1] = sequenceNumber
+		}
+		if kesPeriod != nil {
+			ocert[2] = kesPeriod
+		}
 		encodedOCert, err := cbor.Encode(ocert)
 		if err != nil {
 			t.Fatalf("encode operational certificate array: %v", err)
@@ -270,8 +297,11 @@ func TestGoldenHeaderOCertFieldsRejectNonIntegers(t *testing.T) {
 	} {
 		t.Run(testDef.name, func(t *testing.T) {
 			eraId, headerCbor := readGoldenHeader(t, testDef.golden)
-			blockType := ledger.BlockHeaderToBlockTypeMap[eraId]
-			for _, badCase := range []struct {
+			blockType, ok := ledger.BlockHeaderToBlockTypeMap[eraId]
+			if !ok {
+				t.Fatalf("no block type for era id %d", eraId)
+			}
+			badCases := []struct {
 				name  string
 				value cbor.RawMessage
 			}{
@@ -288,65 +318,45 @@ func TestGoldenHeaderOCertFieldsRejectNonIntegers(t *testing.T) {
 						0x00,
 					},
 				},
+			}
+			for _, field := range []struct {
+				name     string
+				sequence bool
+			}{
+				{name: "sequence number", sequence: true},
+				{name: "KES period"},
 			} {
-				t.Run(badCase.name, func(t *testing.T) {
-					modified := setOCertRaw(
-						t,
-						headerCbor,
-						testDef.tpraos,
-						badCase.value,
-					)
-					if _, err := ledger.NewBlockHeaderFromCbor(blockType, modified); err == nil {
-						t.Errorf(
-							"header with a %s sequence number decoded",
-							badCase.name,
-						)
+				t.Run(field.name, func(t *testing.T) {
+					for _, badCase := range badCases {
+						t.Run(badCase.name, func(t *testing.T) {
+							var sequenceNumber cbor.RawMessage
+							var kesPeriod cbor.RawMessage
+							if field.sequence {
+								sequenceNumber = badCase.value
+							} else {
+								kesPeriod = badCase.value
+							}
+							modified := setOCertRawFields(
+								t,
+								headerCbor,
+								testDef.tpraos,
+								sequenceNumber,
+								kesPeriod,
+							)
+							if _, err := ledger.NewBlockHeaderFromCbor(
+								blockType,
+								modified,
+							); err == nil {
+								t.Errorf(
+									"header with a %s %s decoded",
+									badCase.name,
+									field.name,
+								)
+							}
+						})
 					}
 				})
 			}
 		})
 	}
-}
-
-// setOCertRaw replaces the operational certificate sequence number with
-// arbitrary CBOR.
-func setOCertRaw(
-	t *testing.T,
-	headerCbor []byte,
-	tpraos bool,
-	value cbor.RawMessage,
-) []byte {
-	t.Helper()
-	var header []cbor.RawMessage
-	if _, err := cbor.Decode(headerCbor, &header); err != nil {
-		t.Fatalf("decode header array: %v", err)
-	}
-	var body []cbor.RawMessage
-	if _, err := cbor.Decode(header[0], &body); err != nil {
-		t.Fatalf("decode header body array: %v", err)
-	}
-	if tpraos {
-		body[tPraosOCertOffset] = value
-	} else {
-		var ocert []cbor.RawMessage
-		if _, err := cbor.Decode(body[cPraosOCertIndex], &ocert); err != nil {
-			t.Fatalf("decode operational certificate array: %v", err)
-		}
-		ocert[1] = value
-		encodedOCert, err := cbor.Encode(ocert)
-		if err != nil {
-			t.Fatalf("encode operational certificate array: %v", err)
-		}
-		body[cPraosOCertIndex] = encodedOCert
-	}
-	encodedBody, err := cbor.Encode(body)
-	if err != nil {
-		t.Fatalf("encode header body array: %v", err)
-	}
-	header[0] = encodedBody
-	encodedHeader, err := cbor.Encode(header)
-	if err != nil {
-		t.Fatalf("encode header array: %v", err)
-	}
-	return encodedHeader
 }

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -325,8 +325,8 @@ func (b *BabbageBlockHeaderBody) UnmarshalCBOR(cborData []byte) error {
 type BabbageOpCert struct {
 	cbor.StructAsArray
 	HotVkey        []byte
-	SequenceNumber uint32
-	KesPeriod      uint32
+	SequenceNumber uint64
+	KesPeriod      uint64
 	Signature      []byte
 }
 

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -227,8 +227,8 @@ type ShelleyBlockHeaderBody struct {
 	BlockBodySize        uint64
 	BlockBodyHash        common.Blake2b256
 	OpCertHotVkey        []byte
-	OpCertSequenceNumber uint32
-	OpCertKesPeriod      uint32
+	OpCertSequenceNumber uint64
+	OpCertKesPeriod      uint64
 	OpCertSignature      []byte
 	ProtoMajorVersion    uint64
 	ProtoMinorVersion    uint64
@@ -246,8 +246,8 @@ type shelleyBlockHeaderBodyWire struct {
 	BlockBodySize        uint64
 	BlockBodyHash        common.Blake2b256
 	OpCertHotVkey        []byte
-	OpCertSequenceNumber uint32
-	OpCertKesPeriod      uint32
+	OpCertSequenceNumber uint64
+	OpCertKesPeriod      uint64
 	OpCertSignature      []byte
 	ProtoMajorVersion    uint64
 	ProtoMinorVersion    uint64

--- a/ledger/verify_kes.go
+++ b/ledger/verify_kes.go
@@ -45,19 +45,19 @@ func ExtractKesFields(
 ) (signature []byte, hotVkey []byte, kesPeriod uint64, err error) {
 	switch h := header.(type) {
 	case *shelley.ShelleyBlockHeader:
-		return h.Signature, h.Body.OpCertHotVkey, uint64(h.Body.OpCertKesPeriod), nil
+		return h.Signature, h.Body.OpCertHotVkey, h.Body.OpCertKesPeriod, nil
 	case *allegra.AllegraBlockHeader:
-		return h.Signature, h.Body.OpCertHotVkey, uint64(h.Body.OpCertKesPeriod), nil
+		return h.Signature, h.Body.OpCertHotVkey, h.Body.OpCertKesPeriod, nil
 	case *mary.MaryBlockHeader:
-		return h.Signature, h.Body.OpCertHotVkey, uint64(h.Body.OpCertKesPeriod), nil
+		return h.Signature, h.Body.OpCertHotVkey, h.Body.OpCertKesPeriod, nil
 	case *alonzo.AlonzoBlockHeader:
-		return h.Signature, h.Body.OpCertHotVkey, uint64(h.Body.OpCertKesPeriod), nil
+		return h.Signature, h.Body.OpCertHotVkey, h.Body.OpCertKesPeriod, nil
 	case *babbage.BabbageBlockHeader:
-		return h.Signature, h.Body.OpCert.HotVkey, uint64(h.Body.OpCert.KesPeriod), nil
+		return h.Signature, h.Body.OpCert.HotVkey, h.Body.OpCert.KesPeriod, nil
 	case *conway.ConwayBlockHeader:
-		return h.Signature, h.Body.OpCert.HotVkey, uint64(h.Body.OpCert.KesPeriod), nil
+		return h.Signature, h.Body.OpCert.HotVkey, h.Body.OpCert.KesPeriod, nil
 	case *dijkstra.DijkstraBlockHeader:
-		return h.Signature, h.Body.OpCert.HotVkey, uint64(h.Body.OpCert.KesPeriod), nil
+		return h.Signature, h.Body.OpCert.HotVkey, h.Body.OpCert.KesPeriod, nil
 	default:
 		return nil, nil, 0, common.NewValidationError(
 			common.ValidationErrorTypeProtocol,

--- a/ledger/verify_opcert.go
+++ b/ledger/verify_opcert.go
@@ -204,8 +204,8 @@ func ValidateOpCert(
 // This is a convenience function for working with block headers.
 type OpCertExtractor interface {
 	OpCertHotVkey() []byte
-	OpCertSequenceNumber() uint32
-	OpCertKesPeriod() uint32
+	OpCertSequenceNumber() uint64
+	OpCertKesPeriod() uint64
 	OpCertSignature() []byte
 }
 
@@ -217,8 +217,8 @@ func ExtractOpCert(header OpCertExtractor) *OpCert {
 	}
 	return &OpCert{
 		KesVkey:       header.OpCertHotVkey(),
-		IssueNumber:   uint64(header.OpCertSequenceNumber()),
-		KesPeriod:     uint64(header.OpCertKesPeriod()),
+		IssueNumber:   header.OpCertSequenceNumber(),
+		KesPeriod:     header.OpCertKesPeriod(),
 		ColdSignature: header.OpCertSignature(),
 	}
 }


### PR DESCRIPTION
The operational certificate sequence number and KES period were `uint32` in every Shelley-family header body (`ledger/shelley/shelley.go:230-231`, `:249-250`) and in `BabbageOpCert` (`ledger/babbage/babbage.go:328-329`), which Conway and Dijkstra inherit.

## Reference decoder

`decodeOCertFields` decodes the counter as `Word64` and the period as `KESPeriod`, a `Word` newtype, each with a plain `decCBOR` and no bound (`libs/cardano-protocol/src/Cardano/Protocol/TPraos/OCert.hs:80-93`, `:122-128`). The CDDL agrees: `sequence_number = uint .size 8` and `kes_period = uint .size 8` (`eras/dijkstra/impl/cddl/data/dijkstra.cddl:88,90`).

## Where the constraint belongs

Nowhere in the decoder. The counter is bounded against ledger state by the OCERT rule and the period by the KES expiry check, both of which run after the header decodes. `ledger.ValidateKesPeriod` (`ledger/verify_opcert.go:118`) already rejects a period ahead of the block's own slot, and its underflow guard at `:134` holds for any 64-bit value. What still holds the line at decode is the CBOR major type: the fields remain unsigned integers, so a negative value, a byte string, and a 2^64 bignum are still rejected.

## Wire evidence

Taking the upstream `Header_*` goldens and setting `sequence_number` to 2^32 and `kes_period` to 2^32+7 makes all seven fail with `4294967296 overflows uint32`. The unmodified goldens decode. The reference decodes both.

Because this fails at decode, `handleRollForward` returns the error out of the ChainSync protocol handler (`protocol/chainsync/client.go:1019-1027`), tearing down the connection rather than rejecting one header.

## Changes

- `ledger/shelley/shelley.go`, `ledger/babbage/babbage.go`: the counter and period are `uint64` in the header body and its wire struct.
- `ledger/verify_opcert.go`: `OpCertExtractor` returns `uint64` for both, so an implementer built on a decoded header no longer has to narrow.
- `consensus/validate.go`: `ValidateHeaderInput` carries both as `uint64`. `common.OpCertSignableBytes` already serialized them as big-endian `uint64`, matching `OCertSignable`, so the signed bytes are unchanged for every value below 2^32.
- `consensus/block.go`: `OperationalCert` and `HeaderBody` carry both as `uint64`. CBOR integer encoding is minimal, so a produced header is byte-identical for any value that fit the old type.
- `ledger/verify_kes.go`: drops the conversions the narrower fields required.

## Tests

`internal/test/conformance/opcert_width_conformance_test.go`:

- `TestGoldenHeaderOCertCounterAndKesPeriodWidth` rewrites only the counter and period in each of the seven upstream `Header_*` goldens, decodes the result in Shelley, Allegra, Mary, Alonzo, Babbage, Conway and Dijkstra, checks both values survive, and checks the certificate is then rejected by `ledger.ValidateKesPeriod` rather than by the decoder. Every era fails this on `main` with `4294967296 overflows uint32`.
- `TestGoldenHeaderOCertFieldsRejectNonIntegers` keeps the negative controls: a negative counter, a byte-string counter and a 2^64 bignum are still rejected in both header shapes.

## Downstream

`blinklabs-io/dingo` passes the Shelley-family fields to `shelleyOpCert` (`ledger/verify_opcert.go:97-102`), whose parameters are `uint32`, and builds `babbage.BabbageOpCert` with `uint32(opCert.IssueNumber)` and `uint32(opCert.KESPeriod)` (`ledger/forging/builder.go:912-913`, `:935-936`). Both take the `uint64` value directly instead; the second drops a narrowing conversion on the forging path. Its other call sites — `ledger/verify_opcert.go:114-115`, `api/blockfrost/adapter.go:508-532`, `consensus/praos/view.go:164-179` — already widened to `uint64` and are unaffected.

Fixes #2245

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widen the operational certificate counter and KES period from `uint32` to `uint64` in every Shelley-family header body. A header carrying either value at or above 2^32 previously failed to decode and tore down the ChainSync connection; now it decodes and is rejected by `ValidateKesPeriod` or the OCERT rule, matching the reference decoder. Signed bytes and produced headers are byte-identical for every value that fit the old type, and non-integer CBOR values are still rejected at decode.

**Tests**
- A conformance test rewrites the counter and period in all seven upstream header goldens, checks the widened values decode in every era and are then rejected by `ValidateKesPeriod` instead of the decoder.
- Negative controls keep a negative value, byte string, and 2^64 bignum rejected at decode in either field.

**Downstream**
- `blinklabs-io/dingo`'s `shelleyOpCert` call site and the forging path take the `uint64` value directly instead of narrowing to `uint32`; its other call sites already used `uint64`.

<sup>Written for commit 094f76e8eb414dd2507bc1b1b50df067237d9a56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

