### PR TITLE
fix(cbor): use Plutus general constructor tag

### DIFF
--- a/cbor/constructor.go
+++ b/cbor/constructor.go
@@ -29,16 +29,16 @@ func alternativeToTag(alt uint) (uint64, bool) {
 	case alt <= 127:
 		return uint64(alt) - 7 + CborTagAlternative2Min, false
 	default:
-		return CborTagAlternative3, true
+		return PlutusConstrGeneral, true
 	}
 }
 
 // IsAlternativeTag returns true if the given CBOR tag number represents
-// a constructor/alternative (tags 121-127, 1280-1400, or 101).
+// a constructor/alternative (tags 121-127, 1280-1400, or 102).
 func IsAlternativeTag(tagNum uint64) bool {
 	return (tagNum >= CborTagAlternative1Min && tagNum <= CborTagAlternative1Max) ||
 		(tagNum >= CborTagAlternative2Min && tagNum <= CborTagAlternative2Max) ||
-		tagNum == CborTagAlternative3
+		tagNum == PlutusConstrGeneral
 }
 
 // ConstructorEncoder builds a CBOR constructor/alternative for encoding.
@@ -165,8 +165,8 @@ func (cd *ConstructorDecoder) UnmarshalCBOR(data []byte) error {
 		// Alternatives 7-127 (tags 1280-1400)
 		cd.tag = uint(tmpTag.Number - CborTagAlternative2Min + 7)
 		cd.fields = RawMessage(tmpTag.Content)
-	case tmpTag.Number == CborTagAlternative3:
-		// Alternatives 128+ (tag 101): content is [constructor_number, fields]
+	case tmpTag.Number == PlutusConstrGeneral:
+		// General constructors (tag 102): content is [constructor_number, fields]
 		var outerArray []RawMessage
 		if _, err := Decode(tmpTag.Content, &outerArray); err != nil {
 			return fmt.Errorf("decode alternative 128+ content: %w", err)
@@ -180,6 +180,9 @@ func (cd *ConstructorDecoder) UnmarshalCBOR(data []byte) error {
 		var altNum uint64
 		if _, err := Decode(outerArray[0], &altNum); err != nil {
 			return fmt.Errorf("decode alternative number: %w", err)
+		}
+		if altNum > uint64(^uint(0)) {
+			return fmt.Errorf("alternative number %d overflows uint", altNum)
 		}
 		cd.tag = uint(altNum)
 		cd.fields = outerArray[1]

--- a/cbor/constructor_test.go
+++ b/cbor/constructor_test.go
@@ -45,8 +45,8 @@ var constructorDecoderTestDefs = []struct {
 		fields:  []any{uint64(3), uint64(4), uint64(5)},
 	},
 	{
-		name:    "alternative 999 (tag 101)",
-		cborHex: "D865821903E7820607",
+		name:    "alternative 999 (tag 102)",
+		cborHex: "D866821903E7820607",
 		tag:     999,
 		fields:  []any{uint64(6), uint64(7)},
 	},
@@ -173,9 +173,9 @@ func TestConstructorDecoderAllAlternativeRanges(t *testing.T) {
 		{"alternative 6 (max range 1)", 6},
 		{"alternative 7 (min range 2)", 7},
 		{"alternative 127 (max range 2)", 127},
-		{"alternative 128 (min range 3)", 128},
-		{"alternative 256 (range 3)", 256},
-		{"alternative 65535 (large range 3)", 65535},
+		{"alternative 128 (general tag 102)", 128},
+		{"alternative 256 (general tag 102)", 256},
+		{"alternative 65535 (general tag 102)", 65535},
 	}
 
 	for _, tt := range tests {
@@ -205,6 +205,105 @@ func TestConstructorDecoderAllAlternativeRanges(t *testing.T) {
 			assert.Equal(t, encoded, reEncoded)
 		})
 	}
+}
+
+func TestPlutusConstructorWireVectors(t *testing.T) {
+	tests := []struct {
+		name string
+		alt  uint
+		hex  string
+	}{
+		{"compact maximum 127", 127, "d9057881182a"},
+		{"first general-encoder alternative 128", 128, "d86682188081182a"},
+		{"general 256", 256, "d8668219010081182a"},
+		{"general 65535", 65535, "d8668219ffff81182a"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want, err := hex.DecodeString(tt.hex)
+			require.NoError(t, err)
+			encoded, err := cbor.Encode(
+				cbor.NewConstructorEncoder(tt.alt, []any{uint64(42)}),
+			)
+			require.NoError(t, err)
+			assert.Equal(t, want, encoded)
+
+			var decoded cbor.ConstructorDecoder
+			_, err = cbor.Decode(want, &decoded)
+			require.NoError(t, err)
+			assert.Equal(t, tt.alt, decoded.Tag())
+			var decodedFields []uint64
+			require.NoError(t, decoded.DecodeFields(&decodedFields))
+			assert.Equal(t, []uint64{42}, decodedFields)
+
+			var value cbor.Value
+			_, err = cbor.Decode(want, &value)
+			require.NoError(t, err)
+			valueConstructor, ok := value.Value().(cbor.ConstructorDecoder)
+			require.True(t, ok, "Value must classify tag %d as a constructor", tt.alt)
+			assert.Equal(t, tt.alt, valueConstructor.Tag())
+			var valueFields []uint64
+			require.NoError(t, valueConstructor.DecodeFields(&valueFields))
+			assert.Equal(t, []uint64{42}, valueFields)
+		})
+	}
+}
+
+func TestPlutusConstructorGeneralTagAcceptsAnyIndex(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		alt  uint
+		hex  string
+	}{
+		{"index zero", 0, "d866820081182a"},
+		{"index 127", 127, "d86682187f81182a"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := hex.DecodeString(tt.hex)
+			require.NoError(t, err)
+			var decoded cbor.ConstructorDecoder
+			_, err = cbor.Decode(data, &decoded)
+			require.NoError(t, err)
+			assert.Equal(t, tt.alt, decoded.Tag())
+		})
+	}
+}
+
+func TestPlutusConstructorGeneralAlternativeWidth(t *testing.T) {
+	const maxUint32 = uint64(1<<32 - 1)
+	tests := []struct {
+		name   string
+		alt    uint64
+		hex    string
+		reject bool
+	}{
+		{"maximum uint32", maxUint32, "d866821aFFFFFFFF81182a", false},
+		{"beyond uint32", 1 << 32, "d866821b000000010000000081182a", uint64(^uint(0)) == maxUint32},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := hex.DecodeString(tt.hex)
+			require.NoError(t, err)
+			var decoded cbor.ConstructorDecoder
+			_, err = cbor.Decode(data, &decoded)
+			if tt.reject {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "overflows uint")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, uint(tt.alt), decoded.Tag())
+		})
+	}
+}
+
+func TestPlutusConstructorRejectsAlternativeDataTag101(t *testing.T) {
+	data, err := hex.DecodeString("d86582188081182a")
+	require.NoError(t, err)
+	var decoded cbor.ConstructorDecoder
+	_, err = cbor.Decode(data, &decoded)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported constructor tag: 101")
 }
 
 func TestConstructorDecoderEmptyFields(t *testing.T) {
@@ -259,7 +358,8 @@ func TestIsAlternativeTag(t *testing.T) {
 		{124, true},  // mid range 1
 		{127, true},  // max range 1
 		{128, false}, // gap
-		{101, true},  // alternative 3
+		{101, false}, // unrelated alternative-data tag
+		{102, true},  // Plutus general constructor
 		{100, false},
 		{1279, false},
 		{1280, true},  // min range 2


### PR DESCRIPTION
Use tag 102 for Plutus general-constructor encoding, decoding and Value
classification, preserving compact constructor tags and alternatives/fields.
Reject unrelated tag 101 and general indices that overflow the platform uint.

Independent byte vectors cover the compact/general boundary, general-form
indices below 128, field preservation and the 32-bit index boundary.

Fixes #2037.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Plutus general constructor encoding, decoding, and Value classification from tag 101 to tag 102, matching the Plutus spec. Tag 101 is now rejected as unsupported, and general-form indices that overflow the platform `uint` are rejected.

**Migration**
- Data previously encoded with tag 101 for general constructors must be re-encoded with tag 102.

<sup>Written for commit 01dad3f8b987f4efde80a75e86bdb84cf6be86c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

