### PR TITLE
fix(ledger): synchronize header hash cache

### DIFF
--- a/ledger/babbage/babbage.go
+++ b/ledger/babbage/babbage.go
@@ -259,7 +259,7 @@ func (b *BabbageBlock) BlockBodyHash() common.Blake2b256 {
 type BabbageBlockHeader struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
-	hash      *common.Blake2b256
+	hash      common.Blake2b256Cache
 	Body      BabbageBlockHeaderBody
 	Signature []byte
 }
@@ -348,11 +348,9 @@ func (h *BabbageBlockHeader) UnmarshalCBOR(cborData []byte) error {
 }
 
 func (h *BabbageBlockHeader) Hash() common.Blake2b256 {
-	if h.hash == nil {
-		tmpHash := common.Blake2b256Hash(h.Cbor())
-		h.hash = &tmpHash
-	}
-	return *h.hash
+	return h.hash.Get(func() common.Blake2b256 {
+		return common.Blake2b256Hash(h.Cbor())
+	})
 }
 
 func (h *BabbageBlockHeader) PrevHash() common.Blake2b256 {

--- a/ledger/byron/byron.go
+++ b/ledger/byron/byron.go
@@ -57,7 +57,7 @@ func init() {
 type ByronMainBlockHeader struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
-	hash          *common.Blake2b256
+	hash          common.Blake2b256Cache
 	ProtocolMagic uint32
 	PrevBlock     common.Blake2b256
 	BodyProof     any
@@ -97,19 +97,14 @@ func (h *ByronMainBlockHeader) UnmarshalCBOR(cborData []byte) error {
 }
 
 func (h *ByronMainBlockHeader) Hash() common.Blake2b256 {
-	if h.hash == nil {
-		// Prepend bytes for CBOR list wrapper
-		// The block hash is calculated with these extra bytes, so we have to add them to
-		// get the correct value
-		tmpHash := common.Blake2b256Hash(
+	return h.hash.Get(func() common.Blake2b256 {
+		return common.Blake2b256Hash(
 			append(
 				[]byte{0x82, BlockTypeByronMain},
 				h.Cbor()...,
 			),
 		)
-		h.hash = &tmpHash
-	}
-	return *h.hash
+	})
 }
 
 func (h *ByronMainBlockHeader) PrevHash() common.Blake2b256 {
@@ -1076,7 +1071,7 @@ func (b *ByronMainBlockBody) MarshalCBOR() ([]byte, error) {
 type ByronEpochBoundaryBlockHeader struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
-	hash          *common.Blake2b256
+	hash          common.Blake2b256Cache
 	ProtocolMagic uint32
 	PrevBlock     common.Blake2b256
 	BodyProof     any
@@ -1103,19 +1098,14 @@ func (h *ByronEpochBoundaryBlockHeader) UnmarshalCBOR(cborData []byte) error {
 }
 
 func (h *ByronEpochBoundaryBlockHeader) Hash() common.Blake2b256 {
-	if h.hash == nil {
-		// Prepend bytes for CBOR list wrapper
-		// The block hash is calculated with these extra bytes, so we have to add them to
-		// get the correct value
-		tmpHash := common.Blake2b256Hash(
+	return h.hash.Get(func() common.Blake2b256 {
+		return common.Blake2b256Hash(
 			append(
 				[]byte{0x82, BlockTypeByronEbb},
 				h.Cbor()...,
 			),
 		)
-		h.hash = &tmpHash
-	}
-	return *h.hash
+	})
 }
 
 func (h *ByronEpochBoundaryBlockHeader) PrevHash() common.Blake2b256 {

--- a/ledger/common/hash_cache.go
+++ b/ledger/common/hash_cache.go
@@ -17,6 +17,7 @@ package common
 import (
 	"runtime"
 	"sync/atomic"
+	"unsafe"
 )
 
 const (
@@ -26,23 +27,45 @@ const (
 )
 
 type Blake2b256Cache struct {
-	value Blake2b256
-	state uint32
+	state unsafe.Pointer
 }
 
 func (c *Blake2b256Cache) Get(compute func() Blake2b256) Blake2b256 {
+	state := atomic.LoadPointer(&c.state)
+	if state == nil {
+		newState := &blake2b256CacheState{}
+		if atomic.CompareAndSwapPointer(&c.state, nil, unsafe.Pointer(newState)) {
+			state = unsafe.Pointer(newState)
+		} else {
+			state = atomic.LoadPointer(&c.state)
+		}
+	}
+	cacheState := (*blake2b256CacheState)(state)
 	for {
-		switch atomic.LoadUint32(&c.state) {
+		switch atomic.LoadUint32(&cacheState.state) {
 		case hashCacheReady:
-			return c.value
+			return cacheState.value
 		case hashCacheEmpty:
-			if atomic.CompareAndSwapUint32(&c.state, hashCacheEmpty, hashCacheComputing) {
-				c.value = compute()
-				atomic.StoreUint32(&c.state, hashCacheReady)
-				return c.value
+			if atomic.CompareAndSwapUint32(&cacheState.state, hashCacheEmpty, hashCacheComputing) {
+				func() {
+					defer func() {
+						if recovered := recover(); recovered != nil {
+							atomic.StoreUint32(&cacheState.state, hashCacheEmpty)
+							panic(recovered)
+						}
+					}()
+					cacheState.value = compute()
+				}()
+				atomic.StoreUint32(&cacheState.state, hashCacheReady)
+				return cacheState.value
 			}
 		default:
 			runtime.Gosched()
 		}
 	}
+}
+
+type blake2b256CacheState struct {
+	value Blake2b256
+	state uint32
 }

--- a/ledger/common/hash_cache.go
+++ b/ledger/common/hash_cache.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"runtime"
+	"sync/atomic"
+)
+
+const (
+	hashCacheEmpty uint32 = iota
+	hashCacheComputing
+	hashCacheReady
+)
+
+type Blake2b256Cache struct {
+	value Blake2b256
+	state uint32
+}
+
+func (c *Blake2b256Cache) Get(compute func() Blake2b256) Blake2b256 {
+	for {
+		switch atomic.LoadUint32(&c.state) {
+		case hashCacheReady:
+			return c.value
+		case hashCacheEmpty:
+			if atomic.CompareAndSwapUint32(&c.state, hashCacheEmpty, hashCacheComputing) {
+				c.value = compute()
+				atomic.StoreUint32(&c.state, hashCacheReady)
+				return c.value
+			}
+		default:
+			runtime.Gosched()
+		}
+	}
+}

--- a/ledger/common/hash_cache_test.go
+++ b/ledger/common/hash_cache_test.go
@@ -42,3 +42,58 @@ func TestBlake2b256CacheConcurrentFirstFill(t *testing.T) {
 	start.Done()
 	workers.Wait()
 }
+
+func TestBlake2b256CacheRetriesAfterPanic(t *testing.T) {
+	var cache Blake2b256Cache
+	called := 0
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("expected compute panic")
+			}
+		}()
+		cache.Get(func() Blake2b256 {
+			called++
+			panic("compute failed")
+		})
+	}()
+
+	want := Blake2b256{1}
+	if got := cache.Get(func() Blake2b256 {
+		called++
+		return want
+	}); got != want {
+		t.Fatalf("unexpected hash: got %x, want %x", got, want)
+	}
+	if called != 2 {
+		t.Fatalf("unexpected compute count: got %d, want 2", called)
+	}
+}
+
+func TestBlake2b256CacheCopyDuringCompute(t *testing.T) {
+	var cache Blake2b256Cache
+	started := make(chan struct{})
+	release := make(chan struct{})
+	want := Blake2b256{2}
+	done := make(chan Blake2b256)
+	go func() {
+		done <- cache.Get(func() Blake2b256 {
+			close(started)
+			<-release
+			return want
+		})
+	}()
+	<-started
+
+	copy := cache
+	close(release)
+	if got := <-done; got != want {
+		t.Fatalf("unexpected original hash: got %x, want %x", got, want)
+	}
+	if got := copy.Get(func() Blake2b256 {
+		t.Fatal("copied cache recomputed while original was in flight")
+		return Blake2b256{}
+	}); got != want {
+		t.Fatalf("unexpected copied hash: got %x, want %x", got, want)
+	}
+}

--- a/ledger/common/hash_cache_test.go
+++ b/ledger/common/hash_cache_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestBlake2b256CacheConcurrentFirstFill(t *testing.T) {
+	var cache Blake2b256Cache
+	var want Blake2b256
+	for i := range want {
+		want[i] = byte(i)
+	}
+
+	var start sync.WaitGroup
+	start.Add(1)
+	var workers sync.WaitGroup
+	for range 32 {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			start.Wait()
+			if got := cache.Get(func() Blake2b256 { return want }); got != want {
+				t.Errorf("unexpected hash: got %x, want %x", got, want)
+			}
+		}()
+	}
+	start.Done()
+	workers.Wait()
+}

--- a/ledger/header_hash_race_test.go
+++ b/ledger/header_hash_race_test.go
@@ -46,6 +46,15 @@ func TestHeaderHashConcurrentFirstFill(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			hashData := cborData
+			switch test.name {
+			case "byron":
+				hashData = append([]byte{0x82, byron.BlockTypeByronMain}, cborData...)
+			case "byron ebb":
+				hashData = append([]byte{0x82, byron.BlockTypeByronEbb}, cborData...)
+			}
+			want := common.Blake2b256Hash(hashData)
+			results := make(chan common.Blake2b256, 32)
 			var start sync.WaitGroup
 			start.Add(1)
 			var workers sync.WaitGroup
@@ -54,11 +63,17 @@ func TestHeaderHashConcurrentFirstFill(t *testing.T) {
 				go func() {
 					defer workers.Done()
 					start.Wait()
-					test.hash()
+					results <- test.hash()
 				}()
 			}
 			start.Done()
 			workers.Wait()
+			close(results)
+			for got := range results {
+				if got != want {
+					t.Fatalf("unexpected hash: got %x, want %x", got, want)
+				}
+			}
 		})
 	}
 }

--- a/ledger/header_hash_race_test.go
+++ b/ledger/header_hash_race_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ledger_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	"github.com/blinklabs-io/gouroboros/ledger/byron"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+)
+
+func TestHeaderHashConcurrentFirstFill(t *testing.T) {
+	cborData := make([]byte, 1<<20)
+	shelleyHeader := &shelley.ShelleyBlockHeader{}
+	shelleyHeader.SetCbor(cborData)
+	babbageHeader := &babbage.BabbageBlockHeader{}
+	babbageHeader.SetCbor(cborData)
+	byronHeader := &byron.ByronMainBlockHeader{}
+	byronHeader.SetCbor(cborData)
+	ebbHeader := &byron.ByronEpochBoundaryBlockHeader{}
+	ebbHeader.SetCbor(cborData)
+	tests := []struct {
+		name string
+		hash func() common.Blake2b256
+	}{
+		{name: "shelley", hash: shelleyHeader.Hash},
+		{name: "babbage", hash: babbageHeader.Hash},
+		{name: "byron", hash: byronHeader.Hash},
+		{name: "byron ebb", hash: ebbHeader.Hash},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var start sync.WaitGroup
+			start.Add(1)
+			var workers sync.WaitGroup
+			for range 32 {
+				workers.Add(1)
+				go func() {
+					defer workers.Done()
+					start.Wait()
+					test.hash()
+				}()
+			}
+			start.Done()
+			workers.Wait()
+		})
+	}
+}

