### PR TITLE
fix(txsubmission): reject excessive identifier replies

### DIFF
--- a/protocol/txsubmission/server.go
+++ b/protocol/txsubmission/server.go
@@ -161,6 +161,14 @@ func (s *Server) RequestTxIds(
 		if result.err != nil {
 			return nil, result.err
 		}
+		if len(result.txIds) > reqCount {
+			p.Logger().Error(
+				"TxSubmission reply count exceeded request",
+				"returned", len(result.txIds),
+				"requested", reqCount,
+			)
+			return nil, protocol.ErrProtocolViolationRequestExceeded
+		}
 		// Update ack count for next call
 		s.ackCount = len(result.txIds)
 		return result.txIds, nil

--- a/protocol/txsubmission/server_test.go
+++ b/protocol/txsubmission/server_test.go
@@ -18,11 +18,144 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/gouroboros/connection"
+	"github.com/blinklabs-io/gouroboros/muxer"
 	"github.com/blinklabs-io/gouroboros/protocol"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRequestTxIdsRejectsReplyExceedingRequest(t *testing.T) {
+	localConn, remoteConn := net.Pipe()
+	t.Cleanup(func() {
+		require.NoError(t, localConn.Close())
+		require.NoError(t, remoteConn.Close())
+	})
+	serverMuxer := muxer.New(localConn)
+	clientMuxer := muxer.New(remoteConn)
+	serverMuxer.Start()
+	clientMuxer.Start()
+	t.Cleanup(serverMuxer.Stop)
+	t.Cleanup(clientMuxer.Stop)
+	connectionId := connection.ConnectionId{
+		LocalAddr:  &net.UnixAddr{Name: "local", Net: "unix"},
+		RemoteAddr: &net.UnixAddr{Name: "remote", Net: "unix"},
+	}
+
+	returned := []TxIdAndSize{
+		{TxId: TxId{EraId: 1}},
+		{TxId: TxId{EraId: 1}},
+	}
+	returned[0].TxId.TxId[0] = 2
+	returned[1].TxId.TxId[0] = 3
+	requests := 0
+	acknowledged := make(chan uint16, 2)
+	client := NewClient(
+		protocol.ProtocolOptions{Muxer: clientMuxer, ConnectionId: connectionId},
+		&Config{RequestTxIdsFunc: func(
+			_ CallbackContext,
+			_ bool,
+			ack uint16,
+			_ uint16,
+		) ([]TxIdAndSize, error) {
+			acknowledged <- ack
+			requests++
+			if requests == 1 {
+				first := TxIdAndSize{TxId: TxId{EraId: 1}}
+				first.TxId.TxId[0] = 1
+				return []TxIdAndSize{first}, nil
+			}
+			return returned, nil
+		}},
+	)
+	initReceived := make(chan struct{})
+	server := NewServer(
+		protocol.ProtocolOptions{Muxer: serverMuxer, ConnectionId: connectionId},
+		&Config{InitFunc: func(CallbackContext) error {
+			close(initReceived)
+			return nil
+		}},
+	)
+	server.Start()
+	client.Start()
+	client.Init()
+	select {
+	case <-initReceived:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not receive Init")
+	}
+
+	result, err := server.RequestTxIds(false, 1)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Equal(t, 1, server.ackCount)
+	require.Equal(t, uint16(0), <-acknowledged)
+
+	result, err = server.RequestTxIds(false, 1)
+	require.ErrorIs(t, err, protocol.ErrProtocolViolationRequestExceeded)
+	require.Nil(t, result)
+	require.Equal(t, 1, server.ackCount)
+	require.Equal(t, uint16(1), <-acknowledged)
+}
+
+func TestRequestTxIdsAcceptsReplyWithinRequest(t *testing.T) {
+	localConn, remoteConn := net.Pipe()
+	t.Cleanup(func() {
+		require.NoError(t, localConn.Close())
+		require.NoError(t, remoteConn.Close())
+	})
+	serverMuxer := muxer.New(localConn)
+	clientMuxer := muxer.New(remoteConn)
+	serverMuxer.Start()
+	clientMuxer.Start()
+	t.Cleanup(serverMuxer.Stop)
+	t.Cleanup(clientMuxer.Stop)
+	connectionId := connection.ConnectionId{
+		LocalAddr:  &net.UnixAddr{Name: "local", Net: "unix"},
+		RemoteAddr: &net.UnixAddr{Name: "remote", Net: "unix"},
+	}
+	client := NewClient(
+		protocol.ProtocolOptions{Muxer: clientMuxer, ConnectionId: connectionId},
+		&Config{RequestTxIdsFunc: func(
+			_ CallbackContext,
+			_ bool,
+			_ uint16,
+			req uint16,
+		) ([]TxIdAndSize, error) {
+			if req == 0 {
+				return nil, nil
+			}
+			return []TxIdAndSize{{TxId: TxId{EraId: 1}}}, nil
+		}},
+	)
+	initReceived := make(chan struct{})
+	server := NewServer(
+		protocol.ProtocolOptions{Muxer: serverMuxer, ConnectionId: connectionId},
+		&Config{InitFunc: func(CallbackContext) error {
+			close(initReceived)
+			return nil
+		}},
+	)
+	server.Start()
+	client.Start()
+	client.Init()
+	select {
+	case <-initReceived:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not receive Init")
+	}
+
+	result, err := server.RequestTxIds(false, 1)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	result, err = server.RequestTxIds(false, 2)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	result, err = server.RequestTxIds(false, 0)
+	require.NoError(t, err)
+	require.Empty(t, result)
+}
 
 func TestReplyHandlersSynchronizeProtocolAccessDuringRestart(t *testing.T) {
 	const iterations = 10_000


### PR DESCRIPTION
Reject identifier replies larger than the active request before updating acknowledgements or returning results.

Add real client/server coverage for excess replies, preserved acknowledgement state, exact and partial replies, and nonblocking empty replies.

Addresses the identifier-count portion of #2076. Body correlation and advertised-size validation remain separate.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects identifier replies larger than the active request in `txsubmission` before updating acknowledgements or returning results. This prevents a peer from inflating the ack count and addresses the identifier-count portion of #2076; body correlation and advertised-size validation remain separate. Adds real client/server tests covering excess, exact, partial, and nonblocking replies.

<sup>Written for commit 7053db110b1140fa219dd651b633b79dca2d91f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid transaction ID responses that exceed the requested count are now rejected as protocol violations.
  * Valid responses containing the requested number of IDs or fewer continue to be accepted.
  * Requests for zero transaction IDs now return an empty result correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->