### PR TITLE
fix(handshake): deliver terminal replies before stopping

### DIFF
--- a/protocol/handshake/refusal_wire_test.go
+++ b/protocol/handshake/refusal_wire_test.go
@@ -60,6 +60,9 @@ func TestServerRefusalDeliveryWaitCanBeCancelled(t *testing.T) {
 	))
 	require.NoError(t, err)
 	segment := muxer.NewSegment(handshake.ProtocolId, proposal, false)
+	if segment == nil {
+		t.Fatal("failed to construct proposal segment")
+	}
 	var wire bytes.Buffer
 	require.NoError(t, binary.Write(&wire, binary.BigEndian, segment.SegmentHeader))
 	wire.Write(segment.Payload)
@@ -100,6 +103,9 @@ func TestServerEmptyVersionDataRefusalReachesClientAsText(t *testing.T) {
 	case err := <-clientErrors:
 		var refusal *handshake.DecodeError
 		require.ErrorAs(t, err, &refusal)
+		if refusal == nil {
+			t.Fatal("errors.As matched a nil decode refusal")
+		}
 		require.Equal(t, version, refusal.Version)
 		require.Equal(t,
 			"handshake failed: refused due to empty version data", refusal.Message)

--- a/protocol/handshake/refusal_wire_test.go
+++ b/protocol/handshake/refusal_wire_test.go
@@ -1,0 +1,184 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handshake_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/muxer"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/blinklabs-io/gouroboros/protocol/handshake"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerRefusalDeliveryWaitCanBeCancelled(t *testing.T) {
+	serverConn, peer := net.Pipe()
+	defer serverConn.Close()
+	defer peer.Close()
+	require.NoError(t, peer.SetDeadline(time.Now().Add(5*time.Second)))
+	m := muxer.New(serverConn)
+	m.Start()
+	defer m.Stop()
+	version := uint16(12 + protocol.ProtocolVersionNtCOffset)
+	cfg := handshake.NewConfig(
+		handshake.WithProtocolVersionMap(protocol.ProtocolVersionMap{version: nil}),
+		handshake.WithFinishedFunc(func(handshake.CallbackContext, uint16, protocol.VersionData) error {
+			t.Error("refusal must not invoke acceptance callback")
+			return nil
+		}),
+	)
+	server := handshake.NewServer(protocol.ProtocolOptions{
+		ConnectionId: connection.ConnectionId{
+			LocalAddr: serverConn.LocalAddr(), RemoteAddr: serverConn.RemoteAddr(),
+		},
+		Muxer: m, ErrorChan: make(chan error, 1),
+		Mode: protocol.ProtocolModeNodeToClient,
+	}, &cfg)
+	server.Start()
+	defer server.Stop()
+	proposal, err := cbor.Encode(handshake.NewMsgProposeVersions(
+		protocol.ProtocolVersionMap{version: protocol.VersionDataNtC9to14(42)},
+	))
+	require.NoError(t, err)
+	segment := muxer.NewSegment(handshake.ProtocolId, proposal, false)
+	var wire bytes.Buffer
+	require.NoError(t, binary.Write(&wire, binary.BigEndian, segment.SegmentHeader))
+	wire.Write(segment.Payload)
+	_, err = peer.Write(wire.Bytes())
+	require.NoError(t, err)
+	// Read only the response header. net.Pipe keeps the write blocked on the
+	// remaining payload, so cancellation is exercised during actual delivery.
+	header := make([]byte, 8)
+	_, err = io.ReadFull(peer, header)
+	require.NoError(t, err)
+	require.Positive(t, binary.BigEndian.Uint16(header[6:]))
+	server.Stop()
+	select {
+	case <-server.DoneChan():
+	case <-time.After(5 * time.Second):
+		t.Fatal("refusal delivery wait prevented protocol cancellation")
+	}
+}
+
+func TestServerEmptyVersionDataRefusalReachesClientAsText(t *testing.T) {
+	version := uint16(12 + protocol.ProtocolVersionNtCOffset)
+	finished := func(handshake.CallbackContext, uint16, protocol.VersionData) error {
+		t.Error("refused handshake must not invoke acceptance callback")
+		return nil
+	}
+	serverCfg := handshake.NewConfig(
+		handshake.WithProtocolVersionMap(protocol.ProtocolVersionMap{version: nil}),
+		handshake.WithFinishedFunc(finished),
+	)
+	clientCfg := handshake.NewConfig(
+		handshake.WithProtocolVersionMap(protocol.ProtocolVersionMap{
+			version: protocol.VersionDataNtC9to14(42),
+		}),
+		handshake.WithFinishedFunc(finished),
+	)
+	clientErrors := startHandshakeWirePair(t, &serverCfg, &clientCfg)
+	select {
+	case err := <-clientErrors:
+		var refusal *handshake.DecodeError
+		require.ErrorAs(t, err, &refusal)
+		require.Equal(t, version, refusal.Version)
+		require.Equal(t,
+			"handshake failed: refused due to empty version data", refusal.Message)
+	case <-time.After(5 * time.Second):
+		t.Fatal("client did not receive server refusal")
+	}
+}
+
+func TestServerQueryReplyReachesClientBeforeTermination(t *testing.T) {
+	version := uint16(15 + protocol.ProtocolVersionNtCOffset)
+	data := protocol.VersionDataNtC15andUp{CborNetworkMagic: 42}
+	versions := protocol.ProtocolVersionMap{version: data}
+	finished := func(handshake.CallbackContext, uint16, protocol.VersionData) error {
+		t.Error("query must not invoke acceptance callback")
+		return nil
+	}
+	serverCfg := handshake.NewConfig(
+		handshake.WithProtocolVersionMap(versions),
+		handshake.WithFinishedFunc(finished),
+	)
+	data.CborQuery = true
+	replies := make(chan protocol.ProtocolVersionMap, 1)
+	clientCfg := handshake.NewConfig(
+		handshake.WithProtocolVersionMap(protocol.ProtocolVersionMap{version: data}),
+		handshake.WithQueryReplyFunc(func(_ handshake.CallbackContext, reply protocol.ProtocolVersionMap) error {
+			replies <- reply
+			return nil
+		}),
+	)
+	clientErrors := startHandshakeWirePair(t, &serverCfg, &clientCfg)
+	select {
+	case reply := <-replies:
+		require.Equal(t, versions, reply)
+	case err := <-clientErrors:
+		t.Fatalf("client failed before query reply: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("client did not receive query reply")
+	}
+}
+
+func startHandshakeWirePair(t *testing.T, serverCfg, clientCfg *handshake.Config) <-chan error {
+	t.Helper()
+	serverConn, clientConn := net.Pipe()
+	serverMux := muxer.New(serverConn)
+	clientMux := muxer.New(clientConn)
+	serverMux.Start()
+	clientMux.Start()
+	serverErrors := make(chan error, 1)
+	clientErrors := make(chan error, 1)
+	server := handshake.NewServer(protocol.ProtocolOptions{
+		ConnectionId: connection.ConnectionId{
+			LocalAddr: serverConn.LocalAddr(), RemoteAddr: serverConn.RemoteAddr(),
+		},
+		Muxer: serverMux, ErrorChan: serverErrors,
+		Mode: protocol.ProtocolModeNodeToClient,
+	}, serverCfg)
+	client := handshake.NewClient(protocol.ProtocolOptions{
+		ConnectionId: connection.ConnectionId{
+			LocalAddr: clientConn.LocalAddr(), RemoteAddr: clientConn.RemoteAddr(),
+		},
+		Muxer: clientMux, ErrorChan: clientErrors,
+		Mode: protocol.ProtocolModeNodeToClient,
+	}, clientCfg)
+	t.Cleanup(func() {
+		server.Stop()
+		client.Stop()
+		serverMux.Stop()
+		clientMux.Stop()
+		_ = serverConn.Close()
+		_ = clientConn.Close()
+		for _, done := range []<-chan struct{}{server.DoneChan(), client.DoneChan()} {
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Error("handshake protocol did not stop")
+			}
+		}
+	})
+	server.Start()
+	client.Start()
+	return clientErrors
+}

--- a/protocol/handshake/server.go
+++ b/protocol/handshake/server.go
@@ -100,6 +100,8 @@ func (s *Server) handleProposeVersions(msg protocol.Message) error {
 	}
 	msgProposeVersions := msg.(*MsgProposeVersions)
 
+	// Query and refusal responses must reach the transport before returning
+	// a terminal error, which stops the protocol and can discard queued sends.
 	for proposedVersion, versionDataCbor := range msgProposeVersions.VersionMap {
 		versionInfo := protocol.GetProtocolVersion(proposedVersion)
 		if versionInfo.NewVersionDataFromCborFunc != nil {
@@ -109,7 +111,7 @@ func (s *Server) handleProposeVersions(msg protocol.Message) error {
 			if err == nil && proposedVersionData != nil &&
 				proposedVersionData.Query() {
 				msgQueryReply := NewMsgQueryReply(s.config.ProtocolVersionMap)
-				if err := s.SendMessage(msgQueryReply); err != nil {
+				if err := s.SendMessageAndWait(msgQueryReply); err != nil {
 					return err
 				}
 				return errors.New(
@@ -142,7 +144,7 @@ func (s *Server) handleProposeVersions(msg protocol.Message) error {
 				supportedVersions,
 			},
 		)
-		if err := s.SendMessage(msgRefuse); err != nil {
+		if err := s.SendMessageAndWait(msgRefuse); err != nil {
 			return err
 		}
 		return errors.New("handshake failed: refused due to version mismatch")
@@ -162,12 +164,10 @@ func (s *Server) handleProposeVersions(msg protocol.Message) error {
 			[]any{
 				RefuseReasonDecodeError,
 				proposedVersion,
-				errors.New(
-					"handshake failed: refused due to empty version data",
-				),
+				"handshake failed: refused due to empty version data",
 			},
 		)
-		if err := s.SendMessage(msgRefuse); err != nil {
+		if err := s.SendMessageAndWait(msgRefuse); err != nil {
 			return err
 		}
 		return errors.New("handshake failed: refused due to empty version data")
@@ -183,7 +183,7 @@ func (s *Server) handleProposeVersions(msg protocol.Message) error {
 				err.Error(),
 			},
 		)
-		if err := s.SendMessage(msgRefuse); err != nil {
+		if err := s.SendMessageAndWait(msgRefuse); err != nil {
 			return err
 		}
 		return fmt.Errorf(
@@ -196,12 +196,10 @@ func (s *Server) handleProposeVersions(msg protocol.Message) error {
 			[]any{
 				RefuseReasonDecodeError,
 				proposedVersion,
-				errors.New(
-					"handshake failed: refused due to empty version map",
-				),
+				"handshake failed: refused due to empty version map",
 			},
 		)
-		if err := s.SendMessage(msgRefuse); err != nil {
+		if err := s.SendMessageAndWait(msgRefuse); err != nil {
 			return err
 		}
 		return errors.New("handshake failed: refused due to empty version map")
@@ -217,7 +215,7 @@ func (s *Server) handleProposeVersions(msg protocol.Message) error {
 				errMsg,
 			},
 		)
-		if err := s.SendMessage(msgRefuse); err != nil {
+		if err := s.SendMessageAndWait(msgRefuse); err != nil {
 			return err
 		}
 		return fmt.Errorf(


### PR DESCRIPTION
Encode refusal reasons as protocol text and wait for refusal and query-reply writes before stopping the handshake protocol. Add client/server delivery and blocked-write cancellation regressions.

Fixes #2003.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the handshake server stopping before refusal and query-reply messages reach the client, and changes refusal reasons to protocol-compatible text. Fixes #2003.

- Uses `SendMessageAndWait` so queued writes complete before the protocol stops.
- Encodes refusal reasons as text strings instead of Go error objects, matching the wire format.
- Adds regression tests covering client delivery and blocked-write cancellation during refusals.

<sup>Written for commit 0bad267f7b623114e8cae87548794b546eeeea5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

