### PR TITLE
fix(muxer): bound segment writes

### DIFF
--- a/muxer/muxer.go
+++ b/muxer/muxer.go
@@ -38,6 +38,11 @@ const ProtocolUnknown uint16 = 0xabcd
 // before closing the connection. This prevents slowloris-style DoS attacks.
 const segmentReadTimeout = 120 * time.Second
 
+// segmentWriteTimeout is the maximum time to wait for a complete segment
+// write. The deadline is refreshed for every segment so long-lived healthy
+// connections are not killed by one absolute connection deadline.
+const segmentWriteTimeout = 2 * time.Minute
+
 // DiffusionMode is an enum for the valid muxer diffusion modes
 type DiffusionMode int
 
@@ -357,6 +362,9 @@ func (m *Muxer) Send(msg *Segment) error {
 		return err
 	}
 	buf.Write(msg.Payload)
+	if err := m.conn.SetWriteDeadline(time.Now().Add(segmentWriteTimeout)); err != nil {
+		return err
+	}
 	_, err = m.conn.Write(buf.Bytes())
 	if err != nil {
 		return err

--- a/muxer/muxer_test.go
+++ b/muxer/muxer_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -42,6 +43,45 @@ type mockConn struct {
 
 type failingWriteConn struct {
 	*mockConn
+}
+
+type writeDeadlineErrorConn struct {
+	*mockConn
+	setErr   error
+	writeCnt int
+}
+
+func (c *writeDeadlineErrorConn) SetWriteDeadline(time.Time) error {
+	return c.setErr
+}
+
+func (c *writeDeadlineErrorConn) Write([]byte) (int, error) {
+	c.writeCnt++
+	return 0, errors.New("write should not be attempted")
+}
+
+type trackingWriteDeadlineConn struct {
+	*mockConn
+	deadlines []time.Time
+}
+
+func (c *trackingWriteDeadlineConn) SetWriteDeadline(deadline time.Time) error {
+	c.deadlines = append(c.deadlines, deadline)
+	return nil
+}
+
+type clampedPipeConn struct {
+	net.Conn
+	requestedDeadline chan time.Time
+	clamp             bool
+}
+
+func (c *clampedPipeConn) SetWriteDeadline(deadline time.Time) error {
+	c.requestedDeadline <- deadline
+	if c.clamp {
+		deadline = time.Now().Add(25 * time.Millisecond)
+	}
+	return c.Conn.SetWriteDeadline(deadline)
 }
 
 func (*failingWriteConn) Write([]byte) (int, error) {
@@ -470,6 +510,104 @@ func TestMuxerReportsSegmentDelivery(t *testing.T) {
 				t.Fatal("timed out waiting for segment delivery result")
 			}
 		})
+	}
+}
+
+func TestMuxerSendWriteDeadlineFailureDoesNotWrite(t *testing.T) {
+	deadlineErr := errors.New("test: write deadline failure")
+	conn := &writeDeadlineErrorConn{
+		mockConn: newMockConn(),
+		setErr:   deadlineErr,
+	}
+	m := muxer.New(conn)
+	defer m.Stop()
+
+	err := m.Send(muxer.NewSegment(0x01, []byte("test"), false))
+	require.ErrorIs(t, err, deadlineErr)
+	require.Zero(t, conn.writeCnt)
+}
+
+func TestMuxerSendRefreshesWriteDeadline(t *testing.T) {
+	conn := &trackingWriteDeadlineConn{mockConn: newMockConn()}
+	m := muxer.New(conn)
+	defer m.Stop()
+
+	for i := range 2 {
+		before := time.Now().Add(2 * time.Minute)
+		require.NoError(
+			t,
+			m.Send(muxer.NewSegment(0x01, []byte("test"), false)),
+		)
+		after := time.Now().Add(2 * time.Minute)
+		require.Len(t, conn.deadlines, i+1)
+		require.False(t, conn.deadlines[i].Before(before))
+		require.False(t, conn.deadlines[i].After(after))
+	}
+}
+
+func TestMuxerSendBlockedWriteHonorsDeadline(t *testing.T) {
+	local, remote := net.Pipe()
+	defer remote.Close()
+	requested := make(chan time.Time, 1)
+	conn := &clampedPipeConn{
+		Conn:              local,
+		requestedDeadline: requested,
+		clamp:             true,
+	}
+	m := muxer.New(conn)
+	defer m.Stop()
+
+	result := make(chan error, 1)
+	go func() {
+		result <- m.Send(muxer.NewSegment(0x01, []byte("blocked"), false))
+	}()
+
+	var requestedAt time.Time
+	select {
+	case requestedAt = <-requested:
+	case <-time.After(time.Second):
+		t.Fatal("muxer did not set a write deadline")
+	}
+	require.True(t, requestedAt.After(time.Now()))
+	require.WithinDuration(
+		t,
+		time.Now().Add(2*time.Minute),
+		requestedAt,
+		2*time.Second,
+	)
+
+	select {
+	case err := <-result:
+		require.Error(t, err)
+		require.ErrorIs(t, err, os.ErrDeadlineExceeded)
+	case <-time.After(time.Second):
+		t.Fatal("blocked write did not honor its deadline")
+	}
+}
+
+func TestMuxerSendBlockedWriteUnblocksOnStop(t *testing.T) {
+	local, remote := net.Pipe()
+	defer remote.Close()
+	requested := make(chan time.Time, 1)
+	conn := &clampedPipeConn{Conn: local, requestedDeadline: requested}
+	m := muxer.New(conn)
+	defer m.Stop()
+
+	result := make(chan error, 1)
+	go func() {
+		result <- m.Send(muxer.NewSegment(0x01, []byte("blocked"), false))
+	}()
+	select {
+	case <-requested:
+	case <-time.After(time.Second):
+		t.Fatal("muxer did not start the blocked write")
+	}
+	m.Stop()
+	select {
+	case err := <-result:
+		require.ErrorIs(t, err, io.ErrClosedPipe)
+	case <-time.After(time.Second):
+		t.Fatal("stopped muxer did not unblock the blocked write")
 	}
 }
 

