### PR TITLE
fix(ledger): align Dijkstra with Leios prototype 2026w36

### DIFF
--- a/ledger/dijkstra/dijkstra.go
+++ b/ledger/dijkstra/dijkstra.go
@@ -404,7 +404,10 @@ func (b DijkstraBlockBody) Hash() common.Blake2b256 {
 
 func marshalDijkstraBlockTransaction(t *DijkstraTransaction) ([]byte, error) {
 	if raw := t.DecodeStoreCbor.Cbor(); len(raw) > 0 {
-		return raw, nil
+		var fields []cbor.RawMessage
+		if _, err := cbor.Decode(raw, &fields); err == nil && len(fields) == 4 {
+			return raw, nil
+		}
 	}
 	var aux any
 	if t.auxData != nil && len(t.auxData.Cbor()) > 0 {

--- a/ledger/dijkstra/dijkstra.go
+++ b/ledger/dijkstra/dijkstra.go
@@ -314,6 +314,9 @@ func (b *DijkstraBlockBody) UnmarshalCBOR(cborData []byte) error {
 		if err != nil {
 			return fmt.Errorf("decode Dijkstra transaction %d: %w", idx, err)
 		}
+		if tx == nil {
+			return fmt.Errorf("decode Dijkstra transaction %d: constructor returned nil", idx)
+		}
 		txs[idx] = *tx
 	}
 	if legacy {
@@ -385,31 +388,6 @@ func (b DijkstraBlockBody) Hash() common.Blake2b256 {
 		panic("CBOR encoding that should never fail has failed: " + err.Error())
 	}
 	return common.Blake2b256Hash(cborData)
-}
-
-// invalidTransactionsForEncoding derives the sorted invalid_transactions index
-// set from the block body's transactions and any explicitly set indices. A
-// transaction is invalid when its IsValid() is false. The result feeds the
-// nonempty_set / nil field: an empty result is encoded as CBOR null.
-func (b DijkstraBlockBody) invalidTransactionsForEncoding() []uint {
-	invalidTxMap := make(map[uint]bool, len(b.InvalidTransactions))
-	for _, invalidTxIdx := range b.InvalidTransactions {
-		invalidTxMap[invalidTxIdx] = true
-	}
-	for idx, tx := range b.Transactions {
-		if !tx.IsValid() {
-			invalidTxMap[uint(idx)] = true
-		}
-	}
-	if len(invalidTxMap) == 0 {
-		return nil
-	}
-	ret := make([]uint, 0, len(invalidTxMap))
-	for idx := range invalidTxMap {
-		ret = append(ret, idx)
-	}
-	slices.Sort(ret)
-	return ret
 }
 
 func marshalDijkstraBlockTransaction(t *DijkstraTransaction) ([]byte, error) {

--- a/ledger/dijkstra/dijkstra.go
+++ b/ledger/dijkstra/dijkstra.go
@@ -144,9 +144,8 @@ func (b *DijkstraBlock) Era() common.Era {
 }
 
 func (b *DijkstraBlock) Transactions() []common.Transaction {
-	// Each transaction's IsValid() already reflects membership in the block
-	// body's invalid_transactions index set (applied at decode time); a tx at
-	// index i is invalid iff i is in that set.
+	// Each transaction's IsValid() reflects the per-transaction validity flag;
+	// legacy invalid-transaction indexes are converted to that flag at decode.
 	ret := make([]common.Transaction, len(b.BlockBody.Transactions))
 	for idx := range b.BlockBody.Transactions {
 		ret[idx] = &b.BlockBody.Transactions[idx]
@@ -333,6 +332,7 @@ func (b *DijkstraBlockBody) UnmarshalCBOR(cborData []byte) error {
 		for idx := range txs {
 			txs[idx].TxIsValid = !invalid[uint(idx)]
 		}
+		b.InvalidTransactions = append([]uint(nil), legacyInvalidTxs...)
 	}
 	// items[1] (or items[2] for the compatibility form): leios_certificate.
 	leiosCert, err := decodeDijkstraLeiosCertificate(items[txField+1])
@@ -345,6 +345,9 @@ func (b *DijkstraBlockBody) UnmarshalCBOR(cborData []byte) error {
 		return err
 	}
 	b.Transactions = txs
+	if !legacy {
+		b.InvalidTransactions = nil
+	}
 	b.LeiosCertificate = leiosCert
 	b.PerasCertificate = perasCert
 	b.SetCbor(cborData)
@@ -368,8 +371,17 @@ func (b DijkstraBlockBody) MarshalCBOR() ([]byte, error) {
 		perasField = b.PerasCertificate
 	}
 	rawTxs := make([]cbor.RawMessage, len(txs))
+	invalid := make(map[uint]struct{}, len(b.InvalidTransactions))
+	for _, idx := range b.InvalidTransactions {
+		invalid[idx] = struct{}{}
+	}
 	for idx := range txs {
-		data, err := marshalDijkstraBlockTransaction(&txs[idx])
+		tx := txs[idx]
+		if _, ok := invalid[uint(idx)]; ok {
+			tx.TxIsValid = false
+			tx.SetCbor(nil)
+		}
+		data, err := marshalDijkstraBlockTransaction(&tx)
 		if err != nil {
 			return nil, fmt.Errorf("encode Dijkstra transaction %d: %w", idx, err)
 		}
@@ -391,6 +403,9 @@ func (b DijkstraBlockBody) Hash() common.Blake2b256 {
 }
 
 func marshalDijkstraBlockTransaction(t *DijkstraTransaction) ([]byte, error) {
+	if raw := t.DecodeStoreCbor.Cbor(); len(raw) > 0 {
+		return raw, nil
+	}
 	var aux any
 	if t.auxData != nil && len(t.auxData.Cbor()) > 0 {
 		aux = cbor.RawMessage(t.auxData.Cbor())

--- a/ledger/dijkstra/dijkstra.go
+++ b/ledger/dijkstra/dijkstra.go
@@ -249,22 +249,22 @@ func (c DijkstraLeiosCertificate) MarshalCBOR() ([]byte, error) {
 	return cbor.Encode([]any{c.Signers, c.AggregatedSignature})
 }
 
-// DijkstraBlockBody is the Dijkstra (prototype-2026w27) block body. Per the
-// authoritative cardano-ledger Dijkstra CDDL it is a 4-element array:
+// DijkstraBlockBody is the Dijkstra block body. Per the pinned
+// cardano-ledger Dijkstra CDDL it is a 3-element array:
 //
 //	block_body =
-//	  [ invalid_transactions : invalid_transactions / nil
-//	  , transactions         : [* transaction]
+//	  [ transactions         : [* block_transaction]
 //	  , leios_certificate     : leios_certificate / nil
 //	  , peras_certificate     : peras_certificate / nil ]
 //
 // Unlike pre-Dijkstra eras, transactions are stored inline (each a full
 // [transaction_body, transaction_witness_set, auxiliary_data/nil] array) rather
-// than as parallel tx-body / witness-set / metadata segments, and per-tx
-// validity is conveyed by the invalid_transactions index set rather than a
-// per-transaction is_valid flag.
+// than as parallel tx-body / witness-set / metadata segments. Block
+// transactions carry their validity flag as the final array element.
 type DijkstraBlockBody struct {
 	cbor.DecodeStoreCbor
+	// InvalidTransactions is retained for source compatibility with the
+	// earlier prototype and is not serialized in Dijkstra.
 	InvalidTransactions []uint
 	Transactions        []DijkstraTransaction
 	LeiosCertificate    *DijkstraLeiosCertificate
@@ -279,57 +279,68 @@ func (b *DijkstraBlockBody) UnmarshalCBOR(cborData []byte) error {
 	if _, err := cbor.Decode(cborData, &items); err != nil {
 		return err
 	}
-	if len(items) != 4 {
+	if len(items) != 3 && len(items) != 4 {
 		return fmt.Errorf(
-			"invalid Dijkstra block body: expected 4 components, got %d",
+			"invalid Dijkstra block body: expected 3 components, got %d",
 			len(items),
 		)
 	}
-	// items[0]: invalid_transactions / nil
-	invalidTxs, err := decodeInvalidTransactions(items[0])
-	if err != nil {
-		return err
+	legacy := len(items) == 4
+	txField := 0
+	var legacyInvalidTxs []uint
+	if legacy {
+		txField = 1
+		var err error
+		legacyInvalidTxs, err = decodeInvalidTransactions(items[0])
+		if err != nil {
+			return err
+		}
 	}
-	// items[1]: transactions [* transaction]
+	// items[0] (or items[1] for the pre-respin compatibility form):
+	// transactions [* block_transaction]
 	var rawTxs []cbor.RawMessage
-	if _, err := cbor.Decode(items[1], &rawTxs); err != nil {
+	if _, err := cbor.Decode(items[txField], &rawTxs); err != nil {
 		return fmt.Errorf("decode Dijkstra transactions: %w", err)
 	}
 	txs := make([]DijkstraTransaction, len(rawTxs))
 	for idx, rawTx := range rawTxs {
-		tx, err := newDijkstraTransactionFromCbor(rawTx, false)
+		var tx *DijkstraTransaction
+		var err error
+		if legacy {
+			tx, err = newDijkstraTransactionFromCbor(rawTx, false)
+		} else {
+			tx, err = newDijkstraBlockTransactionFromCbor(rawTx)
+		}
 		if err != nil {
 			return fmt.Errorf("decode Dijkstra transaction %d: %w", idx, err)
 		}
 		txs[idx] = *tx
 	}
-	// items[2]: leios_certificate / nil
-	leiosCert, err := decodeDijkstraLeiosCertificate(items[2])
-	if err != nil {
-		return err
-	}
-	// items[3]: peras_certificate / nil
-	perasCert, err := decodeDijkstraPerasCertificate(items[3])
-	if err != nil {
-		return err
-	}
-	// A transaction at index i is invalid iff i is in invalid_transactions;
-	// every index must reference an existing transaction.
-	invalidTxMap := make(map[uint]bool, len(invalidTxs))
-	for _, invalidTxIdx := range invalidTxs {
-		if invalidTxIdx >= uint(len(txs)) {
-			return fmt.Errorf(
-				"invalid transaction index %d outside transaction list length %d",
-				invalidTxIdx,
-				len(txs),
-			)
+	if legacy {
+		invalid := make(map[uint]bool, len(legacyInvalidTxs))
+		for _, idx := range legacyInvalidTxs {
+			if idx >= uint(len(txs)) {
+				return fmt.Errorf(
+					"invalid transaction index %d outside transaction list length %d",
+					idx, len(txs),
+				)
+			}
+			invalid[idx] = true
 		}
-		invalidTxMap[invalidTxIdx] = true
+		for idx := range txs {
+			txs[idx].TxIsValid = !invalid[uint(idx)]
+		}
 	}
-	for idx := range txs {
-		txs[idx].TxIsValid = !invalidTxMap[uint(idx)]
+	// items[1] (or items[2] for the compatibility form): leios_certificate.
+	leiosCert, err := decodeDijkstraLeiosCertificate(items[txField+1])
+	if err != nil {
+		return err
 	}
-	b.InvalidTransactions = invalidTxs
+	// items[2] (or items[3] for the compatibility form): peras_certificate.
+	perasCert, err := decodeDijkstraPerasCertificate(items[txField+2])
+	if err != nil {
+		return err
+	}
 	b.Transactions = txs
 	b.LeiosCertificate = leiosCert
 	b.PerasCertificate = perasCert
@@ -340,12 +351,6 @@ func (b *DijkstraBlockBody) UnmarshalCBOR(cborData []byte) error {
 func (b DijkstraBlockBody) MarshalCBOR() ([]byte, error) {
 	if b.Cbor() != nil {
 		return b.Cbor(), nil
-	}
-	// invalid_transactions is a nonempty_set / nil: an empty set encodes as
-	// CBOR null, matching the reference node's on-wire encoding.
-	var invalidField any
-	if invalidTxs := b.invalidTransactionsForEncoding(); len(invalidTxs) > 0 {
-		invalidField = invalidTxs
 	}
 	txs := b.Transactions
 	if txs == nil {
@@ -359,7 +364,15 @@ func (b DijkstraBlockBody) MarshalCBOR() ([]byte, error) {
 	if b.PerasCertificate != nil {
 		perasField = b.PerasCertificate
 	}
-	return cbor.Encode([]any{invalidField, txs, leiosField, perasField})
+	rawTxs := make([]cbor.RawMessage, len(txs))
+	for idx := range txs {
+		data, err := marshalDijkstraBlockTransaction(&txs[idx])
+		if err != nil {
+			return nil, fmt.Errorf("encode Dijkstra transaction %d: %w", idx, err)
+		}
+		rawTxs[idx] = data
+	}
+	return cbor.Encode([]any{rawTxs, leiosField, perasField})
 }
 
 // Hash computes the Dijkstra block body hash. The prototype-2026w27 node stores
@@ -397,6 +410,16 @@ func (b DijkstraBlockBody) invalidTransactionsForEncoding() []uint {
 	}
 	slices.Sort(ret)
 	return ret
+}
+
+func marshalDijkstraBlockTransaction(t *DijkstraTransaction) ([]byte, error) {
+	var aux any
+	if t.auxData != nil && len(t.auxData.Cbor()) > 0 {
+		aux = cbor.RawMessage(t.auxData.Cbor())
+	} else if t.TxMetadata != nil {
+		aux = cbor.RawMessage(t.TxMetadata.Cbor())
+	}
+	return cbor.Encode([]any{t.Body, t.WitnessSet, aux, t.TxIsValid})
 }
 
 func decodeDijkstraLeiosCertificate(
@@ -1798,6 +1821,41 @@ func newDijkstraTransactionFromCbor(
 		return nil, err
 	}
 	return newDijkstraTransactionFromCborComponents(data, txArray, allowIsValid)
+}
+
+// newDijkstraBlockTransactionFromCbor decodes the Dijkstra block_transaction
+// form. Unlike mempool_transaction, its validity flag is mandatory and is the
+// final array element.
+func newDijkstraBlockTransactionFromCbor(data []byte) (*DijkstraTransaction, error) {
+	var txArray []cbor.RawMessage
+	if _, err := cbor.Decode(data, &txArray); err != nil {
+		return nil, err
+	}
+	if len(txArray) != 4 {
+		return nil, fmt.Errorf(
+			"invalid Dijkstra block transaction: expected 4 components, got %d",
+			len(txArray),
+		)
+	}
+	var txIsValid bool
+	if _, err := cbor.Decode(txArray[3], &txIsValid); err != nil {
+		return nil, fmt.Errorf("failed to decode TxIsValid: %w", err)
+	}
+	var ret DijkstraTransaction
+	if _, err := cbor.Decode(txArray[0], &ret.Body); err != nil {
+		return nil, fmt.Errorf("failed to decode transaction body: %w", err)
+	}
+	if _, err := cbor.Decode(txArray[1], &ret.WitnessSet); err != nil {
+		return nil, fmt.Errorf("failed to decode transaction witness set: %w", err)
+	}
+	if err := decodeAuxiliaryDataInto(
+		txArray[2], &ret.TxMetadata, &ret.auxData,
+	); err != nil {
+		return nil, err
+	}
+	ret.TxIsValid = txIsValid
+	ret.SetCbor(data)
+	return &ret, nil
 }
 
 func newDijkstraTransactionFromCborComponents(

--- a/ledger/dijkstra/dijkstra_leios_w27_test.go
+++ b/ledger/dijkstra/dijkstra_leios_w27_test.go
@@ -147,8 +147,8 @@ func TestDijkstraPerasCertificateRoundTrip(t *testing.T) {
 	var items []cbor.RawMessage
 	_, err = cbor.Decode(rawNil, &items)
 	require.NoError(t, err)
-	require.Len(t, items, 4)
-	assert.Equal(t, []byte{0xf6}, []byte(items[3])) // peras field is CBOR null
+	require.Len(t, items, 3)
+	assert.Equal(t, []byte{0xf6}, []byte(items[2])) // peras field is CBOR null
 	var decodedNil DijkstraBlockBody
 	require.NoError(t, decodedNil.UnmarshalCBOR(rawNil))
 	assert.Nil(t, decodedNil.PerasCertificate)

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -257,16 +257,23 @@ func testDijkstraOutputWithAssetsCbor(t *testing.T, assets []byte) []byte {
 }
 
 // minimalBlockBodyParts builds a Dijkstra 3-element block_body containing a
-// single 4-field block transaction:
+// single 4-field block transaction with the requested validity.
 //
 //	[ [transaction], leios_cert/nil, peras_cert/nil ]
-func minimalBlockBodyParts(invalidTxs []uint) []any {
-	valid := true
-	if len(invalidTxs) > 0 {
-		valid = false
-	}
+func minimalBlockBodyParts(valid bool) []any {
 	return []any{
 		[]any{[]any{minimalTxParts()[0], minimalTxParts()[1], minimalTxParts()[2], valid}},
+		nil,
+		nil,
+	}
+}
+
+// minimalLegacyBlockBodyParts builds the pre-respin four-element block_body
+// containing a legacy invalid_transactions set and a three-field transaction.
+func minimalLegacyBlockBodyParts(invalidTxs []uint64) []any {
+	return []any{
+		invalidTxs,
+		[]any{minimalTxParts()},
 		nil,
 		nil,
 	}
@@ -376,11 +383,98 @@ func TestDijkstraBlockBodyRejectsWrongComponentCount(t *testing.T) {
 }
 
 func TestDijkstraBlockBodyAppliesInvalidTransactionIndices(t *testing.T) {
-	bodyCbor, err := cbor.Encode(minimalBlockBodyParts([]uint{0}))
+	bodyCbor, err := cbor.Encode(minimalLegacyBlockBodyParts([]uint64{0}))
 	require.NoError(t, err)
 
 	var blockBody DijkstraBlockBody
 	require.NoError(t, blockBody.UnmarshalCBOR(bodyCbor))
+	require.Equal(t, []uint{0}, blockBody.InvalidTransactions)
+	require.Len(t, blockBody.Transactions, 1)
+	require.False(t, blockBody.Transactions[0].IsValid())
+}
+
+func TestDijkstraBlockBodyRejectsLegacyInvalidTransactionIndexOutOfRange(t *testing.T) {
+	bodyCbor, err := cbor.Encode(minimalLegacyBlockBodyParts([]uint64{1}))
+	require.NoError(t, err)
+
+	var blockBody DijkstraBlockBody
+	require.ErrorContains(
+		t,
+		blockBody.UnmarshalCBOR(bodyCbor),
+		"outside transaction list length",
+	)
+}
+
+func TestDijkstraBlockBodyRejectsDuplicateLegacyInvalidTransactionIndex(t *testing.T) {
+	bodyCbor, err := cbor.Encode(minimalLegacyBlockBodyParts([]uint64{0, 0}))
+	require.NoError(t, err)
+
+	var blockBody DijkstraBlockBody
+	require.ErrorContains(
+		t,
+		blockBody.UnmarshalCBOR(bodyCbor),
+		"duplicate",
+	)
+}
+
+func TestDijkstraBlockBodyPreservesRawBlockTransactionCbor(t *testing.T) {
+	parts := minimalTxParts()
+	body, err := cbor.Encode(parts[0])
+	require.NoError(t, err)
+	witnesses, err := cbor.Encode(parts[1])
+	require.NoError(t, err)
+	auxiliary, err := cbor.Encode(parts[2])
+	require.NoError(t, err)
+	rawTx := []byte{0x9f}
+	rawTx = append(rawTx, body...)
+	rawTx = append(rawTx, witnesses...)
+	rawTx = append(rawTx, auxiliary...)
+	rawTx = append(rawTx, 0xf5, 0xff)
+	bodyCbor, err := cbor.Encode([]any{
+		[]cbor.RawMessage{rawTx},
+		nil,
+		nil,
+	})
+	require.NoError(t, err)
+
+	var blockBody DijkstraBlockBody
+	require.NoError(t, blockBody.UnmarshalCBOR(bodyCbor))
+	blockBody.SetCbor(nil)
+	encoded, err := blockBody.MarshalCBOR()
+	require.NoError(t, err)
+	var encodedBody []cbor.RawMessage
+	_, err = cbor.Decode(encoded, &encodedBody)
+	require.NoError(t, err)
+	var encodedTxs []cbor.RawMessage
+	_, err = cbor.Decode(encodedBody[0], &encodedTxs)
+	require.NoError(t, err)
+	require.Equal(t, rawTx, []byte(encodedTxs[0]))
+}
+
+func TestDijkstraBlockBodyEncodesCompatibilityInvalidTransactionIndices(t *testing.T) {
+	bodyCbor, err := cbor.Encode(minimalLegacyBlockBodyParts(nil))
+	require.NoError(t, err)
+
+	var blockBody DijkstraBlockBody
+	require.NoError(t, blockBody.UnmarshalCBOR(bodyCbor))
+	blockBody.InvalidTransactions = []uint{0}
+	blockBody.SetCbor(nil)
+
+	encoded, err := blockBody.MarshalCBOR()
+	require.NoError(t, err)
+	var decoded DijkstraBlockBody
+	require.NoError(t, decoded.UnmarshalCBOR(encoded))
+	require.Len(t, decoded.Transactions, 1)
+	require.False(t, decoded.Transactions[0].IsValid())
+}
+
+func TestDijkstraBlockBodyUsesPerTransactionValidity(t *testing.T) {
+	bodyCbor, err := cbor.Encode(minimalBlockBodyParts(false))
+	require.NoError(t, err)
+
+	var blockBody DijkstraBlockBody
+	require.NoError(t, blockBody.UnmarshalCBOR(bodyCbor))
+	require.Empty(t, blockBody.InvalidTransactions)
 	require.Len(t, blockBody.Transactions, 1)
 	require.False(t, blockBody.Transactions[0].IsValid())
 }
@@ -592,12 +686,10 @@ func TestDijkstraBlockRoundTripWithBodyHash(t *testing.T) {
 	require.Equal(t, []byte(raw[0]), decoded.BlockHeader.Cbor())
 }
 
-// TestDijkstraBlockNonEmptyTransactionsInvalidSet exercises a synthetic block
-// with two inline transactions and an invalid_transactions set that marks the
-// second transaction invalid. It confirms the 2-element block / 4-element body
-// wire shape, body-hash validation, and that Transactions()[i].IsValid()
-// reflects membership in the invalid set (never a per-tx flag).
-func TestDijkstraBlockNonEmptyTransactionsInvalidSet(t *testing.T) {
+// TestDijkstraBlockNonEmptyTransactionsValidity exercises a synthetic block
+// with two inline transactions and per-transaction validity flags. It confirms
+// the block/body wire shape, body-hash validation, and validity propagation.
+func TestDijkstraBlockNonEmptyTransactionsValidity(t *testing.T) {
 	sig := make([]byte, common.LeiosBlsSignatureSize)
 	leiosCert := &DijkstraLeiosCertificate{
 		Signers:             []byte{0x0f},

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -1203,6 +1203,76 @@ func TestDijkstraProtocolParameterUpdateDecodesConwayAndDijkstraFields(
 	require.Equal(t, 0, pparams.RefScriptCostMultiplier.Cmp(big.NewRat(2, 1)))
 }
 
+func TestDijkstraProtocolParameterUpdateDecodesLeiosFields(t *testing.T) {
+	quorum := cbor.Rat{Rat: big.NewRat(3, 4)}
+	exUnits := common.ExUnits{Memory: 123, Steps: 456}
+	updateCbor, err := cbor.Encode(map[uint]any{
+		40: uint32(1000),
+		41: uint32(2000),
+		42: uint32(3000),
+		43: uint16(42),
+		44: quorum,
+		45: uint32(500000),
+		46: uint32(12000000),
+		47: exUnits,
+		48: uint32(1048576),
+	})
+	require.NoError(t, err)
+
+	var update DijkstraProtocolParameterUpdate
+	_, err = cbor.Decode(updateCbor, &update)
+	require.NoError(t, err)
+	require.Equal(t, updateCbor, update.Cbor())
+	require.Equal(t, uint32(1000), *update.LeiosAnnouncementPeriodLength)
+	require.Equal(t, uint32(2000), *update.LeiosVotePeriodLength)
+	require.Equal(t, uint32(3000), *update.LeiosDiffusionPeriodLength)
+	require.Equal(t, uint16(42), *update.LeiosCommitteeSize)
+	require.Equal(t, 0, update.LeiosQuorumStakeThreshold.Cmp(quorum.Rat))
+	require.Equal(t, uint32(500000), *update.MaxEndorserBlockReferencesSize)
+	require.Equal(t, uint32(12000000), *update.MaxEndorserBlockTxsSize)
+	require.Equal(t, exUnits, *update.MaxEndorserBlockExUnits)
+	require.Equal(t, uint32(1048576), *update.MaxRefScriptSizePerEndorserBlock)
+
+	var params DijkstraProtocolParameters
+	params.Update(&update)
+	require.Equal(t, uint32(1000), params.LeiosAnnouncementPeriodLength)
+	require.Equal(t, uint32(2000), params.LeiosVotePeriodLength)
+	require.Equal(t, uint32(3000), params.LeiosDiffusionPeriodLength)
+	require.Equal(t, uint16(42), params.LeiosCommitteeSize)
+	require.Equal(t, 0, params.LeiosQuorumStakeThreshold.Cmp(quorum.Rat))
+	require.Equal(t, uint32(500000), params.MaxEndorserBlockReferencesSize)
+	require.Equal(t, uint32(12000000), params.MaxEndorserBlockTxsSize)
+	require.Equal(t, exUnits, params.MaxEndorserBlockExUnits)
+	require.Equal(t, uint32(1048576), params.MaxRefScriptSizePerEndorserBlock)
+}
+
+func TestDijkstraProtocolParameterUpdateEncodesLeiosFields(t *testing.T) {
+	announcement, vote, diffusion := uint32(1000), uint32(2000), uint32(3000)
+	committee := uint16(42)
+	references, txs, refScripts := uint32(500000), uint32(12000000), uint32(1048576)
+	exUnits := common.ExUnits{Memory: 123, Steps: 456}
+	update := DijkstraProtocolParameterUpdate{
+		LeiosAnnouncementPeriodLength:    &announcement,
+		LeiosVotePeriodLength:            &vote,
+		LeiosDiffusionPeriodLength:       &diffusion,
+		LeiosCommitteeSize:               &committee,
+		LeiosQuorumStakeThreshold:        &cbor.Rat{Rat: big.NewRat(3, 4)},
+		MaxEndorserBlockReferencesSize:   &references,
+		MaxEndorserBlockTxsSize:          &txs,
+		MaxEndorserBlockExUnits:          &exUnits,
+		MaxRefScriptSizePerEndorserBlock: &refScripts,
+	}
+	encoded, err := cbor.Encode(update)
+	require.NoError(t, err)
+
+	var fields map[uint]cbor.RawMessage
+	_, err = cbor.Decode(encoded, &fields)
+	require.NoError(t, err)
+	for _, key := range []uint{40, 41, 42, 43, 44, 45, 46, 47, 48} {
+		require.Contains(t, fields, key)
+	}
+}
+
 func TestDijkstraProtocolParameterUpdateLeiosStakeFieldsExcludedFromCbor(
 	t *testing.T,
 ) {
@@ -1258,6 +1328,33 @@ func TestDijkstraGenesisLeiosStakeParameters(t *testing.T) {
 		0,
 		pparams.QuorumStakeThreshold.Cmp(big.NewRat(3, 4)),
 	)
+}
+
+func TestDijkstraGenesisDecodesLeiosProtocolParameters(t *testing.T) {
+	genesis, err := NewDijkstraGenesisFromReader(strings.NewReader(`{
+  "leiosAnnouncementPeriodLength": 1000,
+  "leiosVotePeriodLength": 2000,
+  "leiosDiffusionPeriodLength": 3000,
+  "leiosCommitteeSize": 42,
+  "leiosQuorumStakeThreshold": 0.75,
+  "maxEndorserBlockReferencesSize": 500000,
+  "maxEndorserBlockTxsSize": 12000000,
+  "maxEndorserBlockExecutionUnits": {"memory": 123, "steps": 456},
+  "maxRefScriptSizePerEndorserBlock": 1048576
+}`))
+	require.NoError(t, err)
+
+	var params DijkstraProtocolParameters
+	require.NoError(t, params.UpdateFromGenesis(&genesis))
+	require.Equal(t, uint32(1000), params.LeiosAnnouncementPeriodLength)
+	require.Equal(t, uint32(2000), params.LeiosVotePeriodLength)
+	require.Equal(t, uint32(3000), params.LeiosDiffusionPeriodLength)
+	require.Equal(t, uint16(42), params.LeiosCommitteeSize)
+	require.Equal(t, 0, params.LeiosQuorumStakeThreshold.Cmp(big.NewRat(3, 4)))
+	require.Equal(t, uint32(500000), params.MaxEndorserBlockReferencesSize)
+	require.Equal(t, uint32(12000000), params.MaxEndorserBlockTxsSize)
+	require.Equal(t, common.ExUnits{Memory: 123, Steps: 456}, params.MaxEndorserBlockExUnits)
+	require.Equal(t, uint32(1048576), params.MaxRefScriptSizePerEndorserBlock)
 }
 
 func TestDijkstraGenesisDefaultsReferenceScriptFeeParameters(t *testing.T) {

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -1295,6 +1295,14 @@ func TestDijkstraProtocolParametersRejectsUnsupportedArrayLength(t *testing.T) {
 	require.Error(t, decoded.UnmarshalCBOR(data))
 }
 
+func TestDijkstraProtocolParametersRejectsOversizedArrayHeader(t *testing.T) {
+	// The arity guard must reject an array whose declared length cannot be
+	// represented before attempting to decode all of its elements.
+	data := []byte{0x9b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+	var decoded DijkstraProtocolParameters
+	require.Error(t, decoded.UnmarshalCBOR(data))
+}
+
 func TestDijkstraProtocolParametersUpdateNil(t *testing.T) {
 	pparams := DijkstraProtocolParameters{
 		MaxRefScriptSizePerBlock: 1000,

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -1480,6 +1480,7 @@ func TestDijkstraGenesisDecodesLeiosProtocolParameters(t *testing.T) {
   "leiosDiffusionPeriodLength": 3000,
   "leiosCommitteeSize": 42,
   "leiosQuorumStakeThreshold": 0.75,
+  "plutusV4CostModel": [4000, 5000, 6000],
   "maxEndorserBlockReferencesSize": 500000,
   "maxEndorserBlockTxsSize": 12000000,
   "maxEndorserBlockExecutionUnits": {"memory": 123, "steps": 456},
@@ -1498,6 +1499,7 @@ func TestDijkstraGenesisDecodesLeiosProtocolParameters(t *testing.T) {
 	require.Equal(t, uint32(12000000), params.MaxEndorserBlockTxsSize)
 	require.Equal(t, common.ExUnits{Memory: 123, Steps: 456}, params.MaxEndorserBlockExUnits)
 	require.Equal(t, uint32(1048576), params.MaxRefScriptSizePerEndorserBlock)
+	require.Equal(t, []int64{4000, 5000, 6000}, params.CostModels[3])
 }
 
 func TestDijkstraGenesisDefaultsReferenceScriptFeeParameters(t *testing.T) {

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -445,9 +445,15 @@ func TestDijkstraBlockBodyPreservesRawBlockTransactionCbor(t *testing.T) {
 	var encodedBody []cbor.RawMessage
 	_, err = cbor.Decode(encoded, &encodedBody)
 	require.NoError(t, err)
+	if len(encodedBody) == 0 {
+		t.Fatal("encoded block body is empty")
+	}
 	var encodedTxs []cbor.RawMessage
 	_, err = cbor.Decode(encodedBody[0], &encodedTxs)
 	require.NoError(t, err)
+	if len(encodedTxs) == 0 {
+		t.Fatal("encoded transaction list is empty")
+	}
 	require.Equal(t, rawTx, []byte(encodedTxs[0]))
 }
 

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -1220,18 +1220,53 @@ func TestDijkstraProtocolParametersRoundTrip(t *testing.T) {
 }
 
 func TestDijkstraProtocolParametersDecodesLegacyArray(t *testing.T) {
+	rat := func(num, denom int64) *cbor.Rat {
+		return &cbor.Rat{Rat: big.NewRat(num, denom)}
+	}
+	ratValue := func(num, denom int64) cbor.Rat {
+		return cbor.Rat{Rat: big.NewRat(num, denom)}
+	}
 	params := DijkstraProtocolParameters{
 		ConwayProtocolParameters: conway.ConwayProtocolParameters{
 			MinFeeA:   44,
 			MaxTxSize: 16384,
+			A0:        rat(1, 2),
+			Rho:       rat(3, 1000),
+			Tau:       rat(1, 5),
+			ExecutionCosts: common.ExUnitPrice{
+				MemPrice:  rat(1, 10),
+				StepPrice: rat(2, 10),
+			},
+			MaxTxExUnits: common.ExUnits{Memory: 1, Steps: 2},
 			MaxBlockExUnits: common.ExUnits{
 				Memory: 100,
 				Steps:  200,
 			},
+			PoolVotingThresholds: conway.PoolVotingThresholds{
+				MotionNoConfidence:    ratValue(1, 2),
+				CommitteeNormal:       ratValue(1, 2),
+				CommitteeNoConfidence: ratValue(1, 2),
+				HardForkInitiation:    ratValue(1, 2),
+				PpSecurityGroup:       ratValue(1, 2),
+			},
+			DRepVotingThresholds: conway.DRepVotingThresholds{
+				MotionNoConfidence:    ratValue(1, 2),
+				CommitteeNormal:       ratValue(1, 2),
+				CommitteeNoConfidence: ratValue(1, 2),
+				UpdateToConstitution:  ratValue(1, 2),
+				HardForkInitiation:    ratValue(1, 2),
+				PpNetworkGroup:        ratValue(1, 2),
+				PpEconomicGroup:       ratValue(1, 2),
+				PpTechnicalGroup:      ratValue(1, 2),
+				PpGovGroup:            ratValue(1, 2),
+				TreasuryWithdrawal:    ratValue(1, 2),
+			},
+			MinFeeRefScriptCostPerByte: rat(15, 1000),
 		},
 		MaxRefScriptSizePerBlock: 1000,
 		MaxRefScriptSizePerTx:    2000,
 		RefScriptCostStride:      3000,
+		RefScriptCostMultiplier:  rat(2, 1),
 	}
 	full, err := cbor.Encode(params.toCbor())
 	require.NoError(t, err)

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -1219,6 +1219,47 @@ func TestDijkstraProtocolParametersRoundTrip(t *testing.T) {
 	require.Equal(t, 0, decoded.RefScriptCostMultiplier.Cmp(big.NewRat(2, 1)))
 }
 
+func TestDijkstraProtocolParametersDecodesLegacyArray(t *testing.T) {
+	params := DijkstraProtocolParameters{
+		ConwayProtocolParameters: conway.ConwayProtocolParameters{
+			MinFeeA:   44,
+			MaxTxSize: 16384,
+			MaxBlockExUnits: common.ExUnits{
+				Memory: 100,
+				Steps:  200,
+			},
+		},
+		MaxRefScriptSizePerBlock: 1000,
+		MaxRefScriptSizePerTx:    2000,
+		RefScriptCostStride:      3000,
+	}
+	full, err := cbor.Encode(params.toCbor())
+	require.NoError(t, err)
+	var fields []cbor.RawMessage
+	_, err = cbor.Decode(full, &fields)
+	require.NoError(t, err)
+	require.Len(t, fields, 46)
+	legacy, err := cbor.Encode(fields[:35])
+	require.NoError(t, err)
+
+	var decoded DijkstraProtocolParameters
+	require.NoError(t, decoded.UnmarshalCBOR(legacy))
+	require.Equal(t, uint(44), decoded.MinFeeA)
+	require.Equal(t, uint(16384), decoded.MaxTxSize)
+	require.Equal(t, uint32(1000), decoded.MaxRefScriptSizePerBlock)
+	require.Equal(t, uint32(2000), decoded.MaxRefScriptSizePerTx)
+	require.Equal(t, uint32(3000), decoded.RefScriptCostStride)
+	require.Zero(t, decoded.MaxPledgeLeverage)
+	require.Zero(t, decoded.LeiosAnnouncementPeriodLength)
+}
+
+func TestDijkstraProtocolParametersRejectsUnsupportedArrayLength(t *testing.T) {
+	data, err := cbor.Encode(make([]any, 34))
+	require.NoError(t, err)
+	var decoded DijkstraProtocolParameters
+	require.Error(t, decoded.UnmarshalCBOR(data))
+}
+
 func TestDijkstraProtocolParametersUpdateNil(t *testing.T) {
 	pparams := DijkstraProtocolParameters{
 		MaxRefScriptSizePerBlock: 1000,

--- a/ledger/dijkstra/dijkstra_test.go
+++ b/ledger/dijkstra/dijkstra_test.go
@@ -256,20 +256,17 @@ func testDijkstraOutputWithAssetsCbor(t *testing.T, assets []byte) []byte {
 	return ret
 }
 
-// minimalBlockBodyParts builds a Dijkstra 4-element block_body containing a
-// single 3-field transaction:
+// minimalBlockBodyParts builds a Dijkstra 3-element block_body containing a
+// single 4-field block transaction:
 //
-//	[ invalid_transactions/nil, [transaction], leios_cert/nil, peras_cert/nil ]
-//
-// invalid_transactions is encoded as CBOR null when empty (a nonempty_set/nil).
+//	[ [transaction], leios_cert/nil, peras_cert/nil ]
 func minimalBlockBodyParts(invalidTxs []uint) []any {
-	var invalidField any
+	valid := true
 	if len(invalidTxs) > 0 {
-		invalidField = invalidTxs
+		valid = false
 	}
 	return []any{
-		invalidField,
-		[]any{minimalTxParts()},
+		[]any{[]any{minimalTxParts()[0], minimalTxParts()[1], minimalTxParts()[2], valid}},
 		nil,
 		nil,
 	}
@@ -366,18 +363,16 @@ func TestDijkstraTransactionRejectsOversizedMalformedCbor(t *testing.T) {
 }
 
 func TestDijkstraBlockBodyRejectsWrongComponentCount(t *testing.T) {
-	// A Dijkstra block body must be a 4-element array; the pre-Dijkstra
-	// 6-component segwit layout is no longer valid.
+	// A Dijkstra block body must be a 3-element array.
 	bodyCbor, err := cbor.Encode([]any{
 		nil,
-		[]any{minimalTxParts()},
 		nil,
 	})
 	require.NoError(t, err)
 
 	var blockBody DijkstraBlockBody
 	err = blockBody.UnmarshalCBOR(bodyCbor)
-	require.ErrorContains(t, err, "expected 4 components")
+	require.ErrorContains(t, err, "expected 3 components")
 }
 
 func TestDijkstraBlockBodyAppliesInvalidTransactionIndices(t *testing.T) {
@@ -390,47 +385,17 @@ func TestDijkstraBlockBodyAppliesInvalidTransactionIndices(t *testing.T) {
 	require.False(t, blockBody.Transactions[0].IsValid())
 }
 
-func TestDijkstraBlockBodyRejectsTransactionIsValidFlag(t *testing.T) {
+func TestDijkstraBlockBodyRequiresTrailingTransactionIsValidFlag(t *testing.T) {
 	parts := minimalTxParts()
-	withTrue := []any{parts[0], parts[1], true, parts[2]}
+	withoutFlag := []any{parts[0], parts[1], parts[2]}
 	bodyCbor, err := cbor.Encode([]any{
-		nil,
-		[]any{withTrue},
-		nil,
-		nil,
+		[]any{withoutFlag}, nil, nil,
 	})
 	require.NoError(t, err)
 
 	var blockBody DijkstraBlockBody
 	err = blockBody.UnmarshalCBOR(bodyCbor)
-	require.ErrorContains(t, err, "cannot include is_valid")
-}
-
-func TestDijkstraBlockBodyRejectsDuplicateTaggedInvalidTransactions(
-	t *testing.T,
-) {
-	bodyCbor, err := cbor.Encode([]any{
-		cbor.NewSetType([]uint64{0, 0}, true),
-		[]any{minimalTxParts()},
-		nil,
-		nil,
-	})
-	require.NoError(t, err)
-
-	var blockBody DijkstraBlockBody
-	err = blockBody.UnmarshalCBOR(bodyCbor)
-	require.ErrorContains(t, err, "duplicate member in set")
-}
-
-func TestDijkstraBlockBodyRejectsInvalidTransactionIndexOutOfRange(
-	t *testing.T,
-) {
-	bodyCbor, err := cbor.Encode(minimalBlockBodyParts([]uint{1}))
-	require.NoError(t, err)
-
-	var blockBody DijkstraBlockBody
-	err = blockBody.UnmarshalCBOR(bodyCbor)
-	require.ErrorContains(t, err, "outside transaction list length")
+	require.ErrorContains(t, err, "expected 4 components")
 }
 
 func TestDijkstraBlockMarshalUsesTwoItemEnvelope(t *testing.T) {
@@ -456,21 +421,19 @@ func TestDijkstraBlockMarshalUsesTwoItemEnvelope(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, raw, 2)
 
-	// block_body = [invalid_transactions/nil, transactions, leios_cert/nil, peras_cert/nil]
+	// block_body = [transactions, leios_cert/nil, peras_cert/nil]
 	var body []cbor.RawMessage
 	_, err = cbor.Decode(raw[1], &body)
 	require.NoError(t, err)
-	require.Len(t, body, 4)
-	// Empty invalid set encodes as CBOR null.
-	require.Equal(t, []byte{0xf6}, []byte(body[0]))
+	require.Len(t, body, 3)
 	// No transactions.
-	require.Equal(t, []byte{0x80}, []byte(body[1]))
+	require.Equal(t, []byte{0x80}, []byte(body[0]))
 	// Real Leios certificate [signers, aggregated_signature].
 	expectedCert, err := cbor.Encode([]any{[]byte{0x01}, sig})
 	require.NoError(t, err)
-	require.Equal(t, expectedCert, []byte(body[2]))
+	require.Equal(t, expectedCert, []byte(body[1]))
 	// No Peras certificate.
-	require.Equal(t, []byte{0xf6}, []byte(body[3]))
+	require.Equal(t, []byte{0xf6}, []byte(body[2]))
 }
 
 // leiosExtendedHeaderHex is a real Dijkstra block header captured from the
@@ -675,7 +638,7 @@ func TestDijkstraBlockNonEmptyTransactionsInvalidSet(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wire shape: block = [header, block_body];
-	// block_body = [invalid_transactions, [tx1, tx2], leios_cert, nil]
+	// block_body = [[tx1, tx2], leios_cert, nil]
 	var raw []cbor.RawMessage
 	_, err = cbor.Decode(blockCbor, &raw)
 	require.NoError(t, err)
@@ -683,26 +646,24 @@ func TestDijkstraBlockNonEmptyTransactionsInvalidSet(t *testing.T) {
 	var body []cbor.RawMessage
 	_, err = cbor.Decode(raw[1], &body)
 	require.NoError(t, err)
-	require.Len(t, body, 4)
+	require.Len(t, body, 3)
 	var wireTxs []cbor.RawMessage
-	_, err = cbor.Decode(body[1], &wireTxs)
+	_, err = cbor.Decode(body[0], &wireTxs)
 	require.NoError(t, err)
 	require.Len(t, wireTxs, 2)
-	// Each transaction is a 3-field array; is_valid is never stored per-tx.
+	// Each block transaction has a trailing is_valid flag.
 	for _, wt := range wireTxs {
 		var txFields []cbor.RawMessage
 		_, err = cbor.Decode(wt, &txFields)
 		require.NoError(t, err)
-		require.Len(t, txFields, 3)
+		require.Len(t, txFields, 4)
 	}
-	require.Equal(t, []byte{0xf6}, []byte(body[3])) // no peras cert
+	require.Equal(t, []byte{0xf6}, []byte(body[2])) // no peras cert
 
 	// Body-hash validation is enabled by default and must pass.
 	decoded, err := NewDijkstraBlockFromCbor(blockCbor)
 	require.NoError(t, err)
 	require.Equal(t, blockBody.Hash(), decoded.BlockBodyHash())
-	require.Equal(t, []uint{1}, decoded.BlockBody.InvalidTransactions)
-
 	txs := decoded.Transactions()
 	require.Len(t, txs, 2)
 	require.True(t, txs[0].IsValid())

--- a/ledger/dijkstra/doc.go
+++ b/ledger/dijkstra/doc.go
@@ -21,15 +21,12 @@
 // maintained in IntersectMBO/cardano-ledger. The pinned version we aim to be
 // compatible with is:
 //
-//	https://github.com/IntersectMBO/cardano-ledger/blob/a24a2d69b6251d41bad96e53dbd40aabfe1bb25c/eras/dijkstra/impl/cddl/data/dijkstra.cddl
+//	https://github.com/IntersectMBO/cardano-ledger/blob/1587f21a7d1306dc590c2749a5c66232ef66aad0/eras/dijkstra/impl/cddl/data/dijkstra.cddl
 //
-// This is the commit the respun ouroboros-leios prototype-2026w27 "musashi"
-// testnet is built against (dated 2026-06-29, two days before the network's
-// 2026-07-01 systemStart). At this revision block = [header, block_body] with a
-// four-field block_body ([invalid_transactions, transactions, leios_certificate,
-// peras_certificate]) and leios_certificate = [signers, aggregated_signature :
-// bytes .size 48]. An earlier revision used a flat seven-element segwit block;
-// this package tracks the two-element form the deployed network actually serves.
+// This is the commit the respun ouroboros-leios prototype-2026w36 "musashi"
+// testnet is built against. At this revision block = [header, block_body] with
+// a three-field block_body ([transactions, leios_certificate, peras_certificate])
+// and a four-field block_transaction carrying its validity flag.
 //
 // A verbatim copy of that revision's CDDL is vendored at
 // testdata/dijkstra.cddl for reference and diffing against upstream.

--- a/ledger/dijkstra/genesis.go
+++ b/ledger/dijkstra/genesis.go
@@ -33,6 +33,7 @@ type DijkstraGenesis struct {
 	RefScriptCostMultiplier          *common.GenesisRat `json:"refScriptCostMultiplier"`
 	MaxPledgeLeverage                *common.GenesisRat `json:"maxPledgeLeverage"`
 	MinPoolMargin                    *common.GenesisRat `json:"minPoolMargin"`
+	PlutusV4CostModel                []int64            `json:"plutusV4CostModel"`
 	LeiosAnnouncementPeriodLength    uint32             `json:"leiosAnnouncementPeriodLength"`
 	LeiosVotePeriodLength            uint32             `json:"leiosVotePeriodLength"`
 	LeiosDiffusionPeriodLength       uint32             `json:"leiosDiffusionPeriodLength"`
@@ -83,6 +84,12 @@ func (p *DijkstraProtocolParameters) UpdateFromGenesis(
 		&genesis.ConwayGenesis,
 	); err != nil {
 		return err
+	}
+	if len(genesis.PlutusV4CostModel) > 0 {
+		if p.CostModels == nil {
+			p.CostModels = make(map[uint][]int64)
+		}
+		p.CostModels[3] = genesis.PlutusV4CostModel
 	}
 	p.MaxRefScriptSizePerBlock = genesis.MaxRefScriptSizePerBlock
 	p.MaxRefScriptSizePerTx = genesis.MaxRefScriptSizePerTx

--- a/ledger/dijkstra/genesis.go
+++ b/ledger/dijkstra/genesis.go
@@ -27,12 +27,23 @@ import (
 
 type DijkstraGenesis struct {
 	conway.ConwayGenesis
-	MaxRefScriptSizePerBlock uint32             `json:"maxRefScriptSizePerBlock"`
-	MaxRefScriptSizePerTx    uint32             `json:"maxRefScriptSizePerTx"`
-	RefScriptCostStride      uint32             `json:"refScriptCostStride"`
-	RefScriptCostMultiplier  *common.GenesisRat `json:"refScriptCostMultiplier"`
-	CommitteeStakeCoverage   *common.GenesisRat `json:"committeeStakeCoverage"`
-	QuorumStakeThreshold     *common.GenesisRat `json:"quorumStakeThreshold"`
+	MaxRefScriptSizePerBlock         uint32             `json:"maxRefScriptSizePerBlock"`
+	MaxRefScriptSizePerTx            uint32             `json:"maxRefScriptSizePerTx"`
+	RefScriptCostStride              uint32             `json:"refScriptCostStride"`
+	RefScriptCostMultiplier          *common.GenesisRat `json:"refScriptCostMultiplier"`
+	MaxPledgeLeverage                *common.GenesisRat `json:"maxPledgeLeverage"`
+	MinPoolMargin                    *common.GenesisRat `json:"minPoolMargin"`
+	LeiosAnnouncementPeriodLength    uint32             `json:"leiosAnnouncementPeriodLength"`
+	LeiosVotePeriodLength            uint32             `json:"leiosVotePeriodLength"`
+	LeiosDiffusionPeriodLength       uint32             `json:"leiosDiffusionPeriodLength"`
+	LeiosCommitteeSize               uint16             `json:"leiosCommitteeSize"`
+	LeiosQuorumStakeThreshold        *common.GenesisRat `json:"leiosQuorumStakeThreshold"`
+	MaxEndorserBlockReferencesSize   uint32             `json:"maxEndorserBlockReferencesSize"`
+	MaxEndorserBlockTxsSize          uint32             `json:"maxEndorserBlockTxsSize"`
+	MaxEndorserBlockExUnits          common.ExUnits     `json:"maxEndorserBlockExecutionUnits"`
+	MaxRefScriptSizePerEndorserBlock uint32             `json:"maxRefScriptSizePerEndorserBlock"`
+	CommitteeStakeCoverage           *common.GenesisRat `json:"committeeStakeCoverage"`
+	QuorumStakeThreshold             *common.GenesisRat `json:"quorumStakeThreshold"`
 }
 
 func NewDijkstraGenesisFromReader(r io.Reader) (DijkstraGenesis, error) {
@@ -77,6 +88,17 @@ func (p *DijkstraProtocolParameters) UpdateFromGenesis(
 	p.MaxRefScriptSizePerTx = genesis.MaxRefScriptSizePerTx
 	p.RefScriptCostStride = genesis.RefScriptCostStride
 	p.RefScriptCostMultiplier = genesisRatToRat(genesis.RefScriptCostMultiplier)
+	p.MaxPledgeLeverage = genesisRatToRat(genesis.MaxPledgeLeverage)
+	p.MinPoolMargin = genesisRatToRat(genesis.MinPoolMargin)
+	p.LeiosAnnouncementPeriodLength = genesis.LeiosAnnouncementPeriodLength
+	p.LeiosVotePeriodLength = genesis.LeiosVotePeriodLength
+	p.LeiosDiffusionPeriodLength = genesis.LeiosDiffusionPeriodLength
+	p.LeiosCommitteeSize = genesis.LeiosCommitteeSize
+	p.LeiosQuorumStakeThreshold = genesisRatToRat(genesis.LeiosQuorumStakeThreshold)
+	p.MaxEndorserBlockReferencesSize = genesis.MaxEndorserBlockReferencesSize
+	p.MaxEndorserBlockTxsSize = genesis.MaxEndorserBlockTxsSize
+	p.MaxEndorserBlockExUnits = genesis.MaxEndorserBlockExUnits
+	p.MaxRefScriptSizePerEndorserBlock = genesis.MaxRefScriptSizePerEndorserBlock
 	applyConwayRefScriptFeeDefaults(p)
 	p.CommitteeStakeCoverage = committeeStakeCoverage
 	p.QuorumStakeThreshold = quorumStakeThreshold

--- a/ledger/dijkstra/pparams.go
+++ b/ledger/dijkstra/pparams.go
@@ -26,51 +26,73 @@ import (
 
 type DijkstraProtocolParameters struct {
 	conway.ConwayProtocolParameters
-	MaxRefScriptSizePerBlock uint32
-	MaxRefScriptSizePerTx    uint32
-	RefScriptCostStride      uint32
-	RefScriptCostMultiplier  *cbor.Rat
-	CommitteeStakeCoverage   *cbor.Rat
-	QuorumStakeThreshold     *cbor.Rat
+	MaxRefScriptSizePerBlock         uint32
+	MaxRefScriptSizePerTx            uint32
+	RefScriptCostStride              uint32
+	RefScriptCostMultiplier          *cbor.Rat
+	MaxPledgeLeverage                *cbor.Rat
+	MinPoolMargin                    *cbor.Rat
+	LeiosAnnouncementPeriodLength    uint32
+	LeiosVotePeriodLength            uint32
+	LeiosDiffusionPeriodLength       uint32
+	LeiosCommitteeSize               uint16
+	LeiosQuorumStakeThreshold        *cbor.Rat
+	MaxEndorserBlockReferencesSize   uint32
+	MaxEndorserBlockTxsSize          uint32
+	MaxEndorserBlockExUnits          common.ExUnits
+	MaxRefScriptSizePerEndorserBlock uint32
+	CommitteeStakeCoverage           *cbor.Rat
+	QuorumStakeThreshold             *cbor.Rat
 }
 
 type dijkstraProtocolParametersCbor struct {
 	cbor.StructAsArray
-	MinFeeA                    uint
-	MinFeeB                    uint
-	MaxBlockBodySize           uint
-	MaxTxSize                  uint
-	MaxBlockHeaderSize         uint
-	KeyDeposit                 uint
-	PoolDeposit                uint
-	MaxEpoch                   uint
-	NOpt                       uint
-	A0                         *cbor.Rat
-	Rho                        *cbor.Rat
-	Tau                        *cbor.Rat
-	ProtocolVersion            common.ProtocolParametersProtocolVersion
-	MinPoolCost                uint64
-	AdaPerUtxoByte             uint64
-	CostModels                 map[uint][]int64
-	ExecutionCosts             common.ExUnitPrice
-	MaxTxExUnits               common.ExUnits
-	MaxBlockExUnits            common.ExUnits
-	MaxValueSize               uint
-	CollateralPercentage       uint
-	MaxCollateralInputs        uint
-	PoolVotingThresholds       conway.PoolVotingThresholds
-	DRepVotingThresholds       conway.DRepVotingThresholds
-	MinCommitteeSize           uint
-	CommitteeTermLimit         uint64
-	GovActionValidityPeriod    uint64
-	GovActionDeposit           uint64
-	DRepDeposit                uint64
-	DRepInactivityPeriod       uint64
-	MinFeeRefScriptCostPerByte *cbor.Rat
-	MaxRefScriptSizePerBlock   uint32
-	MaxRefScriptSizePerTx      uint32
-	RefScriptCostStride        uint32
-	RefScriptCostMultiplier    *cbor.Rat
+	MinFeeA                          uint
+	MinFeeB                          uint
+	MaxBlockBodySize                 uint
+	MaxTxSize                        uint
+	MaxBlockHeaderSize               uint
+	KeyDeposit                       uint
+	PoolDeposit                      uint
+	MaxEpoch                         uint
+	NOpt                             uint
+	A0                               *cbor.Rat
+	Rho                              *cbor.Rat
+	Tau                              *cbor.Rat
+	ProtocolVersion                  common.ProtocolParametersProtocolVersion
+	MinPoolCost                      uint64
+	AdaPerUtxoByte                   uint64
+	CostModels                       map[uint][]int64
+	ExecutionCosts                   common.ExUnitPrice
+	MaxTxExUnits                     common.ExUnits
+	MaxBlockExUnits                  common.ExUnits
+	MaxValueSize                     uint
+	CollateralPercentage             uint
+	MaxCollateralInputs              uint
+	PoolVotingThresholds             conway.PoolVotingThresholds
+	DRepVotingThresholds             conway.DRepVotingThresholds
+	MinCommitteeSize                 uint
+	CommitteeTermLimit               uint64
+	GovActionValidityPeriod          uint64
+	GovActionDeposit                 uint64
+	DRepDeposit                      uint64
+	DRepInactivityPeriod             uint64
+	MinFeeRefScriptCostPerByte       *cbor.Rat
+	MaxRefScriptSizePerBlock         uint32
+	MaxRefScriptSizePerTx            uint32
+	RefScriptCostStride              uint32
+	RefScriptCostMultiplier          *cbor.Rat
+	MaxPledgeLeverage                *cbor.Rat
+	MinPoolMargin                    *cbor.Rat
+	LeiosAnnouncementPeriodLength    uint32
+	LeiosVotePeriodLength            uint32
+	LeiosDiffusionPeriodLength       uint32
+	LeiosCommitteeSize               uint16
+	LeiosQuorumStakeThreshold        *cbor.Rat
+	MaxEndorserBlockReferencesSize   uint32
+	MaxEndorserBlockTxsSize          uint32
+	MaxEndorserBlockExUnits          common.ExUnits
+	MaxRefScriptSizePerEndorserBlock uint32
 }
 
 func (p *DijkstraProtocolParameters) UnmarshalCBOR(cborData []byte) error {
@@ -115,6 +137,17 @@ func (p *DijkstraProtocolParameters) UnmarshalCBOR(cborData []byte) error {
 	p.MaxRefScriptSizePerTx = tmp.MaxRefScriptSizePerTx
 	p.RefScriptCostStride = tmp.RefScriptCostStride
 	p.RefScriptCostMultiplier = tmp.RefScriptCostMultiplier
+	p.MaxPledgeLeverage = tmp.MaxPledgeLeverage
+	p.MinPoolMargin = tmp.MinPoolMargin
+	p.LeiosAnnouncementPeriodLength = tmp.LeiosAnnouncementPeriodLength
+	p.LeiosVotePeriodLength = tmp.LeiosVotePeriodLength
+	p.LeiosDiffusionPeriodLength = tmp.LeiosDiffusionPeriodLength
+	p.LeiosCommitteeSize = tmp.LeiosCommitteeSize
+	p.LeiosQuorumStakeThreshold = tmp.LeiosQuorumStakeThreshold
+	p.MaxEndorserBlockReferencesSize = tmp.MaxEndorserBlockReferencesSize
+	p.MaxEndorserBlockTxsSize = tmp.MaxEndorserBlockTxsSize
+	p.MaxEndorserBlockExUnits = tmp.MaxEndorserBlockExUnits
+	p.MaxRefScriptSizePerEndorserBlock = tmp.MaxRefScriptSizePerEndorserBlock
 	return nil
 }
 
@@ -124,41 +157,52 @@ func (p DijkstraProtocolParameters) MarshalCBOR() ([]byte, error) {
 
 func (p DijkstraProtocolParameters) toCbor() dijkstraProtocolParametersCbor {
 	return dijkstraProtocolParametersCbor{
-		MinFeeA:                    p.MinFeeA,
-		MinFeeB:                    p.MinFeeB,
-		MaxBlockBodySize:           p.MaxBlockBodySize,
-		MaxTxSize:                  p.MaxTxSize,
-		MaxBlockHeaderSize:         p.MaxBlockHeaderSize,
-		KeyDeposit:                 p.KeyDeposit,
-		PoolDeposit:                p.PoolDeposit,
-		MaxEpoch:                   p.MaxEpoch,
-		NOpt:                       p.NOpt,
-		A0:                         p.A0,
-		Rho:                        p.Rho,
-		Tau:                        p.Tau,
-		ProtocolVersion:            p.ProtocolVersion,
-		MinPoolCost:                p.MinPoolCost,
-		AdaPerUtxoByte:             p.AdaPerUtxoByte,
-		CostModels:                 p.CostModels,
-		ExecutionCosts:             p.ExecutionCosts,
-		MaxTxExUnits:               p.MaxTxExUnits,
-		MaxBlockExUnits:            p.MaxBlockExUnits,
-		MaxValueSize:               p.MaxValueSize,
-		CollateralPercentage:       p.CollateralPercentage,
-		MaxCollateralInputs:        p.MaxCollateralInputs,
-		PoolVotingThresholds:       p.PoolVotingThresholds,
-		DRepVotingThresholds:       p.DRepVotingThresholds,
-		MinCommitteeSize:           p.MinCommitteeSize,
-		CommitteeTermLimit:         p.CommitteeTermLimit,
-		GovActionValidityPeriod:    p.GovActionValidityPeriod,
-		GovActionDeposit:           p.GovActionDeposit,
-		DRepDeposit:                p.DRepDeposit,
-		DRepInactivityPeriod:       p.DRepInactivityPeriod,
-		MinFeeRefScriptCostPerByte: p.MinFeeRefScriptCostPerByte,
-		MaxRefScriptSizePerBlock:   p.MaxRefScriptSizePerBlock,
-		MaxRefScriptSizePerTx:      p.MaxRefScriptSizePerTx,
-		RefScriptCostStride:        p.RefScriptCostStride,
-		RefScriptCostMultiplier:    p.RefScriptCostMultiplier,
+		MinFeeA:                          p.MinFeeA,
+		MinFeeB:                          p.MinFeeB,
+		MaxBlockBodySize:                 p.MaxBlockBodySize,
+		MaxTxSize:                        p.MaxTxSize,
+		MaxBlockHeaderSize:               p.MaxBlockHeaderSize,
+		KeyDeposit:                       p.KeyDeposit,
+		PoolDeposit:                      p.PoolDeposit,
+		MaxEpoch:                         p.MaxEpoch,
+		NOpt:                             p.NOpt,
+		A0:                               p.A0,
+		Rho:                              p.Rho,
+		Tau:                              p.Tau,
+		ProtocolVersion:                  p.ProtocolVersion,
+		MinPoolCost:                      p.MinPoolCost,
+		AdaPerUtxoByte:                   p.AdaPerUtxoByte,
+		CostModels:                       p.CostModels,
+		ExecutionCosts:                   p.ExecutionCosts,
+		MaxTxExUnits:                     p.MaxTxExUnits,
+		MaxBlockExUnits:                  p.MaxBlockExUnits,
+		MaxValueSize:                     p.MaxValueSize,
+		CollateralPercentage:             p.CollateralPercentage,
+		MaxCollateralInputs:              p.MaxCollateralInputs,
+		PoolVotingThresholds:             p.PoolVotingThresholds,
+		DRepVotingThresholds:             p.DRepVotingThresholds,
+		MinCommitteeSize:                 p.MinCommitteeSize,
+		CommitteeTermLimit:               p.CommitteeTermLimit,
+		GovActionValidityPeriod:          p.GovActionValidityPeriod,
+		GovActionDeposit:                 p.GovActionDeposit,
+		DRepDeposit:                      p.DRepDeposit,
+		DRepInactivityPeriod:             p.DRepInactivityPeriod,
+		MinFeeRefScriptCostPerByte:       p.MinFeeRefScriptCostPerByte,
+		MaxRefScriptSizePerBlock:         p.MaxRefScriptSizePerBlock,
+		MaxRefScriptSizePerTx:            p.MaxRefScriptSizePerTx,
+		RefScriptCostStride:              p.RefScriptCostStride,
+		RefScriptCostMultiplier:          p.RefScriptCostMultiplier,
+		MaxPledgeLeverage:                p.MaxPledgeLeverage,
+		MinPoolMargin:                    p.MinPoolMargin,
+		LeiosAnnouncementPeriodLength:    p.LeiosAnnouncementPeriodLength,
+		LeiosVotePeriodLength:            p.LeiosVotePeriodLength,
+		LeiosDiffusionPeriodLength:       p.LeiosDiffusionPeriodLength,
+		LeiosCommitteeSize:               p.LeiosCommitteeSize,
+		LeiosQuorumStakeThreshold:        p.LeiosQuorumStakeThreshold,
+		MaxEndorserBlockReferencesSize:   p.MaxEndorserBlockReferencesSize,
+		MaxEndorserBlockTxsSize:          p.MaxEndorserBlockTxsSize,
+		MaxEndorserBlockExUnits:          p.MaxEndorserBlockExUnits,
+		MaxRefScriptSizePerEndorserBlock: p.MaxRefScriptSizePerEndorserBlock,
 	}
 }
 
@@ -186,6 +230,39 @@ func (p *DijkstraProtocolParameters) updateUnchecked(
 	}
 	if paramUpdate.RefScriptCostMultiplier != nil {
 		p.RefScriptCostMultiplier = paramUpdate.RefScriptCostMultiplier
+	}
+	if paramUpdate.MaxPledgeLeverage != nil {
+		p.MaxPledgeLeverage = paramUpdate.MaxPledgeLeverage
+	}
+	if paramUpdate.MinPoolMargin != nil {
+		p.MinPoolMargin = paramUpdate.MinPoolMargin
+	}
+	if paramUpdate.LeiosAnnouncementPeriodLength != nil {
+		p.LeiosAnnouncementPeriodLength = *paramUpdate.LeiosAnnouncementPeriodLength
+	}
+	if paramUpdate.LeiosVotePeriodLength != nil {
+		p.LeiosVotePeriodLength = *paramUpdate.LeiosVotePeriodLength
+	}
+	if paramUpdate.LeiosDiffusionPeriodLength != nil {
+		p.LeiosDiffusionPeriodLength = *paramUpdate.LeiosDiffusionPeriodLength
+	}
+	if paramUpdate.LeiosCommitteeSize != nil {
+		p.LeiosCommitteeSize = *paramUpdate.LeiosCommitteeSize
+	}
+	if paramUpdate.LeiosQuorumStakeThreshold != nil {
+		p.LeiosQuorumStakeThreshold = paramUpdate.LeiosQuorumStakeThreshold
+	}
+	if paramUpdate.MaxEndorserBlockReferencesSize != nil {
+		p.MaxEndorserBlockReferencesSize = *paramUpdate.MaxEndorserBlockReferencesSize
+	}
+	if paramUpdate.MaxEndorserBlockTxsSize != nil {
+		p.MaxEndorserBlockTxsSize = *paramUpdate.MaxEndorserBlockTxsSize
+	}
+	if paramUpdate.MaxEndorserBlockExUnits != nil {
+		p.MaxEndorserBlockExUnits = *paramUpdate.MaxEndorserBlockExUnits
+	}
+	if paramUpdate.MaxRefScriptSizePerEndorserBlock != nil {
+		p.MaxRefScriptSizePerEndorserBlock = *paramUpdate.MaxRefScriptSizePerEndorserBlock
 	}
 	if paramUpdate.CommitteeStakeCoverage != nil {
 		p.CommitteeStakeCoverage = paramUpdate.CommitteeStakeCoverage
@@ -256,45 +333,53 @@ func (p *DijkstraProtocolParameters) DRepDepositAmount() *big.Int {
 
 type DijkstraProtocolParameterUpdate struct {
 	cbor.DecodeStoreCbor
-	MinFeeA                    *uint                                     `cbor:"0,keyasint"`
-	MinFeeB                    *uint                                     `cbor:"1,keyasint"`
-	MaxBlockBodySize           *uint                                     `cbor:"2,keyasint"`
-	MaxTxSize                  *uint                                     `cbor:"3,keyasint"`
-	MaxBlockHeaderSize         *uint                                     `cbor:"4,keyasint"`
-	KeyDeposit                 *uint                                     `cbor:"5,keyasint"`
-	PoolDeposit                *uint                                     `cbor:"6,keyasint"`
-	MaxEpoch                   *uint                                     `cbor:"7,keyasint"`
-	NOpt                       *uint                                     `cbor:"8,keyasint"`
-	A0                         *cbor.Rat                                 `cbor:"9,keyasint"`
-	Rho                        *cbor.Rat                                 `cbor:"10,keyasint"`
-	Tau                        *cbor.Rat                                 `cbor:"11,keyasint"`
-	ProtocolVersion            *common.ProtocolParametersProtocolVersion `cbor:"14,keyasint"`
-	MinPoolCost                *uint64                                   `cbor:"16,keyasint"`
-	AdaPerUtxoByte             *uint64                                   `cbor:"17,keyasint"`
-	CostModels                 map[uint][]int64                          `cbor:"18,keyasint"`
-	ExecutionCosts             *common.ExUnitPrice                       `cbor:"19,keyasint"`
-	MaxTxExUnits               *common.ExUnits                           `cbor:"20,keyasint"`
-	MaxBlockExUnits            *common.ExUnits                           `cbor:"21,keyasint"`
-	MaxValueSize               *uint                                     `cbor:"22,keyasint"`
-	CollateralPercentage       *uint                                     `cbor:"23,keyasint"`
-	MaxCollateralInputs        *uint                                     `cbor:"24,keyasint"`
-	PoolVotingThresholds       *conway.PoolVotingThresholds              `cbor:"25,keyasint"`
-	DRepVotingThresholds       *conway.DRepVotingThresholds              `cbor:"26,keyasint"`
-	MinCommitteeSize           *uint                                     `cbor:"27,keyasint"`
-	CommitteeTermLimit         *uint64                                   `cbor:"28,keyasint"`
-	GovActionValidityPeriod    *uint64                                   `cbor:"29,keyasint"`
-	GovActionDeposit           *uint64                                   `cbor:"30,keyasint"`
-	DRepDeposit                *uint64                                   `cbor:"31,keyasint"`
-	DRepInactivityPeriod       *uint64                                   `cbor:"32,keyasint"`
-	MinFeeRefScriptCostPerByte *cbor.Rat                                 `cbor:"33,keyasint"`
-	MaxRefScriptSizePerBlock   *uint32                                   `cbor:"34,keyasint"`
-	MaxRefScriptSizePerTx      *uint32                                   `cbor:"35,keyasint"`
-	RefScriptCostStride        *uint32                                   `cbor:"36,keyasint"`
-	RefScriptCostMultiplier    *cbor.Rat                                 `cbor:"37,keyasint"`
-	// The current Dijkstra CDDL assigns protocol_param_update keys through 37.
-	// These Leios stake parameters have no confirmed on-chain update keys yet,
-	// so they are intentionally excluded from CBOR and can only be applied from
-	// local genesis/configuration data for now.
+	MinFeeA                          *uint                                     `cbor:"0,keyasint"`
+	MinFeeB                          *uint                                     `cbor:"1,keyasint"`
+	MaxBlockBodySize                 *uint                                     `cbor:"2,keyasint"`
+	MaxTxSize                        *uint                                     `cbor:"3,keyasint"`
+	MaxBlockHeaderSize               *uint                                     `cbor:"4,keyasint"`
+	KeyDeposit                       *uint                                     `cbor:"5,keyasint"`
+	PoolDeposit                      *uint                                     `cbor:"6,keyasint"`
+	MaxEpoch                         *uint                                     `cbor:"7,keyasint"`
+	NOpt                             *uint                                     `cbor:"8,keyasint"`
+	A0                               *cbor.Rat                                 `cbor:"9,keyasint"`
+	Rho                              *cbor.Rat                                 `cbor:"10,keyasint"`
+	Tau                              *cbor.Rat                                 `cbor:"11,keyasint"`
+	ProtocolVersion                  *common.ProtocolParametersProtocolVersion `cbor:"14,keyasint"`
+	MinPoolCost                      *uint64                                   `cbor:"16,keyasint"`
+	AdaPerUtxoByte                   *uint64                                   `cbor:"17,keyasint"`
+	CostModels                       map[uint][]int64                          `cbor:"18,keyasint"`
+	ExecutionCosts                   *common.ExUnitPrice                       `cbor:"19,keyasint"`
+	MaxTxExUnits                     *common.ExUnits                           `cbor:"20,keyasint"`
+	MaxBlockExUnits                  *common.ExUnits                           `cbor:"21,keyasint"`
+	MaxValueSize                     *uint                                     `cbor:"22,keyasint"`
+	CollateralPercentage             *uint                                     `cbor:"23,keyasint"`
+	MaxCollateralInputs              *uint                                     `cbor:"24,keyasint"`
+	PoolVotingThresholds             *conway.PoolVotingThresholds              `cbor:"25,keyasint"`
+	DRepVotingThresholds             *conway.DRepVotingThresholds              `cbor:"26,keyasint"`
+	MinCommitteeSize                 *uint                                     `cbor:"27,keyasint"`
+	CommitteeTermLimit               *uint64                                   `cbor:"28,keyasint"`
+	GovActionValidityPeriod          *uint64                                   `cbor:"29,keyasint"`
+	GovActionDeposit                 *uint64                                   `cbor:"30,keyasint"`
+	DRepDeposit                      *uint64                                   `cbor:"31,keyasint"`
+	DRepInactivityPeriod             *uint64                                   `cbor:"32,keyasint"`
+	MinFeeRefScriptCostPerByte       *cbor.Rat                                 `cbor:"33,keyasint"`
+	MaxRefScriptSizePerBlock         *uint32                                   `cbor:"34,keyasint"`
+	MaxRefScriptSizePerTx            *uint32                                   `cbor:"35,keyasint"`
+	RefScriptCostStride              *uint32                                   `cbor:"36,keyasint"`
+	RefScriptCostMultiplier          *cbor.Rat                                 `cbor:"37,keyasint"`
+	MaxPledgeLeverage                *cbor.Rat                                 `cbor:"38,keyasint"`
+	MinPoolMargin                    *cbor.Rat                                 `cbor:"39,keyasint"`
+	LeiosAnnouncementPeriodLength    *uint32                                   `cbor:"40,keyasint"`
+	LeiosVotePeriodLength            *uint32                                   `cbor:"41,keyasint"`
+	LeiosDiffusionPeriodLength       *uint32                                   `cbor:"42,keyasint"`
+	LeiosCommitteeSize               *uint16                                   `cbor:"43,keyasint"`
+	LeiosQuorumStakeThreshold        *cbor.Rat                                 `cbor:"44,keyasint"`
+	MaxEndorserBlockReferencesSize   *uint32                                   `cbor:"45,keyasint"`
+	MaxEndorserBlockTxsSize          *uint32                                   `cbor:"46,keyasint"`
+	MaxEndorserBlockExUnits          *common.ExUnits                           `cbor:"47,keyasint"`
+	MaxRefScriptSizePerEndorserBlock *uint32                                   `cbor:"48,keyasint"`
+	// These legacy stake parameters remain local-only prototype settings.
 	CommitteeStakeCoverage *cbor.Rat `cbor:"-"`
 	QuorumStakeThreshold   *cbor.Rat `cbor:"-"`
 }
@@ -426,6 +511,39 @@ func (u DijkstraProtocolParameterUpdate) MarshalCBOR() ([]byte, error) {
 	if u.RefScriptCostMultiplier != nil {
 		fields[37] = u.RefScriptCostMultiplier
 	}
+	if u.MaxPledgeLeverage != nil {
+		fields[38] = u.MaxPledgeLeverage
+	}
+	if u.MinPoolMargin != nil {
+		fields[39] = u.MinPoolMargin
+	}
+	if u.LeiosAnnouncementPeriodLength != nil {
+		fields[40] = *u.LeiosAnnouncementPeriodLength
+	}
+	if u.LeiosVotePeriodLength != nil {
+		fields[41] = *u.LeiosVotePeriodLength
+	}
+	if u.LeiosDiffusionPeriodLength != nil {
+		fields[42] = *u.LeiosDiffusionPeriodLength
+	}
+	if u.LeiosCommitteeSize != nil {
+		fields[43] = *u.LeiosCommitteeSize
+	}
+	if u.LeiosQuorumStakeThreshold != nil {
+		fields[44] = u.LeiosQuorumStakeThreshold
+	}
+	if u.MaxEndorserBlockReferencesSize != nil {
+		fields[45] = *u.MaxEndorserBlockReferencesSize
+	}
+	if u.MaxEndorserBlockTxsSize != nil {
+		fields[46] = *u.MaxEndorserBlockTxsSize
+	}
+	if u.MaxEndorserBlockExUnits != nil {
+		fields[47] = *u.MaxEndorserBlockExUnits
+	}
+	if u.MaxRefScriptSizePerEndorserBlock != nil {
+		fields[48] = *u.MaxRefScriptSizePerEndorserBlock
+	}
 	return cbor.Encode(fields)
 }
 
@@ -465,6 +583,17 @@ func (u *DijkstraProtocolParameterUpdate) hasUpdate() bool {
 		u.MaxRefScriptSizePerTx != nil ||
 		u.RefScriptCostStride != nil ||
 		u.RefScriptCostMultiplier != nil ||
+		u.MaxPledgeLeverage != nil ||
+		u.MinPoolMargin != nil ||
+		u.LeiosAnnouncementPeriodLength != nil ||
+		u.LeiosVotePeriodLength != nil ||
+		u.LeiosDiffusionPeriodLength != nil ||
+		u.LeiosCommitteeSize != nil ||
+		u.LeiosQuorumStakeThreshold != nil ||
+		u.MaxEndorserBlockReferencesSize != nil ||
+		u.MaxEndorserBlockTxsSize != nil ||
+		u.MaxEndorserBlockExUnits != nil ||
+		u.MaxRefScriptSizePerEndorserBlock != nil ||
 		u.CommitteeStakeCoverage != nil ||
 		u.QuorumStakeThreshold != nil
 }
@@ -482,6 +611,39 @@ func (u *DijkstraProtocolParameterUpdate) BootstrapRestrictedFields() []string {
 	}
 	if u.RefScriptCostMultiplier != nil {
 		fields = append(fields, "RefScriptCostMultiplier")
+	}
+	if u.MaxPledgeLeverage != nil {
+		fields = append(fields, "MaxPledgeLeverage")
+	}
+	if u.MinPoolMargin != nil {
+		fields = append(fields, "MinPoolMargin")
+	}
+	if u.LeiosAnnouncementPeriodLength != nil {
+		fields = append(fields, "LeiosAnnouncementPeriodLength")
+	}
+	if u.LeiosVotePeriodLength != nil {
+		fields = append(fields, "LeiosVotePeriodLength")
+	}
+	if u.LeiosDiffusionPeriodLength != nil {
+		fields = append(fields, "LeiosDiffusionPeriodLength")
+	}
+	if u.LeiosCommitteeSize != nil {
+		fields = append(fields, "LeiosCommitteeSize")
+	}
+	if u.LeiosQuorumStakeThreshold != nil {
+		fields = append(fields, "LeiosQuorumStakeThreshold")
+	}
+	if u.MaxEndorserBlockReferencesSize != nil {
+		fields = append(fields, "MaxEndorserBlockReferencesSize")
+	}
+	if u.MaxEndorserBlockTxsSize != nil {
+		fields = append(fields, "MaxEndorserBlockTxsSize")
+	}
+	if u.MaxEndorserBlockExUnits != nil {
+		fields = append(fields, "MaxEndorserBlockExUnits")
+	}
+	if u.MaxRefScriptSizePerEndorserBlock != nil {
+		fields = append(fields, "MaxRefScriptSizePerEndorserBlock")
 	}
 	if u.CommitteeStakeCoverage != nil {
 		fields = append(fields, "CommitteeStakeCoverage")
@@ -688,6 +850,42 @@ func (u DijkstraProtocolParameterUpdate) ToPlutusData() data.PlutusData {
 	}
 	if u.RefScriptCostMultiplier != nil {
 		pushRat(37, u.RefScriptCostMultiplier)
+	}
+	if u.MaxPledgeLeverage != nil {
+		pushRat(38, u.MaxPledgeLeverage)
+	}
+	if u.MinPoolMargin != nil {
+		pushRat(39, u.MinPoolMargin)
+	}
+	if u.LeiosAnnouncementPeriodLength != nil {
+		push(40, data.NewInteger(new(big.Int).SetUint64(uint64(*u.LeiosAnnouncementPeriodLength))))
+	}
+	if u.LeiosVotePeriodLength != nil {
+		push(41, data.NewInteger(new(big.Int).SetUint64(uint64(*u.LeiosVotePeriodLength))))
+	}
+	if u.LeiosDiffusionPeriodLength != nil {
+		push(42, data.NewInteger(new(big.Int).SetUint64(uint64(*u.LeiosDiffusionPeriodLength))))
+	}
+	if u.LeiosCommitteeSize != nil {
+		push(43, data.NewInteger(new(big.Int).SetUint64(uint64(*u.LeiosCommitteeSize))))
+	}
+	if u.LeiosQuorumStakeThreshold != nil {
+		pushRat(44, u.LeiosQuorumStakeThreshold)
+	}
+	if u.MaxEndorserBlockReferencesSize != nil {
+		push(45, data.NewInteger(new(big.Int).SetUint64(uint64(*u.MaxEndorserBlockReferencesSize))))
+	}
+	if u.MaxEndorserBlockTxsSize != nil {
+		push(46, data.NewInteger(new(big.Int).SetUint64(uint64(*u.MaxEndorserBlockTxsSize))))
+	}
+	if u.MaxEndorserBlockExUnits != nil {
+		push(47, data.NewList(
+			data.NewInteger(big.NewInt(u.MaxEndorserBlockExUnits.Memory)),
+			data.NewInteger(big.NewInt(u.MaxEndorserBlockExUnits.Steps)),
+		))
+	}
+	if u.MaxRefScriptSizePerEndorserBlock != nil {
+		push(48, data.NewInteger(new(big.Int).SetUint64(uint64(*u.MaxRefScriptSizePerEndorserBlock))))
 	}
 	return data.NewMap(tmpPairs)
 }

--- a/ledger/dijkstra/pparams.go
+++ b/ledger/dijkstra/pparams.go
@@ -15,6 +15,7 @@
 package dijkstra
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -95,9 +96,116 @@ type dijkstraProtocolParametersCbor struct {
 	MaxRefScriptSizePerEndorserBlock uint32
 }
 
+type dijkstraProtocolParametersCborLegacy struct {
+	cbor.StructAsArray
+	MinFeeA                    uint
+	MinFeeB                    uint
+	MaxBlockBodySize           uint
+	MaxTxSize                  uint
+	MaxBlockHeaderSize         uint
+	KeyDeposit                 uint
+	PoolDeposit                uint
+	MaxEpoch                   uint
+	NOpt                       uint
+	A0                         *cbor.Rat
+	Rho                        *cbor.Rat
+	Tau                        *cbor.Rat
+	ProtocolVersion            common.ProtocolParametersProtocolVersion
+	MinPoolCost                uint64
+	AdaPerUtxoByte             uint64
+	CostModels                 map[uint][]int64
+	ExecutionCosts             common.ExUnitPrice
+	MaxTxExUnits               common.ExUnits
+	MaxBlockExUnits            common.ExUnits
+	MaxValueSize               uint
+	CollateralPercentage       uint
+	MaxCollateralInputs        uint
+	PoolVotingThresholds       conway.PoolVotingThresholds
+	DRepVotingThresholds       conway.DRepVotingThresholds
+	MinCommitteeSize           uint
+	CommitteeTermLimit         uint64
+	GovActionValidityPeriod    uint64
+	GovActionDeposit           uint64
+	DRepDeposit                uint64
+	DRepInactivityPeriod       uint64
+	MinFeeRefScriptCostPerByte *cbor.Rat
+	MaxRefScriptSizePerBlock   uint32
+	MaxRefScriptSizePerTx      uint32
+	RefScriptCostStride        uint32
+	RefScriptCostMultiplier    *cbor.Rat
+}
+
+func decodeDijkstraProtocolParametersCbor(
+	cborData []byte,
+) (dijkstraProtocolParametersCbor, error) {
+	var items []cbor.RawMessage
+	if _, err := cbor.Decode(cborData, &items); err != nil {
+		return dijkstraProtocolParametersCbor{}, err
+	}
+	switch len(items) {
+	case 35:
+		var legacy dijkstraProtocolParametersCborLegacy
+		if _, err := cbor.Decode(cborData, &legacy); err != nil {
+			return dijkstraProtocolParametersCbor{}, err
+		}
+		return dijkstraProtocolParametersCbor{
+			MinFeeA:                    legacy.MinFeeA,
+			MinFeeB:                    legacy.MinFeeB,
+			MaxBlockBodySize:           legacy.MaxBlockBodySize,
+			MaxTxSize:                  legacy.MaxTxSize,
+			MaxBlockHeaderSize:         legacy.MaxBlockHeaderSize,
+			KeyDeposit:                 legacy.KeyDeposit,
+			PoolDeposit:                legacy.PoolDeposit,
+			MaxEpoch:                   legacy.MaxEpoch,
+			NOpt:                       legacy.NOpt,
+			A0:                         legacy.A0,
+			Rho:                        legacy.Rho,
+			Tau:                        legacy.Tau,
+			ProtocolVersion:            legacy.ProtocolVersion,
+			MinPoolCost:                legacy.MinPoolCost,
+			AdaPerUtxoByte:             legacy.AdaPerUtxoByte,
+			CostModels:                 legacy.CostModels,
+			ExecutionCosts:             legacy.ExecutionCosts,
+			MaxTxExUnits:               legacy.MaxTxExUnits,
+			MaxBlockExUnits:            legacy.MaxBlockExUnits,
+			MaxValueSize:               legacy.MaxValueSize,
+			CollateralPercentage:       legacy.CollateralPercentage,
+			MaxCollateralInputs:        legacy.MaxCollateralInputs,
+			PoolVotingThresholds:       legacy.PoolVotingThresholds,
+			DRepVotingThresholds:       legacy.DRepVotingThresholds,
+			MinCommitteeSize:           legacy.MinCommitteeSize,
+			CommitteeTermLimit:         legacy.CommitteeTermLimit,
+			GovActionValidityPeriod:    legacy.GovActionValidityPeriod,
+			GovActionDeposit:           legacy.GovActionDeposit,
+			DRepDeposit:                legacy.DRepDeposit,
+			DRepInactivityPeriod:       legacy.DRepInactivityPeriod,
+			MinFeeRefScriptCostPerByte: legacy.MinFeeRefScriptCostPerByte,
+			MaxRefScriptSizePerBlock:   legacy.MaxRefScriptSizePerBlock,
+			MaxRefScriptSizePerTx:      legacy.MaxRefScriptSizePerTx,
+			RefScriptCostStride:        legacy.RefScriptCostStride,
+			RefScriptCostMultiplier:    legacy.RefScriptCostMultiplier,
+		}, nil
+	case 46:
+		var current dijkstraProtocolParametersCbor
+		if _, err := cbor.Decode(cborData, &current); err != nil {
+			return dijkstraProtocolParametersCbor{}, err
+		}
+		return current, nil
+	default:
+		var current dijkstraProtocolParametersCbor
+		if _, err := cbor.Decode(cborData, &current); err != nil {
+			return dijkstraProtocolParametersCbor{}, fmt.Errorf(
+				"decode Dijkstra protocol parameters with %d fields: %w",
+				len(items), err,
+			)
+		}
+		return current, nil
+	}
+}
+
 func (p *DijkstraProtocolParameters) UnmarshalCBOR(cborData []byte) error {
-	var tmp dijkstraProtocolParametersCbor
-	if _, err := cbor.Decode(cborData, &tmp); err != nil {
+	tmp, err := decodeDijkstraProtocolParametersCbor(cborData)
+	if err != nil {
 		return err
 	}
 	p.ConwayProtocolParameters = conway.ConwayProtocolParameters{

--- a/ledger/dijkstra/pparams.go
+++ b/ledger/dijkstra/pparams.go
@@ -138,11 +138,13 @@ type dijkstraProtocolParametersCborLegacy struct {
 func decodeDijkstraProtocolParametersCbor(
 	cborData []byte,
 ) (dijkstraProtocolParametersCbor, error) {
-	var items []cbor.RawMessage
-	if _, err := cbor.Decode(cborData, &items); err != nil {
-		return dijkstraProtocolParametersCbor{}, err
+	arrayLen, _, indefinite := cbor.ArrayInfo(cborData)
+	if arrayLen < 0 || indefinite {
+		return dijkstraProtocolParametersCbor{}, fmt.Errorf(
+			"decode Dijkstra protocol parameters: invalid array header",
+		)
 	}
-	switch len(items) {
+	switch arrayLen {
 	case 35:
 		var legacy dijkstraProtocolParametersCborLegacy
 		if _, err := cbor.Decode(cborData, &legacy); err != nil {
@@ -192,14 +194,10 @@ func decodeDijkstraProtocolParametersCbor(
 		}
 		return current, nil
 	default:
-		var current dijkstraProtocolParametersCbor
-		if _, err := cbor.Decode(cborData, &current); err != nil {
-			return dijkstraProtocolParametersCbor{}, fmt.Errorf(
-				"decode Dijkstra protocol parameters with %d fields: %w",
-				len(items), err,
-			)
-		}
-		return current, nil
+		return dijkstraProtocolParametersCbor{}, fmt.Errorf(
+			"decode Dijkstra protocol parameters: unsupported array length %d",
+			arrayLen,
+		)
 	}
 }
 

--- a/ledger/dijkstra/pparams.go
+++ b/ledger/dijkstra/pparams.go
@@ -15,6 +15,7 @@
 package dijkstra
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -140,7 +141,7 @@ func decodeDijkstraProtocolParametersCbor(
 ) (dijkstraProtocolParametersCbor, error) {
 	arrayLen, _, indefinite := cbor.ArrayInfo(cborData)
 	if arrayLen < 0 || indefinite {
-		return dijkstraProtocolParametersCbor{}, fmt.Errorf(
+		return dijkstraProtocolParametersCbor{}, errors.New(
 			"decode Dijkstra protocol parameters: invalid array header",
 		)
 	}

--- a/ledger/dijkstra/testdata/dijkstra.cddl
+++ b/ledger/dijkstra/testdata/dijkstra.cddl
@@ -15,7 +15,7 @@ block_transaction =
 ;
 ; In the next era `is_valid` flags will not be allowed even in mempool
 ; transactions, so it's strongly recommended to encode transactions
-; according to the `transaction` rule.
+; using the flag-less three-element form below.
 transaction_mempool =
   [ transaction_body, transaction_witness_set, auxiliary_data/ nil
   ]

--- a/ledger/dijkstra/testdata/dijkstra.cddl
+++ b/ledger/dijkstra/testdata/dijkstra.cddl
@@ -2,7 +2,10 @@
 
 block = [header, block_body]
 
-transaction = [transaction_body, transaction_witness_set, auxiliary_data/ nil]
+; Transactions in a block carry a trailing `is_valid` flag, which is set by
+; the block producer.
+block_transaction =
+  [transaction_body, transaction_witness_set, auxiliary_data/ nil, bool]
 
 ; In Dijkstra we're deprecating the `is_valid` flag, but for backwards
 ; compatibility we still allow this flag to be present in incoming
@@ -14,7 +17,8 @@ transaction = [transaction_body, transaction_witness_set, auxiliary_data/ nil]
 ; transactions, so it's strongly recommended to encode transactions
 ; according to the `transaction` rule.
 transaction_mempool =
-  transaction
+  [ transaction_body, transaction_witness_set, auxiliary_data/ nil
+  ]
   / [transaction_body, transaction_witness_set, true, auxiliary_data/ nil]
 
 kes_signature = bytes .size 448
@@ -60,6 +64,8 @@ header_body =
   , block_body_hash  : hash32       ; merkle triple root
   , operational_cert
   , protocol_version
+  , block_body_contains_leios_cert : bool
+  , eb_announcement                : eb_announcement/ nil
   ]
 
 block_number = uint .size 8
@@ -72,7 +78,7 @@ vkey = bytes .size 32
 
 vrf_vkey = bytes .size 32
 
-vrf_cert = [bytes, bytes .size 80]
+vrf_cert = [bytes .size 64, bytes .size 80]
 
 operational_cert =
   [ hot_vkey        : kes_vkey
@@ -93,19 +99,16 @@ protocol_version = [major_protocol_version, uint .size 4]
 
 major_protocol_version = 0 .. 13
 
-; Note that every transaction_index must be strictly smaller than the length of transaction_bodies
+eb_announcement =
+  [ eb_hash : hash32
+  , eb_size : uint .size 4 ; size of the EB block closure
+  ]
+
 block_body =
-  [ invalid_transactions : invalid_transactions/ nil
-  , transactions      : [* transaction]
+  [ transactions      : [* block_transaction]
   , leios_certificate : leios_certificate/ nil
   , peras_certificate : peras_certificate/ nil
   ]
-
-invalid_transactions = nonempty_set<transaction_index>
-
-nonempty_set<a0> = #6.258([+ a0])/ [+ a0]
-
-transaction_index = uint .size 2
 
 transaction_body =
   {   0  : set<transaction_input>
@@ -129,8 +132,10 @@ transaction_body =
   , ? 21 : coin                            ; current treasury value
   , ? 22 : positive_coin                   ; donation
   , ? 23 : sub_transactions                ; sub-transactions (NEW)
+  , ? 24 : required_top_level_guards       ; required top-level guards
   , ? 25 : direct_deposits                 ; direct deposits
   , ? 26 : account_balance_intervals       ; account balance intervals
+  , ? 27 : starting_account_balance_intervals ; starting account balance intervals
   }
 
 set<a0> = #6.258([* a0])/ [* a0]
@@ -459,6 +464,7 @@ pool_registration_cert = (3, pool_params)
 pool_params =
   ( operator       : pool_keyhash
   , vrf_keyhash    : vrf_keyhash
+  , ? bls_key      : bls_key/ nil
   , pledge         : coin
   , cost           : coin
   , margin         : unit_interval
@@ -469,6 +475,9 @@ pool_params =
   )
 
 vrf_keyhash = hash32
+
+; BLS key
+bls_key = [bls_pubkey : bytes .size 96, bls_possession_proof : bytes .size 48]
 
 ; A unit interval is a number in the range between 0 and 1, which
 ; means there are two extra constraints:
@@ -627,6 +636,8 @@ positive_int64 = 1 .. max_int64
 ; representation for empty redeemers.
 script_data_hash = hash32
 
+nonempty_set<a0> = #6.258([+ a0])/ [+ a0]
+
 guards = nonempty_set<addr_keyhash>/ nonempty_oset<credential>
 
 network_id = 0/ 1
@@ -700,6 +711,17 @@ protocol_param_update =
   , ? 35 : uint .size 4           ; max refScript size per tx
   , ? 36 : positive_word32        ; refScript cost stride
   , ? 37 : positive_interval      ; refScript cost multiplier
+  , ? 38 : max_pledge_leverage    ; max pledge leverage
+  , ? 39 : unit_interval           ; min pool margin
+  , ? 40 : uint .size 4           ; leios announcement period length in ms
+  , ? 41 : uint .size 4           ; leios vote period length in ms
+  , ? 42 : uint .size 4           ; leios diffusion period length in ms
+  , ? 43 : uint .size 2           ; leios committee size
+  , ? 44 : unit_interval          ; leios quorum stake threshold
+  , ? 45 : uint .size 4           ; max endorser block references size
+  , ? 46 : uint .size 4           ; max endorser block txs size
+  , ? 47 : ex_units               ; max endorser block ex units
+  , ? 48 : uint .size 4           ; max ref script size per endorser block
   }
 
 epoch_interval = uint .size 4
@@ -757,6 +779,8 @@ max_word32 = 4294967295
 
 positive_interval = #6.30([positive_int, positive_int])
 
+max_pledge_leverage = nonnegative_interval/ nil
+
 guardrails_script_hash = script_hash
 
 hard_fork_initiation_action = (1, gov_action_id/ nil, protocol_version)
@@ -811,12 +835,15 @@ required_top_level_guards = {+ credential => plutus_data/ nil}
 
 direct_deposits = {+ reward_account => coin}
 
-account_balance_intervals = {+ credential => account_balance_interval}
+account_balance_intervals = {+ reward_account => account_balance_interval}
 
 account_balance_interval =
-  [  inclusive_lower_bound : coin, exclusive_upper_bound : coin/ nil
-  // inclusive_lower_bound : coin/ nil, exclusive_upper_bound : coin
-  ]
+  [inclusive_lower_bound : coin, exclusive_upper_bound : coin/ nil]
+  / [inclusive_lower_bound : coin/ nil, exclusive_upper_bound : coin]
+  / coin
+
+starting_account_balance_intervals =
+  {+ reward_account => account_balance_interval}
 
 transaction_witness_set =
   { ? 0 : nonempty_set<vkeywitness>
@@ -890,11 +917,10 @@ auxiliary_data_map =
   )
 
 leios_certificate =
-  [ signers              : bytes           ;bitfield
-  , aggregated_signature : leios_signature
+  [ signers   : bytes .size (0 .. 8192) ;bitfield with up to 65536 entries
+  , signature : leios_signature
   ]
 
 leios_signature = bytes .size 48
 
 peras_certificate = bytes
-


### PR DESCRIPTION
## Summary

- Align Dijkstra block-body and block-transaction encoding with the pinned Leios prototype-2026w36 CDDL.
- Preserve legacy block-body, transaction, and protocol-parameter decoding for existing prototype fixtures.
- Add Leios protocol-parameter fields, including genesis loading and Plutus V4 cost-model propagation under cost-model key 3.
- Add round-trip, validity-flag, legacy-compatibility, parameter, and genesis-decoding coverage.

Reference CDDL: https://github.com/IntersectMBO/cardano-ledger/blob/1587f21a7d1306dc590c2749a5c66232ef66aad0/eras/dijkstra/impl/cddl/data/dijkstra.cddl

## Validation

- `go test ./ledger/dijkstra`
- `git diff --check`
