### PR TITLE
ci: include Go version in test job names

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   go-test:
-    name: go-test (${{ matrix.go-arch }})
+    name: go-test (${{ matrix.go-version }}, ${{ matrix.platform }})
     strategy:
       matrix:
         go-version: [1.25.x, 1.26.x]

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   go-test:
-    name: go-test (${{ matrix.go-version }}, ${{ matrix.platform }})
+    name: go-test (${{ matrix.go-version }}, ${{ matrix.platform }}, ${{ matrix.go-arch }})
     strategy:
       matrix:
         go-version: [1.25.x, 1.26.x]


### PR DESCRIPTION
## Summary

Include the Go version, runner platform, and architecture in `go-test` job
names so required status contexts identify every matrix job uniquely.

## Validation

- `actionlint .github/workflows/go-test.yml`
- `git diff --check`

## Review note

The job name retains the unique `amd64`/`386` dimension while adding the
version and platform required by CI status checks.
