### PR TITLE
fix(protocol): validate Cardano Point decoding

### DIFF
--- a/protocol/blockfetch/client_test.go
+++ b/protocol/blockfetch/client_test.go
@@ -21,7 +21,6 @@ import (
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/cbor"
-	"github.com/blinklabs-io/gouroboros/internal/test"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	"github.com/blinklabs-io/gouroboros/protocol/blockfetch"
@@ -200,7 +199,7 @@ func TestGetBlockNoBlocks(t *testing.T) {
 			_, err := oConn.BlockFetch().Client.GetBlock(
 				pcommon.NewPoint(
 					12345,
-					test.DecodeHexString("abcdef0123456789"),
+					testPointHash(0xab),
 				),
 			)
 			if err == nil {
@@ -437,7 +436,7 @@ func TestGetBlockRangeReleasesBusyOnDisconnectBeforeBatchDone(t *testing.T) {
 	client := oConn.BlockFetch().Client
 	point := pcommon.NewPoint(
 		12345,
-		test.DecodeHexString("abcdef0123456789"),
+		testPointHash(0xab),
 	)
 	require.NoError(t, client.GetBlockRange(point, point))
 

--- a/protocol/blockfetch/messages_test.go
+++ b/protocol/blockfetch/messages_test.go
@@ -34,15 +34,15 @@ type testDefinition struct {
 
 var tests = []testDefinition{
 	{
-		CborHex: "830082187b480102030405060708821901c848090a0b0c0d0e0f10",
+		CborHex: "830082187b58200101010101010101010101010101010101010101010101010101010101010101821901c858200909090909090909090909090909090909090909090909090909090909090909",
 		Message: NewMsgRequestRange(
 			pcommon.NewPoint(
 				123,
-				[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+				testPointHash(0x01),
 			),
 			pcommon.NewPoint(
 				456,
-				[]byte{0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+				testPointHash(0x09),
 			),
 		),
 		MessageType: MessageTypeRequestRange,

--- a/protocol/blockfetch/point_fixture_external_test.go
+++ b/protocol/blockfetch/point_fixture_external_test.go
@@ -1,0 +1,21 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blockfetch_test
+
+import "bytes"
+
+func testPointHash(fill byte) []byte {
+	return bytes.Repeat([]byte{fill}, 32)
+}

--- a/protocol/blockfetch/point_fixture_test.go
+++ b/protocol/blockfetch/point_fixture_test.go
@@ -1,0 +1,21 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package blockfetch
+
+import "bytes"
+
+func testPointHash(fill byte) []byte {
+	return bytes.Repeat([]byte{fill}, 32)
+}

--- a/protocol/chainsync/client_callback_test.go
+++ b/protocol/chainsync/client_callback_test.go
@@ -30,8 +30,8 @@ import (
 )
 
 func TestExactTipCallbacksExposeIntersectionBeforeAwaitReply(t *testing.T) {
-	intersect := pcommon.NewPoint(100, []byte("intersection"))
-	tip := Tip{Point: pcommon.NewPoint(100, []byte("tip")), BlockNumber: 10}
+	intersect := pcommon.NewPoint(100, testPointHash(0x01))
+	tip := Tip{Point: pcommon.NewPoint(100, testPointHash(0x02)), BlockNumber: 10}
 	var callbacks []string
 	client := NewClient(
 		protocol.ProtocolOptions{ConnectionId: testConnectionId()},
@@ -64,8 +64,8 @@ func TestExactTipCallbacksExposeIntersectionBeforeAwaitReply(t *testing.T) {
 func TestAtTipCallbackErrorsPropagate(t *testing.T) {
 	awaitReplyErr := errors.New("await reply callback failed")
 	intersectFoundErr := errors.New("intersect found callback failed")
-	intersect := pcommon.NewPoint(100, []byte("intersection"))
-	tip := Tip{Point: pcommon.NewPoint(100, []byte("tip")), BlockNumber: 10}
+	intersect := pcommon.NewPoint(100, testPointHash(0x01))
+	tip := Tip{Point: pcommon.NewPoint(100, testPointHash(0x02)), BlockNumber: 10}
 
 	t.Run("await reply", func(t *testing.T) {
 		client := NewClient(

--- a/protocol/chainsync/client_test.go
+++ b/protocol/chainsync/client_test.go
@@ -24,7 +24,6 @@ import (
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/cbor"
-	"github.com/blinklabs-io/gouroboros/internal/test"
 	"github.com/blinklabs-io/gouroboros/ledger"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	"github.com/blinklabs-io/gouroboros/protocol/chainsync"
@@ -153,7 +152,7 @@ func TestGetCurrentTip(t *testing.T) {
 		BlockNumber: 12345,
 		Point: pcommon.NewPoint(
 			23456,
-			test.DecodeHexString("0123456789abcdef"),
+			testPointHash(0x01),
 		),
 	}
 	conversation := append(
@@ -191,13 +190,13 @@ func TestGetCurrentTip(t *testing.T) {
 func TestGetAvailableBlockRange(t *testing.T) {
 	expectedIntersect := pcommon.NewPoint(
 		20001,
-		test.DecodeHexString("123456789abcdef0"),
+		testPointHash(0x12),
 	)
 	expectedTip := chainsync.Tip{
 		BlockNumber: 12345,
 		Point: pcommon.NewPoint(
 			23456,
-			test.DecodeHexString("0123456789abcdef"),
+			testPointHash(0x01),
 		),
 	}
 	// Create basic block and round-trip it through the CBOR encoder to get the hash populated
@@ -332,14 +331,14 @@ func TestUseCase_GetCurrentTip_Stop_Start_GetCurrentTip(t *testing.T) {
 		BlockNumber: 111,
 		Point: pcommon.NewPoint(
 			222,
-			test.DecodeHexString("0123456789abcdef"),
+			testPointHash(0x01),
 		),
 	}
 	expectedTip2 := chainsync.Tip{
 		BlockNumber: 333,
 		Point: pcommon.NewPoint(
 			444,
-			test.DecodeHexString("fedcba9876543210"),
+			testPointHash(0xfe),
 		),
 	}
 	conversation := []ouroboros_mock.ConversationEntry{
@@ -427,7 +426,7 @@ func TestSyncPipelining(t *testing.T) {
 
 	expectedIntersect := pcommon.NewPoint(
 		0,
-		test.DecodeHexString("0000000000000000"),
+		testPointHash(0x00),
 	)
 
 	// Create test blocks
@@ -636,13 +635,13 @@ func TestSyncPipelining(t *testing.T) {
 func TestSyncCallbacksExposeExactTipIntersection(t *testing.T) {
 	intersect := pcommon.NewPoint(
 		100,
-		test.DecodeHexString("0102030405060708"),
+		testPointHash(0x01),
 	)
 	tip := chainsync.Tip{
 		BlockNumber: 10,
 		Point: pcommon.NewPoint(
 			100,
-			test.DecodeHexString("1112131415161718"),
+			testPointHash(0x11),
 		),
 	}
 	conversation := append(
@@ -737,21 +736,21 @@ func TestUseCase_MultiCycle_GetCurrentTip_Stop_Start(t *testing.T) {
 		BlockNumber: 1,
 		Point: pcommon.NewPoint(
 			10,
-			test.DecodeHexString("0102030405060708"),
+			testPointHash(0x01),
 		),
 	}
 	expectedTip2 := chainsync.Tip{
 		BlockNumber: 2,
 		Point: pcommon.NewPoint(
 			20,
-			test.DecodeHexString("1112131415161718"),
+			testPointHash(0x11),
 		),
 	}
 	expectedTip3 := chainsync.Tip{
 		BlockNumber: 3,
 		Point: pcommon.NewPoint(
 			30,
-			test.DecodeHexString("2122232425262728"),
+			testPointHash(0x21),
 		),
 	}
 

--- a/protocol/chainsync/messages_test.go
+++ b/protocol/chainsync/messages_test.go
@@ -200,7 +200,7 @@ func TestMsgRollForwardNodeToNode_CorruptedCBOR(t *testing.T) {
 		Tip{
 			Point: pcommon.Point{
 				Slot: 1,
-				Hash: []byte{0xDE, 0xAD, 0xBE, 0xEF},
+				Hash: testPointHash(0xde),
 			},
 			BlockNumber: 1,
 		},

--- a/protocol/chainsync/point_fixture_external_test.go
+++ b/protocol/chainsync/point_fixture_external_test.go
@@ -1,0 +1,21 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsync_test
+
+import "bytes"
+
+func testPointHash(fill byte) []byte {
+	return bytes.Repeat([]byte{fill}, 32)
+}

--- a/protocol/chainsync/point_fixture_test.go
+++ b/protocol/chainsync/point_fixture_test.go
@@ -1,0 +1,21 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsync
+
+import "bytes"
+
+func testPointHash(fill byte) []byte {
+	return bytes.Repeat([]byte{fill}, 32)
+}

--- a/protocol/chainsync/server_test.go
+++ b/protocol/chainsync/server_test.go
@@ -67,7 +67,7 @@ func TestLogRollForwardDoesNotLogBlockData(t *testing.T) {
 	tip := Tip{
 		Point: pcommon.Point{
 			Slot: 42,
-			Hash: []byte{0xca, 0xfe},
+			Hash: testPointHash(0xca),
 		},
 		BlockNumber: 24,
 	}

--- a/protocol/common/point_decode_test.go
+++ b/protocol/common/point_decode_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"bytes"
+	"math"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPointDecodeOriginClearsPreviousPoint(t *testing.T) {
+	t.Parallel()
+	point := NewPoint(42, bytes.Repeat([]byte{0xab}, 32))
+	require.NoError(t, point.UnmarshalCBOR([]byte{0x80}))
+	require.Equal(t, NewPointOrigin(), point)
+	encoded, err := point.MarshalCBOR()
+	require.NoError(t, err)
+	require.Equal(t, []byte{0x80}, encoded)
+}
+
+func TestPointDecodeConcreteRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, slot := range []uint64{0, 1, math.MaxUint64} {
+		want := NewPoint(slot, bytes.Repeat([]byte{0xcd}, 32))
+		encoded, err := want.MarshalCBOR()
+		require.NoError(t, err)
+		point := NewPointOrigin()
+		require.NoError(t, point.UnmarshalCBOR(encoded))
+		require.Equal(t, want, point)
+	}
+}
+
+func TestPointDecodeRejectsInvalidEnvelope(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		data []byte
+	}{
+		{"empty", nil},
+		{"trailing value", []byte{0x80, 0x00}},
+		{"indefinite array", []byte{0x9f, 0xff}},
+		{"tagged array", []byte{0xc0, 0x80}},
+		{"truncated array", []byte{0x82, 0x00}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			point := NewPoint(42, bytes.Repeat([]byte{0xee}, 32))
+			want := NewPoint(point.Slot, bytes.Clone(point.Hash))
+			require.Error(t, point.UnmarshalCBOR(tc.data))
+			require.Equal(t, want, point)
+		})
+	}
+}
+
+func TestPointDecodeRejectsMalformedWithoutMutation(t *testing.T) {
+	t.Parallel()
+	hash := bytes.Repeat([]byte{0xab}, 32)
+	cases := []struct {
+		name  string
+		value any
+	}{
+		{"null", nil},
+		{"one element", []any{uint64(1)}},
+		{"three elements", []any{uint64(1), hash, uint64(2)}},
+		{"negative slot", []any{int64(-1), hash}},
+		{"text slot", []any{"1", hash}},
+		{"text hash", []any{uint64(1), "hash"}},
+		{"null hash", []any{uint64(1), nil}},
+		{"empty hash", []any{uint64(1), []byte{}}},
+		{"short hash", []any{uint64(1), hash[:31]}},
+		{"long hash", []any{uint64(1), append(bytes.Clone(hash), 0)}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			encoded, err := cbor.Encode(tc.value)
+			require.NoError(t, err)
+			want := NewPoint(42, bytes.Repeat([]byte{0xee}, 32))
+			point := NewPoint(want.Slot, bytes.Clone(want.Hash))
+			require.Error(t, point.UnmarshalCBOR(encoded))
+			require.Equal(t, want, point)
+		})
+	}
+}

--- a/protocol/common/point_message_test.go
+++ b/protocol/common/point_message_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/protocol"
+	"github.com/blinklabs-io/gouroboros/protocol/blockfetch"
+	"github.com/blinklabs-io/gouroboros/protocol/chainsync"
+	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPointMessageDecodersPreserveValidFormsAndRejectMalformed(t *testing.T) {
+	t.Parallel()
+	decoders := []struct {
+		name   string
+		kind   uint
+		decode func(uint, []byte) (protocol.Message, error)
+		body   func(any) []any
+	}{
+		{"chainsync_ntn", chainsync.MessageTypeFindIntersect,
+			func(kind uint, data []byte) (protocol.Message, error) {
+				return chainsync.NewMsgFromCbor(protocol.ProtocolModeNodeToNode, kind, data)
+			},
+			func(p any) []any { return []any{uint64(4), []any{p}} }},
+		{"chainsync_ntc", chainsync.MessageTypeFindIntersect,
+			func(kind uint, data []byte) (protocol.Message, error) {
+				return chainsync.NewMsgFromCbor(protocol.ProtocolModeNodeToClient, kind, data)
+			},
+			func(p any) []any { return []any{uint64(4), []any{p}} }},
+		{"blockfetch", blockfetch.MessageTypeRequestRange,
+			blockfetch.NewMsgFromCbor,
+			func(p any) []any { return []any{uint64(0), p, p} }},
+		{"localstatequery", localstatequery.MessageTypeAcquire,
+			localstatequery.NewMsgFromCbor,
+			func(p any) []any { return []any{uint64(0), p} }},
+	}
+	for _, decoder := range decoders {
+		t.Run(decoder.name, func(t *testing.T) {
+			t.Parallel()
+			for _, point := range []any{
+				[]any{},
+				[]any{uint64(1), bytes.Repeat([]byte{0xab}, 32)},
+			} {
+				data, err := cbor.Encode(decoder.body(point))
+				require.NoError(t, err)
+				msg, err := decoder.decode(decoder.kind, data)
+				require.NoError(t, err)
+				require.NotNil(t, msg)
+			}
+			for _, tc := range []struct {
+				name  string
+				point any
+			}{
+				{"null", nil},
+				{"one element", []any{uint64(1)}},
+				{"short hash", []any{uint64(1), []byte{0xab}}},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					t.Parallel()
+					data, err := cbor.Encode(decoder.body(tc.point))
+					require.NoError(t, err)
+					_, err = decoder.decode(decoder.kind, data)
+					require.Error(t, err)
+				})
+			}
+		})
+	}
+}

--- a/protocol/common/types.go
+++ b/protocol/common/types.go
@@ -16,6 +16,7 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -44,11 +45,22 @@ func NewPointOrigin() Point {
 // UnmarshalCBOR is a helper function for decoding a Point object from CBOR. The object content can vary,
 // so we need to do some special handling when decoding. It is not intended to be called directly.
 func (p *Point) UnmarshalCBOR(data []byte) error {
+	// Points use a definite-length array: [] for origin or [slot, hash].
+	if len(data) == 0 || data[0]>>5 != 4 || data[0] == 0x9f {
+		return errors.New("Point must be a definite-length array")
+	}
 	var tmp []any
-	if _, err := cbor.Decode(data, &tmp); err != nil {
+	consumed, err := cbor.Decode(data, &tmp)
+	if err != nil {
 		return err
 	}
-	if len(tmp) == 2 {
+	if consumed != len(data) {
+		return errors.New("Point contains trailing CBOR data")
+	}
+	switch len(tmp) {
+	case 0:
+		*p = NewPointOrigin()
+	case 2:
 		slot, ok := tmp[0].(uint64)
 		if !ok {
 			return fmt.Errorf("Point slot must be uint64, got %T", tmp[0])
@@ -57,8 +69,14 @@ func (p *Point) UnmarshalCBOR(data []byte) error {
 		if !ok {
 			return fmt.Errorf("Point hash must be []byte, got %T", tmp[1])
 		}
+		// Cardano block-header hashes are Blake2b-256 in every era.
+		if len(hash) != 32 {
+			return fmt.Errorf("Point hash must be 32 bytes, got %d", len(hash))
+		}
 		p.Slot = slot
 		p.Hash = hash
+	default:
+		return fmt.Errorf("Point must contain 0 or 2 elements, got %d", len(tmp))
 	}
 	return nil
 }

--- a/protocol/leiosfetch/client_test.go
+++ b/protocol/leiosfetch/client_test.go
@@ -303,7 +303,7 @@ func TestClientMessageHandlerUnexpectedType(t *testing.T) {
 	client := NewClient(protoOptions, nil)
 
 	// Create a message with an unexpected type
-	msg := NewMsgBlockRequest(pcommon.NewPoint(123, []byte{0x01, 0x02}))
+	msg := NewMsgBlockRequest(pcommon.NewPoint(123, testPointHash(0x01)))
 
 	err := client.messageHandler(msg)
 

--- a/protocol/leiosfetch/leiosfetch_test.go
+++ b/protocol/leiosfetch/leiosfetch_test.go
@@ -181,7 +181,7 @@ func TestBlockRequestNoBlock(t *testing.T) {
 		func(t *testing.T, oConn *ouroboros.Connection) {
 			resp, err := oConn.LeiosFetch().Client.BlockRequest(
 				context.Background(),
-				pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+				pcommon.NewPoint(12345, testPointHash(0x01)),
 			)
 			require.Error(t, err)
 			assert.ErrorIs(t, err, leiosfetch.ErrBlockNotFound)
@@ -213,7 +213,7 @@ func TestBlockTxsRequestNoBlockTxs(t *testing.T) {
 		func(t *testing.T, oConn *ouroboros.Connection) {
 			resp, err := oConn.LeiosFetch().Client.BlockTxsRequest(
 				context.Background(),
-				pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+				pcommon.NewPoint(12345, testPointHash(0x01)),
 				map[uint16]uint64{0: 0xff00000000000000},
 			)
 			require.Error(t, err)
@@ -249,7 +249,7 @@ func TestBlockRequestSuccess(t *testing.T) {
 		func(t *testing.T, oConn *ouroboros.Connection) {
 			resp, err := oConn.LeiosFetch().Client.BlockRequest(
 				context.Background(),
-				pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+				pcommon.NewPoint(12345, testPointHash(0x01)),
 			)
 			require.NoError(t, err)
 			require.IsType(t, &leiosfetch.MsgBlock{}, resp)
@@ -300,7 +300,7 @@ func TestBlockRequestSubsequentAfterAbandonedNoResponse(t *testing.T) {
 			defer cancel1()
 			resp1, err1 := client.BlockRequest(
 				ctx1,
-				pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+				pcommon.NewPoint(12345, testPointHash(0x01)),
 			)
 			require.ErrorIs(t, err1, context.DeadlineExceeded)
 			assert.Nil(t, resp1)
@@ -318,7 +318,7 @@ func TestBlockRequestSubsequentAfterAbandonedNoResponse(t *testing.T) {
 			go func() {
 				resp, err := client.BlockRequest(
 					context.Background(),
-					pcommon.NewPoint(23456, []byte{0x05, 0x06, 0x07, 0x08}),
+					pcommon.NewPoint(23456, testPointHash(0x05)),
 				)
 				resultChan <- reqResult{resp: resp, err: err}
 			}()
@@ -379,7 +379,7 @@ func TestBlockTxsRequestSubsequentAfterAbandonedNoResponse(t *testing.T) {
 			defer cancel1()
 			_, err1 := client.BlockTxsRequest(
 				ctx1,
-				pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+				pcommon.NewPoint(12345, testPointHash(0x01)),
 				bitmaps,
 			)
 			require.ErrorIs(t, err1, context.DeadlineExceeded)
@@ -388,7 +388,7 @@ func TestBlockTxsRequestSubsequentAfterAbandonedNoResponse(t *testing.T) {
 			go func() {
 				_, err := client.BlockTxsRequest(
 					context.Background(),
-					pcommon.NewPoint(23456, []byte{0x05, 0x06, 0x07, 0x08}),
+					pcommon.NewPoint(23456, testPointHash(0x05)),
 					bitmaps,
 				)
 				errChan <- err
@@ -440,7 +440,7 @@ func TestBlockRequestContextCancelledNonFatal(t *testing.T) {
 			defer cancel()
 			resp, err := oConn.LeiosFetch().Client.BlockRequest(
 				ctx,
-				pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+				pcommon.NewPoint(12345, testPointHash(0x01)),
 			)
 			require.Error(t, err)
 			assert.True(
@@ -506,7 +506,7 @@ func TestBlockRequestSubsequentAfterAbandoned(t *testing.T) {
 			defer cancel1()
 			resp1, err1 := client.BlockRequest(
 				ctx1,
-				pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}),
+				pcommon.NewPoint(12345, testPointHash(0x01)),
 			)
 			require.Error(t, err1)
 			assert.True(
@@ -525,7 +525,7 @@ func TestBlockRequestSubsequentAfterAbandoned(t *testing.T) {
 			defer cancel2()
 			resp2, err2 := client.BlockRequest(
 				ctx2,
-				pcommon.NewPoint(23456, []byte{0x05, 0x06, 0x07, 0x08}),
+				pcommon.NewPoint(23456, testPointHash(0x05)),
 			)
 			require.NoError(t, err2)
 			require.NotNil(t, resp2)
@@ -595,8 +595,8 @@ func TestBlockRangeRequestSubsequentAfterAbandoned(t *testing.T) {
 			defer cancel1()
 			resp1, err1 := client.BlockRangeRequest(
 				ctx1,
-				pcommon.NewPoint(12345, []byte{0x01}),
-				pcommon.NewPoint(12346, []byte{0x02}),
+				pcommon.NewPoint(12345, testPointHash(0x01)),
+				pcommon.NewPoint(12346, testPointHash(0x02)),
 			)
 			require.ErrorIs(t, err1, context.DeadlineExceeded)
 			assert.Nil(t, resp1)
@@ -608,8 +608,8 @@ func TestBlockRangeRequestSubsequentAfterAbandoned(t *testing.T) {
 			defer cancel2()
 			resp2, err2 := client.BlockRangeRequest(
 				ctx2,
-				pcommon.NewPoint(23456, []byte{0x03}),
-				pcommon.NewPoint(23457, []byte{0x04}),
+				pcommon.NewPoint(23456, testPointHash(0x03)),
+				pcommon.NewPoint(23457, testPointHash(0x04)),
 			)
 			require.NoError(t, err2)
 			require.Len(t, resp2, 1)
@@ -641,8 +641,8 @@ func TestBlockRangeRequestStreamsMultipleMessages(t *testing.T) {
 		client := oConn.LeiosFetch().Client
 		resp, err := client.BlockRangeRequest(
 			context.Background(),
-			pcommon.NewPoint(12345, []byte{0x01}),
-			pcommon.NewPoint(12346, []byte{0x02}),
+			pcommon.NewPoint(12345, testPointHash(0x01)),
+			pcommon.NewPoint(12346, testPointHash(0x02)),
 		)
 		require.NoError(t, err)
 		require.Len(t, resp, 3)
@@ -677,8 +677,8 @@ func TestNonBlockRequestsAfterAbandonedBlockRequestFailFast(t *testing.T) {
 			request: func(c *leiosfetch.Client) error {
 				_, err := c.BlockRangeRequest(
 					context.Background(),
-					pcommon.NewPoint(23456, []byte{0x05, 0x06, 0x07, 0x08}),
-					pcommon.NewPoint(34567, []byte{0x09, 0x0a, 0x0b, 0x0c}),
+					pcommon.NewPoint(23456, testPointHash(0x05)),
+					pcommon.NewPoint(34567, testPointHash(0x09)),
 				)
 				return err
 			},
@@ -710,7 +710,7 @@ func TestNonBlockRequestsAfterAbandonedBlockRequestFailFast(t *testing.T) {
 						ctx1,
 						pcommon.NewPoint(
 							12345,
-							[]byte{0x01, 0x02, 0x03, 0x04},
+							testPointHash(0x01),
 						),
 					)
 					require.ErrorIs(t, err1, context.DeadlineExceeded)

--- a/protocol/leiosfetch/messages_test.go
+++ b/protocol/leiosfetch/messages_test.go
@@ -47,7 +47,7 @@ func getTestDefinitions() []testDefinition {
 			Message: NewMsgBlockRequest(
 				pcommon.NewPoint(
 					12345,
-					[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+					testPointHash(0x01),
 				),
 			),
 			MessageType: MessageTypeBlockRequest,
@@ -64,7 +64,7 @@ func getTestDefinitions() []testDefinition {
 			Message: NewMsgBlockTxsRequest(
 				pcommon.NewPoint(
 					12345,
-					[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+					testPointHash(0x01),
 				),
 				map[uint16]uint64{
 					0:  0xff00000000000000,
@@ -108,11 +108,11 @@ func getTestDefinitions() []testDefinition {
 			Message: NewMsgBlockRangeRequest(
 				pcommon.NewPoint(
 					123,
-					[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+					testPointHash(0x01),
 				),
 				pcommon.NewPoint(
 					456,
-					[]byte{0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+					testPointHash(0x09),
 				),
 			),
 			MessageType: MessageTypeBlockRangeRequest,
@@ -216,7 +216,7 @@ func TestEncode(t *testing.T) {
 
 func TestMsgBlockRequest(t *testing.T) {
 	slot := uint64(123456)
-	hash := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	hash := testPointHash(0x01)
 
 	msg := NewMsgBlockRequest(pcommon.NewPoint(slot, hash))
 
@@ -236,7 +236,7 @@ func TestMsgBlock(t *testing.T) {
 
 func TestMsgBlockTxsRequest(t *testing.T) {
 	slot := uint64(123456)
-	hash := []byte{0x01, 0x02, 0x03, 0x04}
+	hash := testPointHash(0x01)
 	bitmaps := map[uint16]uint64{
 		0: 0xff00000000000000,
 	}
@@ -262,7 +262,7 @@ func TestMsgBlockTxs(t *testing.T) {
 }
 
 func TestMsgBlockTxsFullUsesRequestBitmapEncoding(t *testing.T) {
-	point := pcommon.NewPoint(123, []byte{0x01, 0x02})
+	point := pcommon.NewPoint(123, testPointHash(0x01))
 	bitmaps := map[uint16]uint64{
 		0:  1,
 		64: 0x00ff000000000000,
@@ -363,8 +363,8 @@ func TestMsgVotesDecodeVotesRejectsInvalidVote(t *testing.T) {
 }
 
 func TestMsgBlockRangeRequest(t *testing.T) {
-	start := pcommon.NewPoint(100, []byte{0x01, 0x02, 0x03, 0x04})
-	end := pcommon.NewPoint(200, []byte{0x05, 0x06, 0x07, 0x08})
+	start := pcommon.NewPoint(100, testPointHash(0x01))
+	end := pcommon.NewPoint(200, testPointHash(0x05))
 
 	msg := NewMsgBlockRangeRequest(start, end)
 
@@ -446,7 +446,7 @@ func TestNewMsgFromCborUnknownType(t *testing.T) {
 
 func TestMsgBlockTxsRequestEmptyBitmaps(t *testing.T) {
 	slot := uint64(123)
-	hash := []byte{0x01, 0x02}
+	hash := testPointHash(0x01)
 	bitmaps := map[uint16]uint64{}
 
 	msg := NewMsgBlockTxsRequest(pcommon.NewPoint(slot, hash), bitmaps)

--- a/protocol/leiosfetch/point_fixture_external_test.go
+++ b/protocol/leiosfetch/point_fixture_external_test.go
@@ -1,0 +1,21 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leiosfetch_test
+
+import "bytes"
+
+func testPointHash(fill byte) []byte {
+	return bytes.Repeat([]byte{fill}, 32)
+}

--- a/protocol/leiosfetch/point_fixture_test.go
+++ b/protocol/leiosfetch/point_fixture_test.go
@@ -1,0 +1,21 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leiosfetch
+
+import "bytes"
+
+func testPointHash(fill byte) []byte {
+	return bytes.Repeat([]byte{fill}, 32)
+}

--- a/protocol/leiosfetch/server_test.go
+++ b/protocol/leiosfetch/server_test.go
@@ -95,7 +95,7 @@ func TestUnconfiguredBlockResponderAnswersAbsence(t *testing.T) {
 		{
 			name: "block",
 			request: NewMsgBlockRequest(
-				pcommon.NewPoint(12345, []byte{0x01, 0x02}),
+				pcommon.NewPoint(12345, testPointHash(0x01)),
 			),
 			expectedType:    uint(MessageTypeNoBlock),
 			expectedPayload: []byte{0x81, MessageTypeNoBlock},
@@ -103,7 +103,7 @@ func TestUnconfiguredBlockResponderAnswersAbsence(t *testing.T) {
 		{
 			name: "block transactions",
 			request: NewMsgBlockTxsRequest(
-				pcommon.NewPoint(12345, []byte{0x01, 0x02}),
+				pcommon.NewPoint(12345, testPointHash(0x01)),
 				nil,
 			),
 			expectedType:    uint(MessageTypeNoBlockTxs),
@@ -147,7 +147,7 @@ func TestUnconfiguredBlockResponderAnswersAbsenceNilConfig(t *testing.T) {
 	})
 
 	requestData, err := cbor.Encode(
-		NewMsgBlockTxsRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02}), nil),
+		NewMsgBlockTxsRequest(pcommon.NewPoint(12345, testPointHash(0x01)), nil),
 	)
 	require.NoError(t, err)
 	writeLeiosFetchTestSegment(
@@ -198,8 +198,8 @@ func TestUnconfiguredBlockRangeResponderFailsConnection(t *testing.T) {
 
 	requestData, err := cbor.Encode(
 		NewMsgBlockRangeRequest(
-			pcommon.NewPoint(12345, []byte{0x01, 0x02}),
-			pcommon.NewPoint(23456, []byte{0x03, 0x04}),
+			pcommon.NewPoint(12345, testPointHash(0x01)),
+			pcommon.NewPoint(23456, testPointHash(0x03)),
 		),
 	)
 	require.NoError(t, err)
@@ -338,7 +338,7 @@ func TestHandleBlockRequest_CallbackIsCalled(t *testing.T) {
 
 	called := false
 	expectedSlot := uint64(12345)
-	expectedHash := []byte{0x01, 0x02, 0x03, 0x04}
+	expectedHash := testPointHash(0x01)
 
 	cfg := NewConfig(
 		WithBlockRequestFunc(func(ctx CallbackContext, point pcommon.Point) (protocol.Message, error) {
@@ -368,7 +368,7 @@ func TestHandleBlockRequest_NilCallback(t *testing.T) {
 	msgType, payload := sendNotFoundTest(
 		t,
 		NewConfig(),
-		NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02})),
+		NewMsgBlockRequest(pcommon.NewPoint(12345, testPointHash(0x01))),
 	)
 	require.Equal(t, uint(MessageTypeNoBlock), msgType)
 	require.Equal(t, []byte{0x81, MessageTypeNoBlock}, payload)
@@ -393,7 +393,7 @@ func TestHandleBlockRequest_CallbackError(t *testing.T) {
 	}
 	server.initProtocol()
 
-	msg := NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02}))
+	msg := NewMsgBlockRequest(pcommon.NewPoint(12345, testPointHash(0x01)))
 	err := server.handleBlockRequest(msg)
 
 	assert.Error(t, err)
@@ -418,7 +418,7 @@ func TestHandleBlockRequest_NilResponse(t *testing.T) {
 	}
 	server.initProtocol()
 
-	msg := NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02}))
+	msg := NewMsgBlockRequest(pcommon.NewPoint(12345, testPointHash(0x01)))
 	err := server.handleBlockRequest(msg)
 
 	assert.Error(t, err)
@@ -434,7 +434,7 @@ func TestHandleBlockRequestNotFoundSendsMsgNoBlock(t *testing.T) {
 	msgType, _ := sendNotFoundTest(
 		t,
 		cfg,
-		NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02})),
+		NewMsgBlockRequest(pcommon.NewPoint(12345, testPointHash(0x01))),
 	)
 	assert.Equal(t, uint(MessageTypeNoBlock), msgType)
 }
@@ -452,7 +452,7 @@ func TestHandleBlockRequestWrappedNotFoundSendsMsgNoBlock(t *testing.T) {
 	msgType, _ := sendNotFoundTest(
 		t,
 		cfg,
-		NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02})),
+		NewMsgBlockRequest(pcommon.NewPoint(12345, testPointHash(0x01))),
 	)
 	assert.Equal(t, uint(MessageTypeNoBlock), msgType)
 }
@@ -466,7 +466,7 @@ func TestHandleBlockTxsRequestNotFoundSendsMsgNoBlockTxs(t *testing.T) {
 	msgType, _ := sendNotFoundTest(
 		t,
 		cfg,
-		NewMsgBlockTxsRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02}), nil),
+		NewMsgBlockTxsRequest(pcommon.NewPoint(12345, testPointHash(0x01)), nil),
 	)
 	require.Equal(t, uint(MessageTypeNoBlockTxs), msgType)
 }
@@ -490,7 +490,7 @@ func TestHandleBlockRequest_NonNotFoundErrorPropagates(t *testing.T) {
 	}
 	server.initProtocol()
 
-	msg := NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02}))
+	msg := NewMsgBlockRequest(pcommon.NewPoint(12345, testPointHash(0x01)))
 	err := server.handleBlockRequest(msg)
 
 	// A non-not-found error is still propagated as a protocol violation
@@ -506,7 +506,7 @@ func TestHandleBlockTxsRequest_CallbackIsCalled(t *testing.T) {
 
 	called := false
 	expectedSlot := uint64(12345)
-	expectedHash := []byte{0x01, 0x02, 0x03, 0x04}
+	expectedHash := testPointHash(0x01)
 	expectedBitmaps := map[uint16]uint64{
 		0: 0xff00000000000000,
 	}
@@ -540,7 +540,7 @@ func TestHandleBlockTxsRequest_NilCallback(t *testing.T) {
 	msgType, payload := sendNotFoundTest(
 		t,
 		NewConfig(),
-		NewMsgBlockTxsRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02}), nil),
+		NewMsgBlockTxsRequest(pcommon.NewPoint(12345, testPointHash(0x01)), nil),
 	)
 	require.Equal(t, uint(MessageTypeNoBlockTxs), msgType)
 	require.Equal(t, []byte{0x81, MessageTypeNoBlockTxs}, payload)
@@ -594,8 +594,8 @@ func TestHandleBlockRangeRequest_Callback(t *testing.T) {
 	}
 
 	called := false
-	expectedStart := pcommon.NewPoint(100, []byte{0x01, 0x02, 0x03, 0x04})
-	expectedEnd := pcommon.NewPoint(200, []byte{0x05, 0x06, 0x07, 0x08})
+	expectedStart := pcommon.NewPoint(100, testPointHash(0x01))
+	expectedEnd := pcommon.NewPoint(200, testPointHash(0x05))
 
 	cfg := NewConfig(
 		WithBlockRangeRequestFunc(func(ctx CallbackContext, start, end pcommon.Point) error {
@@ -685,11 +685,11 @@ func TestServerMessageHandler_AllTypes(t *testing.T) {
 	}{
 		{
 			name: "BlockRequest",
-			msg:  NewMsgBlockRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02})),
+			msg:  NewMsgBlockRequest(pcommon.NewPoint(12345, testPointHash(0x01))),
 		},
 		{
 			name: "BlockTxsRequest",
-			msg:  NewMsgBlockTxsRequest(pcommon.NewPoint(12345, []byte{0x01, 0x02}), nil),
+			msg:  NewMsgBlockTxsRequest(pcommon.NewPoint(12345, testPointHash(0x01)), nil),
 		},
 		{
 			name: "VotesRequest",

--- a/protocol/leiosnotify/client_test.go
+++ b/protocol/leiosnotify/client_test.go
@@ -83,12 +83,12 @@ func TestClientMessageHandler(t *testing.T) {
 		},
 		{
 			name:        "BlockOffer message",
-			msg:         NewMsgBlockOffer(pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}), 12345),
+			msg:         NewMsgBlockOffer(pcommon.NewPoint(12345, testPointHash(0x01)), 12345),
 			expectError: false,
 		},
 		{
 			name:        "BlockTxsOffer message",
-			msg:         NewMsgBlockTxsOffer(pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04})),
+			msg:         NewMsgBlockTxsOffer(pcommon.NewPoint(12345, testPointHash(0x01))),
 			expectError: false,
 		},
 		{
@@ -275,7 +275,7 @@ func TestClientHandleBlockOffer(t *testing.T) {
 	}
 	client := NewClient(protoOptions, nil)
 
-	msg := NewMsgBlockOffer(pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}), 12345)
+	msg := NewMsgBlockOffer(pcommon.NewPoint(12345, testPointHash(0x01)), 12345)
 
 	// Start a goroutine to receive the message
 	received := make(chan protocol.Message, 1)
@@ -303,7 +303,7 @@ func TestClientHandleBlockTxsOffer(t *testing.T) {
 	}
 	client := NewClient(protoOptions, nil)
 
-	msg := NewMsgBlockTxsOffer(pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}))
+	msg := NewMsgBlockTxsOffer(pcommon.NewPoint(12345, testPointHash(0x01)))
 
 	// Start a goroutine to receive the message
 	received := make(chan protocol.Message, 1)

--- a/protocol/leiosnotify/messages_test.go
+++ b/protocol/leiosnotify/messages_test.go
@@ -52,7 +52,7 @@ func getTestDefinitions() []testDefinition {
 			Message: NewMsgBlockOffer(
 				pcommon.NewPoint(
 					12345,
-					[]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+					testPointHash(0x01),
 				),
 				12345,
 			),
@@ -63,7 +63,7 @@ func getTestDefinitions() []testDefinition {
 			Message: NewMsgBlockTxsOffer(
 				pcommon.NewPoint(
 					67890,
-					[]byte{0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+					testPointHash(0x09),
 				),
 			),
 			MessageType: MessageTypeBlockTxsOffer,
@@ -161,7 +161,7 @@ func TestMsgBlockAnnouncement(t *testing.T) {
 
 func TestMsgBlockOffer(t *testing.T) {
 	slot := uint64(123456)
-	hash := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	hash := testPointHash(0x01)
 
 	msg := NewMsgBlockOffer(pcommon.NewPoint(slot, hash), 12345)
 
@@ -172,7 +172,7 @@ func TestMsgBlockOffer(t *testing.T) {
 
 func TestMsgBlockTxsOffer(t *testing.T) {
 	slot := uint64(123456)
-	hash := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	hash := testPointHash(0x01)
 
 	msg := NewMsgBlockTxsOffer(pcommon.NewPoint(slot, hash))
 

--- a/protocol/leiosnotify/point_fixture_test.go
+++ b/protocol/leiosnotify/point_fixture_test.go
@@ -1,0 +1,21 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package leiosnotify
+
+import "bytes"
+
+func testPointHash(fill byte) []byte {
+	return bytes.Repeat([]byte{fill}, 32)
+}

--- a/protocol/leiosnotify/server_test.go
+++ b/protocol/leiosnotify/server_test.go
@@ -448,7 +448,7 @@ func TestServerMessageHandler_UnexpectedType(t *testing.T) {
 	server := NewServer(protoOptions, &cfg)
 
 	// Create a message with an unexpected type for the server
-	msg := NewMsgBlockOffer(pcommon.NewPoint(12345, []byte{0x01, 0x02}), 12345)
+	msg := NewMsgBlockOffer(pcommon.NewPoint(12345, testPointHash(0x01)), 12345)
 
 	err := server.messageHandler(msg)
 
@@ -532,11 +532,11 @@ func TestCallbackResponseTypes(t *testing.T) {
 		},
 		{
 			name:     "BlockOffer response",
-			response: NewMsgBlockOffer(pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04}), 12345),
+			response: NewMsgBlockOffer(pcommon.NewPoint(12345, testPointHash(0x01)), 12345),
 		},
 		{
 			name:     "BlockTxsOffer response",
-			response: NewMsgBlockTxsOffer(pcommon.NewPoint(12345, []byte{0x01, 0x02, 0x03, 0x04})),
+			response: NewMsgBlockTxsOffer(pcommon.NewPoint(12345, testPointHash(0x01))),
 		},
 		{
 			name: "VotesOffer response",

--- a/protocol/localstatequery/client_test.go
+++ b/protocol/localstatequery/client_test.go
@@ -151,7 +151,7 @@ func TestGetCurrentEra(t *testing.T) {
 }
 
 func TestGetChainPoint(t *testing.T) {
-	expectedPoint := pcommon.NewPoint(123, []byte{0xa, 0xb, 0xc})
+	expectedPoint := pcommon.NewPoint(123, testPointHash(0x0a))
 	cborData, err := cbor.Encode(expectedPoint)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)

--- a/protocol/localstatequery/point_fixture_external_test.go
+++ b/protocol/localstatequery/point_fixture_external_test.go
@@ -1,0 +1,21 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localstatequery_test
+
+import "bytes"
+
+func testPointHash(fill byte) []byte {
+	return bytes.Repeat([]byte{fill}, 32)
+}


### PR DESCRIPTION
Validate Cardano Point decoding as a definite array containing either origin or a slot and 32-byte block hash, rejecting malformed and trailing CBOR without mutating the receiver. Update protocol fixtures to use valid 32-byte Cardano hashes.

Fixes #2001


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens Cardano Point CBOR decoding so malformed points are rejected without mutating the receiver.

Previously, `Point.UnmarshalCBOR` accepted arrays of any length with short or missing hashes. It now requires a definite-length array containing either origin or a slot plus a 32-byte hash, and rejects trailing CBOR data. The receiver is left unchanged on any error.

**Test fixtures**
- Adds decode tests covering origin, concrete points, and malformed inputs across `chainsync`, `blockfetch`, and `localstatequery` message decoders.
- Updates existing protocol tests to use valid 32-byte hashes via a new `testPointHash` helper.

<sup>Written for commit ef041adfce7316fd445b2520b5c27f67f5734616. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

