### PR TITLE
test: assert deterministic consensus leadership

### DIFF
--- a/consensus/block_test.go
+++ b/consensus/block_test.go
@@ -17,7 +17,6 @@ package consensus
 import (
 	"bytes"
 	"crypto/ed25519"
-	"errors"
 	"math/big"
 	"testing"
 
@@ -131,7 +130,7 @@ func TestBuildHeaderEligible(t *testing.T) {
 	}
 	poolId := make([]byte, 28)
 
-	// Use high active slot coefficient to increase chance of eligibility
+	// Use a high active slot coefficient with fixed inputs for deterministic eligibility.
 	builder := NewBlockBuilder(
 		vrfSigner,
 		kesSigner,
@@ -149,33 +148,22 @@ func TestBuildHeaderEligible(t *testing.T) {
 	prevHash := make([]byte, 32)
 	bodyHash := make([]byte, 32)
 
-	// Try multiple slots to find one where we're eligible
-	var header *Header
-	var result *LeaderElectionResult
-
-	for slot := uint64(1); slot <= 100; slot++ {
-		input := BuildHeaderInput{
-			Slot:          slot,
-			BlockNumber:   slot,
-			PrevHash:      prevHash,
-			EpochNonce:    epochNonce,
-			PoolStake:     1000000000,
-			TotalStake:    1000000000, // 100% stake
-			BlockBodyHash: bodyHash,
-			BlockBodySize: 1024,
-			ProtoMajor:    9,
-			ProtoMinor:    0,
-		}
-
-		header, result, err = builder.BuildHeader(input)
-		if err == nil && header != nil {
-			break
-		}
+	// Slot 1 is a deterministic eligible case for these fixed test inputs.
+	input := BuildHeaderInput{
+		Slot:          1,
+		BlockNumber:   1,
+		PrevHash:      prevHash,
+		EpochNonce:    epochNonce,
+		PoolStake:     1000000000,
+		TotalStake:    1000000000, // 100% stake
+		BlockBodyHash: bodyHash,
+		BlockBodySize: 1024,
+		ProtoMajor:    9,
+		ProtoMinor:    0,
 	}
-
-	if header == nil {
-		t.Skip("no eligible slot found in range (unlikely but possible)")
-	}
+	header, result, err := builder.BuildHeader(input)
+	require.NoError(t, err)
+	require.NotNil(t, header)
 
 	// Verify header structure
 	if header.Body.BlockNumber == 0 {
@@ -202,9 +190,8 @@ func TestBuildHeaderEligible(t *testing.T) {
 			len(header.Signature),
 		)
 	}
-	if result == nil || !result.Eligible {
-		t.Error("expected eligible result")
-	}
+	require.NotNil(t, result)
+	require.True(t, result.Eligible)
 }
 
 func TestBuildHeaderNotEligible(t *testing.T) {
@@ -255,16 +242,7 @@ func TestBuildHeaderNotEligible(t *testing.T) {
 	}
 
 	_, _, err = builder.BuildHeader(input)
-
-	// Most likely not eligible with such small relative stake
-	if err == nil {
-		// If somehow eligible, that's fine - just skip
-		t.Skip("unexpectedly eligible (very unlikely but possible)")
-	}
-
-	if !errors.Is(err, ErrNotSlotLeader) {
-		t.Fatalf("expected ErrNotSlotLeader, got: %v", err)
-	}
+	require.ErrorIs(t, err, ErrNotSlotLeader)
 }
 
 func TestBuildHeaderMissingInputs(t *testing.T) {

--- a/consensus/leader_test.go
+++ b/consensus/leader_test.go
@@ -434,8 +434,7 @@ func TestFindNextSlotLeadership(t *testing.T) {
 		10,
 	) // 90% active slot coefficient for faster tests
 
-	// With 100% stake and f=0.9, probability per slot ≈ 0.9
-	// We should find eligibility very quickly
+	// With 100% stake and these fixed inputs, slot 1 is eligible.
 	slot, proof, output, err := FindNextSlotLeadership(
 		1,   // start slot
 		100, // max slot (reduced from 1000)
@@ -449,17 +448,11 @@ func TestFindNextSlotLeadership(t *testing.T) {
 		t.Fatalf("FindNextSlotLeadership failed: %v", err)
 	}
 
-	if slot == 0 {
-		// This is probabilistically unlikely but possible
-		t.Log("no slot leadership found in range (may be valid but unlikely)")
-	} else {
-		if proof == nil || output == nil {
-			t.Error("if slot found, proof and output should not be nil")
-		}
-		if slot < 1 || slot > 100 {
-			t.Errorf("found slot %d outside search range", slot)
-		}
-	}
+	// Slot 1 is deterministic for these fixed inputs; require the search to
+	// return it rather than silently accepting an untested no-leader result.
+	require.Equal(t, uint64(1), slot)
+	require.NotNil(t, proof)
+	require.NotNil(t, output)
 }
 
 func TestFindNextSlotLeadershipNoEligibility(t *testing.T) {


### PR DESCRIPTION
Replaces probabilistic skip/log-only consensus tests with deterministic assertions for eligible, ineligible, and next-leadership-slot behavior.

Refs #2023