--- a/muxer/muxer_test.go
+++ b/muxer/muxer_test.go
@@ -522,7 +522,11 @@ func TestMuxerSendWriteDeadlineFailureDoesNotWrite(t *testing.T) {
 	m := muxer.New(conn)
 	defer m.Stop()
 
-	err := m.Send(muxer.NewSegment(0x01, []byte("test"), false))
+	segment := muxer.NewSegment(0x01, []byte("test"), false)
+	if segment == nil {
+		t.Fatal("failed to create segment")
+	}
+	err := m.Send(segment)
 	require.ErrorIs(t, err, deadlineErr)
 	require.Zero(t, conn.writeCnt)
 }
@@ -533,11 +537,12 @@ func TestMuxerSendRefreshesWriteDeadline(t *testing.T) {
 	defer m.Stop()
 
 	for i := range 2 {
+		segment := muxer.NewSegment(0x01, []byte("test"), false)
+		if segment == nil {
+			t.Fatal("failed to create segment")
+		}
 		before := time.Now().Add(2 * time.Minute)
-		require.NoError(
-			t,
-			m.Send(muxer.NewSegment(0x01, []byte("test"), false)),
-		)
+		require.NoError(t, m.Send(segment))
 		after := time.Now().Add(2 * time.Minute)
 		require.Len(t, conn.deadlines, i+1)
 		require.False(t, conn.deadlines[i].Before(before))
@@ -558,8 +563,12 @@ func TestMuxerSendBlockedWriteHonorsDeadline(t *testing.T) {
 	defer m.Stop()
 
 	result := make(chan error, 1)
+	segment := muxer.NewSegment(0x01, []byte("blocked"), false)
+	if segment == nil {
+		t.Fatal("failed to create segment")
+	}
 	go func() {
-		result <- m.Send(muxer.NewSegment(0x01, []byte("blocked"), false))
+		result <- m.Send(segment)
 	}()
 
 	var requestedAt time.Time
@@ -594,8 +603,12 @@ func TestMuxerSendBlockedWriteUnblocksOnStop(t *testing.T) {
 	defer m.Stop()
 
 	result := make(chan error, 1)
+	segment := muxer.NewSegment(0x01, []byte("blocked"), false)
+	if segment == nil {
+		t.Fatal("failed to create segment")
+	}
 	go func() {
-		result <- m.Send(muxer.NewSegment(0x01, []byte("blocked"), false))
+		result <- m.Send(segment)
 	}()
 	select {
 	case <-requested:

--- a/protocol/PROTOCOL_LIMITS.md
+++ b/protocol/PROTOCOL_LIMITS.md
@@ -11,6 +11,19 @@ make the expected transition before the timeout expires. These are transport
 and state-machine safeguards, not application-level transaction or block
 validation.
 
+## Muxer socket deadlines
+
+The muxer sets a 120-second write deadline immediately before each segment
+write, after acquiring its connection-wide send lock. A deadline-setting error
+is returned without attempting the write. The deadline bounds the socket write,
+not time spent waiting for the send lock or the protocol's outbound queue.
+
+Read deadlines remain independently managed per segment. Connection wrappers
+must preserve those read deadlines and support `SetWriteDeadline`. The muxer
+replaces an existing write deadline; wrappers that enforce a shorter external
+deadline must cap the requested value. Stopping the muxer closes the underlying
+connection to interrupt pending socket operations.
+
 ## Chain Sync
 
 The N2N map (`protocol/chainsync/chainsync.go`) has the following limits:


### PR DESCRIPTION
Bound stalled muxer segment writes with a fresh two-minute socket write deadline before each segment. Deadline-setting errors are returned without writing, read deadlines remain independent, and shutdown still closes the connection to interrupt blocked writes.

This is implementation liveness and resource hardening; it is not a new wire-protocol requirement. Chapter 4 of the Ouroboros Network Specification defines receiver-side mux SDU timeouts and mini-protocol timeouts, but does not prescribe sender-side socket write deadlines. The change does not alter wire encoding or mini-protocol state machines.

Tests cover deadline refresh, setter failures, blocked writes, and shutdown. Protocol documentation records deadline ownership and that queue or lock wait time is outside this per-segment socket deadline.

Related to #2073; aggregate connection and node-to-client byte budgets remain separate.