### PR TITLE
feat(localstatequery): add paginated GetUTxOWhole vendor extension

### DIFF
--- a/protocol/localstatequery/client.go
+++ b/protocol/localstatequery/client.go
@@ -1745,8 +1745,17 @@ func (c *Client) handleAcquired() error {
 	default:
 	}
 	c.acquired = true
-	c.acquireResultChan <- nil
+	// Invalidate the cached era before signaling completion on
+	// acquireResultChan, not after: a caller blocked in acquire() wakes up
+	// on that channel receive and can immediately call a query that reads
+	// currentEra (getCurrentEra, via GetCurrentProtocolParams/GetEpochNo/
+	// etc.). Writing it after the send has no happens-before relationship
+	// to that caller's subsequent read -- a data race under the Go memory
+	// model, confirmed live under -race with a low-latency (fast, local)
+	// server, where the window between the two statements is otherwise
+	// too narrow to hit against normal network latency.
 	c.currentEra = -1
+	c.acquireResultChan <- nil
 	return nil
 }
 

--- a/protocol/localstatequery/client.go
+++ b/protocol/localstatequery/client.go
@@ -571,6 +571,47 @@ func (c *Client) GetUTxOWhole() (*UTxOsResult, error) {
 	return &result, nil
 }
 
+// GetUTxOWholePaginated is GetUTxOWhole's paginated vendor-extension form --
+// see QueryTypeShelleyUtxoWholePaginated's doc comment. cursorTxId/cursorIdx
+// name the last UtxoId the previous call returned (nil/0 for the first
+// page); limit bounds how many UTxOs this call returns. Only a
+// Dingo-aware server answers this; sending it to a real cardano-node fails
+// with an unknown-query error.
+func (c *Client) GetUTxOWholePaginated(
+	cursorTxId []byte,
+	cursorIdx uint32,
+	limit uint32,
+) (*UTxOWholePaginatedResult, error) {
+	c.Protocol.Logger().
+		Debug(fmt.Sprintf(
+			"calling GetUTxOWholePaginated(cursorTxId: %x, cursorIdx: %d, limit: %d)",
+			cursorTxId, cursorIdx, limit,
+		),
+			"component", "network",
+			"protocol", ProtocolName,
+			"role", "client",
+			"connection_id", c.callbackContext.ConnectionId.String(),
+		)
+	c.busyMutex.Lock()
+	defer c.busyMutex.Unlock()
+	currentEra, err := c.getCurrentEra()
+	if err != nil {
+		return nil, err
+	}
+	query := buildShelleyQuery(
+		currentEra,
+		QueryTypeShelleyUtxoWholePaginated,
+		cursorTxId,
+		cursorIdx,
+		limit,
+	)
+	var result UTxOWholePaginatedResult
+	if err := c.runQuery(query, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 func (c *Client) DebugEpochState() (*DebugEpochStateResult, error) {
 	c.Protocol.Logger().
 		Debug("calling DebugEpochState()",

--- a/protocol/localstatequery/client.go
+++ b/protocol/localstatequery/client.go
@@ -574,14 +574,22 @@ func (c *Client) GetUTxOWhole() (*UTxOsResult, error) {
 // GetUTxOWholePaginated is GetUTxOWhole's paginated vendor-extension form --
 // see QueryTypeShelleyUtxoWholePaginated's doc comment. cursorTxId/cursorIdx
 // name the last UtxoId the previous call returned (nil/0 for the first
-// page); limit bounds how many UTxOs this call returns. Only a
-// Dingo-aware server answers this; sending it to a real cardano-node fails
-// with an unknown-query error.
+// page); limit bounds how many UTxOs this call returns and must be greater
+// than zero (see ShelleyUtxoWholePaginatedQuery's doc comment for why).
+// Only a Dingo-aware server answers this: cardano-node's own decoder does
+// not register this query type at all, so sending it to a real cardano-node
+// fails the whole LocalStateQuery connection on an unknown-query decode
+// error rather than returning a recoverable per-query error.
 func (c *Client) GetUTxOWholePaginated(
 	cursorTxId []byte,
 	cursorIdx uint32,
 	limit uint32,
 ) (*UTxOWholePaginatedResult, error) {
+	if limit == 0 {
+		return nil, errors.New(
+			"GetUTxOWholePaginated: limit must be greater than zero",
+		)
+	}
 	c.Protocol.Logger().
 		Debug(fmt.Sprintf(
 			"calling GetUTxOWholePaginated(cursorTxId: %x, cursorIdx: %d, limit: %d)",

--- a/protocol/localstatequery/client_test.go
+++ b/protocol/localstatequery/client_test.go
@@ -310,6 +310,19 @@ var conversationConwayEra = append(
 	},
 )
 
+// TestGetUTxOWholePaginatedRejectsZeroLimit proves the client refuses a
+// zero limit before ever touching the connection -- see
+// ShelleyUtxoWholePaginatedQuery's doc comment for why a zero limit is
+// ambiguous (no limit vs. no rows) and could otherwise stall a paging
+// caller on a repeated no-progress request.
+func TestGetUTxOWholePaginatedRejectsZeroLimit(t *testing.T) {
+	c := &localstatequery.Client{}
+	_, err := c.GetUTxOWholePaginated(nil, 0, 0)
+	if err == nil {
+		t.Fatal("expected an error for a zero limit, got nil")
+	}
+}
+
 func TestGetConstitution(t *testing.T) {
 	// Constitution result: [anchor, script_hash]
 	// anchor: [url, data_hash]

--- a/protocol/localstatequery/queries.go
+++ b/protocol/localstatequery/queries.go
@@ -84,6 +84,25 @@ const (
 	// GetPoolDistr2 (Shelley sub-query 36) replaces GetPoolDistr from NtC v21.
 	// cardano-cli sends it while computing a leadership schedule.
 	QueryTypeShelleyPoolDistr2 = 36
+
+	// QueryTypeShelleyUtxoWholePaginated is a blinklabs-io vendor extension,
+	// not part of the real Ouroboros/cardano-ledger CDDL spec: no real
+	// cardano-node understands it, and it is never sent to one. It exists
+	// so a Dingo-aware client (e.g. dingo's own node-parity tool) can pull
+	// GetUTxOWhole's answer in bounded pages instead of one single-shot
+	// reply, working around LocalStateQuery's synchronous one-request/
+	// one-reply design: the server cannot send anything until the whole
+	// query result is ready (see Server.handleQuery), so an answer that
+	// takes minutes to assemble silently exceeds the muxer's fixed 120s
+	// segment-read timeout with nothing the client can do about it
+	// (blinklabs-io/dingo#4082). Paging the query itself, rather than the
+	// reply, keeps every individual request/reply cycle fast regardless of
+	// how large the whole answer is.
+	//
+	// Tag chosen far outside the real spec's currently-assigned range
+	// (0-36) specifically to avoid ever colliding with a genuine future
+	// protocol addition.
+	QueryTypeShelleyUtxoWholePaginated = 9001
 )
 
 // LedgerPeerKind selects which ledger peers the snapshot covers.
@@ -255,6 +274,7 @@ func shelleyQueryTypes() map[int]any {
 		QueryTypeShelleyGetProposals:           &ShelleyGetProposalsQuery{},
 		QueryTypeShelleyGetRatifyState:         &ShelleyGetRatifyStateQuery{},
 		QueryTypeShelleyGetLedgerPeerSnapshot:  &ShelleyGetLedgerPeerSnapshotQuery{},
+		QueryTypeShelleyUtxoWholePaginated:     &ShelleyUtxoWholePaginatedQuery{},
 	}
 }
 
@@ -336,6 +356,19 @@ type ShelleyUtxoByAddressQuery struct {
 
 type ShelleyUtxoWholeQuery struct {
 	simpleQueryBase
+}
+
+// ShelleyUtxoWholePaginatedQuery is the vendor-extension paginated form of
+// ShelleyUtxoWholeQuery -- see QueryTypeShelleyUtxoWholePaginated's doc
+// comment. CursorTxId/CursorIdx name the last UtxoId returned by the
+// previous page (both zero-valued/empty for the first page); the server
+// returns up to Limit live UTxOs ordered strictly after that reference.
+type ShelleyUtxoWholePaginatedQuery struct {
+	cbor.StructAsArray
+	Type       int
+	CursorTxId []byte
+	CursorIdx  uint32
+	Limit      uint32
 }
 
 type ShelleyDebugEpochStateQuery struct {
@@ -735,6 +768,18 @@ type (
 	UTxOByAddressResult = UTxOsResult
 	UTxOWholeResult     = UTxOsResult
 )
+
+// UTxOWholePaginatedResult is ShelleyUtxoWholePaginatedQuery's result: one
+// page of live UTxOs, plus a cursor for the next page. HasMore is false on
+// the final page, at which point NextCursorTxId/NextCursorIdx are
+// meaningless and should be ignored.
+type UTxOWholePaginatedResult struct {
+	cbor.StructAsArray
+	Results        map[UtxoId]ledger.BabbageTransactionOutput
+	HasMore        bool
+	NextCursorTxId []byte
+	NextCursorIdx  uint32
+}
 
 type UtxoId struct {
 	cbor.StructAsArray

--- a/protocol/localstatequery/queries.go
+++ b/protocol/localstatequery/queries.go
@@ -363,6 +363,11 @@ type ShelleyUtxoWholeQuery struct {
 // comment. CursorTxId/CursorIdx name the last UtxoId returned by the
 // previous page (both zero-valued/empty for the first page); the server
 // returns up to Limit live UTxOs ordered strictly after that reference.
+// Limit must be greater than zero -- GetUTxOWholePaginated rejects a zero
+// limit before sending the query, since a server could otherwise read 0 as
+// "no limit" or as "return no rows," and the latter would return an empty
+// page with HasMore still true, stalling a paging caller on a repeated
+// no-progress request.
 type ShelleyUtxoWholePaginatedQuery struct {
 	cbor.StructAsArray
 	Type       int

--- a/protocol/localstatequery/utxo_whole_paginated_test.go
+++ b/protocol/localstatequery/utxo_whole_paginated_test.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localstatequery_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+)
+
+// TestUtxoWholePaginatedQueryIsDispatchable checks the vendor-extension
+// paginated query reaches a server through the same dispatch table a real
+// connection uses -- the same regression class TestPoolDistr2QueryIsDispatchable
+// covers: registering a result type without registering the query's tag in
+// shelleyQueryTypes leaves a server failing the whole connection on decode
+// rather than just rejecting the one query.
+func TestUtxoWholePaginatedQueryIsDispatchable(t *testing.T) {
+	cursorTxId := bytes.Repeat([]byte{0xAB}, 32)
+	blockQuery, err := cbor.Encode(
+		[]any{
+			localstatequery.QueryTypeShelleyUtxoWholePaginated,
+			cursorTxId,
+			uint32(3),
+			uint32(50000),
+		},
+	)
+	if err != nil {
+		t.Fatalf("encoding query: %v", err)
+	}
+	// A Shelley leaf query travels wrapped in its era and block-query envelopes.
+	wrapped, err := cbor.Encode(
+		[]any{
+			localstatequery.QueryTypeBlock,
+			[]any{
+				localstatequery.QueryTypeShelley,
+				[]any{ledger.EraIdConway, cbor.RawMessage(blockQuery)},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("encoding wrapper: %v", err)
+	}
+	var query localstatequery.QueryWrapper
+	if _, err := cbor.Decode(wrapped, &query); err != nil {
+		t.Fatalf("decoding wrapped query: %v", err)
+	}
+	blockQ, ok := query.Query.(*localstatequery.BlockQuery)
+	if !ok {
+		t.Fatalf("expected a block query, got %T", query.Query)
+	}
+	shelleyQ, ok := blockQ.Query.(*localstatequery.ShelleyQuery)
+	if !ok {
+		t.Fatalf("expected a shelley query, got %T", blockQ.Query)
+	}
+	paginatedQ, ok := shelleyQ.Query.(*localstatequery.ShelleyUtxoWholePaginatedQuery)
+	if !ok {
+		t.Fatalf(
+			"expected a GetUTxOWholePaginated query, got %T",
+			shelleyQ.Query,
+		)
+	}
+	if !bytes.Equal(paginatedQ.CursorTxId, cursorTxId) {
+		t.Errorf(
+			"cursor tx id: got %x, want %x",
+			paginatedQ.CursorTxId,
+			cursorTxId,
+		)
+	}
+	if paginatedQ.CursorIdx != 3 {
+		t.Errorf("cursor idx: got %d, want 3", paginatedQ.CursorIdx)
+	}
+	if paginatedQ.Limit != 50000 {
+		t.Errorf("limit: got %d, want 50000", paginatedQ.Limit)
+	}
+}
+
+// TestUtxoWholePaginatedResultDecodes proves UTxOWholePaginatedResult
+// decodes the shape the server actually sends -- see
+// ledger.queryShelleyUtxoWholePaginated on the dingo side, which destructures
+// its fields into a bare []any the way queryShelleyUtxoWhole already does for
+// UTxOsResult, rather than encoding the Go struct directly.
+func TestUtxoWholePaginatedResultDecodes(t *testing.T) {
+	var txId [32]byte
+	copy(txId[:], bytes.Repeat([]byte{0xCD}, 32))
+	utxoId := localstatequery.UtxoId{
+		Hash: ledger.NewBlake2b256(txId[:]),
+		Idx:  2,
+	}
+	nextCursorTxId := bytes.Repeat([]byte{0xEF}, 32)
+
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkTestnet,
+		bytes.Repeat([]byte{0xAA}, lcommon.AddressHashSize),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("building fixture address: %v", err)
+	}
+	output := babbage.BabbageTransactionOutput{
+		OutputAddress: addr,
+		OutputAmount:  mary.MaryTransactionOutputValue{Amount: 5_000_000},
+	}
+	outputCbor, err := cbor.Encode(&output)
+	if err != nil {
+		t.Fatalf("encoding fixture output: %v", err)
+	}
+
+	encoded, err := cbor.Encode(
+		[]any{
+			map[any]any{
+				utxoId: cbor.RawMessage(outputCbor),
+			},
+			true,
+			nextCursorTxId,
+			uint32(7),
+		},
+	)
+	if err != nil {
+		t.Fatalf("encoding result: %v", err)
+	}
+	var result localstatequery.UTxOWholePaginatedResult
+	if _, err := cbor.Decode(encoded, &result); err != nil {
+		t.Fatalf("decoding result: %v", err)
+	}
+	if !result.HasMore {
+		t.Errorf("has more: got false, want true")
+	}
+	if !bytes.Equal(result.NextCursorTxId, nextCursorTxId) {
+		t.Errorf(
+			"next cursor tx id: got %x, want %x",
+			result.NextCursorTxId,
+			nextCursorTxId,
+		)
+	}
+	if result.NextCursorIdx != 7 {
+		t.Errorf("next cursor idx: got %d, want 7", result.NextCursorIdx)
+	}
+	if len(result.Results) != 1 {
+		t.Fatalf("results: got %d entries, want 1", len(result.Results))
+	}
+}

--- a/protocol/localstatequery/utxo_whole_paginated_test.go
+++ b/protocol/localstatequery/utxo_whole_paginated_test.go
@@ -157,4 +157,21 @@ func TestUtxoWholePaginatedResultDecodes(t *testing.T) {
 	if len(result.Results) != 1 {
 		t.Fatalf("results: got %d entries, want 1", len(result.Results))
 	}
+	decodedOutput, ok := result.Results[utxoId]
+	if !ok {
+		t.Fatalf("results: missing entry for key %+v", utxoId)
+	}
+	if decodedOutput.Amount().Uint64() != 5_000_000 {
+		t.Errorf(
+			"decoded output amount: got %d, want 5000000",
+			decodedOutput.Amount().Uint64(),
+		)
+	}
+	if decodedOutput.Address().String() != addr.String() {
+		t.Errorf(
+			"decoded output address: got %s, want %s",
+			decodedOutput.Address().String(),
+			addr.String(),
+		)
+	}
 }


### PR DESCRIPTION
## Summary

LocalStateQuery's synchronous one-request/one-reply design means the server
cannot send anything until the whole query result is ready, so a
`GetUTxOWhole` reply that takes minutes to assemble (a disk-backed node with
a large live UTxO set) silently exceeds the muxer's fixed 120s
segment-read timeout with nothing the client can do about it
(blinklabs-io/dingo#4082). `ShelleyUtxoWholePaginatedQuery` pages the query
itself instead, keeping each request/reply cycle fast regardless of the
whole answer's size.

This is a blinklabs-io vendor extension outside the real Ouroboros/
cardano-ledger CDDL spec (tag 9001, chosen far outside the real spec's
assigned range): no real `cardano-node` understands it, and it is only ever
sent to a Dingo-aware server.

A second, unrelated commit fixes a real data race found while building test
coverage for the above: `handleAcquired` signaled `Acquire`'s completion
channel before writing `currentEra = -1` rather than after, so a caller
unblocked by that signal could read `currentEra` (via
`GetCurrentProtocolParams`/`GetEpochNo`) with no happens-before relationship
to the write. Confirmed under `-race` against a low-latency local test
server, where the window between the two statements is otherwise too narrow
to hit over normal network latency.

## Testing

- `go build ./...`, `go vet ./...` clean.
- `go test -race ./...` -- full suite passes.
- `make lint` -- 0 issues.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `GetUTxOWholePaginated`, a paginated vendor extension to LocalStateQuery, so big UTxO-set queries no longer time out against the muxer's fixed 120s segment-read limit. Also fixes a data race where `handleAcquired` unblocked `acquire()` callers before invalidating the cached era.

- The old single-shot `GetUTxOWhole` can't send anything until the whole result is assembled, which can take minutes on disk-backed nodes with large UTxO sets.
- The new form takes a cursor and limit, pages the query itself, and keeps every request/reply cycle fast; it's Dingo-only (tag 9001) and real `cardano-node` rejects it as unknown.
- The client rejects a zero limit before sending, since a server could otherwise return an empty page with `HasMore` still true and stall paging on no-progress requests.
- The race fix writes `currentEra = -1` before signaling the completion channel, confirmed under `-race` against a low-latency local server.

<sup>Written for commit a5e6c8c90971eb50abeb5df2c1e4bea707b3103d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paginated UTxO queries, allowing results to be retrieved in manageable pages using cursor and limit controls.
  * Added continuation information and a flag indicating whether additional results are available.

* **Bug Fixes**
  * Improved state handling during acquisition to prevent stale era information and related race conditions.

* **Tests**
  * Added coverage for paginated query requests, cursor handling, result decoding, and continuation metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->