### PR TITLE
test: assert the contracts the muxer and VRF conformance tests name

### DIFF
--- a/internal/test/conformance/vrf_conformance_test.go
+++ b/internal/test/conformance/vrf_conformance_test.go
@@ -202,6 +202,26 @@ func TestVRFProveConformance(t *testing.T) {
 		testedCount,
 		skippedCount,
 	)
+	// A vector is skipped when its sk does not regenerate the listed pk. A
+	// regression in KeyGen skips every vector, which leaves the conformance
+	// assertions below unexecuted while the test still passes, so the
+	// denominator is asserted rather than logged.
+	if testedCount == 0 {
+		t.Fatalf(
+			"no prove vector was tested; %d of %d skipped on a derived-pubkey mismatch",
+			skippedCount,
+			len(vectors.Vectors),
+		)
+	}
+	if testedCount+skippedCount != len(vectors.Vectors) {
+		t.Fatalf(
+			"accounted for %d vectors (%d tested, %d skipped), want %d",
+			testedCount+skippedCount,
+			testedCount,
+			skippedCount,
+			len(vectors.Vectors),
+		)
+	}
 }
 
 // formatVectorName creates a descriptive test name from vector index and alpha

--- a/internal/test/conformance/vrf_conformance_test.go
+++ b/internal/test/conformance/vrf_conformance_test.go
@@ -41,11 +41,13 @@ type VRFTestVector struct {
 	Alpha string `json:"alpha"` // Input message (variable length hex)
 }
 
+// The corpus excludes the two verification-only vectors from the original 31.
+// All remaining vectors must exercise both proof generation and verification.
+const requiredVRFVectorCount = 29
+
 // TestVRFVerifyConformance tests VRF verification against official test vectors.
 // These vectors test that the proof verifies correctly with the given public key,
 // and that ProofToHash produces the expected output.
