### PR TITLE
fix(chainsync): expose connection shutdown to callbacks

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -530,10 +530,11 @@ func (c *Connection) setupConnection() error {
 		}
 	})
 	protoOptions := protocol.ProtocolOptions{
-		ConnectionId: c.id,
-		Muxer:        c.muxer,
-		Logger:       c.logger,
-		ErrorChan:    c.protoErrorChan,
+		ConnectionId:       c.id,
+		ConnectionDoneChan: c.doneChan,
+		Muxer:              c.muxer,
+		Logger:             c.logger,
+		ErrorChan:          c.protoErrorChan,
 	}
 	if c.useNodeToNodeProto {
 		protoOptions.Mode = protocol.ProtocolModeNodeToNode

--- a/connection_test.go
+++ b/connection_test.go
@@ -17,6 +17,7 @@ package ouroboros_test
 import (
 	"fmt"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
@@ -461,10 +462,14 @@ func TestErrorOnUngracefulClose(t *testing.T) {
 	// Use a long-running FindIntersect callback so the protocol stays in a
 	// non-idle (Intersect) state when the connection is closed.
 	callbackDone := make(chan struct{})
-	defer close(callbackDone)
+	callbackEntered := make(chan (<-chan any), 1)
+	var releaseCallback sync.Once
+	release := func() { releaseCallback.Do(func() { close(callbackDone) }) }
+	defer release()
 	chainSyncCfg := chainsync.NewConfig(
 		chainsync.WithFindIntersectFunc(
-			func(_ chainsync.CallbackContext, _ []pcommon.Point) (pcommon.Point, chainsync.Tip, error) {
+			func(ctx chainsync.CallbackContext, _ []pcommon.Point) (pcommon.Point, chainsync.Tip, error) {
+				callbackEntered <- ctx.ConnectionDoneChan
 				// Block until test cleanup – the connection will be closed before this returns
 				<-callbackDone
 				return pcommon.Point{}, chainsync.Tip{}, fmt.Errorf("test done")
@@ -526,6 +531,12 @@ func TestErrorOnUngracefulClose(t *testing.T) {
 	require.NoError(t, err, "unexpected error when creating Connection object")
 
 	// We should receive a connection error since the protocol was in a non-idle state
+	var connectionDone <-chan any
+	select {
+	case connectionDone = <-callbackEntered:
+	case <-time.After(5 * time.Second):
+		require.FailNow(t, "timed out waiting for FindIntersect callback")
+	}
 	select {
 	case err, ok := <-oConn.ErrorChan():
 		require.True(t, ok, "error channel closed without receiving an error")
@@ -534,6 +545,12 @@ func TestErrorOnUngracefulClose(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		require.Fail(t, "timed out waiting for connection error")
 	}
+	select {
+	case <-connectionDone:
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "connection lifecycle channel did not close")
+	}
 
-	oConn.Close()
+	release()
+	require.NoError(t, oConn.Close())
 }

--- a/protocol/chainsync/chainsync.go
+++ b/protocol/chainsync/chainsync.go
@@ -220,8 +220,12 @@ const (
 // Callback context
 type CallbackContext struct {
 	ConnectionId connection.ConnectionId
-	Client       *Client
-	Server       *Server
+	// ConnectionDoneChan is closed when the owning connection begins shutdown.
+	// It is distinct from the current protocol instance's DoneChan and is nil
+	// when the protocol was constructed without an owning connection.
+	ConnectionDoneChan <-chan any
+	Client             *Client
+	Server             *Server
 }
 
 // Callback function types

--- a/protocol/chainsync/client.go
+++ b/protocol/chainsync/client.go
@@ -110,8 +110,9 @@ func NewClient(
 		readyForNextBlockChan: nil,
 	}
 	c.callbackContext = CallbackContext{
-		Client:       c,
-		ConnectionId: protoOptions.ConnectionId,
+		Client:             c,
+		ConnectionId:       protoOptions.ConnectionId,
+		ConnectionDoneChan: protoOptions.ConnectionDoneChan,
 	}
 	c.initProtocol()
 	return c

--- a/protocol/chainsync/server.go
+++ b/protocol/chainsync/server.go
@@ -54,8 +54,9 @@ func NewServer(
 		protoOptions: protoOptions,
 	}
 	s.callbackContext = CallbackContext{
-		Server:       s,
-		ConnectionId: protoOptions.ConnectionId,
+		Server:             s,
+		ConnectionId:       protoOptions.ConnectionId,
+		ConnectionDoneChan: protoOptions.ConnectionDoneChan,
 	}
 	s.initProtocol()
 	return s

--- a/protocol/chainsync/server_test.go
+++ b/protocol/chainsync/server_test.go
@@ -108,3 +108,37 @@ func TestRollForwardNtNRejectsUnknownBlockType(t *testing.T) {
 
 	require.EqualError(t, err, "unknown block type: 999")
 }
+
+func TestNewServerPropagatesConnectionDoneChan(t *testing.T) {
+	done := make(chan any)
+	server := NewServer(
+		protocol.ProtocolOptions{
+			ConnectionId:       testConnectionId(),
+			ConnectionDoneChan: done,
+		},
+		nil,
+	)
+	close(done)
+	select {
+	case <-server.callbackContext.ConnectionDoneChan:
+	default:
+		t.Fatal("connection lifecycle channel did not close")
+	}
+}
+
+func TestNewClientPropagatesConnectionDoneChan(t *testing.T) {
+	done := make(chan any)
+	client := NewClient(
+		protocol.ProtocolOptions{
+			ConnectionId:       testConnectionId(),
+			ConnectionDoneChan: done,
+		},
+		nil,
+	)
+	close(done)
+	select {
+	case <-client.callbackContext.ConnectionDoneChan:
+	default:
+		t.Fatal("connection lifecycle channel did not close")
+	}
+}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -116,10 +116,13 @@ const (
 // ProtocolOptions provides common arguments for all mini-protocols
 type ProtocolOptions struct {
 	ConnectionId connection.ConnectionId
-	Muxer        *muxer.Muxer
-	Logger       *slog.Logger
-	ErrorChan    chan error
-	Mode         ProtocolMode
+	// ConnectionDoneChan is closed when the owning connection begins
+	// shutdown, before protocol goroutines have necessarily returned.
+	ConnectionDoneChan <-chan any
+	Muxer              *muxer.Muxer
+	Logger             *slog.Logger
+	ErrorChan          chan error
+	Mode               ProtocolMode
 	// TODO(cleanup): Role field may be redundant with Mode - evaluate removal
 	Role    ProtocolRole
 	Version uint16


### PR DESCRIPTION
Propagate a connection-start shutdown channel into ChainSync client and server callback contexts.

The channel closes before protocol goroutines finish, allowing callbacks to distinguish connection shutdown from protocol-instance completion. Standalone protocol construction remains compatible with a nil channel.

Related to blinklabs-io/dingo#4160.