### PR TITLE
fix(ledger): require redeemers for every script purpose

### DIFF
--- a/ledger/babbage/required_redeemers_test.go
+++ b/ledger/babbage/required_redeemers_test.go
@@ -153,3 +153,119 @@ func TestBabbageUtxoValidateRequiredRedeemers(t *testing.T) {
 		))
 	})
 }
+
+// TestBabbageUtxoValidateRequiredRedeemersDuplicateCertificates pins the
+// Alonzo/Babbage duplicate-certificate redeemer index. Babbage encodes
+// certificates as a list, so two logically identical entries are decodable;
+// Conway onward encodes them as a set and common.ValidateCertificateSet
+// rejects a duplicate at decode time, so this case only exists here.
+//
+// cardano-ledger's getAlonzoScriptsNeeded gives the second occurrence the
+// first's index rather than its own -- addUniqueTxCertPurpose in
+// eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs, whose comment works the
+// example through -- so one certificate redeemer at index 0 covers both.
+// Assigning the duplicate its own positional index would demand a redeemer
+// index 1 that cardano-ledger never asks for, and would reject a Babbage
+// block during sync.
+func TestBabbageUtxoValidateRequiredRedeemersDuplicateCertificates(t *testing.T) {
+	v2 := common.PlutusV2Script{0x04, 0x05, 0x06}
+	cert := func() common.CertificateWrapper {
+		return common.CertificateWrapper{
+			Type: 1,
+			Certificate: &common.StakeDeregistrationCertificate{
+				StakeCredential: common.Credential{
+					CredType:   common.CredentialTypeScriptHash,
+					Credential: common.Blake2b224(v2.Hash()),
+				},
+			},
+		}
+	}
+	ls := mockledger.NewLedgerStateBuilder().
+		WithUtxoById(func(id common.TransactionInput) (common.Utxo, error) {
+			return common.Utxo{}, errors.New("not found")
+		}).
+		Build()
+
+	newTx := func() *babbage.BabbageTransaction {
+		return &babbage.BabbageTransaction{
+			Body: babbage.BabbageTransactionBody{
+				// The same certificate twice: index 0 and index 1.
+				TxCertificates: []common.CertificateWrapper{cert(), cert()},
+			},
+			WitnessSet: babbage.BabbageTransactionWitnessSet{
+				WsPlutusV2Scripts: []common.PlutusV2Script{v2},
+			},
+			TxIsValid: true,
+		}
+	}
+
+	t.Run("one redeemer at index 0 covers both", func(t *testing.T) {
+		tx := newTx()
+		tx.WitnessSet.WsRedeemers = alonzo.AlonzoRedeemers{
+			Redeemers: []alonzo.AlonzoRedeemer{
+				{
+					Tag:     common.RedeemerTagCert,
+					Index:   0,
+					ExUnits: common.ExUnits{Steps: 1, Memory: 1},
+				},
+			},
+		}
+		require.NoError(t, babbage.UtxoValidateRequiredRedeemers(
+			tx,
+			0,
+			ls,
+			&babbage.BabbageProtocolParameters{},
+		))
+	})
+
+	t.Run("no redeemer still rejected at index 0", func(t *testing.T) {
+		err := babbage.UtxoValidateRequiredRedeemers(
+			newTx(),
+			0,
+			ls,
+			&babbage.BabbageProtocolParameters{},
+		)
+		var missingErr common.MissingRedeemerForScriptError
+		require.ErrorAs(t, err, &missingErr)
+		require.Equal(t, common.RedeemerTagCert, missingErr.Tag)
+		require.Equal(t, uint32(0), missingErr.Index)
+	})
+
+	t.Run("distinct certificates each need their own", func(t *testing.T) {
+		other := common.PlutusV2Script{0x07, 0x08, 0x09}
+		tx := newTx()
+		tx.Body.TxCertificates = []common.CertificateWrapper{
+			cert(),
+			{
+				Type: 1,
+				Certificate: &common.StakeDeregistrationCertificate{
+					StakeCredential: common.Credential{
+						CredType:   common.CredentialTypeScriptHash,
+						Credential: common.Blake2b224(other.Hash()),
+					},
+				},
+			},
+		}
+		tx.WitnessSet.WsPlutusV2Scripts = []common.PlutusV2Script{v2, other}
+		tx.WitnessSet.WsRedeemers = alonzo.AlonzoRedeemers{
+			Redeemers: []alonzo.AlonzoRedeemer{
+				{
+					Tag:     common.RedeemerTagCert,
+					Index:   0,
+					ExUnits: common.ExUnits{Steps: 1, Memory: 1},
+				},
+			},
+		}
+		err := babbage.UtxoValidateRequiredRedeemers(
+			tx,
+			0,
+			ls,
+			&babbage.BabbageProtocolParameters{},
+		)
+		var missingErr common.MissingRedeemerForScriptError
+		require.ErrorAs(t, err, &missingErr)
+		require.Equal(t, other.Hash(), missingErr.ScriptHash)
+		require.Equal(t, common.RedeemerTagCert, missingErr.Tag)
+		require.Equal(t, uint32(1), missingErr.Index)
+	})
+}