-// Note: Some vectors have sk/pk pairs that don't match (they're testing verification
-// with known-good proofs, not key generation).
 func TestVRFVerifyConformance(t *testing.T) {
 	// Load test vectors
 	vectorsPath := filepath.Join(".", "vrf_vectors.json")
@@ -57,6 +59,10 @@ func TestVRFVerifyConformance(t *testing.T) {
 	var vectors VRFTestVectors
 	if err := json.Unmarshal(data, &vectors); err != nil {
 		t.Fatalf("Failed to parse VRF vectors: %v", err)
+	}
+	if len(vectors.Vectors) != requiredVRFVectorCount {
+		t.Fatalf("VRF corpus has %d vectors, want %d",
+			len(vectors.Vectors), requiredVRFVectorCount)
 	}
 
 	t.Logf(
@@ -114,7 +120,7 @@ func TestVRFVerifyConformance(t *testing.T) {
 }
 
 // TestVRFProveConformance tests that our Prove function produces correct outputs
-// for vectors where the sk/pk pair is consistent (sk generates the listed pk).
+// for every required vector, including its secret/public key correspondence.
 func TestVRFProveConformance(t *testing.T) {
 	// Load test vectors
 	vectorsPath := filepath.Join(".", "vrf_vectors.json")
@@ -127,9 +133,12 @@ func TestVRFProveConformance(t *testing.T) {
 	if err := json.Unmarshal(data, &vectors); err != nil {
 		t.Fatalf("Failed to parse VRF vectors: %v", err)
 	}
+	if len(vectors.Vectors) != requiredVRFVectorCount {
+		t.Fatalf("VRF corpus has %d vectors, want %d",
+			len(vectors.Vectors), requiredVRFVectorCount)
+	}
 
 	testedCount := 0
-	skippedCount := 0
 
 	for i, v := range vectors.Vectors {
 		t.Run(formatVectorName(i, v.Alpha), func(t *testing.T) {
@@ -144,20 +153,12 @@ func TestVRFProveConformance(t *testing.T) {
 				t.Fatalf("Failed to decode alpha: %v", err)
 			}
 
-			// First check if sk generates the expected pk
-			// Some test vectors have mismatched sk/pk pairs for verification testing
 			pk, _, err := vrf.KeyGen(sk)
 			if err != nil {
 				t.Fatalf("KeyGen failed: %v", err)
 			}
-
 			if hex.EncodeToString(pk) != v.PK {
-				// Skip this vector - sk doesn't match pk (this is expected for some vectors)
-				skippedCount++
-				t.Skipf(
-					"Skipping: sk does not generate listed pk (verification-only vector)",
-				)
-				return
+				t.Fatal("KeyGen public key differs from required vector")
 			}
 
 			testedCount++
@@ -197,30 +198,10 @@ func TestVRFProveConformance(t *testing.T) {
 		})
 	}
 
-	t.Logf(
-		"Tested %d vectors, skipped %d verification-only vectors",
-		testedCount,
-		skippedCount,
-	)
-	// A vector is skipped when its sk does not regenerate the listed pk. A
-	// regression in KeyGen skips every vector, which leaves the conformance
-	// assertions below unexecuted while the test still passes, so the
-	// denominator is asserted rather than logged.
-	if testedCount == 0 {
-		t.Fatalf(
-			"no prove vector was tested; %d of %d skipped on a derived-pubkey mismatch",
-			skippedCount,
-			len(vectors.Vectors),
-		)
-	}
-	if testedCount+skippedCount != len(vectors.Vectors) {
-		t.Fatalf(
-			"accounted for %d vectors (%d tested, %d skipped), want %d",
-			testedCount+skippedCount,
-			testedCount,
-			skippedCount,
-			len(vectors.Vectors),
-		)
+	t.Logf("Tested %d required prove vectors", testedCount)
+	if testedCount != requiredVRFVectorCount {
+		t.Fatalf("tested %d prove vectors, want %d",
+			testedCount, requiredVRFVectorCount)
 	}
 }
 

--- a/muxer/muxer_test.go
+++ b/muxer/muxer_test.go
@@ -33,10 +33,11 @@ import (
 
 // mockConn implements net.Conn for testing
 type mockConn struct {
-	readBuf  *bytes.Buffer
-	writeBuf *bytes.Buffer
-	closed   bool
-	mu       sync.Mutex
+	readBuf    *bytes.Buffer
+	writeBuf   *bytes.Buffer
+	closed     bool
+	writeCalls int
+	mu         sync.Mutex
 }
 
 type failingWriteConn struct {
@@ -71,6 +72,7 @@ func (m *mockConn) Read(b []byte) (int, error) {
 func (m *mockConn) Write(b []byte) (int, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.writeCalls++
 	if m.closed {
 		return 0, io.ErrClosedPipe
 	}
@@ -110,6 +112,12 @@ func (m *mockConn) WrittenLen() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.writeBuf.Len()
+}
+
+func (m *mockConn) WriteCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.writeCalls
 }
 
 // TestSegmentCreation tests segment creation and basic properties
@@ -838,10 +846,7 @@ func TestMuxerSendAfterStop(t *testing.T) {
 
 	conn := newMockConn()
 	m := muxer.New(conn)
-
-	// Start and then stop the muxer
-	m.Start()
-	m.Stop()
+	defer m.Stop()
 
 	// Create a segment
 	segment := muxer.NewSegment(0x01, []byte("test"), false)
@@ -849,12 +854,19 @@ func TestMuxerSendAfterStop(t *testing.T) {
 		t.Fatal("failed to create segment")
 	}
 
-	// Stop closes doneChan before it returns, and Send selects on that
-	// channel before touching the connection, so the error is required
-	// rather than timing-dependent.
-	if err := m.Send(segment); err == nil {
-		t.Fatal("Send after Stop returned nil, want an error")
-	}
+	// A live muxer writes the segment, establishing that the counter observes
+	// Send before testing the shutdown guard.
+	require.NoError(t, m.Send(segment))
+	require.Equal(t, 1, conn.WriteCalls())
+	m.Start()
+	m.Stop()
+
+	// Connection cleanup is asynchronous and can independently make Write
+	// fail. Check attempted writes, including failures on a closed connection,
+	// so that cleanup cannot hide a missing Send shutdown guard.
+	err := m.Send(segment)
+	require.Equal(t, 1, conn.WriteCalls(), "Send after Stop attempted a write")
+	require.Error(t, err)
 }
 
 // TestProtocolRoleConstants tests protocol role constants

--- a/muxer/muxer_test.go
+++ b/muxer/muxer_test.go
@@ -843,20 +843,17 @@ func TestMuxerSendAfterStop(t *testing.T) {
 	m.Start()
 	m.Stop()
 
-	// Give time for shutdown
-	time.Sleep(10 * time.Millisecond)
-
 	// Create a segment
 	segment := muxer.NewSegment(0x01, []byte("test"), false)
 	if segment == nil {
 		t.Fatal("failed to create segment")
 	}
 
-	// Send should return an error (or silently fail) after shutdown
-	err := m.Send(segment)
-	// After stop, Send should return an error
-	if err == nil {
-		t.Log("Send after stop returned nil (acceptable behavior)")
+	// Stop closes doneChan before it returns, and Send selects on that
+	// channel before touching the connection, so the error is required
+	// rather than timing-dependent.
+	if err := m.Send(segment); err == nil {
+		t.Fatal("Send after Stop returned nil, want an error")
 	}
 }
 


### PR DESCRIPTION
Refs #2023.

`TestMuxerSendAfterStop` now requires an error with no attempted connection
write after `Stop`. A successful pre-stop write validates the counter, so
asynchronous connection cleanup cannot mask a missing shutdown guard.

Both VRF conformance tests require the complete 29-vector corpus. Proof
generation fails on any derived-key mismatch instead of skipping the vector.

Mutation checks detect removal of the Send shutdown guard, a single-vector
KeyGen regression, and removal of a corpus entry. The full test suite,
conformance suite, build and lint pass.
