### PR TITLE
fix(handshake): validate accepted protocol parameters

### DIFF
--- a/protocol/handshake/client.go
+++ b/protocol/handshake/client.go
@@ -134,6 +134,13 @@ func (c *Client) handleAcceptVersion(msg protocol.Message) error {
 		)
 	}
 	msgAcceptVersion := msg.(*MsgAcceptVersion)
+	proposedData, ok := c.config.ProtocolVersionMap[msgAcceptVersion.Version]
+	if !ok {
+		return fmt.Errorf(
+			"unproposed protocol version accepted by peer: %d",
+			msgAcceptVersion.Version,
+		)
+	}
 	protoVersion := protocol.GetProtocolVersion(msgAcceptVersion.Version)
 	if protoVersion.NewVersionDataFromCborFunc == nil {
 		return fmt.Errorf(
@@ -146,6 +153,14 @@ func (c *Client) handleAcceptVersion(msg protocol.Message) error {
 	)
 	if err != nil {
 		return err
+	}
+	if versionData.NetworkMagic() != proposedData.NetworkMagic() {
+		return fmt.Errorf(
+			"network magic mismatch for accepted protocol version %d: got %d, want %d",
+			msgAcceptVersion.Version,
+			versionData.NetworkMagic(),
+			proposedData.NetworkMagic(),
+		)
 	}
 	return c.config.FinishedFunc(
 		c.callbackContext,

--- a/protocol/handshake/client_test.go
+++ b/protocol/handshake/client_test.go
@@ -16,16 +16,159 @@ package handshake_test
 
 import (
 	"fmt"
+	"net"
 	"reflect"
 	"testing"
 	"time"
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/muxer"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	"github.com/blinklabs-io/gouroboros/protocol/handshake"
 	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
+
+func TestClientAcceptVersionValidation(t *testing.T) {
+	for _, version := range []uint16{
+		7, 11, 13,
+		14 + protocol.ProtocolVersionNtCOffset,
+		15 + protocol.ProtocolVersionNtCOffset,
+		1 + protocol.ProtocolVersionDMQNtCOffset,
+		protocol.ProtocolVersionDMQNtN1,
+		protocol.ProtocolVersionDMQNtN2,
+	} {
+		t.Run(fmt.Sprintf("version_%d", version), func(t *testing.T) {
+			for _, scenario := range []struct {
+				name          string
+				returnedMagic uint32
+				unproposed    bool
+				wantError     string
+			}{
+				{
+					name:          "matching",
+					returnedMagic: ouroboros_mock.MockNetworkMagic,
+				},
+				{
+					name:          "wrong_network",
+					returnedMagic: ouroboros_mock.MockNetworkMagic + 1,
+					wantError:     "network magic mismatch",
+				},
+				{
+					name:          "unproposed",
+					returnedMagic: ouroboros_mock.MockNetworkMagic,
+					unproposed:    true,
+					wantError:     "unproposed protocol version",
+				},
+			} {
+				t.Run(scenario.name, func(t *testing.T) {
+					defer goleak.VerifyNone(t)
+					mode := protocol.ProtocolModeNodeToNode
+					if version >= protocol.ProtocolVersionNtCOffset {
+						mode = protocol.ProtocolModeNodeToClient
+					}
+					versionMap := func(magic uint32) protocol.ProtocolVersionMap {
+						switch version {
+						case 1 + protocol.ProtocolVersionDMQNtCOffset:
+							return protocol.GetProtocolVersionMapDMQNtC(magic, false)
+						case protocol.ProtocolVersionDMQNtN1,
+							protocol.ProtocolVersionDMQNtN2:
+							return protocol.GetProtocolVersionMapDMQNtN(
+								magic, protocol.DiffusionModeInitiatorOnly, false, false,
+							)
+						default:
+							return protocol.GetProtocolVersionMap(
+								mode, magic, protocol.DiffusionModeInitiatorOnly,
+								false, false,
+							)
+						}
+					}
+					proposedData := versionMap(ouroboros_mock.MockNetworkMagic)[version]
+					returnedData := versionMap(scenario.returnedMagic)[version]
+					require.NotNil(t, proposedData)
+					require.NotNil(t, returnedData)
+					proposedVersions := protocol.ProtocolVersionMap{
+						version: proposedData,
+					}
+					if scenario.unproposed {
+						delete(proposedVersions, version)
+						for otherVersion, otherData := range versionMap(
+							ouroboros_mock.MockNetworkMagic,
+						) {
+							if otherVersion != version {
+								proposedVersions[otherVersion] = otherData
+							}
+						}
+					}
+					mockConn := ouroboros_mock.NewConnection(
+						ouroboros_mock.ProtocolRoleClient,
+						[]ouroboros_mock.ConversationEntry{
+							ouroboros_mock.ConversationEntryInput{
+								ProtocolId:      handshake.ProtocolId,
+								MsgFromCborFunc: handshake.NewMsgFromCbor,
+								Message:         handshake.NewMsgProposeVersions(proposedVersions),
+							},
+							ouroboros_mock.ConversationEntryOutput{
+								ProtocolId: handshake.ProtocolId,
+								IsResponse: true,
+								Messages: []protocol.Message{
+									handshake.NewMsgAcceptVersion(version, returnedData),
+								},
+							},
+						},
+					)
+					protoMuxer := muxer.New(mockConn)
+					defer protoMuxer.Stop()
+					errorChan := make(chan error, 1)
+					finishedChan := make(chan struct {
+						version uint16
+						data    protocol.VersionData
+					}, 1)
+					config := handshake.NewConfig(
+						handshake.WithProtocolVersionMap(proposedVersions),
+						handshake.WithFinishedFunc(func(
+							_ handshake.CallbackContext,
+							acceptedVersion uint16,
+							acceptedData protocol.VersionData,
+						) error {
+							finishedChan <- struct {
+								version uint16
+								data    protocol.VersionData
+							}{acceptedVersion, acceptedData}
+							return nil
+						}),
+					)
+					client := handshake.NewClient(protocol.ProtocolOptions{
+						ConnectionId: connection.ConnectionId{
+							LocalAddr:  &net.TCPAddr{},
+							RemoteAddr: &net.TCPAddr{},
+						},
+						Muxer: protoMuxer, ErrorChan: errorChan, Mode: mode,
+					}, &config)
+					defer client.Stop()
+					client.Start()
+					protoMuxer.StartOnce()
+					select {
+					case err := <-errorChan:
+						require.NotEmpty(t, scenario.wantError)
+						require.ErrorContains(t, err, scenario.wantError)
+						require.Empty(t, finishedChan,
+							"invalid acceptance invoked FinishedFunc")
+					case finished := <-finishedChan:
+						require.Empty(t, scenario.wantError,
+							"invalid acceptance invoked FinishedFunc")
+						require.Equal(t, version, finished.version)
+						require.Equal(t, returnedData, finished.data)
+					case <-time.After(5 * time.Second):
+						t.Fatal("timed out waiting for handshake result")
+					}
+				})
+			}
+		})
+	}
+}
 
 const (
 	mockProtocolVersionNtC    uint16 = (14 + protocol.ProtocolVersionNtCOffset)


### PR DESCRIPTION
Validate that accepted handshake versions were proposed and that returned network magic matches the proposed version data. Adds regression coverage for unproposed versions and network mismatches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates that accepted handshake versions were proposed by the client and that the peer's returned network magic matches the proposed version data, preventing the client from completing a handshake with unproposed versions or mismatched networks.

- Rejects accepted versions that were never proposed, returning an error instead of invoking `FinishedFunc`.
- Rejects accepted versions whose network magic differs from the proposed value.
- Adds regression tests covering matching, wrong network magic, and unproposed version scenarios across all supported protocol versions.

<sup>Written for commit aec2a8a076e28b4912f7076846ae7a41687c7585. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