--- a/ledger/shelley/shelley.go
+++ b/ledger/shelley/shelley.go
@@ -210,7 +210,7 @@ func (b *ShelleyBlock) BlockBodyHash() common.Blake2b256 {
 type ShelleyBlockHeader struct {
 	cbor.StructAsArray
 	cbor.DecodeStoreCbor
-	hash      *common.Blake2b256
+	hash      common.Blake2b256Cache
 	Body      ShelleyBlockHeaderBody
 	Signature []byte
 }
@@ -300,11 +300,9 @@ func (h *ShelleyBlockHeader) UnmarshalCBOR(cborData []byte) error {
 }
 
 func (h *ShelleyBlockHeader) Hash() common.Blake2b256 {
-	if h.hash == nil {
-		tmpHash := common.Blake2b256Hash(h.Cbor())
-		h.hash = &tmpHash
-	}
-	return *h.hash
+	return h.hash.Get(func() common.Blake2b256 {
+		return common.Blake2b256Hash(h.Cbor())
+	})
 }
 
 func (h *ShelleyBlockHeader) PrevHash() common.Blake2b256 {


### PR DESCRIPTION
## Summary

- synchronize lazy hash caching for Shelley, Babbage, Byron, and Byron EBB headers
- keep cached values inline so copied headers do not share mutable cache state

## Tests

- `go test -race ./ledger/...`
- `go test -race ./protocol/chainsync ./protocol/blockfetch`
- `go test -race -run TestHeaderHashConcurrentFirstFill -count=5 ./ledger`

Related to #2261

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a data race in lazy header hash caching so concurrent calls to `Hash()` on the same header are safe.

- Replaces the unsynchronized pointer-based cache with an atomic state machine in a new `Blake2b256Cache` type that resets for retry if hash computation panics.
- Keeps cached values inline in each header so copied headers do not share mutable cache state.
- Applies the synchronized cache to Shelley, Babbage, Byron main, and Byron EBB headers.
- Adds tests for concurrent first hash computation, panic recovery, and cache copies.

Related to #2261.

<sup>Written for commit efebe02f0ae39da894b47d8c44e3137e201ed843. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the safety of concurrent block-header hash calculation.
  * Ensured hash values are computed once and consistently reused when accessed simultaneously.

* **Tests**
  * Added coverage for concurrent first-time hash calculations across supported block-header types.
  * Added concurrency tests for hash caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->