### PR TITLE
fix(protocol): arm opted-in initial handshake timeout

### DIFF
--- a/protocol/PROTOCOL_LIMITS.md
+++ b/protocol/PROTOCOL_LIMITS.md
@@ -84,9 +84,12 @@ counts outside those bounds with `ErrProtocolViolationRequestExceeded`.
 
 ## Handshake
 
-For N2N, `Propose` and `Confirm` each have a 10-second timeout. N2C has no
-state timeouts. Client and server instances copy the N2N map and can override
-the applicable timeout with `WithTimeout`; the N2C map remains timeout-free.
+For N2N, `Propose` and `Confirm` each have a 10-second timeout. The framework
+does not arm the initial state's timer by default; the N2N handshake server
+opts into its configured `Propose` timeout. N2C has no state timeouts and does
+not opt in. After the initial transition, `Confirm` uses the normal state
+timeout. Client and server instances copy the N2N map and can override the
+applicable timeout with `WithTimeout`; the N2C map remains timeout-free.
 
 ## Keep Alive
 

--- a/protocol/handshake/server.go
+++ b/protocol/handshake/server.go
@@ -64,6 +64,7 @@ func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 		MessageFromCborFunc: NewMsgFromCbor,
 		StateMap:            stateMap,
 		InitialState:        statePropose,
+		InitialStateTimeout: protoOptions.Mode == protocol.ProtocolModeNodeToNode,
 	}
 	s.Protocol = protocol.New(protoConfig)
 	return s

--- a/protocol/handshake/server_test.go
+++ b/protocol/handshake/server_test.go
@@ -17,18 +17,76 @@ package handshake_test
 import (
 	"errors"
 	"fmt"
+	"net"
 	"strings"
 	"testing"
 	"time"
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/muxer"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	"github.com/blinklabs-io/gouroboros/protocol/handshake"
 	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
 	"go.uber.org/goleak"
 )
 