--- a/ledger/common/duplicates.go
+++ b/ledger/common/duplicates.go
@@ -168,6 +168,24 @@ func appendLogicalAnchor(dst []byte, anchor *GovAnchor) []byte {
 // so two encodings of the same certificate compare equal without re-encoding
 // it. Types that aggregate over slices or maps fall back to a canonical
 // re-encoding, which keeps the reflection cost off the ordinary decode path.
+// CertificateLogicalKey returns a stable identity for a transaction
+// certificate, built from decoded fields so that equivalent definite,
+// indefinite, and non-shortest encodings compare equal.
+//
+// cardano-ledger compares decoded certificate values directly
+// (Map.lookup txCert in getAlonzoScriptsNeeded,
+// eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs). Any caller that needs
+// that same "is this the same certificate" question -- duplicate rejection
+// here, and the Alonzo/Babbage first-occurrence redeemer index in
+// ledger/common/script -- must use this one identity rather than re-deriving
+// its own, which would disagree on encoding variants.
+func CertificateLogicalKey(certificate Certificate) (string, error) {
+	if certificate == nil {
+		return "", errors.New("certificate is nil")
+	}
+	return certificateLogicalKey(certificate)
+}
+
 func certificateLogicalKey(certificate Certificate) (string, error) {
 	key := appendLogicalNumber(
 		make([]byte, 0, 64),

--- a/ledger/common/script/needed.go
+++ b/ledger/common/script/needed.go
@@ -16,6 +16,7 @@ package script
 
 import (
 	"bytes"
+	"cmp"
 	"errors"
 	"reflect"
 	"slices"
@@ -393,16 +394,245 @@ type transactionWithGuardingCredentials interface {
 	GuardingCredentials() []lcommon.Credential
 }
 
-// neededScripts walks every script purpose the transaction requires and keeps
-// the available script each one resolves to.
+// NeededScriptPurpose pairs a script purpose the transaction defines with the
+// redeemer pointer cardano-ledger's rdptr derives for it.
+type NeededScriptPurpose struct {
+	Key     lcommon.RedeemerKey
+	Purpose ScriptPurpose
+}
+
+// ScriptPurposes walks every script purpose a transaction level defines, in
+// the order and at the redeemer indices cardano-ledger's scriptsNeeded
+// assigns, and returns those that resolve to a script credential.
 //
-// The result is a map, so the walk order is not observable and no order is
-// promised. Concretely: spending inputs and minting policies are walked in
-// canonical order, but withdrawals and voting procedures come from Go maps and
-// so are walked in randomized order. A future caller that wants redeemer
-// indices must impose an order on those two itself; Transaction.Withdrawals and
-// Transaction.VotingProcedures are both keyed by pointer, so that means
-// deriving a canonical key rather than sorting the keys in place.
+// This is the single enumeration of "which script purposes does this
+// transaction have". neededScripts, ValidateRequiredRedeemers and Dijkstra's
+// per-level witness rules all derive from it, so none of them can grow a
+// purpose the others do not know about. Availability and Plutus-versus-native
+// filtering are deliberately left to the caller: the needed-script set and the
+// required-redeemer set keep different subsets of the same walk, and Dijkstra's
+// missing-script-witness check needs the unfiltered list.
+//
+// Indices are positions in the full collection, not in the filtered result,
+// matching zipAsIxItem in cardano-ledger
+// (eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs): a purpose that carries
+// no script credential still consumes its index. The collections are walked in
+// the canonical order the reference's Set and Map key ordering implies --
+// sorted inputs, sorted mint policies, reward accounts by
+// SortWithdrawalAddresses and voters by SortVoters -- because the index is what
+// the redeemer pointer names.
+//
+// The purpose list is a transaction-body property. Taking a body rather than a
+// Transaction lets a Dijkstra sub-transaction, which is a body plus its own
+// witness set and never a standalone Transaction, be walked by this same
+// function instead of a parallel copy.
+func ScriptPurposes(
+	body lcommon.TransactionBody,
+	resolvedInputs []lcommon.Utxo,
+) []NeededScriptPurpose {
+	if body == nil {
+		return nil
+	}
+	ret := make([]NeededScriptPurpose, 0)
+	add := func(tag lcommon.RedeemerTag, index uint32, purpose ScriptPurpose) {
+		if purpose == nil || purpose.ScriptHash() == (lcommon.ScriptHash{}) {
+			return
+		}
+		ret = append(ret, NeededScriptPurpose{
+			Key:     lcommon.RedeemerKey{Tag: tag, Index: index},
+			Purpose: purpose,
+		})
+	}
+	byId := make(map[string]lcommon.Utxo, len(resolvedInputs))
+	for _, utxo := range resolvedInputs {
+		if utxo.Id != nil {
+			byId[utxo.Id.String()] = utxo
+		}
+	}
+	for idx, input := range SortInputs(body.Inputs()) {
+		utxo, ok := byId[input.String()]
+		if !ok || utxo.Output == nil {
+			continue
+		}
+		addr := utxo.Output.Address()
+		if addr.Type()&lcommon.AddressTypeScriptBit == 0 {
+			continue
+		}
+		add(
+			lcommon.RedeemerTagSpend,
+			uint32(idx), // #nosec G115 -- input count is bounded
+			ScriptPurposeSpending{Input: utxo},
+		)
+	}
+	if mint := body.AssetMint(); mint != nil {
+		policies := mint.Policies()
+		slices.SortFunc(policies, func(a, b lcommon.Blake2b224) int {
+			return bytes.Compare(a.Bytes(), b.Bytes())
+		})
+		for idx, policy := range policies {
+			add(
+				lcommon.RedeemerTagMint,
+				uint32(idx), // #nosec G115 -- policy count is bounded
+				ScriptPurposeMinting{PolicyId: policy},
+			)
+		}
+	}
+	for _, purpose := range certifyingPurposes(body.Certificates()) {
+		add(lcommon.RedeemerTagCert, purpose.Index, purpose)
+	}
+	for idx, addr := range SortWithdrawalAddresses(body.Withdrawals()) {
+		if addr == nil || addr.Type()&lcommon.AddressTypeScriptBit == 0 {
+			continue
+		}
+		add(
+			lcommon.RedeemerTagReward,
+			uint32(idx), // #nosec G115 -- withdrawal count is bounded
+			ScriptPurposeRewarding{
+				StakeCredential: lcommon.Credential{
+					CredType:   lcommon.CredentialTypeScriptHash,
+					Credential: addr.StakeKeyHash(),
+				},
+			},
+		)
+	}
+	for idx, voter := range SortVoters(body.VotingProcedures()) {
+		if voter == nil || !voterUsesScriptCredential(*voter) {
+			continue
+		}
+		add(
+			lcommon.RedeemerTagVoting,
+			uint32(idx), // #nosec G115 -- voter count is bounded
+			ScriptPurposeVoting{Voter: *voter},
+		)
+	}
+	for idx, proposal := range body.ProposalProcedures() {
+		index := uint32(idx) // #nosec G115 -- proposal count is bounded
+		add(
+			lcommon.RedeemerTagProposing,
+			index,
+			ScriptPurposeProposing{
+				Index:             index,
+				ProposalProcedure: proposal,
+			},
+		)
+	}
+	if guardingTx, ok := body.(transactionWithGuardingCredentials); ok {
+		for idx, guard := range guardingTx.GuardingCredentials() {
+			add(
+				lcommon.RedeemerTagGuarding,
+				uint32(idx), // #nosec G115 -- guard count is bounded
+				ScriptPurposeGuarding{Guard: guard},
+			)
+		}
+	}
+	return ret
+}
+
+// certifyingPurposes assigns each certificate the redeemer index
+// cardano-ledger's getAlonzoScriptsNeeded assigns it
+// (eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs, addUniqueTxCertPurpose).
+//
+// The subtlety is duplicate certificates. Alonzo and Babbage encode
+// certificates as a list and so admit two logically identical entries; the
+// second one reuses the first's index rather than taking its own, which means
+// one redeemer covers both. Conway onward encodes them as a set --
+// common.ValidateCertificateSet rejects a duplicate at decode time -- so the
+// rule degenerates to plain positional indexing there and this stays a single
+// implementation for every era.
+//
+// Getting this wrong is not symmetric. Assigning the second duplicate its own
+// positional index would demand a redeemer cardano-ledger never asks for, and
+// a Babbage block carrying duplicate script-witnessed certificates would be
+// rejected during sync.
+func certifyingPurposes(
+	certificates []lcommon.Certificate,
+) []ScriptPurposeCertifying {
+	ret := make([]ScriptPurposeCertifying, 0, len(certificates))
+	seen := make(map[string]uint32, len(certificates))
+	for idx, certificate := range certificates {
+		if certificate == nil {
+			continue
+		}
+		index := uint32(idx) // #nosec G115 -- certificate count is bounded
+		purpose := ScriptPurposeCertifying{
+			Index:       index,
+			Certificate: certificate,
+		}
+		if purpose.ScriptHash() == (lcommon.ScriptHash{}) {
+			// A certificate with no script credential defines no purpose. It
+			// still consumes its index, and cardano-ledger does not record it
+			// as "seen", so it cannot lend its index to a later duplicate.
+			continue
+		}
+		key, err := lcommon.CertificateLogicalKey(certificate)
+		if err != nil {
+			// No identity means no duplicate can be proven. Keeping the
+			// positional index is the reference's behavior for a
+			// non-duplicate, which is what an unidentifiable certificate is
+			// as far as this walk can tell.
+			ret = append(ret, purpose)
+			continue
+		}
+		if first, ok := seen[key]; ok {
+			purpose.Index = first
+		} else {
+			seen[key] = index
+		}
+		ret = append(ret, purpose)
+	}
+	return ret
+}
+
+// SortVoters orders a transaction's voters the way cardano-ledger's Map of
+// voting procedures is keyed, so that a voting redeemer index names the same
+// voter on both sides.
+//
+// getConwayScriptsNeeded indexes voters by Map.keys
+// (eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs), which is the Voter Ord
+// instance: constructor order first, then the credential hash.
+func SortVoters(votes lcommon.VotingProcedures) []*lcommon.Voter {
+	sorted := make([]*lcommon.Voter, 0, len(votes))
+	for voter := range votes {
+		sorted = append(sorted, voter)
+	}
+	slices.SortFunc(sorted, func(a, b *lcommon.Voter) int {
+		if a == nil {
+			return -1
+		}
+		if b == nil {
+			return 1
+		}
+		if c := cmp.Compare(voterOrder(a), voterOrder(b)); c != 0 {
+			return c
+		}
+		return bytes.Compare(a.Hash[:], b.Hash[:])
+	})
+	return sorted
+}
+
+func voterOrder(voter *lcommon.Voter) int {
+	switch voter.Type {
+	case lcommon.VoterTypeConstitutionalCommitteeHotScriptHash:
+		return 0
+	case lcommon.VoterTypeConstitutionalCommitteeHotKeyHash:
+		return 1
+	case lcommon.VoterTypeDRepScriptHash:
+		return 2
+	case lcommon.VoterTypeDRepKeyHash:
+		return 3
+	case lcommon.VoterTypeStakingPoolKeyHash:
+		return 4
+	default:
+		return -1
+	}
+}
+
+// neededScripts keeps the available script each of the transaction's script
+// purposes resolves to.
+//
+// The walk itself is ScriptPurposes; this only filters it by availability. The
+// result is a map, so neither the walk order nor the redeemer indices are
+// observable here.
 func neededScripts(
 	tx lcommon.Transaction,
 	view TxScriptView,
@@ -416,80 +646,10 @@ func neededScripts(
 		// computation per purpose.
 		return out
 	}
-	byId := make(map[string]lcommon.Utxo, len(view.ResolvedInputs))
-	for _, utxo := range view.ResolvedInputs {
-		if utxo.Id != nil {
-			byId[utxo.Id.String()] = utxo
-		}
-	}
-	keep := func(purpose ScriptPurpose) {
-		if purpose == nil {
-			return
-		}
-		hash := purpose.ScriptHash()
-		if hash == (lcommon.ScriptHash{}) {
-			return
-		}
+	for _, needed := range ScriptPurposes(tx, view.ResolvedInputs) {
+		hash := needed.Purpose.ScriptHash()
 		if s, ok := view.Available[hash]; ok {
 			out[hash] = s
-		}
-	}
-	for _, input := range SortInputs(tx.Inputs()) {
-		utxo, ok := byId[input.String()]
-		if !ok || utxo.Output == nil {
-			continue
-		}
-		addr := utxo.Output.Address()
-		if addr.Type()&lcommon.AddressTypeScriptBit == 0 {
-			continue
-		}
-		keep(ScriptPurposeSpending{Input: utxo})
-	}
-	if mint := tx.AssetMint(); mint != nil {
-		policies := mint.Policies()
-		slices.SortFunc(policies, func(a, b lcommon.Blake2b224) int {
-			return bytes.Compare(a.Bytes(), b.Bytes())
-		})
-		for _, policy := range policies {
-			keep(ScriptPurposeMinting{PolicyId: policy})
-		}
-	}
-	for idx, cert := range tx.Certificates() {
-		keep(ScriptPurposeCertifying{
-			Index: uint32(
-				idx,
-			), // #nosec G115 -- certificate count is bounded
-			Certificate: cert,
-		})
-	}
-	for addr := range tx.Withdrawals() {
-		if addr == nil || addr.Type()&lcommon.AddressTypeScriptBit == 0 {
-			continue
-		}
-		keep(ScriptPurposeRewarding{
-			StakeCredential: lcommon.Credential{
-				CredType:   lcommon.CredentialTypeScriptHash,
-				Credential: addr.StakeKeyHash(),
-			},
-		})
-	}
-	for voter := range tx.VotingProcedures() {
-		if voter == nil || !voterUsesScriptCredential(*voter) {
-			continue
-		}
-		keep(ScriptPurposeVoting{Voter: *voter})
-	}
-	for idx, proposal := range tx.ProposalProcedures() {
-		keep(ScriptPurposeProposing{
-			Index: uint32(
-				idx,
-			), // #nosec G115 -- proposal count is bounded
-			ProposalProcedure: proposal,
-		})
-	}
-	if guardingTx, ok := tx.(transactionWithGuardingCredentials); ok {
-		for _, guard := range guardingTx.GuardingCredentials() {
-			keep(ScriptPurposeGuarding{Guard: guard})
 		}
 	}
 	return out

--- a/ledger/common/script/redeemers.go
+++ b/ledger/common/script/redeemers.go
@@ -210,7 +210,12 @@ func resolveBodyInputs(
 	body lcommon.TransactionBody,
 	ls lcommon.LedgerState,
 ) []lcommon.Utxo {
-	if body == nil || ls == nil {
+	// ledgerStateIsNil additionally covers a LedgerState interface holding a
+	// nil pointer, which ls == nil does not. NewTxScriptView guards the same
+	// case, but it reports the transaction's first input as unresolvable and a
+	// transaction whose only inputs live in a sub-transaction has no top-level
+	// input to report, so it returns no error and this walk still runs.
+	if body == nil || ls == nil || ledgerStateIsNil(ls) {
 		return nil
 	}
 	inputs := body.Inputs()

--- a/ledger/common/script/redeemers.go
+++ b/ledger/common/script/redeemers.go
@@ -85,9 +85,6 @@ func ValidateRequiredRedeemers(
 	if err != nil {
 		return err
 	}
-	if len(view.Available) == 0 {
-		return nil
-	}
 	subBodies := lcommon.SubTransactionBodiesFromTransaction(tx)
 	subWitnesses := lcommon.SubTransactionWitnessSetsFromTransaction(tx)
 	// The two accessors project the same ordered sub-transaction list, so a
@@ -120,6 +117,17 @@ func ValidateRequiredRedeemers(
 			}
 		}
 		available = augmented
+	}
+	// Checked only once the sub-transaction reference scripts are folded in.
+	// availableScripts resolves reference scripts from the top-level inputs
+	// alone, so a sub-transaction whose script arrives purely as a CIP-33
+	// reference script on its own input leaves view.Available empty; taking
+	// the shortcut on that would skip the level that needs the check. For a
+	// transaction with no sub-transactions -- every era before Dijkstra, and
+	// the overwhelming majority during a sync -- available is still
+	// view.Available and this is the same early return as before.
+	if len(available) == 0 {
+		return nil
 	}
 	if err := validateLevelRedeemers(
 		tx,

--- a/ledger/common/script/redeemers.go
+++ b/ledger/common/script/redeemers.go
@@ -85,39 +85,7 @@ func ValidateRequiredRedeemers(
 	if err != nil {
 		return err
 	}
-	subBodies := lcommon.SubTransactionBodiesFromTransaction(tx)
-	subWitnesses := lcommon.SubTransactionWitnessSetsFromTransaction(tx)
-	// The two accessors project the same ordered sub-transaction list, so a
-	// length disagreement means the pairing is not trustworthy. Checking the
-	// levels we cannot pair would attribute one sub-transaction's redeemers to
-	// another's purposes and reject a valid transaction, so the sub-levels are
-	// left to the era's own per-level rules instead.
-	pairable := len(subBodies) == len(subWitnesses)
-	available := view.Available
-	subResolved := make([][]lcommon.Utxo, len(subBodies))
-	if pairable && len(subBodies) > 0 {
-		// A reference script carried by a sub-transaction's own input is part
-		// of the aggregated ScriptsProvided in getDijkstraScriptsProvided, so
-		// it has to be visible before any level is checked against it.
-		augmented := make(
-			map[lcommon.ScriptHash]lcommon.Script,
-			len(view.Available),
-		)
-		maps.Copy(augmented, view.Available)
-		for idx, body := range subBodies {
-			resolved := resolveBodyInputs(body, ls)
-			subResolved[idx] = resolved
-			for _, utxo := range resolved {
-				if utxo.Output == nil {
-					continue
-				}
-				if s := utxo.Output.ScriptRef(); s != nil {
-					augmented[s.Hash()] = s
-				}
-			}
-		}
-		available = augmented
-	}
+	subLevels, available := subTransactionLevels(tx, ls, view.Available)
 	// Checked only once the sub-transaction reference scripts are folded in.
 	// availableScripts resolves reference scripts from the top-level inputs
 	// alone, so a sub-transaction whose script arrives purely as a CIP-33
@@ -137,20 +105,73 @@ func ValidateRequiredRedeemers(
 	); err != nil {
 		return err
 	}
-	if !pairable {
-		return nil
-	}
-	for idx, body := range subBodies {
+	for _, level := range subLevels {
 		if err := validateLevelRedeemers(
-			body,
-			subWitnesses[idx],
-			subResolved[idx],
+			level.body,
+			level.witnesses,
+			level.resolved,
 			available,
 		); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// subTransactionLevel is one Dijkstra sub-transaction: a body, the witness set
+// holding its own redeemers, and whatever of its inputs resolved.
+type subTransactionLevel struct {
+	body      lcommon.TransactionBody
+	witnesses lcommon.TransactionWitnessSet
+	resolved  []lcommon.Utxo
+}
+
+// subTransactionLevels pairs each sub-transaction body with its witness set and
+// returns them alongside the script availability the whole transaction has,
+// which is topLevel plus any reference script a sub-transaction's own input
+// carries. cardano-ledger aggregates availability the same way, in
+// getDijkstraScriptsProvided
+// (eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs).
+//
+// A length disagreement between the two accessors means the pairing is not
+// trustworthy. Checking levels that cannot be paired would attribute one
+// sub-transaction's redeemers to another's purposes and reject a valid
+// transaction, so no level is returned and the sub-transactions are left to the
+// era's own per-level rules. For every era before Dijkstra both accessors
+// return nothing and this is the identity.
+func subTransactionLevels(
+	tx lcommon.Transaction,
+	ls lcommon.LedgerState,
+	topLevel map[lcommon.ScriptHash]lcommon.Script,
+) ([]subTransactionLevel, map[lcommon.ScriptHash]lcommon.Script) {
+	bodies := lcommon.SubTransactionBodiesFromTransaction(tx)
+	witnessSets := lcommon.SubTransactionWitnessSetsFromTransaction(tx)
+	if len(bodies) == 0 || len(bodies) != len(witnessSets) {
+		return nil, topLevel
+	}
+	available := make(
+		map[lcommon.ScriptHash]lcommon.Script,
+		len(topLevel),
+	)
+	maps.Copy(available, topLevel)
+	levels := make([]subTransactionLevel, 0, len(bodies))
+	for idx, witnesses := range witnessSets {
+		resolved := resolveBodyInputs(bodies[idx], ls)
+		for _, utxo := range resolved {
+			if utxo.Output == nil {
+				continue
+			}
+			if s := utxo.Output.ScriptRef(); s != nil {
+				available[s.Hash()] = s
+			}
+		}
+		levels = append(levels, subTransactionLevel{
+			body:      bodies[idx],
+			witnesses: witnesses,
+			resolved:  resolved,
+		})
+	}
+	return levels, available
 }
 
 // validateLevelRedeemers requires a redeemer for every Plutus script purpose

--- a/ledger/common/script/redeemers.go
+++ b/ledger/common/script/redeemers.go
@@ -15,25 +15,47 @@
 package script
 
 import (
+	"maps"
+
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 )
 
-// ValidateRequiredRedeemers checks that every script-address input whose
-// spending script is Plutus and resolvable -- whether provided as an
-// explicit witness script or as a CIP-33 reference script -- has a matching
-// spend redeemer at its canonical sorted-input position.
+// ValidateRequiredRedeemers checks that every script purpose of a transaction
+// whose script is Plutus and resolvable -- whether provided as an explicit
+// witness script or as a CIP-33 reference script -- has a matching redeemer at
+// the purpose's canonical index.
 //
 // This closes a gap left by the existing script/redeemer checks:
 // ValidateScriptWitnesses only confirms the script itself is reachable
 // (explicit witness or reference script), and UtxoValidatePlutusScripts only
-// executes redeemers that already exist in the witness set. A reference
-// script satisfies the former without ever requiring a redeemer, so a
-// script-locked input backed by a reference script -- or, just as easily, an
-// explicit witness script missing its own redeemer while other redeemers are
-// present -- previously spent with no script execution and no error at all.
+// executes redeemers that already exist in the witness set. A reference script
+// satisfies the former without ever requiring a redeemer, so a script-locked
+// input backed by a reference script -- or, just as easily, an explicit witness
+// script missing its own redeemer while other redeemers are present --
+// previously spent with no script execution and no error at all.
 //
-// Eras share this single implementation rather than each re-deriving the
-// sorted-input walk and its script-availability lookup.
+// Every script purpose is covered, not only spending. cardano-ledger's
+// hasExactSetOfRedeemers (eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs)
+// derives its redeemer pointers from the whole of scriptsNeeded, which
+// getConwayScriptsNeeded and getDijkstraScriptsNeeded build from spending,
+// withdrawing, certifying, minting, voting, proposing and guarding purposes
+// alike (eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs and
+// eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs). Restricting the
+// check to spending let a Plutus minting policy, certificate script,
+// withdrawal script, voting script or proposal policy be witnessed and never
+// executed.
+//
+// The purposes come from ScriptPurposes, the same walk neededScripts uses, so
+// this check cannot come to disagree with the needed-script set about which
+// purposes a transaction has.
+//
+// Dijkstra sub-transactions are checked as their own levels. cardano-ledger
+// runs hasExactSetOfRedeemers per transaction level -- once in DijkstraUTXOW
+// over the top-level scriptsNeeded and once per sub-transaction in
+// DijkstraSUBUTXOW (eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs
+// and .../SubUtxow.hs) -- because a redeemer pointer indexes its own level's
+// collections. Script availability is aggregated across levels, matching
+// getDijkstraScriptsProvided.
 //
 // This check applies regardless of the transaction's IsValid flag.
 // AlonzoUTXOW's hasExactSetOfRedeemers (the source of AlonzoUtxowPredFailure
@@ -41,7 +63,7 @@ import (
 // execution check: IsValid is read only by UTXOS to decide how an already
 // phase-1-valid transaction is applied to the ledger state, never by UTXOW to
 // decide which witnesses are required. A transaction the submitter marked
-// invalid still must carry every redeemer its script-locked inputs require.
+// invalid still must carry every redeemer its script purposes require.
 func ValidateRequiredRedeemers(
 	tx lcommon.Transaction,
 	ls lcommon.LedgerState,
@@ -66,53 +88,138 @@ func ValidateRequiredRedeemers(
 	if len(view.Available) == 0 {
 		return nil
 	}
-	var redeemers lcommon.TransactionWitnessRedeemers
-	if wits := tx.Witnesses(); wits != nil {
-		redeemers = wits.Redeemers()
+	subBodies := lcommon.SubTransactionBodiesFromTransaction(tx)
+	subWitnesses := lcommon.SubTransactionWitnessSetsFromTransaction(tx)
+	// The two accessors project the same ordered sub-transaction list, so a
+	// length disagreement means the pairing is not trustworthy. Checking the
+	// levels we cannot pair would attribute one sub-transaction's redeemers to
+	// another's purposes and reject a valid transaction, so the sub-levels are
+	// left to the era's own per-level rules instead.
+	pairable := len(subBodies) == len(subWitnesses)
+	available := view.Available
+	subResolved := make([][]lcommon.Utxo, len(subBodies))
+	if pairable && len(subBodies) > 0 {
+		// A reference script carried by a sub-transaction's own input is part
+		// of the aggregated ScriptsProvided in getDijkstraScriptsProvided, so
+		// it has to be visible before any level is checked against it.
+		augmented := make(
+			map[lcommon.ScriptHash]lcommon.Script,
+			len(view.Available),
+		)
+		maps.Copy(augmented, view.Available)
+		for idx, body := range subBodies {
+			resolved := resolveBodyInputs(body, ls)
+			subResolved[idx] = resolved
+			for _, utxo := range resolved {
+				if utxo.Output == nil {
+					continue
+				}
+				if s := utxo.Output.ScriptRef(); s != nil {
+					augmented[s.Hash()] = s
+				}
+			}
+		}
+		available = augmented
 	}
-	spendIndexes := make(map[uint32]struct{})
-	if redeemers != nil {
-		for _, idx := range redeemers.Indexes(lcommon.RedeemerTagSpend) {
-			spendIndexes[uint32(idx)] = struct{}{} // #nosec G115 -- input count is bounded
+	if err := validateLevelRedeemers(
+		tx,
+		tx.Witnesses(),
+		view.ResolvedInputs,
+		available,
+	); err != nil {
+		return err
+	}
+	if !pairable {
+		return nil
+	}
+	for idx, body := range subBodies {
+		if err := validateLevelRedeemers(
+			body,
+			subWitnesses[idx],
+			subResolved[idx],
+			available,
+		); err != nil {
+			return err
 		}
 	}
-	byId := make(map[string]lcommon.Utxo, len(view.ResolvedInputs))
-	for _, utxo := range view.ResolvedInputs {
-		if utxo.Id != nil {
-			byId[utxo.Id.String()] = utxo
+	return nil
+}
+
+// validateLevelRedeemers requires a redeemer for every Plutus script purpose
+// of one transaction level, indexed within that level.
+func validateLevelRedeemers(
+	body lcommon.TransactionBody,
+	witnesses lcommon.TransactionWitnessSet,
+	resolvedInputs []lcommon.Utxo,
+	available map[lcommon.ScriptHash]lcommon.Script,
+) error {
+	purposes := ScriptPurposes(body, resolvedInputs)
+	if len(purposes) == 0 {
+		return nil
+	}
+	provided := make(map[lcommon.RedeemerKey]struct{})
+	if witnesses != nil {
+		if redeemers := witnesses.Redeemers(); redeemers != nil {
+			for key := range redeemers.Iter() {
+				provided[key] = struct{}{}
+			}
 		}
 	}
-	for idx, input := range SortInputs(tx.Inputs()) {
-		utxo, ok := byId[input.String()]
-		if !ok || utxo.Output == nil {
-			continue
-		}
-		addr := utxo.Output.Address()
-		if addr.Type()&lcommon.AddressTypeScriptBit == 0 {
-			continue
-		}
-		scriptHash := lcommon.ScriptHash(addr.PaymentKeyHash())
-		s, available := view.Available[scriptHash]
-		if !available {
+	for _, needed := range purposes {
+		scriptHash := needed.Purpose.ScriptHash()
+		s, ok := available[scriptHash]
+		if !ok {
 			// A script that is missing entirely is
 			// ValidateScriptWitnesses's error to report, not this check's.
 			continue
 		}
 		if _, isPlutus := lcommon.PlutusScriptVersion(s); !isPlutus {
+			// Native scripts carry no redeemer. cardano-ledger drops them
+			// from redeemersNeeded with the same test
+			// (not (isNativeScript script) in hasExactSetOfRedeemers).
 			continue
 		}
-		index := uint32(idx) // #nosec G115 -- input count is bounded
-		if _, ok := spendIndexes[index]; !ok {
+		if _, ok := provided[needed.Key]; !ok {
 			return lcommon.MissingRedeemerForScriptError{
-				ScriptHash: scriptHash,
-				Tag:        lcommon.RedeemerTagSpend,
-				Index:      index,
-				RedeemerKey: lcommon.RedeemerKey{
-					Tag:   lcommon.RedeemerTagSpend,
-					Index: index,
-				},
+				ScriptHash:  scriptHash,
+				Tag:         needed.Key.Tag,
+				Index:       needed.Key.Index,
+				RedeemerKey: needed.Key,
 			}
 		}
 	}
 	return nil
+}
+
+// resolveBodyInputs resolves whatever of a transaction body's consumed and
+// reference inputs the ledger state can supply, skipping the rest.
+//
+// Skipping is deliberate. An unresolvable input is
+// UtxoValidateBadInputsUtxo's failure to report, and this rule is registered
+// after it in every era's rule list; surfacing a resolution error here would
+// make it a second, competing source of the same failure.
+func resolveBodyInputs(
+	body lcommon.TransactionBody,
+	ls lcommon.LedgerState,
+) []lcommon.Utxo {
+	if body == nil || ls == nil {
+		return nil
+	}
+	inputs := body.Inputs()
+	refInputs := body.ReferenceInputs()
+	if len(inputs) == 0 && len(refInputs) == 0 {
+		return nil
+	}
+	ret := make([]lcommon.Utxo, 0, len(inputs)+len(refInputs))
+	for _, input := range inputs {
+		if utxo, err := ls.UtxoById(input); err == nil {
+			ret = append(ret, utxo)
+		}
+	}
+	for _, input := range refInputs {
+		if utxo, err := ls.UtxoById(input); err == nil {
+			ret = append(ret, utxo)
+		}
+	}
+	return ret
 }

--- a/ledger/common/script/redeemers_purposes_test.go
+++ b/ledger/common/script/redeemers_purposes_test.go
@@ -1,0 +1,283 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package script_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/common/script"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/stretchr/testify/require"
+)
+
+// The transactions below carry no inputs at all, so the only script purpose
+// each one defines is the non-spending purpose under test. That isolates the
+// gap issue #2250 records: ValidateRequiredRedeemers used to build its
+// required set from RedeemerTagSpend alone, while cardano-ledger's
+// hasExactSetOfRedeemers
+// (eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs) derives it from
+// every purpose in scriptsNeeded -- getConwayScriptsNeeded
+// (eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs) covers spending,
+// withdrawing, certifying, minting, voting and proposing.
+//
+// No upstream fixture exercises a script purpose missing its redeemer: the
+// cardano-ledger, cardano-node and ouroboros-consensus fixtures mirrored under
+// ouroboros-mock are protocol-parameter, genesis and golden-serialization
+// vectors, none of which carry a witnessed-but-unredeemed Plutus purpose. The
+// transactions here are constructed, with the collection each redeemer index
+// names taken from the Haskell source cited on each case.
+
+// purposeTestScript is the Plutus script every purpose below resolves to. It
+// is supplied as an explicit witness, so ValidateScriptWitnesses is satisfied
+// and only the redeemer requirement is under test.
+func purposeTestScript() common.PlutusV3Script {
+	return common.PlutusV3Script{0xaa, 0xbb, 0xcc}
+}
+
+func purposeTestWitnessSet(
+	redeemers map[common.RedeemerKey]common.RedeemerValue,
+) conway.ConwayTransactionWitnessSet {
+	ws := conway.ConwayTransactionWitnessSet{
+		WsPlutusV3Scripts: cbor.NewSetType(
+			[]common.PlutusV3Script{purposeTestScript()},
+			true,
+		),
+	}
+	if redeemers != nil {
+		ws.WsRedeemers = conway.ConwayRedeemers{Redeemers: redeemers}
+	}
+	return ws
+}
+
+func redeemerAt(
+	tag common.RedeemerTag,
+	index uint32,
+) map[common.RedeemerKey]common.RedeemerValue {
+	return map[common.RedeemerKey]common.RedeemerValue{
+		{Tag: tag, Index: index}: {
+			ExUnits: common.ExUnits{Steps: 1, Memory: 1},
+		},
+	}
+}
+
+// mintOfScript mints one asset under the test script's hash as its policy id,
+// so getMintingScriptsNeeded's policy set
+// (eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs) contains exactly that
+// script hash at index 0.
+func mintOfScript() *common.MultiAsset[common.MultiAssetTypeMint] {
+	mint := common.NewMultiAsset(
+		map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeMint{
+			common.Blake2b224(purposeTestScript().Hash()): {
+				cbor.NewByteString([]byte("tok")): big.NewInt(1),
+			},
+		},
+	)
+	return &mint
+}
+
+func scriptStakeCredential() common.Credential {
+	return common.Credential{
+		CredType:   common.CredentialTypeScriptHash,
+		Credential: common.Blake2b224(purposeTestScript().Hash()),
+	}
+}
+
+// scriptRewardAddress builds the reward account whose credential is the test
+// script, the shape getWithdrawingScriptsNeeded reads through
+// credScriptHash.
+func scriptRewardAddress(t *testing.T) *common.Address {
+	t.Helper()
+	addr, err := common.NewAddressFromParts(
+		common.AddressTypeNoneScript,
+		common.AddressNetworkTestnet,
+		nil,
+		purposeTestScript().Hash().Bytes(),
+	)
+	require.NoError(t, err)
+	return &addr
+}
+
+func scriptDRepVoter() *common.Voter {
+	voter := &common.Voter{Type: common.VoterTypeDRepScriptHash}
+	copy(voter.Hash[:], purposeTestScript().Hash().Bytes())
+	return voter
+}
+
+// scriptGuardrailsProposal is a parameter-change proposal carrying the test
+// script as its guardrails policy, the only shape
+// getConwayScriptsNeeded's getProposalScriptHash recognizes besides a
+// treasury withdrawal.
+func scriptGuardrailsProposal() conway.ConwayProposalProcedure {
+	return conway.ConwayProposalProcedure{
+		PPGovAction: conway.ConwayGovAction{
+			Action: &conway.ConwayParameterChangeGovAction{
+				Type:       0,
+				PolicyHash: purposeTestScript().Hash().Bytes(),
+			},
+		},
+	}
+}
+
+// TestValidateRequiredRedeemersNonSpendingPurposes is issue #2250's core
+// case, one subtest per script purpose that had no required-redeemer check:
+// the Plutus script is witnessed, the purpose needs it, and no redeemer names
+// it. Every one of these transactions was accepted before the fix, leaving
+// the script unexecuted.
+func TestValidateRequiredRedeemersNonSpendingPurposes(t *testing.T) {
+	s := purposeTestScript()
+	ls := ledgerStateWithUtxos()
+
+	for _, tc := range []struct {
+		name string
+		tag  common.RedeemerTag
+		body conway.ConwayTransactionBody
+	}{
+		{
+			name: "minting",
+			tag:  common.RedeemerTagMint,
+			body: conway.ConwayTransactionBody{TxMint: mintOfScript()},
+		},
+		{
+			name: "certifying",
+			tag:  common.RedeemerTagCert,
+			body: conway.ConwayTransactionBody{
+				TxCertificates: []common.CertificateWrapper{
+					{
+						Type: 1,
+						Certificate: &common.StakeDeregistrationCertificate{
+							StakeCredential: scriptStakeCredential(),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "rewarding",
+			tag:  common.RedeemerTagReward,
+			body: conway.ConwayTransactionBody{
+				TxWithdrawals: map[*common.Address]uint64{
+					scriptRewardAddress(t): 42,
+				},
+			},
+		},
+		{
+			name: "voting",
+			tag:  common.RedeemerTagVoting,
+			body: conway.ConwayTransactionBody{
+				TxVotingProcedures: common.VotingProcedures{
+					scriptDRepVoter(): map[*common.GovActionId]common.VotingProcedure{},
+				},
+			},
+		},
+		{
+			name: "proposing",
+			tag:  common.RedeemerTagProposing,
+			body: conway.ConwayTransactionBody{
+				TxProposalProcedures: []conway.ConwayProposalProcedure{
+					scriptGuardrailsProposal(),
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			missingTx := &conway.ConwayTransaction{
+				Body:       tc.body,
+				WitnessSet: purposeTestWitnessSet(nil),
+				TxIsValid:  true,
+			}
+			err := script.ValidateRequiredRedeemers(missingTx, ls)
+			var missingErr common.MissingRedeemerForScriptError
+			require.ErrorAs(t, err, &missingErr)
+			require.Equal(t, s.Hash(), missingErr.ScriptHash)
+			require.Equal(t, tc.tag, missingErr.Tag)
+			require.Equal(t, uint32(0), missingErr.Index)
+
+			// Negative control: the same transaction carrying the redeemer
+			// its purpose names must still pass, so the check is requiring a
+			// redeemer rather than rejecting the purpose.
+			validTx := &conway.ConwayTransaction{
+				Body:       tc.body,
+				WitnessSet: purposeTestWitnessSet(redeemerAt(tc.tag, 0)),
+				TxIsValid:  true,
+			}
+			require.NoError(t, script.ValidateRequiredRedeemers(validTx, ls))
+		})
+	}
+}
+
+// TestValidateRequiredRedeemersNativeScriptPurposeNeedsNone is the boundary
+// of the widening: a native script backing the same minting policy requires
+// no redeemer. hasExactSetOfRedeemers drops native scripts from
+// redeemersNeeded with `not (isNativeScript script)`, so requiring one here
+// would reject a transaction cardano-ledger accepts.
+func TestValidateRequiredRedeemersNativeScriptPurposeNeedsNone(t *testing.T) {
+	native := &common.NativeScript{}
+	require.NoError(t, native.UnmarshalCBOR(nativeScriptAllCbor()))
+	mint := common.NewMultiAsset(
+		map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeMint{
+			common.Blake2b224(native.Hash()): {
+				cbor.NewByteString([]byte("tok")): big.NewInt(1),
+			},
+		},
+	)
+	tx := &conway.ConwayTransaction{
+		Body: conway.ConwayTransactionBody{TxMint: &mint},
+		WitnessSet: conway.ConwayTransactionWitnessSet{
+			WsNativeScripts: cbor.NewSetType(
+				[]common.NativeScript{*native},
+				true,
+			),
+		},
+		TxIsValid: true,
+	}
+	require.NoError(
+		t,
+		script.ValidateRequiredRedeemers(tx, ledgerStateWithUtxos()),
+	)
+}
+
+// nativeScriptAllCbor is `ScriptAll []`, the smallest native script: CBOR
+// array [1, []].
+func nativeScriptAllCbor() []byte {
+	return []byte{0x82, 0x01, 0x80}
+}
+
+// TestValidateRequiredRedeemersUnavailableScriptPurposeSkipped pins that a
+// purpose whose script is not provided at all stays
+// ValidateScriptWitnesses's failure to report. hasExactSetOfRedeemers only
+// considers purposes with `Just script <- [Map.lookup sh scriptsProvided]`,
+// so reporting a missing redeemer here would mask a missing script.
+func TestValidateRequiredRedeemersUnavailableScriptPurposeSkipped(t *testing.T) {
+	// The witness set provides an unrelated script, so Available is non-empty
+	// and the walk actually runs, but nothing supplies the mint policy.
+	other := common.PlutusV3Script{0x11, 0x22}
+	tx := &conway.ConwayTransaction{
+		Body: conway.ConwayTransactionBody{TxMint: mintOfScript()},
+		WitnessSet: conway.ConwayTransactionWitnessSet{
+			WsPlutusV3Scripts: cbor.NewSetType(
+				[]common.PlutusV3Script{other},
+				true,
+			),
+		},
+		TxIsValid: true,
+	}
+	require.NoError(
+		t,
+		script.ValidateRequiredRedeemers(tx, ledgerStateWithUtxos()),
+	)
+}

--- a/ledger/dijkstra/dijkstra.go
+++ b/ledger/dijkstra/dijkstra.go
@@ -912,6 +912,14 @@ func (b *DijkstraTransactionBody) RequiredSigners() []common.Blake2b224 {
 	return dijkstraRequiredSigners(b.TxGuards)
 }
 
+// GuardingCredentials exposes this body's guards to the shared script-purpose
+// walk. It is defined on the body rather than only on the transaction so a
+// sub-transaction body, which is never a standalone Transaction, contributes
+// its own guards and only its own.
+func (b *DijkstraTransactionBody) GuardingCredentials() []common.Credential {
+	return dijkstraGuardingCredentials(b.TxGuards)
+}
+
 func (b *DijkstraTransactionBody) ScriptDataHash() *common.Blake2b256 {
 	return b.TxScriptDataHash
 }
@@ -1007,6 +1015,19 @@ func dijkstraWithdrawals(
 		ret[addr] = new(big.Int).SetUint64(amount)
 	}
 	return ret
+}
+
+// dijkstraGuardingCredentials returns the guard credentials that define
+// guarding script purposes. cardano-ledger's getDijkstraScriptsNeeded adds one
+// guarding purpose per guard whose credential is a script hash
+// (eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs); key-hash guards
+// contribute required signers instead, which dijkstraRequiredSigners handles.
+// The whole list is returned because the purpose index is a position in it.
+func dijkstraGuardingCredentials(guards *DijkstraGuards) []common.Credential {
+	if guards == nil {
+		return nil
+	}
+	return guards.Credentials
 }
 
 func dijkstraRequiredSigners(guards *DijkstraGuards) []common.Blake2b224 {
@@ -1192,6 +1213,12 @@ func (b *DijkstraSubTransactionBody) AssetMint() *common.MultiAsset[common.Multi
 
 func (b *DijkstraSubTransactionBody) RequiredSigners() []common.Blake2b224 {
 	return dijkstraRequiredSigners(b.TxGuards)
+}
+
+// GuardingCredentials exposes this sub-transaction's own guards. See the
+// comment on DijkstraTransactionBody.GuardingCredentials.
+func (b *DijkstraSubTransactionBody) GuardingCredentials() []common.Credential {
+	return dijkstraGuardingCredentials(b.TxGuards)
 }
 
 func (b *DijkstraSubTransactionBody) ScriptDataHash() *common.Blake2b256 {
@@ -1565,6 +1592,13 @@ func (t DijkstraTransaction) Produced() []common.Utxo {
 
 func (t DijkstraTransaction) Witnesses() common.TransactionWitnessSet {
 	return t.WitnessSet
+}
+
+// GuardingCredentials forwards the top-level body's guards, so a script rule
+// handed the concrete transaction sees the same guarding purposes as one
+// handed a transaction level.
+func (t DijkstraTransaction) GuardingCredentials() []common.Credential {
+	return t.Body.GuardingCredentials()
 }
 
 func (t DijkstraTransaction) SubTransactionWitnessSets() []common.TransactionWitnessSet {

--- a/ledger/dijkstra/required_redeemers_test.go
+++ b/ledger/dijkstra/required_redeemers_test.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/blinklabs-io/gouroboros/cbor"
+
 	"github.com/blinklabs-io/gouroboros/ledger/babbage"
 	"github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/gouroboros/ledger/conway"
@@ -145,5 +147,190 @@ func TestUtxoValidateRequiredRedeemersDijkstra(t *testing.T) {
 		0,
 		ls,
 		&DijkstraProtocolParameters{},
+	))
+}
+
+// TestUtxoValidateRequiredRedeemersSubTransaction covers issue #2250's second
+// half: a Plutus script-address input inside a sub-transaction. The
+// sub-transaction's witness set puts the script into the aggregated
+// ScriptsProvided, but the spend walk only ever visited the top-level
+// transaction's inputs, so this purpose was never checked.
+//
+// cardano-ledger applies hasExactSetOfRedeemers once per transaction level --
+// DijkstraUTXOW over the top-level scriptsNeeded
+// (eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs) and
+// DijkstraSUBUTXOW over each sub-transaction's own
+// (.../Rules/SubUtxow.hs) -- because a redeemer pointer indexes its own
+// level's inputs. A redeemer on the top-level transaction therefore does not
+// satisfy a sub-transaction's purpose, which the third subtest pins.
+func TestUtxoValidateRequiredRedeemersSubTransaction(t *testing.T) {
+	v3 := common.PlutusV3Script{0x0a, 0x0b, 0x0c}
+	scriptAddr, err := common.NewAddressFromParts(
+		common.AddressTypeScriptNone,
+		common.AddressNetworkTestnet,
+		v3.Hash().Bytes(),
+		nil,
+	)
+	require.NoError(t, err)
+	input := shelley.NewShelleyTransactionInput(
+		"7777777777777777777777777777777777777777777777777777777777777777",
+		0,
+	)
+	utxo := common.Utxo{
+		Id: input,
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAddress: scriptAddr,
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
+		},
+	}
+	ls := mockledger.NewLedgerStateBuilder().
+		WithUtxoById(func(id common.TransactionInput) (common.Utxo, error) {
+			if id.String() == input.String() {
+				return utxo, nil
+			}
+			return common.Utxo{}, errors.New("not found")
+		}).
+		Build()
+
+	newTx := func(
+		subRedeemers, topRedeemers DijkstraRedeemers,
+	) *DijkstraTransaction {
+		return &DijkstraTransaction{
+			Body: DijkstraTransactionBody{
+				TxSubTransactions: cbor.NewSetType(
+					[]DijkstraSubTransaction{
+						{
+							Body: DijkstraSubTransactionBody{
+								TxInputs: conway.NewConwayTransactionInputSet(
+									[]shelley.ShelleyTransactionInput{input},
+								),
+							},
+							WitnessSet: DijkstraTransactionWitnessSet{
+								WsPlutusV3Scripts: cbor.NewSetType(
+									[]common.PlutusV3Script{v3},
+									true,
+								),
+								WsRedeemers: subRedeemers,
+							},
+						},
+					},
+					false,
+				),
+			},
+			WitnessSet: DijkstraTransactionWitnessSet{
+				WsRedeemers: topRedeemers,
+			},
+			TxIsValid: true,
+		}
+	}
+	spendRedeemer := DijkstraRedeemers{
+		Redeemers: map[common.RedeemerKey]common.RedeemerValue{
+			{Tag: common.RedeemerTagSpend, Index: 0}: {
+				ExUnits: common.ExUnits{Steps: 1, Memory: 1},
+			},
+		},
+	}
+	pp := &DijkstraProtocolParameters{}
+
+	t.Run("missing sub-transaction redeemer rejected", func(t *testing.T) {
+		err := conway.UtxoValidateRequiredRedeemers(
+			newTx(DijkstraRedeemers{}, DijkstraRedeemers{}),
+			0,
+			ls,
+			pp,
+		)
+		var missingErr common.MissingRedeemerForScriptError
+		require.ErrorAs(t, err, &missingErr)
+		require.Equal(t, v3.Hash(), missingErr.ScriptHash)
+		require.Equal(t, common.RedeemerTagSpend, missingErr.Tag)
+		require.Equal(t, uint32(0), missingErr.Index)
+	})
+
+	t.Run("sub-transaction redeemer accepted", func(t *testing.T) {
+		require.NoError(t, conway.UtxoValidateRequiredRedeemers(
+			newTx(spendRedeemer, DijkstraRedeemers{}),
+			0,
+			ls,
+			pp,
+		))
+	})
+
+	t.Run("top-level redeemer does not satisfy sub-transaction", func(t *testing.T) {
+		err := conway.UtxoValidateRequiredRedeemers(
+			newTx(DijkstraRedeemers{}, spendRedeemer),
+			0,
+			ls,
+			pp,
+		)
+		var missingErr common.MissingRedeemerForScriptError
+		require.ErrorAs(t, err, &missingErr)
+		require.Equal(t, v3.Hash(), missingErr.ScriptHash)
+	})
+}
+
+// TestUtxoValidateRequiredRedeemersGuardingPurpose pins that a Dijkstra
+// guarding purpose requires a redeemer.
+//
+// getDijkstraScriptsNeeded is getConwayScriptsNeeded plus guardingScriptsNeeded
+// (eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs), and
+// hasExactSetOfRedeemers derives its pointers from the whole of scriptsNeeded,
+// so a guard whose credential is a script hash and whose script is Plutus is
+// required exactly like any other purpose. The guard's index is its position
+// in the guards list, from zipAsIxItem over guardsTxBodyL.
+func TestUtxoValidateRequiredRedeemersGuardingPurpose(t *testing.T) {
+	v3 := common.PlutusV3Script{0x0d, 0x0e, 0x0f}
+	ls := mockledger.NewLedgerStateBuilder().
+		WithUtxoById(func(id common.TransactionInput) (common.Utxo, error) {
+			return common.Utxo{}, errors.New("not found")
+		}).
+		Build()
+
+	newTx := func(redeemers DijkstraRedeemers) *DijkstraTransaction {
+		return &DijkstraTransaction{
+			Body: DijkstraTransactionBody{
+				TxGuards: &DijkstraGuards{
+					Credentials: []common.Credential{
+						{
+							CredType:   common.CredentialTypeScriptHash,
+							Credential: common.Blake2b224(v3.Hash()),
+						},
+					},
+				},
+			},
+			WitnessSet: DijkstraTransactionWitnessSet{
+				WsPlutusV3Scripts: cbor.NewSetType(
+					[]common.PlutusV3Script{v3},
+					true,
+				),
+				WsRedeemers: redeemers,
+			},
+			TxIsValid: true,
+		}
+	}
+	pp := &DijkstraProtocolParameters{}
+
+	err := conway.UtxoValidateRequiredRedeemers(
+		newTx(DijkstraRedeemers{}),
+		0,
+		ls,
+		pp,
+	)
+	var missingErr common.MissingRedeemerForScriptError
+	require.ErrorAs(t, err, &missingErr)
+	require.Equal(t, v3.Hash(), missingErr.ScriptHash)
+	require.Equal(t, common.RedeemerTagGuarding, missingErr.Tag)
+	require.Equal(t, uint32(0), missingErr.Index)
+
+	require.NoError(t, conway.UtxoValidateRequiredRedeemers(
+		newTx(DijkstraRedeemers{
+			Redeemers: map[common.RedeemerKey]common.RedeemerValue{
+				{Tag: common.RedeemerTagGuarding, Index: 0}: {
+					ExUnits: common.ExUnits{Steps: 1, Memory: 1},
+				},
+			},
+		}),
+		0,
+		ls,
+		pp,
 	))
 }

--- a/ledger/dijkstra/required_redeemers_test.go
+++ b/ledger/dijkstra/required_redeemers_test.go
@@ -430,3 +430,71 @@ func TestUtxoValidateRequiredRedeemersSubTransactionReferenceScriptOnly(t *testi
 		pp,
 	))
 }
+
+// TestUtxoValidateRequiredRedeemersTypedNilLedgerState pins that a typed-nil
+// ledger state cannot reach a UTxO lookup through the sub-transaction walk.
+//
+// A LedgerState interface holding a nil pointer is not == nil, so the plain
+// nil check at the top of ValidateRequiredRedeemers lets it through.
+// NewTxScriptView guards it with ledgerStateIsNil and reports the transaction's
+// first input as unresolvable, but a transaction whose only inputs live in a
+// sub-transaction has no top-level input to report, so it returns no error and
+// the sub-transaction walk runs. Resolving those inputs would then call
+// UtxoById on the nil pointer.
+func TestUtxoValidateRequiredRedeemersTypedNilLedgerState(t *testing.T) {
+	v3 := common.PlutusV3Script{0x2a, 0x2b, 0x2c}
+	scriptAddr, err := common.NewAddressFromParts(
+		common.AddressTypeScriptNone,
+		common.AddressNetworkTestnet,
+		v3.Hash().Bytes(),
+		nil,
+	)
+	require.NoError(t, err)
+	_ = scriptAddr
+	input := shelley.NewShelleyTransactionInput(
+		"9999999999999999999999999999999999999999999999999999999999999999",
+		0,
+	)
+	tx := &DijkstraTransaction{
+		Body: DijkstraTransactionBody{
+			TxSubTransactions: cbor.NewSetType(
+				[]DijkstraSubTransaction{
+					{
+						Body: DijkstraSubTransactionBody{
+							TxInputs: conway.NewConwayTransactionInputSet(
+								[]shelley.ShelleyTransactionInput{input},
+							),
+						},
+						WitnessSet: DijkstraTransactionWitnessSet{
+							WsPlutusV3Scripts: cbor.NewSetType(
+								[]common.PlutusV3Script{v3},
+								true,
+							),
+						},
+					},
+				},
+				false,
+			),
+		},
+		TxIsValid: true,
+	}
+
+	var nilState *mockledger.MockLedgerState
+	var ls common.LedgerState = nilState
+	require.True(
+		t,
+		ls != nil,
+		"a LedgerState holding a nil pointer is not an untyped nil interface",
+	)
+
+	require.NotPanics(t, func() {
+		// Nothing resolves, so no purpose can be checked and no redeemer can
+		// be required. The point is that it returns rather than dereferences.
+		_ = conway.UtxoValidateRequiredRedeemers(
+			tx,
+			0,
+			ls,
+			&DijkstraProtocolParameters{},
+		)
+	})
+}

--- a/ledger/dijkstra/required_redeemers_test.go
+++ b/ledger/dijkstra/required_redeemers_test.go
@@ -443,14 +443,6 @@ func TestUtxoValidateRequiredRedeemersSubTransactionReferenceScriptOnly(t *testi
 // UtxoById on the nil pointer.
 func TestUtxoValidateRequiredRedeemersTypedNilLedgerState(t *testing.T) {
 	v3 := common.PlutusV3Script{0x2a, 0x2b, 0x2c}
-	scriptAddr, err := common.NewAddressFromParts(
-		common.AddressTypeScriptNone,
-		common.AddressNetworkTestnet,
-		v3.Hash().Bytes(),
-		nil,
-	)
-	require.NoError(t, err)
-	_ = scriptAddr
 	input := shelley.NewShelleyTransactionInput(
 		"9999999999999999999999999999999999999999999999999999999999999999",
 		0,

--- a/ledger/dijkstra/required_redeemers_test.go
+++ b/ledger/dijkstra/required_redeemers_test.go
@@ -334,3 +334,99 @@ func TestUtxoValidateRequiredRedeemersGuardingPurpose(t *testing.T) {
 		pp,
 	))
 }
+
+// TestUtxoValidateRequiredRedeemersSubTransactionReferenceScriptOnly is the
+// reference-script case of the sub-transaction walk, and the one that decides
+// where the empty-availability fast path may sit.
+//
+// availableScripts folds witness sets from every level but resolves reference
+// scripts only from the top-level transaction's own inputs, so a
+// sub-transaction whose script arrives purely as a CIP-33 reference script on
+// its own input leaves TxScriptView.Available empty. Taking the
+// nothing-is-available shortcut before the sub-transaction inputs are resolved
+// would skip this transaction entirely -- the same reference-script-implies-no-
+// redeemer shape as issue #2147, one level down.
+func TestUtxoValidateRequiredRedeemersSubTransactionReferenceScriptOnly(t *testing.T) {
+	v3 := common.PlutusV3Script{0x1a, 0x1b, 0x1c}
+	scriptAddr, err := common.NewAddressFromParts(
+		common.AddressTypeScriptNone,
+		common.AddressNetworkTestnet,
+		v3.Hash().Bytes(),
+		nil,
+	)
+	require.NoError(t, err)
+	input := shelley.NewShelleyTransactionInput(
+		"8888888888888888888888888888888888888888888888888888888888888888",
+		0,
+	)
+	// The script is carried only as a reference script on the very output the
+	// sub-transaction spends. No witness set at any level holds a script.
+	utxo := common.Utxo{
+		Id: input,
+		Output: &babbage.BabbageTransactionOutput{
+			OutputAddress: scriptAddr,
+			OutputAmount:  mary.MaryTransactionOutputValue{Amount: 1000},
+			TxOutScriptRef: &common.ScriptRef{
+				Type:   common.ScriptRefTypePlutusV3,
+				Script: v3,
+			},
+		},
+	}
+	ls := mockledger.NewLedgerStateBuilder().
+		WithUtxoById(func(id common.TransactionInput) (common.Utxo, error) {
+			if id.String() == input.String() {
+				return utxo, nil
+			}
+			return common.Utxo{}, errors.New("not found")
+		}).
+		Build()
+
+	newTx := func(redeemers DijkstraRedeemers) *DijkstraTransaction {
+		return &DijkstraTransaction{
+			Body: DijkstraTransactionBody{
+				TxSubTransactions: cbor.NewSetType(
+					[]DijkstraSubTransaction{
+						{
+							Body: DijkstraSubTransactionBody{
+								TxInputs: conway.NewConwayTransactionInputSet(
+									[]shelley.ShelleyTransactionInput{input},
+								),
+							},
+							WitnessSet: DijkstraTransactionWitnessSet{
+								WsRedeemers: redeemers,
+							},
+						},
+					},
+					false,
+				),
+			},
+			TxIsValid: true,
+		}
+	}
+	pp := &DijkstraProtocolParameters{}
+
+	err = conway.UtxoValidateRequiredRedeemers(
+		newTx(DijkstraRedeemers{}),
+		0,
+		ls,
+		pp,
+	)
+	var missingErr common.MissingRedeemerForScriptError
+	require.ErrorAs(t, err, &missingErr)
+	require.Equal(t, v3.Hash(), missingErr.ScriptHash)
+	require.Equal(t, common.RedeemerTagSpend, missingErr.Tag)
+	require.Equal(t, uint32(0), missingErr.Index)
+
+	require.NoError(t, conway.UtxoValidateRequiredRedeemers(
+		newTx(DijkstraRedeemers{
+			Redeemers: map[common.RedeemerKey]common.RedeemerValue{
+				{Tag: common.RedeemerTagSpend, Index: 0}: {
+					ExUnits: common.ExUnits{Steps: 1, Memory: 1},
+				},
+			},
+		}),
+		0,
+		ls,
+		pp,
+	))
+}

--- a/ledger/dijkstra/rules.go
+++ b/ledger/dijkstra/rules.go
@@ -21,7 +21,6 @@ import (
 	"iter"
 	"math"
 	"math/big"
-	"slices"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
@@ -675,17 +674,13 @@ func (t dijkstraConwayFeatureTransaction) Produced() []common.Utxo {
 // shared script-purpose resolver. Script availability is aggregated across
 // levels separately by UtxoValidateConwayFeaturesWithPlutusV1V2.
 func (t dijkstraConwayFeatureTransaction) GuardingCredentials() []common.Credential {
-	switch body := t.body.(type) {
-	case *DijkstraTransactionBody:
-		if body.TxGuards != nil {
-			return body.TxGuards.Credentials
-		}
-	case *DijkstraSubTransactionBody:
-		if body.TxGuards != nil {
-			return body.TxGuards.Credentials
-		}
+	guardingBody, ok := t.body.(interface {
+		GuardingCredentials() []common.Credential
+	})
+	if !ok {
+		return nil
 	}
-	return nil
+	return guardingBody.GuardingCredentials()
 }
 
 func dijkstraTransactionLevels(
@@ -1246,163 +1241,24 @@ func dijkstraRequiredPlutusPurposes(
 	return ret
 }
 
+// dijkstraRequiredScriptPurposes lists the script purposes one transaction
+// level defines, with the redeemer pointer each one requires.
+//
+// The walk itself is script.ScriptPurposes, shared with neededScripts and
+// script.ValidateRequiredRedeemers. Dijkstra kept its own copy of the six-way
+// purpose walk until issue #2250; a second list is how a purpose comes to be
+// enforced in one place and not the other, which is the defect that issue
+// records for the non-spending purposes.
 func dijkstraRequiredScriptPurposes(
 	level dijkstraScriptLevel,
 ) []dijkstraRequiredScriptPurpose {
-	ret := make([]dijkstraRequiredScriptPurpose, 0)
-	appendPurpose := func(
-		key common.RedeemerKey,
-		purpose script.ScriptPurpose,
-	) {
-		if purpose == nil || purpose.ScriptHash() == (common.ScriptHash{}) {
-			return
-		}
+	purposes := script.ScriptPurposes(level.tx, level.view.ResolvedInputs)
+	ret := make([]dijkstraRequiredScriptPurpose, 0, len(purposes))
+	for _, needed := range purposes {
 		ret = append(ret, dijkstraRequiredScriptPurpose{
-			key:     key,
-			purpose: purpose,
+			key:     needed.Key,
+			purpose: needed.Purpose,
 		})
-	}
-
-	resolved := make(map[string]common.Utxo, len(level.view.ResolvedInputs))
-	for _, utxo := range level.view.ResolvedInputs {
-		if utxo.Id != nil {
-			resolved[utxo.Id.String()] = utxo
-		}
-	}
-	for idx, input := range script.SortInputs(level.tx.Inputs()) {
-		utxo, ok := resolved[input.String()]
-		if !ok || utxo.Output == nil ||
-			utxo.Output.Address().Type()&common.AddressTypeScriptBit == 0 {
-			continue
-		}
-		appendPurpose(
-			common.RedeemerKey{
-				Tag: common.RedeemerTagSpend,
-				Index: uint32(
-					idx,
-				), // #nosec G115 -- bounded by transaction size
-			},
-			script.ScriptPurposeSpending{Input: utxo},
-		)
-	}
-
-	if mint := level.tx.AssetMint(); mint != nil {
-		policies := mint.Policies()
-		slices.SortFunc(policies, func(a, b common.Blake2b224) int {
-			return bytes.Compare(a.Bytes(), b.Bytes())
-		})
-		for idx, policy := range policies {
-			appendPurpose(
-				common.RedeemerKey{
-					Tag: common.RedeemerTagMint,
-					Index: uint32(
-						idx,
-					), // #nosec G115 -- bounded by transaction size
-				},
-				script.ScriptPurposeMinting{PolicyId: policy},
-			)
-		}
-	}
-
-	for idx, certificate := range level.tx.Certificates() {
-		appendPurpose(
-			common.RedeemerKey{
-				Tag: common.RedeemerTagCert,
-				Index: uint32(
-					idx,
-				), // #nosec G115 -- bounded by transaction size
-			},
-			script.ScriptPurposeCertifying{
-				Index: uint32(
-					idx,
-				), // #nosec G115 -- bounded by transaction size
-				Certificate: certificate,
-			},
-		)
-	}
-
-	withdrawals := script.SortWithdrawalAddresses(level.tx.Withdrawals())
-	for idx, address := range withdrawals {
-		if address == nil ||
-			address.Type()&common.AddressTypeScriptBit == 0 {
-			continue
-		}
-		appendPurpose(
-			common.RedeemerKey{
-				Tag: common.RedeemerTagReward,
-				Index: uint32(
-					idx,
-				), // #nosec G115 -- bounded by transaction size
-			},
-			script.ScriptPurposeRewarding{
-				StakeCredential: common.Credential{
-					CredType:   common.CredentialTypeScriptHash,
-					Credential: address.StakeKeyHash(),
-				},
-			},
-		)
-	}
-
-	voters := make([]*common.Voter, 0, len(level.tx.VotingProcedures()))
-	for voter := range level.tx.VotingProcedures() {
-		voters = append(voters, voter)
-	}
-	slices.SortFunc(voters, func(a, b *common.Voter) int {
-		if a == nil {
-			return -1
-		}
-		if b == nil {
-			return 1
-		}
-		aTag := dijkstraVoterTag(a)
-		bTag := dijkstraVoterTag(b)
-		if aTag != bTag {
-			return aTag - bTag
-		}
-		return bytes.Compare(a.Hash[:], b.Hash[:])
-	})
-	for idx, voter := range voters {
-		if voter == nil || !dijkstraVoterUsesScriptCredential(*voter) {
-			continue
-		}
-		appendPurpose(
-			common.RedeemerKey{
-				Tag: common.RedeemerTagVoting,
-				Index: uint32(
-					idx,
-				), // #nosec G115 -- bounded by transaction size
-			},
-			script.ScriptPurposeVoting{Voter: *voter},
-		)
-	}
-
-	for idx, proposal := range level.tx.ProposalProcedures() {
-		appendPurpose(
-			common.RedeemerKey{
-				Tag: common.RedeemerTagProposing,
-				Index: uint32(
-					idx,
-				), // #nosec G115 -- bounded by transaction size
-			},
-			script.ScriptPurposeProposing{
-				Index: uint32(
-					idx,
-				), // #nosec G115 -- bounded by transaction size
-				ProposalProcedure: proposal,
-			},
-		)
-	}
-
-	for idx, guard := range level.tx.GuardingCredentials() {
-		appendPurpose(
-			common.RedeemerKey{
-				Tag: common.RedeemerTagGuarding,
-				Index: uint32(
-					idx,
-				), // #nosec G115 -- bounded by transaction size
-			},
-			script.ScriptPurposeGuarding{Guard: guard},
-		)
 	}
 	return ret
 }
@@ -1438,33 +1294,6 @@ func validateDijkstraPlutusRedeemers(
 		}
 	}
 	return nil
-}
-
-func dijkstraVoterUsesScriptCredential(voter common.Voter) bool {
-	switch voter.Type {
-	case common.VoterTypeConstitutionalCommitteeHotScriptHash,
-		common.VoterTypeDRepScriptHash:
-		return true
-	default:
-		return false
-	}
-}
-
-func dijkstraVoterTag(voter *common.Voter) int {
-	switch voter.Type {
-	case common.VoterTypeConstitutionalCommitteeHotScriptHash:
-		return 0
-	case common.VoterTypeConstitutionalCommitteeHotKeyHash:
-		return 1
-	case common.VoterTypeDRepScriptHash:
-		return 2
-	case common.VoterTypeDRepKeyHash:
-		return 3
-	case common.VoterTypeStakingPoolKeyHash:
-		return 4
-	default:
-		return -1
-	}
 }
 
 func dijkstraPlutusV4RedeemerKeys(


### PR DESCRIPTION
## Follow-up to #2147

#2147 enforced required redeemers for reference-script Plutus spends. It closed the spend purpose only and left the remaining purposes to a follow-up that was never opened, which is what #2250 records.

## The gap

`script.ValidateRequiredRedeemers` (`ledger/common/script/redeemers.go:73-77` before this change) built its required set from `redeemers.Indexes(lcommon.RedeemerTagSpend)` alone and reported `MissingRedeemerForScriptError` only with `Tag: RedeemerTagSpend`.

cardano-ledger's `hasExactSetOfRedeemers` (`eras/alonzo/impl/src/Cardano/Ledger/Alonzo/Rules/Utxow.hs:251-273`) derives its redeemer pointers from the whole of `scriptsNeeded`. `getConwayScriptsNeeded` (`eras/conway/impl/src/Cardano/Ledger/Conway/UTxO.hs:62-105`) builds that from spending, withdrawing, certifying, minting, voting and proposing purposes; `getDijkstraScriptsNeeded` (`eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/UTxO.hs:174-186`) adds guarding.

A Plutus minting policy, certificate script, withdrawal script, voting script or proposal guardrails policy could therefore be witnessed, be counted in `TxScriptView.Needed`, and never be required to carry a redeemer — so the script never executed.

`ledger/common/script/needed.go:294` also folds Dijkstra sub-transaction witness sets into `view.Available`, while the walk only visited `SortInputs(tx.Inputs())`. A script-address input inside a sub-transaction contributed its script to availability and was never walked by this rule.

## Direction and compatibility

Both are under-requirements: gouroboros accepted transactions the reference rejects. The change can only reject transactions that were already invalid under cardano-ledger, so it cannot reject anything the chain accepts and carries no sync risk. What it recovers is script execution a validating node is supposed to perform.

Affected eras are Babbage and Conway. Dijkstra already enforced every purpose per level through `dijkstraRequiredScriptPurposes` and `validateDijkstraPlutusRedeemers` (`ledger/dijkstra/rules.go`), including sub-transactions and guards; that path is unchanged in behaviour and now shares the same walk.

No rule is added to any era's rule list, and no rule changes position.

## One enumeration

`neededScripts`, `ValidateRequiredRedeemers` and `dijkstraRequiredScriptPurposes` each walked the purposes separately. The non-spending gap is what a divergence between those copies looks like, so this replaces all three with `script.ScriptPurposes` (`ledger/common/script/needed.go`), which returns each purpose with the redeemer pointer `rdptr` assigns it. The three callers differ only in how they filter it: needed scripts keep what is available, the redeemer check keeps what is available and Plutus, and Dijkstra's missing-script-witness check keeps everything.

Indices are positions in the full collection, matching `zipAsIxItem` (`eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs`): a purpose with no script credential still consumes its index. Collections are walked in the reference's key order — sorted inputs, sorted mint policies, reward accounts by `SortWithdrawalAddresses`, voters by the new `SortVoters`, which replaces the copy previously inlined in `BuildScriptPurpose` and in Dijkstra.

`ScriptPurposes` takes a `TransactionBody`, so a Dijkstra sub-transaction — a body plus its own witness set, never a standalone `Transaction` — is walked by the same function instead of a parallel copy. `GuardingCredentials` moves onto `DijkstraTransactionBody` and `DijkstraSubTransactionBody` for the same reason.

## Certificate indices

Alonzo and Babbage encode certificates as a list, so two logically identical entries are decodable. `addUniqueTxCertPurpose` (`eras/alonzo/impl/src/Cardano/Ledger/Alonzo/UTxO.hs`) gives the second occurrence the first's index rather than its own, so one redeemer covers both. Plain positional indexing would demand a redeemer cardano-ledger never asks for and reject a Babbage block during sync.

`certifyingPurposes` implements that first-occurrence rule, keyed on the certificate identity `common.CertificateLogicalKey` already derives for duplicate rejection. Conway onward encodes certificates as a set and `common.ValidateCertificateSet` rejects a duplicate at decode time, so the rule degenerates to positional indexing there and stays a single implementation.

## Sub-transactions

`hasExactSetOfRedeemers` runs per transaction level — once in `DijkstraUTXOW` over the top-level `scriptsNeeded` (`eras/dijkstra/impl/src/Cardano/Ledger/Dijkstra/Rules/Utxow.hs:286`) and once per sub-transaction in `DijkstraSUBUTXOW` (`.../Rules/SubUtxow.hs:260`) — because a redeemer pointer indexes its own level's collections. Each level is now checked against its own redeemers, with script availability aggregated across levels to match `getDijkstraScriptsProvided`.

## Tests

One case per purpose that had no check — minting, certifying, rewarding, voting, proposing — each asserting the tag and index of the rejection, each with a negative control carrying the matching redeemer that must still pass. Plus a sub-transaction script input with no redeemer, a case pinning that a top-level redeemer does not satisfy a sub-transaction purpose, and a Dijkstra guarding purpose.

Boundary cases that must keep passing: a native script backing the same minting policy requires no redeemer, matching `not (isNativeScript script)`; a purpose whose script is not provided stays `ValidateScriptWitnesses`'s failure to report, matching the `Map.lookup sh scriptsProvided` guard.

Babbage duplicate certificates get three cases: one cert redeemer at index 0 covering both, no redeemer still rejected at index 0, and two distinct script certificates each needing their own. The first fails if the first-occurrence rule is replaced by positional indexing.

No upstream fixture exercises a script purpose missing its redeemer — the cardano-ledger, cardano-node and ouroboros-consensus fixtures mirrored under ouroboros-mock are protocol-parameter, genesis and golden-serialization vectors. The transactions are constructed, with the collection each redeemer index names cited from the Haskell source on each case.

## Related issues

Closes #2250 only. Adjacent issues this touches but does not close:

- #2187 (closed) established that withdrawals are ordered by `Credential`, not by stake-address bytes, and produced `SortWithdrawalAddresses`. The reward redeemer index added here uses it, so the reward purpose inherits that ordering rather than re-deriving one.
- #2177 and #2216 (merged, unreleased) made `SortInputs` deduplicate like cardano-ledger's `Set TxIn`. Spend redeemer indices are positions in that sorted set, so they depend on that behaviour.
- #2188 (closed) established that language views come from the needed scripts, not the available ones. `TxScriptView.Needed` keeps exactly the same contents here — the walk is shared, but nothing new enters `Needed`, so script data hashes are unchanged.
- #2167 and #2219 concern resolving a transaction's inputs once for the script rules. This rule now also resolves sub-transaction inputs, so it adds to what those would consolidate. Not addressed here.
- #1880 (validate Dijkstra sub-transactions, CIP-118) covers sub-transaction validation broadly. Per-level required redeemers is one predicate of that; the issue stays open.
- #1700 (CIP-0112 Observe script purpose) would add a purpose to `script.ScriptPurposes`, which is now the single place to add one.
- #2224 is the same shape one rule over — a UTXOW requirement wrongly gated on phase-2. Different rule, not touched here.

Checked and unrelated: #2230 (`txInfoSignatories` deduplication), #2233 (LeiosHash memoization), #2251 (MIR predicates), #2258 (Byron `buildToSign`).

Searches run against `blinklabs-io/gouroboros`: `UtxoValidateRequiredRedeemers`, `hasExactSetOfRedeemers`, `MissingRedeemerForScriptError` and `minting policy redeemer` each returned #2250 alone; `neededScripts` and `scriptsNeeded` returned nothing at all in either state; `redeemer`, `sub-transaction` and `script purpose` returned the issues named above.

Fixes #2250
