### PR TITLE
fix(consensus): order every candidate on one density scale

### DIFF
--- a/consensus/selection.go
+++ b/consensus/selection.go
@@ -16,6 +16,7 @@ package consensus
 
 import (
 	"log/slog"
+	"math"
 	"math/big"
 	"sync"
 )
@@ -69,7 +70,14 @@ type PraosChainSelector struct {
 
 	// warnFallbackDensity throttles the legacy-metric warning to once per
 	// selector.
-	warnFallbackDensity sync.Once
+	//
+	// It is a POINTER deliberately. A sync.Once value would make
+	// PraosChainSelector non-copyable, and `go vet` copylocks would then
+	// fail any downstream code that passes or stores the selector by
+	// value — which it could do before this field existed. A nil pointer
+	// (zero-value selector) simply skips the warning; see
+	// warnLegacyDensity.
+	warnFallbackDensity *sync.Once
 }
 
 // ForkPoint identifies the intersection between the current selection and
@@ -119,7 +127,8 @@ type WindowBlockCounter interface {
 // NewPraosChainSelectorWithWindow for the canonical Genesis metric.
 func NewPraosChainSelector(securityParam uint64) *PraosChainSelector {
 	return &PraosChainSelector{
-		SecurityParam: securityParam,
+		SecurityParam:       securityParam,
+		warnFallbackDensity: new(sync.Once),
 	}
 }
 
@@ -134,8 +143,9 @@ func NewPraosChainSelectorWithWindow(
 	genesisWindowSlots uint64,
 ) *PraosChainSelector {
 	return &PraosChainSelector{
-		SecurityParam:      securityParam,
-		GenesisWindowSlots: genesisWindowSlots,
+		SecurityParam:       securityParam,
+		GenesisWindowSlots:  genesisWindowSlots,
+		warnFallbackDensity: new(sync.Once),
 	}
 }
 
@@ -225,31 +235,72 @@ func (p *PraosChainSelector) IsDeepFork(
 // after fork. It returns a positive value if a is denser, a negative value
 // if b is denser, and zero if they are equal.
 //
-// The canonical Genesis metric is an integer count of blocks within the
-// window, which requires a configured window and both tips to implement
-// WindowBlockCounter. When either is missing this falls back to the legacy
-// ChainTip.Density ratio and warns once, because that ratio is measured
-// over the whole fork suffix rather than a fixed window and so is not the
-// Genesis metric.
+// Which metric applies is decided by the SELECTOR's configuration, never by
+// the pair of tips in hand. That distinction is load-bearing: selection
+// scans a candidate set pairwise, so a metric chosen per pair can order one
+// pair by an integer block count and the next by a [0,1] ratio. Those are
+// different scales, the resulting relation is not transitive, and a
+// non-transitive comparator makes the selected chain depend on the order
+// candidates happen to arrive in — two honest nodes holding the same
+// candidates would disagree.
+//
+// So: with a genesis window configured every candidate is ordered by the
+// canonical integer count, including one that does not implement
+// WindowBlockCounter — its legacy ratio is projected onto the window by
+// windowBlocks so it lands on the same scale. With no window configured
+// every candidate is ordered by the legacy ratio. One scale either way.
 func (p *PraosChainSelector) compareDensity(
 	a, b ChainTip,
 	fork ForkPoint,
 ) int {
-	aCounter, aOK := a.(WindowBlockCounter)
-	bCounter, bOK := b.(WindowBlockCounter)
-
-	if p.GenesisWindowSlots > 0 && aOK && bOK {
-		aBlocks := aCounter.BlocksInWindow(fork.Slot, p.GenesisWindowSlots)
-		bBlocks := bCounter.BlocksInWindow(fork.Slot, p.GenesisWindowSlots)
-		if aBlocks > bBlocks {
-			return 1
-		}
-		if bBlocks > aBlocks {
-			return -1
-		}
-		return 0
+	if p.GenesisWindowSlots > 0 {
+		return compareUint64(
+			p.windowBlocks(a, fork),
+			p.windowBlocks(b, fork),
+		)
 	}
 
+	p.warnLegacyDensity()
+
+	return compareFloat64(a.Density(fork.Slot), b.Density(fork.Slot))
+}
+
+// windowBlocks returns the tip's block count within the genesis window.
+//
+// A tip implementing WindowBlockCounter answers directly. A tip that does
+// not is projected onto the window from its legacy ratio — density times
+// window length, rounded — so that it is ordered on the same scale as the
+// rest of the candidate set rather than being compared on a different one.
+// The projection is an approximation of a metric the tip cannot supply
+// exactly, which is why it warns; it is not a substitute for implementing
+// WindowBlockCounter.
+func (p *PraosChainSelector) windowBlocks(
+	tip ChainTip,
+	fork ForkPoint,
+) uint64 {
+	if counter, ok := tip.(WindowBlockCounter); ok {
+		return counter.BlocksInWindow(fork.Slot, p.GenesisWindowSlots)
+	}
+
+	p.warnLegacyDensity()
+
+	density := tip.Density(fork.Slot)
+	if density <= 0 || math.IsNaN(density) {
+		return 0
+	}
+	projected := math.Round(density * float64(p.GenesisWindowSlots))
+	if math.IsInf(projected, 1) || projected > math.MaxUint64 {
+		return math.MaxUint64
+	}
+	return uint64(projected)
+}
+
+// warnLegacyDensity reports once per selector that a comparison could not
+// use the canonical Genesis metric, so the degraded metric is never silent.
+func (p *PraosChainSelector) warnLegacyDensity() {
+	if p.warnFallbackDensity == nil {
+		return
+	}
 	p.warnFallbackDensity.Do(func() {
 		slog.Warn(
 			"deep-fork comparison using legacy density ratio; configure a "+
@@ -259,13 +310,23 @@ func (p *PraosChainSelector) compareDensity(
 			"genesisWindowSlots", p.GenesisWindowSlots,
 		)
 	})
+}
 
-	aDensity := a.Density(fork.Slot)
-	bDensity := b.Density(fork.Slot)
-	if aDensity > bDensity {
+func compareUint64(a, b uint64) int {
+	switch {
+	case a > b:
 		return 1
+	case b > a:
+		return -1
 	}
-	if bDensity > aDensity {
+	return 0
+}
+
+func compareFloat64(a, b float64) int {
+	switch {
+	case a > b:
+		return 1
+	case b > a:
 		return -1
 	}
 	return 0
@@ -418,7 +479,12 @@ func NewSimpleChainTipWithDensity(
 // carry the method at all — otherwise it would claim the capability and
 // answer zero, which selection cannot distinguish from a chain that
 // genuinely has no blocks in the window. Keeping the capability and the
-// data in the same type makes that state unrepresentable.
+// data in the same type removes that hazard from the constructors.
+//
+// It does not make the state impossible: the struct and its embedded field
+// are exported, so a composite literal can still produce a
+// WindowedChainTip with no block slots, and the zero value has a nil
+// embedded tip that panics on access. Use NewWindowedChainTip.
 type WindowedChainTip struct {
 	*SimpleChainTip
 	// blockSlots holds the slot of each block on this chain.

--- a/consensus/selection.go
+++ b/consensus/selection.go
@@ -262,7 +262,32 @@ func (p *PraosChainSelector) compareDensity(
 
 	p.warnLegacyDensity()
 
-	return compareFloat64(a.Density(fork.Slot), b.Density(fork.Slot))
+	return compareFloat64(
+		legacyDensity(a, fork.Slot),
+		legacyDensity(b, fork.Slot),
+	)
+}
+
+// legacyDensity reads a tip's ratio for the no-window path, mapping NaN to
+// zero the way windowBlocks does.
+//
+// NaN is the one value that would break the ordering rather than merely sort
+// low: every comparison against NaN is false, so compareFloat64 returns 0 and
+// the pair falls through to the ordinary Compare. Finite pairs would still be
+// ordered by density, so the relation would mix two orderings and stop being
+// transitive — the same defect this selector exists to avoid, reached through
+// the no-window path.
+//
+// Infinities and negative densities need no such treatment: they are totally
+// ordered by `<`, so they sort to the ends and transitivity holds. They are
+// deliberately left to order naturally rather than collapsed to zero, which
+// would discard the distinction between a negative ratio and an absent one.
+func legacyDensity(tip ChainTip, forkSlot uint64) float64 {
+	density := tip.Density(forkSlot)
+	if math.IsNaN(density) {
+		return 0
+	}
+	return density
 }
 
 // windowBlocks returns the tip's block count within the genesis window.
@@ -289,7 +314,14 @@ func (p *PraosChainSelector) windowBlocks(
 		return 0
 	}
 	projected := math.Round(density * float64(p.GenesisWindowSlots))
-	if math.IsInf(projected, 1) || projected > math.MaxUint64 {
+	// Reject at the boundary rather than reasoning about the conversion.
+	// float64(math.MaxUint64) is exactly 2^64, so `>` would let a projected
+	// value of 2^64 reach uint64(), and Go leaves an out-of-range float to
+	// integer conversion implementation-defined. `>=` keeps the value out of
+	// the conversion entirely, which is correct on every platform rather than
+	// on the ones we happened to measure. The largest float64 below 2^64 is
+	// 2^64-2048 and converts exactly, so nothing is lost by clamping here.
+	if math.IsInf(projected, 1) || projected >= float64(math.MaxUint64) {
 		return math.MaxUint64
 	}
 	return uint64(projected)

--- a/consensus/selection.go
+++ b/consensus/selection.go
@@ -62,10 +62,15 @@ type PraosChainSelector struct {
 	SecurityParam uint64
 	// GenesisWindowSlots is the Ouroboros Genesis density window sgen, in
 	// SLOTS after the fork point. For Shelley-family eras this is 3k/f
-	// (see genesis.ComputeGenesisWindow; mainnet 129600). When it is zero,
-	// or when the tips being compared do not implement WindowBlockCounter,
-	// deep-fork comparison falls back to the legacy ChainTip.Density
-	// ratio; see compareDensity.
+	// (see genesis.ComputeGenesisWindow; mainnet 129600).
+	//
+	// When it is non-zero, every candidate is ordered by its block count
+	// within that window: a tip implementing WindowBlockCounter answers
+	// directly, and a tip that does not has its ChainTip.Density ratio
+	// projected onto the window so that one scale orders the whole set.
+	//
+	// Only when it is zero does comparison fall back to the ChainTip.Density
+	// ratio. See compareDensity.
 	GenesisWindowSlots uint64
 
 	// warnFallbackDensity throttles the legacy-metric warning to once per

--- a/consensus/selection_test.go
+++ b/consensus/selection_test.go
@@ -15,6 +15,7 @@
 package consensus
 
 import (
+	"math"
 	"math/rand"
 	"testing"
 
@@ -1020,32 +1021,224 @@ func TestDeepForkLegacyTipsStillDiscriminate(t *testing.T) {
 	)
 }
 
-// TestWindowedTipDensityFallback covers the mixed case: a windowed tip
-// compared against a ChainTip-only tip falls back to the ratio, so the
-// windowed tip must derive a meaningful ratio from its block slots rather
-// than reporting zero and losing by default.
-func TestWindowedTipDensityFallback(t *testing.T) {
+// TestWindowedTipComparedOnTheWindowScale covers the mixed case: a windowed
+// tip against a ChainTip-only tip.
+//
+// An earlier revision of this test asserted the opposite outcome, because it
+// compared the windowed tip's ratio measured over 100 slots against the
+// legacy tip's ratio measured over its own span — two different
+// denominators. That is precisely the incommensurable comparison that made
+// the comparator intransitive. Both candidates are now placed on the one
+// scale the selector is configured for, and the expectation follows from
+// that rather than from whichever ratio looked larger.
+func TestWindowedTipComparedOnTheWindowScale(t *testing.T) {
 	selector := NewPraosChainSelectorWithWindow(2160, mainnetWindow)
 	fork, tip := deepFork(1000)
 
-	// 10 blocks in the 100 slots after the fork: ratio 0.1.
+	// 10 blocks, all in the first 100 slots after the fork. Across the
+	// whole 129,600-slot genesis window that is a very sparse chain.
 	slots := make([]uint64, 0, 10)
 	for i := uint64(1); i <= 10; i++ {
 		slots = append(slots, 1000+i*10)
 	}
-	windowed := NewWindowedChainTip(1100, 10, make([]byte, 64), slots)
-	assert.InDelta(
+	burst := NewWindowedChainTip(1100, 10, make([]byte, 64), slots)
+	require.Equal(t, uint64(10), burst.BlocksInWindow(1000, mainnetWindow))
+
+	// A tip sustaining mainnet density over the window projects to
+	// 0.05 * 129600 = 6480 blocks there, so it is far denser and must win.
+	sustained := legacyTip{blockNumber: 10, density: 0.05}
+	require.Equal(
+		t, uint64(6480), selector.windowBlocks(sustained, fork),
+	)
+	assert.Negative(
 		t,
-		0.1,
-		windowed.Density(1000),
-		1e-9,
-		"a windowed tip must derive its legacy ratio from its block slots",
+		selector.CompareWithDensity(burst, sustained, fork, tip),
+		"a short burst must lose to a chain dense across the whole window",
 	)
 
-	sparse := legacyTip{blockNumber: 10, density: 0.05}
+	// The converse, so the direction is not an artefact: a windowed tip
+	// with more blocks in the window than the projection wins.
+	dense := make([]uint64, 0, 8000)
+	for i := uint64(1); i <= 8000; i++ {
+		dense = append(dense, 1000+i*15)
+	}
+	rich := NewWindowedChainTip(1000+8000*15, 8000, make([]byte, 64), dense)
+	require.Greater(
+		t,
+		rich.BlocksInWindow(1000, mainnetWindow),
+		selector.windowBlocks(sustained, fork),
+	)
 	assert.Positive(
 		t,
-		selector.CompareWithDensity(windowed, sparse, fork, tip),
-		"mixed comparison must fall back to a meaningful ratio",
+		selector.CompareWithDensity(rich, sustained, fork, tip),
+		"a windowed tip with more blocks in the window must win",
 	)
+}
+
+// --- Mixed candidate sets: one metric must order the whole set -----------
+
+// TestMixedCandidateSetIsTransitive is the regression for the defect this
+// change fixes. When the metric was chosen per pair, a set mixing
+// WindowBlockCounter tips with ChainTip-only tips was ordered on two
+// incommensurable scales — an unbounded block count against a [0,1] ratio —
+// and the relation cycled. These three candidates produced A > B > C > A.
+//
+// All three carry the same block number, so the fallthrough to Compare
+// cannot be what orders them: density alone must, and it must be a total
+// order.
+func TestMixedCandidateSetIsTransitive(t *testing.T) {
+	selector := NewPraosChainSelectorWithWindow(2160, mainnetWindow)
+	vrf := make([]byte, 64)
+	fork := ForkPoint{Slot: 1000, BlockNumber: 0}
+	tipBlockNumber := uint64(100000)
+	require.True(t, selector.IsDeepFork(fork, tipBlockNumber))
+
+	a := NewWindowedChainTip(
+		1050, 100, vrf, []uint64{1010, 1020, 1030, 1040, 1050},
+	)
+	b := NewWindowedChainTip(1002, 100, vrf, []uint64{1001, 1002})
+	c := NewSimpleChainTipWithDensity(1010, 100, vrf, 5, 10)
+
+	candidates := []ChainTip{a, b, c}
+	for _, x := range candidates {
+		for _, y := range candidates {
+			for _, z := range candidates {
+				xy := sign(selector.CompareWithDensity(x, y, fork, tipBlockNumber))
+				yz := sign(selector.CompareWithDensity(y, z, fork, tipBlockNumber))
+				xz := sign(selector.CompareWithDensity(x, z, fork, tipBlockNumber))
+				if xy > 0 && yz > 0 {
+					require.Positive(
+						t, xz,
+						"transitivity: x>y and y>z requires x>z",
+					)
+				}
+			}
+		}
+	}
+}
+
+// TestMixedCandidateSetSelectionIsOrderIndependent pins the consequence a
+// user actually sees: PreferredWithDensity returned three different winners
+// over rotations of this one candidate set while the comparator cycled.
+func TestMixedCandidateSetSelectionIsOrderIndependent(t *testing.T) {
+	selector := NewPraosChainSelectorWithWindow(2160, mainnetWindow)
+	fork := ForkPoint{Slot: 1000, BlockNumber: 0}
+	tipBlockNumber := uint64(100000)
+
+	// Distinct VRF outputs on purpose. With a shared one these candidates
+	// tie all the way down to Compare's tiebreak, and selectPreferred's
+	// keep-the-incumbent rule would make the sweep pass for a reason that
+	// has nothing to do with the ordering being total.
+	a := NewWindowedChainTip(
+		1050, 100, vrfByte(0x11), []uint64{1010, 1020, 1030, 1040, 1050},
+	)
+	b := NewWindowedChainTip(1002, 100, vrfByte(0x22), []uint64{1001, 1002})
+	c := NewSimpleChainTipWithDensity(1010, 100, vrfByte(0x33), 5, 10)
+
+	assertSelectionIsOrderIndependent(t, selector, fork, tipBlockNumber, a, b, c)
+}
+
+// TestWindowedCandidateSetSelectionIsOrderIndependent is the control for the
+// test above: the same three shapes with NO mixing, so every candidate is
+// ordered by the window count. It bounds the claim - selection is
+// order-independent here both before and after the change - and it fails if
+// a future edit makes the ordering non-total for reasons unrelated to mixing.
+func TestWindowedCandidateSetSelectionIsOrderIndependent(t *testing.T) {
+	selector := NewPraosChainSelectorWithWindow(2160, mainnetWindow)
+	fork := ForkPoint{Slot: 1000, BlockNumber: 0}
+	tipBlockNumber := uint64(100000)
+
+	a := NewWindowedChainTip(
+		1050, 100, vrfByte(0x11), []uint64{1010, 1020, 1030, 1040, 1050},
+	)
+	b := NewWindowedChainTip(1002, 100, vrfByte(0x22), []uint64{1001, 1002})
+	c := NewWindowedChainTip(
+		1010, 100, vrfByte(0x33), []uint64{1002, 1004, 1006, 1008, 1010},
+	)
+
+	assertSelectionIsOrderIndependent(t, selector, fork, tipBlockNumber, a, b, c)
+}
+
+// vrfByte returns a VRF output distinguishable from any other produced here.
+func vrfByte(n byte) []byte {
+	v := make([]byte, 64)
+	v[0] = n
+	return v
+}
+
+// assertSelectionIsOrderIndependent runs all six arrival orders of three
+// candidates through PreferredWithDensity and requires one winner. Fixed
+// orders, no randomisation - this runs on every CI build.
+func assertSelectionIsOrderIndependent(
+	t *testing.T,
+	selector *PraosChainSelector,
+	fork ForkPoint,
+	tipBlockNumber uint64,
+	a, b, c ChainTip,
+) {
+	t.Helper()
+	orders := [][]ChainTip{
+		{a, b, c}, {a, c, b}, {b, a, c},
+		{b, c, a}, {c, a, b}, {c, b, a},
+	}
+	want := selector.PreferredWithDensity(orders[0], fork, tipBlockNumber)
+	for _, order := range orders[1:] {
+		assert.Same(
+			t,
+			want,
+			selector.PreferredWithDensity(order, fork, tipBlockNumber),
+			"selection must not depend on candidate arrival order",
+		)
+	}
+}
+
+// TestLegacyTipProjectedOntoWindow documents the mechanism: with a window
+// configured, a tip that cannot count is ordered by its ratio projected onto
+// the window, so it shares one scale with the tips that can count.
+func TestLegacyTipProjectedOntoWindow(t *testing.T) {
+	selector := NewPraosChainSelectorWithWindow(2160, 1000)
+	fork := ForkPoint{Slot: 1000, BlockNumber: 0}
+
+	// ratio 0.5 over a 1000-slot window projects to 500 blocks.
+	legacy := legacyTip{blockNumber: 10, density: 0.5}
+	assert.Equal(t, uint64(500), selector.windowBlocks(legacy, fork))
+
+	// A windowed tip answers exactly, with no projection.
+	windowed := NewWindowedChainTip(
+		1300, 10, make([]byte, 64), []uint64{1100, 1200, 1300},
+	)
+	assert.Equal(t, uint64(3), selector.windowBlocks(windowed, fork))
+
+	// Degenerate ratios project to zero rather than to a wrapped value.
+	assert.Zero(t, selector.windowBlocks(
+		legacyTip{blockNumber: 1, density: 0}, fork,
+	))
+	assert.Zero(t, selector.windowBlocks(
+		legacyTip{blockNumber: 1, density: math.NaN()}, fork,
+	))
+	assert.Equal(t, uint64(math.MaxUint64), selector.windowBlocks(
+		legacyTip{blockNumber: 1, density: math.Inf(1)}, fork,
+	))
+}
+
+// TestSelectorRemainsCopyable guards the copylocks regression: the selector
+// was freely copyable before a throttle field was added, so downstream code
+// that passes or stores it by value must keep compiling and keep passing
+// `go vet`. A sync.Once VALUE here would break both.
+func TestSelectorRemainsCopyable(t *testing.T) {
+	selector := NewPraosChainSelectorWithWindow(2160, mainnetWindow)
+	byValue := *selector
+	assert.Equal(t, uint64(2160), byValue.SecurityParam)
+	assert.Equal(t, mainnetWindow, byValue.GenesisWindowSlots)
+
+	// A zero-value selector must not panic on the warning path.
+	var zero PraosChainSelector
+	assert.NotPanics(t, func() {
+		zero.CompareWithDensity(
+			NewSimpleChainTip(1, 1, nil),
+			NewSimpleChainTip(2, 2, nil),
+			ForkPoint{Slot: 0, BlockNumber: 0},
+			10,
+		)
+	})
 }

--- a/consensus/selection_test.go
+++ b/consensus/selection_test.go
@@ -1231,6 +1231,18 @@ func TestSelectorRemainsCopyable(t *testing.T) {
 	assert.Equal(t, uint64(2160), byValue.SecurityParam)
 	assert.Equal(t, mainnetWindow, byValue.GenesisWindowSlots)
 
+	// Assert the property that makes the copy safe, not merely that a copy
+	// compiles. copylocks lives in `go vet`, which `go test` does not run, so
+	// a bare copy here would pass even if the field went back to a sync.Once
+	// value. Requiring a shared pointer fails under `go test` if it does.
+	require.NotNil(t, selector.warnFallbackDensity)
+	assert.Same(
+		t,
+		selector.warnFallbackDensity,
+		byValue.warnFallbackDensity,
+		"copies must share the throttle, so the field must stay a pointer",
+	)
+
 	// A zero-value selector must not panic on the warning path.
 	var zero PraosChainSelector
 	assert.NotPanics(t, func() {
@@ -1241,4 +1253,194 @@ func TestSelectorRemainsCopyable(t *testing.T) {
 			10,
 		)
 	})
+}
+
+// --- Degenerate density inputs -------------------------------------------
+
+// oddTip implements only ChainTip and reports whatever density it is given,
+// with a distinct VRF per instance so ties resolve rather than dead-heat.
+type oddTip struct {
+	name    string
+	block   uint64
+	vrf     byte
+	density float64
+}
+
+func (o oddTip) Slot() uint64             { return o.block * 20 }
+func (o oddTip) BlockNumber() uint64      { return o.block }
+func (o oddTip) VRFOutput() []byte        { return vrfByte(o.vrf) }
+func (o oddTip) Density(_ uint64) float64 { return o.density }
+
+// degeneratePopulation covers the value classes a float64 density can take.
+// The earlier sweeps carried only plausible densities, which is why they could
+// not detect a defect that only appears at the edges.
+func degeneratePopulation() []ChainTip {
+	// Block numbers are assigned to CONFLICT with the density ordering, and
+	// NaN sits in the middle of the block range rather than at either end.
+	// Both are load-bearing. A NaN tip parked at the lowest block number loses
+	// every fallthrough comparison and no cycle can form, so a population
+	// built that way passes even with the NaN handling removed - it cannot
+	// express the defect it exists to detect.
+	//
+	// With this layout the triple (one > mainnet-f by density, mainnet-f > nan
+	// by block, nan > one by block) closes a cycle the moment NaN is left
+	// unnormalised.
+	specs := []struct {
+		name    string
+		block   uint64
+		density float64
+	}{
+		{"one", 10, 1.0},
+		{"+inf", 15, math.Inf(1)},
+		{"half", 20, 0.5},
+		{"nan", 50, math.NaN()},
+		{"zero", 80, 0},
+		{"negative", 85, -0.25},
+		{"mainnet-f", 90, 0.05},
+		{"-inf", 95, math.Inf(-1)},
+	}
+	out := make([]ChainTip, 0, len(specs))
+	for i, sp := range specs {
+		out = append(out, oddTip{
+			name:    sp.name,
+			block:   sp.block,
+			vrf:     byte(i + 1),
+			density: sp.density,
+		})
+	}
+	return out
+}
+
+// TestDegenerateDensitiesKeepOrderingTotal is the population fix. It runs the
+// same value classes through BOTH configurations, because the two take
+// different paths: with a window the density is projected onto the window, and
+// without one it is compared as a raw ratio. A guard added to one path is not
+// a guard on the other.
+func TestDegenerateDensitiesKeepOrderingTotal(t *testing.T) {
+	fork := ForkPoint{Slot: 1000, BlockNumber: 0}
+	tipBlockNumber := uint64(100000) // deep fork: the density rule governs
+
+	for _, cfg := range []struct {
+		name     string
+		selector *PraosChainSelector
+	}{
+		{"windowed", NewPraosChainSelectorWithWindow(2160, mainnetWindow)},
+		{"no-window", NewPraosChainSelector(2160)},
+	} {
+		t.Run(cfg.name, func(t *testing.T) {
+			pop := degeneratePopulation()
+			sel := cfg.selector
+
+			cmp := func(x, y ChainTip) int {
+				return sign(sel.CompareWithDensity(x, y, fork, tipBlockNumber))
+			}
+
+			for _, a := range pop {
+				for _, b := range pop {
+					require.Equal(
+						t, cmp(a, b), -cmp(b, a),
+						"antisymmetry: %s vs %s",
+						a.(oddTip).name, b.(oddTip).name,
+					)
+				}
+			}
+
+			for _, a := range pop {
+				for _, b := range pop {
+					for _, c := range pop {
+						if cmp(a, b) >= 0 && cmp(b, c) >= 0 {
+							require.GreaterOrEqual(
+								t, cmp(a, c), 0,
+								"transitivity: %s >= %s >= %s",
+								a.(oddTip).name, b.(oddTip).name,
+								c.(oddTip).name,
+							)
+						}
+					}
+				}
+			}
+
+			// The consequence a caller sees: one winner, whatever the order.
+			want := sel.PreferredWithDensity(pop, fork, tipBlockNumber)
+			shuffled := make([]ChainTip, len(pop))
+			for i := range pop {
+				shuffled[i] = pop[len(pop)-1-i]
+			}
+			got := sel.PreferredWithDensity(shuffled, fork, tipBlockNumber)
+			assert.Equal(
+				t, want.(oddTip).name, got.(oddTip).name,
+				"selection must not depend on candidate order",
+			)
+		})
+	}
+}
+
+// TestNaNDensityIsDecidedByDensityNotFallthrough is the named case behind the
+// NaN normalisation. A sweep that only checks transitivity proves the ordering
+// is total but does not show WHICH rule decided, so this pins the mechanism.
+//
+// The two candidates are arranged so density and the ordinary Compare would
+// give OPPOSITE answers: the denser chain has the LOWER block number. If NaN
+// were left unnormalised the pair would compare equal on density and fall
+// through to Compare, and the NaN chain would win on block number. Density
+// must decide instead.
+func TestNaNDensityIsDecidedByDensityNotFallthrough(t *testing.T) {
+	selector := NewPraosChainSelector(2160) // no window: the legacy path
+	fork := ForkPoint{Slot: 1000, BlockNumber: 0}
+	tipBlockNumber := uint64(100000)
+	require.True(t, selector.IsDeepFork(fork, tipBlockNumber))
+
+	nan := oddTip{name: "nan", block: 90, vrf: 1, density: math.NaN()}
+	dense := oddTip{name: "dense", block: 10, vrf: 2, density: 0.9}
+
+	require.Negative(
+		t,
+		selector.Compare(dense, nan),
+		"setup: the ordinary rule alone would prefer the NaN chain",
+	)
+	assert.Positive(
+		t,
+		selector.CompareWithDensity(dense, nan, fork, tipBlockNumber),
+		"density must decide, not the Compare fallthrough",
+	)
+
+	// NaN normalises to zero, so a NaN chain and a genuine zero-density chain
+	// are equal under the metric and legitimately fall through to Compare.
+	// That is a tie between equals, not a NaN artefact, and it stays
+	// transitive - pinned here so the distinction is not lost later.
+	zero := oddTip{name: "zero", block: 20, vrf: 3, density: 0}
+	assert.Equal(
+		t,
+		selector.Compare(nan, zero),
+		selector.CompareWithDensity(nan, zero, fork, tipBlockNumber),
+		"NaN and zero density tie, so the ordinary rule breaks the tie",
+	)
+}
+
+// TestProjectionSaturatesAtTheBoundary pins the clamp. With a window at
+// math.MaxUint64 a density of 1 projects to exactly 2^64, which is not
+// representable as a uint64; the value must be rejected before the conversion
+// rather than converted and hoped for.
+func TestProjectionSaturatesAtTheBoundary(t *testing.T) {
+	sel := NewPraosChainSelectorWithWindow(2160, math.MaxUint64)
+	fork := ForkPoint{Slot: 0, BlockNumber: 0}
+
+	dense := oddTip{name: "one", block: 10, vrf: 1, density: 1.0}
+	half := oddTip{name: "half", block: 20, vrf: 2, density: 0.5}
+
+	assert.Equal(
+		t, uint64(math.MaxUint64), sel.windowBlocks(dense, fork),
+		"a density of 1 must saturate, not convert out of range",
+	)
+
+	// Unclamped, both of these land on 2^63 and compare equal, which is a
+	// spurious tie between the densest possible chain and a half-density one.
+	assert.Greater(
+		t, sel.windowBlocks(dense, fork), sel.windowBlocks(half, fork),
+		"the densest chain must outrank a half-density chain",
+	)
+	assert.Positive(
+		t, sel.compareDensity(dense, half, fork),
+		"density 1.0 must beat density 0.5 at the window boundary",
+	)
 }


### PR DESCRIPTION
Fixes the order dependence reported in #2271. Please read the note on scope at the bottom before merging — this deliberately does not say "Closes".

## What it changes

`compareDensity` currently chooses its metric per pair: the integer window count when both operands implement `WindowBlockCounter`, the float `Density` ratio otherwise. A candidate set mixing the two is therefore ordered on two scales that are not commensurable, the comparator is not transitive, and `selectPreferred` — which walks the slice once against a running winner — returns a different chain depending on arrival order.

The metric becomes a property of the selector's configuration instead. With a genesis window configured every candidate is ordered by the window count, and a tip that cannot answer has its ratio projected onto the window (`density × windowSlots`, rounded) so it lands on the same scale. With no window configured every candidate is ordered by the ratio, as before. The ordering is then lexicographic on (window blocks, block number, VRF).

Measured over a population deliberately built to contain tips whose count ordering and ratio ordering disagree — the only shape that can expose this, which is why a uniform population finds nothing — checking every ordered triple for transitivity and every pair for antisymmetry: on `main` the transitivity violations are non-zero, and with this change they are zero. Antisymmetry holds throughout. The rate itself is an artefact of a constructed population and means nothing; only zero-versus-non-zero does.

## This is a fix, and it is not the only one

This closes the order dependence: violations go to zero, the six arrival orders in #2271's reproduction collapse to one winner, and the regression test pins it.

It is not the uniquely determined fix, because the total-order requirement constrains the relation, not what to order by. Requiring homogeneity — treating a tip that cannot answer the window count as not comparable on the Genesis metric, so it is ordered below every tip that can — also restores a total order. We implemented that variant to check rather than assume, and it does. It is not included here.

The two differ in behaviour. Given a legacy tip that is genuinely the densest candidate (sustained 0.05, mainnet `f`) against a windowed tip holding 2 blocks in the window: projecting onto one scale, the denser legacy tip **wins** — density decides. Requiring homogeneity, it **loses** — the capability decides.

For what it is worth, and this is an opinion rather than a result: we would take projection, because under homogeneity a genuinely denser chain is excluded from selection by which Go interface its tip happens to implement, and interface membership carries no consensus meaning. Projection keeps density as the deciding quantity, at the cost of approximating a metric the tip cannot supply exactly. The call is yours and a one-line preference either way is enough for us to follow.

## Tests

`TestMixedCandidateSetSelectionIsOrderIndependent` runs all six arrival orders of a mixed candidate set and requires one winner. It fails before this change.

`TestWindowedCandidateSetSelectionIsOrderIndependent` is the control: the same sweep with no mixing. It passes both before and after, which is what shows the behaviour is specific to mixed sets rather than to selection generally.

Both use fixed orders and distinct VRF outputs, with no randomisation — a shared VRF would let the candidates tie down to `selectPreferred`'s keep-the-incumbent rule and pass for a reason unrelated to the ordering being total.

## Also in this change

`PraosChainSelector` held a `sync.Once` value, which made the exported struct non-copyable: `go vet` copylocks rejects downstream code that passes or stores the selector by value, which was legal before that field existed. The field is now a pointer, and a zero-value selector skips the warning rather than panicking. Note this never affected this repository — `go vet ./...` passes on `main`, since nothing here copies the selector.

The `WindowedChainTip` doc comment claimed a slotless windowed tip was unrepresentable. The struct and its embedded field are exported, so a composite literal produces one and the zero value panics on access. The comment now claims only what the type split achieves.

## Verification

`go build ./...`, `go vet ./consensus/...`, `make test` (full race suite) and `make lint` are all clean, with 0 lint issues across the module and examples. Fail-before/pass-after confirmed for the regression test against `main`. No exported signature changes, so no breaking-change marker. `go.mod` and `go.sum` are untouched; the diff is two files.

## Scope — why this says Refs and not Closes

Merging this addresses the order dependence. It does **not** settle the question #2271 raises under its own heading: whether the ratio or the integer window count should be authoritative. Every candidate fix, including this one, depends on that answer, and it is the part only a maintainer can decide.

So this is deliberately `Refs #2271` rather than `Closes`, to avoid auto-closing the issue and taking the open question down with it. Whether the issue closes when this merges is your call.

---

Developed with AI assistance (Claude), with the verification above run in a clean container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes order dependence in `PreferredWithDensity` so the same candidate set always selects the same chain regardless of arrival order. Previously a mixed set of windowed and legacy tips was ordered on two different scales, making selection depend on arrival order.

**Bug Fixes**
- `compareDensity` now picks one metric for the whole candidate set: window block count when a genesis window is configured, otherwise the legacy density ratio. Legacy tips without a window counter are projected onto the window via `density × windowSlots` so they share the scale.
- NaN density normalizes to zero on both windowed and no-window paths, and projection saturates at `uint64` max, keeping the ordering total.
- `PraosChainSelector` now stores its `sync.Once` as a pointer, keeping the struct copyable and `go vet` clean.
- Corrected stale doc comments on `WindowedChainTip` and `GenesisWindowSlots`.
- Added regression tests covering all six arrival orders of a mixed candidate set, transitivity checks, and degenerate density values (NaN, infinities, zero, negative).

<sup>Written for commit c0ced6c6106d1fdac85762d5efcb72f335ec09c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chain selection consistency when comparing candidates across Genesis windows.
  * Ensured candidate selection remains deterministic regardless of candidate ordering.
  * Improved compatibility when evaluating legacy and windowed candidate data.
  * Preserved consistent ordering in edge cases involving unusual or invalid density values.
  * Reduced repeated warnings during legacy fallback handling.

* **Documentation**
  * Clarified that directly constructed windowed-tip state may contain invalid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->