-func TestServerBasicHandshake(t *testing.T) {
+func TestServerInitialProposeTimeout(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	for _, test := range []struct {
+		name        string
+		mode        protocol.ProtocolMode
+		timeout     time.Duration
+		wantTimeout bool
+	}{
+		{"node-to-node", protocol.ProtocolModeNodeToNode, 20 * time.Millisecond, true},
+		{"node-to-client", protocol.ProtocolModeNodeToClient, 20 * time.Millisecond, false},
+		{"node-to-node zero timeout", protocol.ProtocolModeNodeToNode, 0, false},
+		{"node-to-node negative timeout", protocol.ProtocolModeNodeToNode, -time.Second, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			serverConn, peerConn := net.Pipe()
+			defer serverConn.Close()
+			defer peerConn.Close()
+			m := muxer.New(serverConn)
+			m.Start()
+			defer m.Stop()
+			errorChan := make(chan error, 1)
+			cfg := handshake.NewConfig(
+				handshake.WithTimeout(test.timeout),
+			)
+			s := handshake.NewServer(protocol.ProtocolOptions{
+				Muxer:     m,
+				ErrorChan: errorChan,
+				Mode:      test.mode,
+				Role:      protocol.ProtocolRoleServer,
+			}, &cfg)
+			s.Start()
+			defer s.Stop()
+
+			if test.wantTimeout {
+				select {
+				case err := <-errorChan:
+					if err == nil {
+						t.Fatal("received nil timeout error")
+					}
+					if !strings.Contains(err.Error(), "timeout waiting on transition") {
+						t.Fatalf("unexpected timeout error: %v", err)
+					}
+				case <-time.After(time.Second):
+					t.Fatal("server did not enforce initial Propose timeout")
+				}
+				return
+			}
+			select {
+			case err := <-errorChan:
+				t.Fatalf("unexpected initial timeout: %v", err)
+			case <-time.After(50 * time.Millisecond):
+			}
+		})
+	}
+}
+
+func TestServerBasicN2NHandshake(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	mockConn := ouroboros_mock.NewConnection(
 		ouroboros_mock.ProtocolRoleServer,
@@ -39,15 +97,10 @@ func TestServerBasicHandshake(t *testing.T) {
 				Messages: []protocol.Message{
 					handshake.NewMsgProposeVersions(
 						protocol.ProtocolVersionMap{
-							(10 + protocol.ProtocolVersionNtCOffset): protocol.VersionDataNtC9to14(
-								ouroboros_mock.MockNetworkMagic,
-							),
-							(11 + protocol.ProtocolVersionNtCOffset): protocol.VersionDataNtC9to14(
-								ouroboros_mock.MockNetworkMagic,
-							),
-							(12 + protocol.ProtocolVersionNtCOffset): protocol.VersionDataNtC9to14(
-								ouroboros_mock.MockNetworkMagic,
-							),
+							10: protocol.VersionDataNtN7to10{
+								CborNetworkMagic:                       ouroboros_mock.MockNetworkMagic,
+								CborInitiatorAndResponderDiffusionMode: true,
+							},
 						},
 					),
 				},
@@ -58,10 +111,11 @@ func TestServerBasicHandshake(t *testing.T) {
 				IsResponse:      true,
 				MsgFromCborFunc: handshake.NewMsgFromCbor,
 				Message: handshake.NewMsgAcceptVersion(
-					(12 + protocol.ProtocolVersionNtCOffset),
-					protocol.VersionDataNtC9to14(
-						ouroboros_mock.MockNetworkMagic,
-					),
+					10,
+					protocol.VersionDataNtN7to10{
+						CborNetworkMagic:                       ouroboros_mock.MockNetworkMagic,
+						CborInitiatorAndResponderDiffusionMode: true,
+					},
 				),
 			},
 		},
@@ -69,6 +123,7 @@ func TestServerBasicHandshake(t *testing.T) {
 	oConn, err := ouroboros.New(
 		ouroboros.WithConnection(mockConn),
 		ouroboros.WithNetworkMagic(ouroboros_mock.MockNetworkMagic),
+		ouroboros.WithNodeToNode(true),
 		ouroboros.WithServer(true),
 	)
 	if err != nil {
@@ -88,6 +143,65 @@ func TestServerBasicHandshake(t *testing.T) {
 		t.Fatalf("unexpected error when closing Ouroboros object: %s", err)
 	}
 	// Wait for connection shutdown
+	select {
+	case <-oConn.ErrorChan():
+	case <-time.After(10 * time.Second):
+		t.Errorf("did not shutdown within timeout")
+	}
+}
+
+func TestServerBasicHandshake(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	mockConn := ouroboros_mock.NewConnection(
+		ouroboros_mock.ProtocolRoleServer,
+		[]ouroboros_mock.ConversationEntry{
+			ouroboros_mock.ConversationEntryOutput{
+				ProtocolId: handshake.ProtocolId,
+				Messages: []protocol.Message{
+					handshake.NewMsgProposeVersions(
+						protocol.ProtocolVersionMap{
+							(10 + protocol.ProtocolVersionNtCOffset): protocol.VersionDataNtC9to14(
+								ouroboros_mock.MockNetworkMagic,
+							),
+							(11 + protocol.ProtocolVersionNtCOffset): protocol.VersionDataNtC9to14(
+								ouroboros_mock.MockNetworkMagic,
+							),
+							(12 + protocol.ProtocolVersionNtCOffset): protocol.VersionDataNtC9to14(
+								ouroboros_mock.MockNetworkMagic,
+							),
+						},
+					),
+				},
+			},
+			ouroboros_mock.ConversationEntryInput{
+				ProtocolId:      handshake.ProtocolId,
+				IsResponse:      true,
+				MsgFromCborFunc: handshake.NewMsgFromCbor,
+				Message: handshake.NewMsgAcceptVersion(
+					(12 + protocol.ProtocolVersionNtCOffset),
+					protocol.VersionDataNtC9to14(ouroboros_mock.MockNetworkMagic),
+				),
+			},
+		},
+	)
+	oConn, err := ouroboros.New(
+		ouroboros.WithConnection(mockConn),
+		ouroboros.WithNetworkMagic(ouroboros_mock.MockNetworkMagic),
+		ouroboros.WithServer(true),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error when creating Ouroboros object: %s", err)
+	}
+	go func() {
+		err, ok := <-oConn.ErrorChan()
+		if !ok {
+			return
+		}
+		panic(fmt.Sprintf("unexpected Ouroboros error: %s", err))
+	}()
+	if err := oConn.Close(); err != nil {
+		t.Fatalf("unexpected error when closing Ouroboros object: %s", err)
+	}
 	select {
 	case <-oConn.ErrorChan():
 	case <-time.After(10 * time.Second):

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -87,6 +87,10 @@ type ProtocolConfig struct {
 	StateMap            StateMap
 	StateContext        any
 	InitialState        State
+	// InitialStateTimeout enables the initial state's configured timeout.
+	// It is disabled by default because most protocols begin timing out only
+	// after their first state transition.
+	InitialStateTimeout bool
 	RecvQueueSize       int
 }
 
@@ -1019,8 +1023,9 @@ func (p *Protocol) stateLoop(ch <-chan protocolStateTransition) {
 			}
 		}
 
-		// Don't activate timeouts on initial protocol state
-		if !initialStateSet {
+		// Don't activate timeouts on initial protocol state unless explicitly
+		// enabled by the protocol owner.
+		if !initialStateSet && !p.config.InitialStateTimeout {
 			return
 		}
 

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -17,11 +17,121 @@ package protocol
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net"
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/gouroboros/muxer"
 	"github.com/stretchr/testify/require"
 )
+
+func TestInitialStateTimeoutOptIn(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		enabled     bool
+		timeout     time.Duration
+		wantTimeout bool
+	}{
+		{"disabled by default", false, 20 * time.Millisecond, false},
+		{"enabled explicitly", true, 20 * time.Millisecond, true},
+		{"enabled with zero timeout", true, 0, false},
+		{"enabled with negative timeout", true, -time.Second, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			serverConn, peerConn := net.Pipe()
+			defer serverConn.Close()
+			defer peerConn.Close()
+			m := muxer.New(serverConn)
+			m.Start()
+			defer m.Stop()
+			errorChan := make(chan error, 1)
+			state := NewState(1, "Initial")
+			p := New(ProtocolConfig{
+				ErrorChan: errorChan,
+				Muxer:     m,
+				Role:      ProtocolRoleServer,
+				StateMap: StateMap{state: {
+					Agency:  AgencyClient,
+					Timeout: test.timeout,
+				}},
+				InitialState:        state,
+				InitialStateTimeout: test.enabled,
+			})
+			p.Start()
+			defer p.Stop()
+
+			if test.wantTimeout {
+				select {
+				case err := <-errorChan:
+					require.NotNil(t, err)
+					require.Contains(t, err.Error(), "timeout waiting on transition")
+				case <-time.After(time.Second):
+					t.Fatal("initial timeout was not enforced")
+				}
+				return
+			}
+			select {
+			case err := <-errorChan:
+				t.Fatalf("unexpected initial timeout: %v", err)
+			case <-time.After(50 * time.Millisecond):
+			}
+		})
+	}
+}
+
+func TestSubsequentStateTimeoutRemainsActive(t *testing.T) {
+	for _, initialStateTimeout := range []bool{false, true} {
+		t.Run(fmt.Sprintf("initial timeout enabled=%t", initialStateTimeout), func(t *testing.T) {
+			testSubsequentStateTimeoutRemainsActive(t, initialStateTimeout)
+		})
+	}
+}
+
+func testSubsequentStateTimeoutRemainsActive(t *testing.T, initialStateTimeout bool) {
+	serverConn, peerConn := net.Pipe()
+	defer serverConn.Close()
+	defer peerConn.Close()
+	m := muxer.New(serverConn)
+	m.Start()
+	defer m.Stop()
+	errorChan := make(chan error, 1)
+	initialState := NewState(1, "Initial")
+	confirmState := NewState(2, "Confirm")
+	p := New(ProtocolConfig{
+		ErrorChan: errorChan,
+		Muxer:     m,
+		Role:      ProtocolRoleServer,
+		StateMap: StateMap{
+			initialState: {
+				Agency: AgencyClient,
+				Transitions: []StateTransition{{
+					MsgType:  1,
+					NewState: confirmState,
+				}},
+			},
+			confirmState: {
+				Agency:  AgencyServer,
+				Timeout: 20 * time.Millisecond,
+			},
+		},
+		InitialState:        initialState,
+		InitialStateTimeout: initialStateTimeout,
+	})
+	p.Start()
+	defer p.Stop()
+
+	msg := &MessageBase{MessageType: 1}
+	require.NoError(t, p.transitionState(msg))
+
+	select {
+	case err := <-errorChan:
+		require.NotNil(t, err)
+		require.Contains(t, err.Error(), "timeout waiting on transition")
+	case <-time.After(time.Second):
+		t.Fatal("subsequent state timeout was not enforced")
+	}
+}
 
 func TestEnqueueMessageReturnsWhenFullQueueShutsDown(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Arm the configured initial Propose timeout for N2N handshake servers through a default-off ProtocolConfig opt-in. Preserve N2C behavior and subsequent-state timers.

Add successful N2N handshake and timeout controls, and document the opt-in.

Related to #2073.