### PR TITLE
fix(ledger): recompute LeiosHash instead of caching it

### DIFF
--- a/ledger/allegra/allegra.go
+++ b/ledger/allegra/allegra.go
@@ -335,7 +335,6 @@ func (b *AllegraTransactionBody) Utxorpc() (*utxorpc.Tx, error) {
 type AllegraTransaction struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
-	hash       *common.Blake2b256
 	Body       AllegraTransactionBody
 	WitnessSet shelley.ShelleyTransactionWitnessSet
 	TxMetadata common.TransactionMetadatum
@@ -344,7 +343,6 @@ type AllegraTransaction struct {
 
 func (t *AllegraTransaction) UnmarshalCBOR(cborData []byte) error {
 	// Reset cached/derived fields to avoid stale state on receiver reuse
-	t.hash = nil
 	t.TxMetadata = nil
 	t.auxData = nil
 
@@ -421,12 +419,12 @@ func (t AllegraTransaction) Id() common.Blake2b256 {
 	return t.Body.Id()
 }
 
+// LeiosHash returns the Blake2b-256 hash of the transaction's CBOR. The value
+// is recomputed on every call: it is not memoized on the transaction, because
+// era transaction types are copied by value and an in-struct cache cannot be
+// populated safely from a shared receiver.
 func (t AllegraTransaction) LeiosHash() common.Blake2b256 {
-	if t.hash == nil {
-		tmpHash := common.Blake2b256Hash(t.Cbor())
-		t.hash = &tmpHash
-	}
-	return *t.hash
+	return common.Blake2b256Hash(t.Cbor())
 }
 
 func (t AllegraTransaction) Inputs() []common.TransactionInput {

--- a/ledger/alonzo/alonzo.go
+++ b/ledger/alonzo/alonzo.go
@@ -873,7 +873,6 @@ func (w AlonzoTransactionWitnessSet) Redeemers() common.TransactionWitnessRedeem
 type AlonzoTransaction struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
-	hash       *common.Blake2b256
 	Body       AlonzoTransactionBody
 	WitnessSet AlonzoTransactionWitnessSet
 	TxIsValid  bool
@@ -883,7 +882,6 @@ type AlonzoTransaction struct {
 
 func (t *AlonzoTransaction) UnmarshalCBOR(cborData []byte) error {
 	// Reset cached/derived fields to avoid stale state on receiver reuse
-	t.hash = nil
 	t.TxMetadata = nil
 	t.auxData = nil
 
@@ -977,12 +975,12 @@ func (t AlonzoTransaction) Id() common.Blake2b256 {
 	return t.Body.Id()
 }
 
+// LeiosHash returns the Blake2b-256 hash of the transaction's CBOR. The value
+// is recomputed on every call: it is not memoized on the transaction, because
+// era transaction types are copied by value and an in-struct cache cannot be
+// populated safely from a shared receiver.
 func (t AlonzoTransaction) LeiosHash() common.Blake2b256 {
-	if t.hash == nil {
-		tmpHash := common.Blake2b256Hash(t.Cbor())
-		t.hash = &tmpHash
-	}
-	return *t.hash
+	return common.Blake2b256Hash(t.Cbor())
 }
 
 func (t AlonzoTransaction) Inputs() []common.TransactionInput {

--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -1052,7 +1052,6 @@ func (w BabbageTransactionWitnessSet) Redeemers() common.TransactionWitnessRedee
 type BabbageTransaction struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
-	hash       *common.Blake2b256
 	Body       BabbageTransactionBody
 	WitnessSet BabbageTransactionWitnessSet
 	TxIsValid  bool
@@ -1062,7 +1061,6 @@ type BabbageTransaction struct {
 
 func (t *BabbageTransaction) UnmarshalCBOR(cborData []byte) error {
 	// Reset cached/derived fields to avoid stale state on receiver reuse
-	t.hash = nil
 	t.TxMetadata = nil
 	t.auxData = nil
 
@@ -1156,12 +1154,12 @@ func (t BabbageTransaction) Id() common.Blake2b256 {
 	return t.Body.Id()
 }
 
+// LeiosHash returns the Blake2b-256 hash of the transaction's CBOR. The value
+// is recomputed on every call: it is not memoized on the transaction, because
+// era transaction types are copied by value and an in-struct cache cannot be
+// populated safely from a shared receiver.
 func (t BabbageTransaction) LeiosHash() common.Blake2b256 {
-	if t.hash == nil {
-		tmpHash := common.Blake2b256Hash(t.Cbor())
-		t.hash = &tmpHash
-	}
-	return *t.hash
+	return common.Blake2b256Hash(t.Cbor())
 }
 
 func (t BabbageTransaction) Inputs() []common.TransactionInput {

--- a/ledger/byron/byron.go
+++ b/ledger/byron/byron.go
@@ -350,7 +350,6 @@ func (t *ByronTransactionBody) ProtocolParameterUpdates() (uint64, map[common.Bl
 type ByronTransaction struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
-	hash       *common.Blake2b256
 	Body       ByronTransactionBody
 	Twit       []cbor.Value
 	twitCbor   []byte // Original CBOR of witnesses for merkle tree computation
@@ -520,12 +519,12 @@ func (t *ByronTransaction) AuxiliaryData() common.AuxiliaryData {
 	return nil
 }
 
+// LeiosHash returns the Blake2b-256 hash of the transaction's CBOR. The value
+// is recomputed on every call: it is not memoized on the transaction, because
+// era transaction types are copied by value and an in-struct cache cannot be
+// populated safely from a shared receiver.
 func (t *ByronTransaction) LeiosHash() common.Blake2b256 {
-	if t.hash == nil {
-		tmpHash := common.Blake2b256Hash(t.Cbor())
-		t.hash = &tmpHash
-	}
-	return *t.hash
+	return common.Blake2b256Hash(t.Cbor())
 }
 
 func (t *ByronTransaction) IsValid() bool {

--- a/ledger/common/tx.go
+++ b/ledger/common/tx.go
@@ -35,6 +35,10 @@ type Transaction interface {
 	Type() int
 	Cbor() []byte
 	Hash() Blake2b256
+	// LeiosHash returns the Blake2b-256 hash of the transaction's CBOR.
+	// Implementations recompute it on every call rather than caching it on
+	// the transaction: era transaction types are copied by value, so an
+	// in-struct cache cannot be populated safely from a shared receiver.
 	LeiosHash() Blake2b256
 	Metadata() TransactionMetadatum
 	AuxiliaryData() AuxiliaryData

--- a/ledger/conway/conway.go
+++ b/ledger/conway/conway.go
@@ -947,7 +947,6 @@ func (b *ConwayTransactionBody) Utxorpc() (*utxorpc.Tx, error) {
 type ConwayTransaction struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
-	hash       *common.Blake2b256
 	Body       ConwayTransactionBody
 	WitnessSet ConwayTransactionWitnessSet
 	TxIsValid  bool
@@ -957,7 +956,6 @@ type ConwayTransaction struct {
 
 func (t *ConwayTransaction) UnmarshalCBOR(cborData []byte) error {
 	// Reset cached/derived fields to avoid stale state on receiver reuse
-	t.hash = nil
 	t.TxMetadata = nil
 	t.auxData = nil
 
@@ -1051,12 +1049,12 @@ func (t ConwayTransaction) Id() common.Blake2b256 {
 	return t.Body.Id()
 }
 
+// LeiosHash returns the Blake2b-256 hash of the transaction's CBOR. The value
+// is recomputed on every call: it is not memoized on the transaction, because
+// era transaction types are copied by value and an in-struct cache cannot be
+// populated safely from a shared receiver.
 func (t ConwayTransaction) LeiosHash() common.Blake2b256 {
-	if t.hash == nil {
-		tmpHash := common.Blake2b256Hash(t.Cbor())
-		t.hash = &tmpHash
-	}
-	return *t.hash
+	return common.Blake2b256Hash(t.Cbor())
 }
 
 func (t ConwayTransaction) Inputs() []common.TransactionInput {

--- a/ledger/dijkstra/dijkstra.go
+++ b/ledger/dijkstra/dijkstra.go
@@ -1383,7 +1383,6 @@ func (w DijkstraTransactionWitnessSet) Redeemers() common.TransactionWitnessRede
 type DijkstraTransaction struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
-	hash       *common.Blake2b256
 	Body       DijkstraTransactionBody
 	WitnessSet DijkstraTransactionWitnessSet
 	TxIsValid  bool
@@ -1420,12 +1419,12 @@ func (t DijkstraTransaction) Id() common.Blake2b256 {
 	return t.Body.Id()
 }
 
+// LeiosHash returns the Blake2b-256 hash of the transaction's CBOR. The value
+// is recomputed on every call: it is not memoized on the transaction, because
+// era transaction types are copied by value and an in-struct cache cannot be
+// populated safely from a shared receiver.
 func (t *DijkstraTransaction) LeiosHash() common.Blake2b256 {
-	if t.hash == nil {
-		tmpHash := common.Blake2b256Hash(t.Cbor())
-		t.hash = &tmpHash
-	}
-	return *t.hash
+	return common.Blake2b256Hash(t.Cbor())
 }
 
 func (t DijkstraTransaction) Inputs() []common.TransactionInput {

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -1401,16 +1401,3 @@ func TestDijkstraParameterChangeGovActionDecodesDijkstraUpdateFields(
 		*decodedAction.ParamUpdate.MaxRefScriptSizePerBlock,
 	)
 }
-
-func TestDijkstraTransactionLeiosHashCaches(t *testing.T) {
-	tx := &DijkstraTransaction{}
-	tx.SetCbor([]byte{0x83, 0xa0, 0xa0, 0xa0})
-
-	first := tx.LeiosHash()
-	require.NotNil(t, tx.hash)
-	cached := tx.hash
-
-	second := tx.LeiosHash()
-	require.Equal(t, first, second)
-	require.True(t, cached == tx.hash)
-}

--- a/ledger/leios_hash_test.go
+++ b/ledger/leios_hash_test.go
@@ -1,0 +1,233 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests that pin the LeiosHash contract for every era transaction type:
+// LeiosHash is the Blake2b-256 hash of the transaction's current CBOR, it is
+// recomputed on every call rather than memoized, the transaction types stay
+// copyable, and concurrent callers on one shared transaction agree. They live
+// in package ledger_test rather than in each era package so that a new era
+// cannot be added without being listed here.
+
+package ledger_test
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/allegra"
+	"github.com/blinklabs-io/gouroboros/ledger/alonzo"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/conway"
+	"github.com/blinklabs-io/gouroboros/ledger/dijkstra"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+// leiosHashTx is the part of common.Transaction these tests exercise. Every
+// era transaction type satisfies it through its pointer type.
+type leiosHashTx interface {
+	SetCbor([]byte)
+	Cbor() []byte
+	LeiosHash() lcommon.Blake2b256
+}
+
+// leiosHashEras lists one entry per era transaction type. Adding an era
+// without adding it here leaves that era's LeiosHash unpinned.
+var leiosHashEras = []struct {
+	name  string
+	newTx func() leiosHashTx
+}{
+	{"byron", func() leiosHashTx { return &byron.ByronTransaction{} }},
+	{"shelley", func() leiosHashTx { return &shelley.ShelleyTransaction{} }},
+	{"allegra", func() leiosHashTx { return &allegra.AllegraTransaction{} }},
+	{"mary", func() leiosHashTx { return &mary.MaryTransaction{} }},
+	{"alonzo", func() leiosHashTx { return &alonzo.AlonzoTransaction{} }},
+	{"babbage", func() leiosHashTx { return &babbage.BabbageTransaction{} }},
+	{"conway", func() leiosHashTx { return &conway.ConwayTransaction{} }},
+	{"dijkstra", func() leiosHashTx { return &dijkstra.DijkstraTransaction{} }},
+}
+
+// Two distinct, well-formed transaction-shaped CBOR payloads. The bytes only
+// have to differ: LeiosHash hashes the stored CBOR without interpreting it.
+var (
+	leiosHashCborA = []byte{0x83, 0xa0, 0xa0, 0xa0}
+	leiosHashCborB = []byte{0x83, 0xa0, 0xa0, 0xf6}
+)
+
+// TestLeiosHashMatchesCbor pins that LeiosHash is the Blake2b-256 hash of the
+// transaction's CBOR and is stable across repeated calls.
+func TestLeiosHashMatchesCbor(t *testing.T) {
+	want := lcommon.Blake2b256Hash(leiosHashCborA)
+	for _, era := range leiosHashEras {
+		t.Run(era.name, func(t *testing.T) {
+			tx := era.newTx()
+			tx.SetCbor(leiosHashCborA)
+			first := tx.LeiosHash()
+			if first != want {
+				t.Fatalf(
+					"LeiosHash = %s, want Blake2b256Hash(Cbor()) = %s",
+					first,
+					want,
+				)
+			}
+			for i := range 4 {
+				if got := tx.LeiosHash(); got != first {
+					t.Fatalf("call %d returned %s, want %s", i+2, got, first)
+				}
+			}
+		})
+	}
+}
+
+// TestLeiosHashTracksCbor pins that LeiosHash follows the transaction's
+// current CBOR. A memo populated on the first call and never invalidated
+// would keep returning the first payload's hash.
+func TestLeiosHashTracksCbor(t *testing.T) {
+	wantA := lcommon.Blake2b256Hash(leiosHashCborA)
+	wantB := lcommon.Blake2b256Hash(leiosHashCborB)
+	if wantA == wantB {
+		t.Fatal("test payloads must hash differently")
+	}
+	for _, era := range leiosHashEras {
+		t.Run(era.name, func(t *testing.T) {
+			tx := era.newTx()
+			tx.SetCbor(leiosHashCborA)
+			if got := tx.LeiosHash(); got != wantA {
+				t.Fatalf("first payload: LeiosHash = %s, want %s", got, wantA)
+			}
+			tx.SetCbor(leiosHashCborB)
+			if got := tx.LeiosHash(); got != wantB {
+				t.Fatalf(
+					"second payload: LeiosHash = %s, want %s (stale cache from the first payload?)",
+					got,
+					wantB,
+				)
+			}
+		})
+	}
+}
+
+// TestLeiosHashCopyIsIndependent pins that a value copy of a transaction
+// carries no state shared with its source: replacing the copy's CBOR must
+// change only the copy's LeiosHash.
+func TestLeiosHashCopyIsIndependent(t *testing.T) {
+	wantA := lcommon.Blake2b256Hash(leiosHashCborA)
+	wantB := lcommon.Blake2b256Hash(leiosHashCborB)
+	for _, era := range leiosHashEras {
+		t.Run(era.name, func(t *testing.T) {
+			tx := era.newTx()
+			tx.SetCbor(leiosHashCborA)
+			// Populate anything the original might cache before copying.
+			if got := tx.LeiosHash(); got != wantA {
+				t.Fatalf("original: LeiosHash = %s, want %s", got, wantA)
+			}
+			// Copy the transaction by value, the way the tree passes these
+			// types around, and give the copy different CBOR.
+			src := reflect.ValueOf(tx).Elem()
+			cp, ok := reflect.New(src.Type()).Interface().(leiosHashTx)
+			if !ok {
+				t.Fatalf("copy of %s does not satisfy leiosHashTx", src.Type())
+			}
+			reflect.ValueOf(cp).Elem().Set(src)
+			cp.SetCbor(leiosHashCborB)
+			if got := cp.LeiosHash(); got != wantB {
+				t.Fatalf(
+					"copy: LeiosHash = %s, want %s (state shared with the original?)",
+					got,
+					wantB,
+				)
+			}
+			if got := tx.LeiosHash(); got != wantA {
+				t.Fatalf(
+					"original after copy was modified: LeiosHash = %s, want %s",
+					got,
+					wantA,
+				)
+			}
+		})
+	}
+}
+
+// TestLeiosHashConcurrent pins that concurrent LeiosHash calls on one shared
+// transaction are safe and agree. Run under -race, this fails if LeiosHash
+// writes to the receiver.
+func TestLeiosHashConcurrent(t *testing.T) {
+	const goroutines = 16
+	want := lcommon.Blake2b256Hash(leiosHashCborA)
+	for _, era := range leiosHashEras {
+		t.Run(era.name, func(t *testing.T) {
+			tx := era.newTx()
+			tx.SetCbor(leiosHashCborA)
+			results := make([]lcommon.Blake2b256, goroutines)
+			var start sync.WaitGroup
+			var done sync.WaitGroup
+			start.Add(1)
+			for i := range goroutines {
+				done.Add(1)
+				go func(i int) {
+					defer done.Done()
+					start.Wait()
+					results[i] = tx.LeiosHash()
+				}(i)
+			}
+			start.Done()
+			done.Wait()
+			for i, got := range results {
+				if got != want {
+					t.Fatalf("goroutine %d: LeiosHash = %s, want %s", i, got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestLeiosHashNoCacheField pins that no era transaction type carries a hash
+// cache or a synchronization primitive of its own. Either one would reopen
+// this contract: a cache needs invalidating on every CBOR change, and a
+// synchronization primitive -- including one held behind a pointer, which
+// go vet's copylocks check does not flag -- makes copying the transaction
+// unsafe.
+func TestLeiosHashNoCacheField(t *testing.T) {
+	lockerType := reflect.TypeOf((*sync.Locker)(nil)).Elem()
+	for _, era := range leiosHashEras {
+		t.Run(era.name, func(t *testing.T) {
+			txType := reflect.TypeOf(era.newTx()).Elem()
+			for i := range txType.NumField() {
+				field := txType.Field(i)
+				if field.Name == "hash" {
+					t.Errorf(
+						"%s has a %q field: LeiosHash is contractually recomputed, not cached",
+						txType,
+						field.Name,
+					)
+				}
+				fieldType := field.Type
+				for fieldType.Kind() == reflect.Pointer {
+					fieldType = fieldType.Elem()
+				}
+				if reflect.PointerTo(fieldType).Implements(lockerType) {
+					t.Errorf(
+						"%s field %q is a synchronization primitive (%s); era transaction types must stay copyable",
+						txType,
+						field.Name,
+						field.Type,
+					)
+				}
+			}
+		})
+	}
+}

--- a/ledger/leios_hash_test.go
+++ b/ledger/leios_hash_test.go
@@ -196,38 +196,73 @@ func TestLeiosHashConcurrent(t *testing.T) {
 }
 
 // TestLeiosHashNoCacheField pins that no era transaction type carries a hash
-// cache or a synchronization primitive of its own. Either one would reopen
-// this contract: a cache needs invalidating on every CBOR change, and a
-// synchronization primitive -- including one held behind a pointer, which
-// go vet's copylocks check does not flag -- makes copying the transaction
-// unsafe.
+// cache of its own, and that nothing reachable from it by value carries a
+// synchronization primitive. Either one would reopen this contract: a cache
+// needs invalidating on every CBOR change, and a synchronization primitive --
+// including one held behind a pointer, which go vet's copylocks check does not
+// flag -- makes copying the transaction unsafe.
+//
+// The hash check is deliberately shallow. Transaction *bodies* and block
+// headers do keep a hash cache, populated through a pointer receiver, and
+// those are outside this contract; only the transaction-level cache removed
+// here is forbidden. The locker check is deep, because a primitive anywhere
+// in the transaction's value graph makes the transaction itself unsafe to
+// copy. Fields reached only through an interface cannot be inspected
+// statically and are not covered.
 func TestLeiosHashNoCacheField(t *testing.T) {
-	lockerType := reflect.TypeOf((*sync.Locker)(nil)).Elem()
 	for _, era := range leiosHashEras {
 		t.Run(era.name, func(t *testing.T) {
 			txType := reflect.TypeOf(era.newTx()).Elem()
 			for i := range txType.NumField() {
-				field := txType.Field(i)
-				if field.Name == "hash" {
+				if name := txType.Field(i).Name; name == "hash" {
 					t.Errorf(
 						"%s has a %q field: LeiosHash is contractually recomputed, not cached",
 						txType,
-						field.Name,
-					)
-				}
-				fieldType := field.Type
-				for fieldType.Kind() == reflect.Pointer {
-					fieldType = fieldType.Elem()
-				}
-				if reflect.PointerTo(fieldType).Implements(lockerType) {
-					t.Errorf(
-						"%s field %q is a synchronization primitive (%s); era transaction types must stay copyable",
-						txType,
-						field.Name,
-						field.Type,
+						name,
 					)
 				}
 			}
+			assertNoLocker(t, txType, txType.String(), map[reflect.Type]bool{})
 		})
+	}
+}
+
+// assertNoLocker reports any synchronization primitive reachable from typ,
+// following struct fields and pointer, slice, array and map element types.
+// visited breaks the cycles those indirections allow.
+func assertNoLocker(
+	t *testing.T,
+	typ reflect.Type,
+	path string,
+	visited map[reflect.Type]bool,
+) {
+	t.Helper()
+	if visited[typ] {
+		return
+	}
+	visited[typ] = true
+
+	lockerType := reflect.TypeOf((*sync.Locker)(nil)).Elem()
+	if typ.Kind() != reflect.Interface &&
+		reflect.PointerTo(typ).Implements(lockerType) {
+		t.Errorf(
+			"%s is a synchronization primitive (%s); era transaction types must stay copyable",
+			path,
+			typ,
+		)
+		return
+	}
+
+	switch typ.Kind() {
+	case reflect.Struct:
+		for i := range typ.NumField() {
+			field := typ.Field(i)
+			assertNoLocker(t, field.Type, path+"."+field.Name, visited)
+		}
+	case reflect.Pointer, reflect.Slice, reflect.Array:
+		assertNoLocker(t, typ.Elem(), path+"[]", visited)
+	case reflect.Map:
+		assertNoLocker(t, typ.Key(), path+"[key]", visited)
+		assertNoLocker(t, typ.Elem(), path+"[value]", visited)
 	}
 }

--- a/ledger/mary/mary.go
+++ b/ledger/mary/mary.go
@@ -349,7 +349,6 @@ func (b *MaryTransactionBody) Utxorpc() (*utxorpc.Tx, error) {
 type MaryTransaction struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
-	hash       *common.Blake2b256
 	Body       MaryTransactionBody
 	WitnessSet shelley.ShelleyTransactionWitnessSet
 	TxMetadata common.TransactionMetadatum
@@ -358,7 +357,6 @@ type MaryTransaction struct {
 
 func (t *MaryTransaction) UnmarshalCBOR(cborData []byte) error {
 	// Reset cached/derived fields to avoid stale state on receiver reuse
-	t.hash = nil
 	t.TxMetadata = nil
 	t.auxData = nil
 
@@ -449,12 +447,12 @@ func (t MaryTransaction) Id() common.Blake2b256 {
 	return t.Body.Id()
 }
 
+// LeiosHash returns the Blake2b-256 hash of the transaction's CBOR. The value
+// is recomputed on every call: it is not memoized on the transaction, because
+// era transaction types are copied by value and an in-struct cache cannot be
+// populated safely from a shared receiver.
 func (t MaryTransaction) LeiosHash() common.Blake2b256 {
-	if t.hash == nil {
-		tmpHash := common.Blake2b256Hash(t.Cbor())
-		t.hash = &tmpHash
-	}
-	return *t.hash
+	return common.Blake2b256Hash(t.Cbor())
 }
 
 func (t MaryTransaction) Inputs() []common.TransactionInput {

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -715,7 +715,6 @@ func (w ShelleyTransactionWitnessSet) Redeemers() common.TransactionWitnessRedee
 type ShelleyTransaction struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
-	hash       *common.Blake2b256
 	Body       ShelleyTransactionBody
 	WitnessSet ShelleyTransactionWitnessSet
 	TxMetadata common.TransactionMetadatum
@@ -724,7 +723,6 @@ type ShelleyTransaction struct {
 
 func (t *ShelleyTransaction) UnmarshalCBOR(cborData []byte) error {
 	// Reset cached/derived fields to avoid stale state on receiver reuse
-	t.hash = nil
 	t.TxMetadata = nil
 	t.auxData = nil
 
@@ -814,12 +812,12 @@ func (t ShelleyTransaction) Id() common.Blake2b256 {
 	return t.Body.Id()
 }
 
+// LeiosHash returns the Blake2b-256 hash of the transaction's CBOR. The value
+// is recomputed on every call: it is not memoized on the transaction, because
+// era transaction types are copied by value and an in-struct cache cannot be
+// populated safely from a shared receiver.
 func (t ShelleyTransaction) LeiosHash() common.Blake2b256 {
-	if t.hash == nil {
-		tmpHash := common.Blake2b256Hash(t.Cbor())
-		t.hash = &tmpHash
-	}
-	return *t.hash
+	return common.Blake2b256Hash(t.Cbor())
 }
 
 func (t ShelleyTransaction) Inputs() []common.TransactionInput {


### PR DESCRIPTION
## Defect

Every era transaction type carried a `hash *common.Blake2b256` field that
`LeiosHash` populated on first use. The field behaved differently depending on
the receiver, and neither behaviour was correct.

Six eras write `t.hash = &tmpHash` through a **value** receiver, so the
assignment lands on the copy and is discarded. The field is never non-nil and
every call recomputes the hash:

| era | receiver | line on `main` |
|---|---|---|
| Shelley | `ShelleyTransaction` | `ledger/shelley/shelley.go:820` |
| Allegra | `AllegraTransaction` | `ledger/allegra/allegra.go:427` |
| Mary | `MaryTransaction` | `ledger/mary/mary.go:455` |
| Alonzo | `AlonzoTransaction` | `ledger/alonzo/alonzo.go:983` |
| Babbage | `BabbageTransaction` | `ledger/babbage/babbage.go:1162` |
| Conway | `ConwayTransaction` | `ledger/conway/conway.go:1057` |

Two eras write it through a **pointer** receiver, so the memo is live and
carries two further defects:

| era | receiver | line on `main` |
|---|---|---|
| Byron | `*ByronTransaction` | `ledger/byron/byron.go:526` |
| Dijkstra | `*DijkstraTransaction` | `ledger/dijkstra/dijkstra.go:1426` |

- Concurrent `LeiosHash` calls on one transaction race on the field. `go test
  -race` reports the write at `byron.go:526` and `dijkstra.go:1426` against the
  concurrent reads at `byron.go:524` and `dijkstra.go:1424`.
- `(*ByronTransaction).UnmarshalCBOR` (`ledger/byron/byron.go:360`) does not
  reset `t.hash`, unlike the six value-receiver eras, whose `UnmarshalCBOR`
  cleared it. A reused Byron receiver returns the previous payload's hash.

## Contract

`LeiosHash` is the Blake2b-256 hash of the transaction's stored CBOR, derived on
every call and not cached on the transaction. The `hash` field is removed from
all eight era transaction types and the contract is documented on
`common.Transaction.LeiosHash` (`ledger/common/tx.go:38`).

The alternative — making the memo work in all eight eras — requires guarding the
field, and the transaction types are copied by value throughout the tree. A
`sync.Mutex`, `atomic.Pointer`, or any type embedding `noCopy` placed in the
struct makes every such copy a `copylocks` violation. Holding the primitive
behind a pointer field evades `copylocks` but not the problem: lazily
initialising it from `LeiosHash` is itself an unsynchronized read-modify-write
of the pointer, and a struct copy then aliases both the mutex and the cached
hash. Computing the hash eagerly at decode time would be safe but charges every
decoded transaction a Blake2b-256 pass over its full CBOR.

`LeiosHash` has no callers in this repository or in Dingo, so no hot path
depended on the memo. Recomputation keeps the types copyable, makes the
behaviour identical in every era, and leaves reintroducing a cache open should a
consumer and a measurement justify one.

Note for reviewers: the head of #2225 (`fix(ledger): synchronize transaction
hash caches`) changes the same `LeiosHash` methods in the opposite direction,
adding a `hashMu *sync.Mutex` field and pointer receivers. The two branches
conflict in all eight files and only one contract can land.

## Tests

`ledger/leios_hash_test.go` covers all eight eras in every case, in
`package ledger_test` so a new era cannot be added without being listed:

- `TestLeiosHashMatchesCbor` — `LeiosHash()` equals `Blake2b256Hash(Cbor())` and
  is stable across repeated calls.
- `TestLeiosHashTracksCbor` — after the transaction's CBOR is replaced,
  `LeiosHash` returns the new payload's hash. Fails on `main` for Byron and
  Dijkstra, which return the first payload's hash.
- `TestLeiosHashCopyIsIndependent` — a value copy shares no state with its
  source. Fails on `main` for Byron and Dijkstra.
- `TestLeiosHashConcurrent` — 16 goroutines call `LeiosHash` on one shared
  transaction and agree. Reports a data race on `main` under `-race` for Byron
  and Dijkstra.
- `TestLeiosHashNoCacheField` — no era transaction type declares a `hash` field
  or a synchronization primitive, including one held behind a pointer, which
  `copylocks` does not flag. Fails on `main` for all eight eras.

`TestDijkstraTransactionLeiosHashCaches` asserted the opposite contract and is
removed; `TestLeiosHashMatchesCbor/dijkstra` replaces its stability assertion.

Fixes #2233

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the cached `hash` field from all eight era transaction types and recomputes `LeiosHash` from the transaction's current CBOR on every call. The old memo was discarded in six eras (value receivers) and caused stale hashes and data races in Byron and Dijkstra (pointer receivers).

**Bug Fixes**
- Reused Byron receivers no longer return the previous payload's hash.
- Concurrent `LeiosHash` calls on one transaction are now race-free.
- Removes `TestDijkstraTransactionLeiosHashCaches`, which asserted the old caching contract; new tests cover all eight eras.
- `TestLeiosHashNoCacheField` walks the whole transaction value graph for synchronization primitives, catching cases `copylocks` does not flag.

Fixes #2233.

<sup>Written for commit 43c75944cdbc5b5d33618a2382a3f83a5002454e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Transaction hashes now consistently reflect the transaction’s current CBOR data, including after updates and when transactions are copied.
  - Repeated and concurrent hash calculations now return consistent results across all supported ledger eras.

- **Documentation**
  - Clarified that transaction hashes are recalculated from the current transaction data whenever requested.

- **Tests**
  - Added coverage for hash accuracy, updates, copies, repeated calls, and concurrent access across all ledger eras.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->