### PR TITLE
fix(ledger): preserve pool certificate identity

### DIFF
--- a/ledger/common/duplicates.go
+++ b/ledger/common/duplicates.go
@@ -15,9 +15,11 @@
 package common
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 )
@@ -204,6 +206,31 @@ func certificateLogicalKey(certificate Certificate) (string, error) {
 		}
 		key = appendLogicalCredential(key, *c.StakeCredential)
 		key = append(key, c.PoolKeyHash[:]...)
+	case *PoolRegistrationCertificate:
+		// cardano-ledger StakePoolParams compares owners as a Set, while
+		// relays retain sequence order. Sort a copy to preserve the decoded
+		// certificate and its original bytes.
+		normalized := *c
+		normalized.PoolOwners = slices.Clone(c.PoolOwners)
+		slices.SortFunc(normalized.PoolOwners, func(a, b AddrKeyHash) int {
+			return bytes.Compare(a[:], b[:])
+		})
+		normalized.PoolOwners = slices.Compact(normalized.PoolOwners)
+		encoded, err := cbor.EncodeGeneric(&normalized)
+		if err != nil {
+			return "", fmt.Errorf("encode pool certificate: %w", err)
+		}
+		key = appendLogicalBytes(key, encoded)
+		// EncodeGeneric omits private fields. The reward account's header
+		// carries both credential type and network, and both affect identity.
+		key = appendLogicalCredential(key, c.RewardAccountCredential())
+		network, known := c.RewardAccountNetworkId()
+		if known {
+			key = append(key, 1)
+		} else {
+			key = append(key, 0)
+		}
+		key = appendLogicalNumber(key, network)
 	case *PoolRetirementCertificate:
 		key = append(key, c.PoolKeyHash[:]...)
 		key = appendLogicalNumber(key, c.Epoch)
@@ -254,9 +281,9 @@ func certificateLogicalKey(certificate Certificate) (string, error) {
 		key = appendLogicalCredential(key, c.DrepCredential)
 		key = appendLogicalAnchor(key, c.Anchor)
 	default:
-		// PoolRegistrationCertificate and MoveInstantaneousRewardsCertificate
-		// aggregate over slices and maps, and a certificate type added later
-		// has no enumerated identity here yet. A canonical re-encoding is a
+		// MoveInstantaneousRewardsCertificate aggregates over maps. Types
+		// added later have no enumerated identity here yet. A canonical
+		// re-encoding is a
 		// correct identity for all of them, so a new certificate type keeps
 		// working without touching this file.
 		encoded, err := cbor.EncodeGeneric(certificate)

--- a/ledger/common/pool_certificate_identity_test.go
+++ b/ledger/common/pool_certificate_identity_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/stretchr/testify/require"
+)
+
+// StakePoolParams derives Eq/Ord with Set-valued owners and an account address
+// containing both network and credential. Certificate identity uses those
+// decoded values rather than the original owner order or rational encoding.
+func TestPoolCertificateOwnerSetIdentity(t *testing.T) {
+	ownerA := make([]byte, 28)
+	ownerB := make([]byte, 28)
+	ownerB[0] = 1
+	makeCert := func(owners any, header byte) []any {
+		reward := make([]byte, 29)
+		reward[0] = header
+		return []any{3, make([]byte, 28), make([]byte, 32), 1, 1,
+			cbor.Tag{
+				Number:  30,
+				Content: []uint{1, 2},
+			}, reward, owners, []any{}, nil}
+	}
+	equivalentMargin := makeCert([][]byte{ownerA, ownerB}, 0xe0)
+	equivalentMargin[5] = cbor.Tag{Number: 30, Content: []uint{2, 4}}
+	distinctMargin := makeCert([][]byte{ownerA, ownerB}, 0xe0)
+	distinctMargin[5] = cbor.Tag{Number: 30, Content: []uint{1, 3}}
+	for name, tc := range map[string]struct {
+		second    []any
+		duplicate bool
+	}{
+		"identical":                       {makeCert([][]byte{ownerA, ownerB}, 0xe0), true},
+		"reordered owners":                {makeCert([][]byte{ownerB, ownerA}, 0xe0), true},
+		"tagged reordered owners":         {makeCert(cbor.Tag{Number: 258, Content: [][]byte{ownerB, ownerA}}, 0xe0), true},
+		"equivalent margin":               {equivalentMargin, true},
+		"distinct margin":                 {distinctMargin, false},
+		"distinct owners":                 {makeCert([][]byte{ownerA}, 0xe0), false},
+		"distinct reward credential type": {makeCert([][]byte{ownerA, ownerB}, 0xf0), false},
+		"distinct reward network":         {makeCert([][]byte{ownerA, ownerB}, 0xe1), false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			for _, tagged := range []bool{false, true} {
+				encoding := "untagged"
+				certs := any(
+					[]any{makeCert([][]byte{ownerA, ownerB}, 0xe0), tc.second},
+				)
+				if tagged {
+					encoding = "tagged"
+					certs = cbor.Tag{Number: 258, Content: certs}
+				}
+				t.Run(encoding, func(t *testing.T) {
+					body, err := cbor.Encode(map[uint]any{4: certs})
+					require.NoError(t, err)
+					for era, newBody := range orderedSetCertificateTransactionBodyDecoders() {
+						t.Run(era, func(t *testing.T) {
+							err := newBody().UnmarshalCBOR(body)
+							if tc.duplicate {
+								var target common.DuplicateCertificateError
+								require.ErrorAs(
+									t,
+									err,
+									&target,
+									"equivalent pool certificates must be rejected",
+								)
+							} else {
+								require.NoError(t, err, "distinct pool registrations must remain distinct")
+							}
+						})
+					}
+					if !tagged {
+						for era, newBody := range preConwayTransactionBodyDecoders() {
+							t.Run(
+								era,
+								func(t *testing.T) { require.NoError(t, newBody().UnmarshalCBOR(body)) },
+							)
+						}
+					}
+				})
+			}
+		})
+	}
+	// Calling the public identity API must preserve original bytes and owner order.
+	encoded, err := cbor.Encode(makeCert([][]byte{ownerB, ownerA}, 0xe0))
+	require.NoError(t, err)
+	var cert common.PoolRegistrationCertificate
+	_, err = cbor.Decode(encoded, &cert)
+	require.NoError(t, err)
+	ownersBefore := append([]common.AddrKeyHash(nil), cert.PoolOwners...)
+	_, err = common.CertificateLogicalKey(&cert)
+	require.NoError(t, err)
+	require.Equal(t, ownersBefore, cert.PoolOwners)
+	require.Equal(t, encoded, cert.Cbor())
+	knownKey, err := common.CertificateLogicalKey(&cert)
+	require.NoError(t, err)
+	unknown := cert
+	unknown.SetCbor(encoded)
+	_, known := unknown.RewardAccountNetworkId()
+	require.False(t, known)
+	unknownKey, err := common.CertificateLogicalKey(&unknown)
+	require.NoError(t, err)
+	require.NotEqual(t, knownKey, unknownKey,
+		"unknown reward network must not identify as known testnet")
+	unknownCopy := unknown
+	unknownCopyKey, err := common.CertificateLogicalKey(&unknownCopy)
+	require.NoError(t, err)
+	require.Equal(t, unknownKey, unknownCopyKey)
+}


### PR DESCRIPTION
Compare pool registration owners as a set and retain reward-account credential and network identity when detecting duplicate certificates. Preserve the decoded owner order and cached CBOR.

Add tagged/untagged Conway and Dijkstra decoder coverage, pre-Conway compatibility controls, equivalent-margin cases, and public identity API checks.

Fixes #2267.
