### PR TITLE
fix(muxer): make the segment-read timeout overridable, disable it for trusted LocalStateQuery connections

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -117,6 +117,9 @@ type Connection struct {
 	localMessageSubmissionConfig   *localmessagesubmission.Config
 	localMessageNotification       *localmessagenotification.LocalMessageNotification
 	localMessageNotificationConfig *localmessagenotification.Config
+	// muxerSegmentReadTimeout overrides the muxer's default segment-read
+	// timeout when non-nil; see WithMuxerSegmentReadTimeout.
+	muxerSegmentReadTimeout *time.Duration
 }
 
 // NewConnection returns a new Connection object with the specified options. If a connection is provided, the
@@ -496,7 +499,14 @@ func (c *Connection) setupConnection() error {
 		RemoteAddr: c.conn.RemoteAddr(),
 	}
 	// Create muxer instance
-	c.muxer = muxer.New(c.conn)
+	if c.muxerSegmentReadTimeout != nil {
+		c.muxer = muxer.NewWithSegmentReadTimeout(
+			c.conn,
+			*c.muxerSegmentReadTimeout,
+		)
+	} else {
+		c.muxer = muxer.New(c.conn)
+	}
 	// Start Goroutine to pass along errors from the muxer
 	c.waitGroup.Go(func() {
 		select {

--- a/connection_options.go
+++ b/connection_options.go
@@ -17,6 +17,7 @@ package ouroboros
 import (
 	"log/slog"
 	"net"
+	"time"
 
 	"github.com/blinklabs-io/gouroboros/protocol/blockfetch"
 	"github.com/blinklabs-io/gouroboros/protocol/chainsync"
@@ -106,6 +107,32 @@ func WithDMQ(useDMQ bool) ConnectionOptionFunc {
 func WithKeepAlive(keepAlive bool) ConnectionOptionFunc {
 	return func(c *Connection) {
 		c.sendKeepAlives = keepAlive
+	}
+}
+
+// WithMuxerSegmentReadTimeout overrides how long the muxer waits for the
+// next segment before closing the connection (the default,
+// muxer.defaultSegmentReadTimeout, is 120s). Pass a duration <= 0 to disable
+// the timeout entirely.
+//
+// The default exists to guard an untrusted remote peer (a slowloris-style
+// DoS) and is appropriate for node-to-node connections. It is not a
+// requirement of the Ouroboros Network Specification, which defines no
+// timeout at the mux/transport layer at all -- timeouts are specified per
+// mini-protocol, per state, in each protocol's own chapter, and
+// LocalStateQuery's own timeout table (section 3.13.4) reads "No timeouts":
+// a query is expected to be able to take an arbitrarily long time. Real
+// cardano-node's own mux implementation matches this -- it applies no
+// bearer-level read timeout at all on local Unix-domain-socket connections,
+// which is what node-to-client (and so LocalStateQuery) normally uses.
+//
+// A node-to-client connection over a channel you already trust (a local
+// socket, or a bridge you control) should generally disable this, so a
+// legitimate, still-computing LocalStateQuery reply (e.g. a whole-UTxO-set
+// dump against a large chain) is never killed mid-flight.
+func WithMuxerSegmentReadTimeout(timeout time.Duration) ConnectionOptionFunc {
+	return func(c *Connection) {
+		c.muxerSegmentReadTimeout = &timeout
 	}
 }
 

--- a/muxer/muxer.go
+++ b/muxer/muxer.go
@@ -34,9 +34,28 @@ import (
 // Magic number chosen to represent unknown protocols
 const ProtocolUnknown uint16 = 0xabcd
 
-// segmentReadTimeout is the maximum time to wait for a complete segment read
-// before closing the connection. This prevents slowloris-style DoS attacks.
-const segmentReadTimeout = 120 * time.Second
+// defaultSegmentReadTimeout is the default maximum time to wait for the next
+// segment before closing the connection. This is meant to prevent
+// slowloris-style DoS attacks against an untrusted remote peer.
+//
+// This is a gouroboros-specific implementation choice, not a requirement of
+// the Ouroboros Network Specification: the spec's Multiplexing chapter
+// defines no timeout at the mux/transport layer at all, and per-protocol
+// timeouts are instead specified individually, per state, in each
+// mini-protocol's own chapter. LocalStateQuery's own timeout table
+// (section 3.13.4) reads "No timeouts" -- a large query is expected to be
+// able to take an arbitrarily long time. The real ouroboros-network
+// (Haskell) implementation matches this: its own mux-level SDU timeout (30s)
+// only bounds an already-in-progress segment read (a minimum-bandwidth
+// guard), never how long a peer may take before replying at all, and it is
+// not applied at all on local Unix-domain-socket connections -- exactly the
+// transport LocalStateQuery normally uses. Applying a fixed, unconditional
+// deadline to every connection (as this constant did on its own, with no
+// way to disable it) killed legitimate, still-computing LocalStateQuery
+// replies that the spec says must not be timed out. See
+// WithMuxerSegmentReadTimeout to override or disable this for a connection
+// known to be a trusted NtC channel.
+const defaultSegmentReadTimeout = 120 * time.Second
 
 // DiffusionMode is an enum for the valid muxer diffusion modes
 type DiffusionMode int
@@ -74,6 +93,12 @@ type Muxer struct {
 	protocolReceiversMutex sync.Mutex
 	diffusionMode          atomic.Int64
 	onceStop               sync.Once
+	// segmentReadTimeout bounds how long the read loop waits for the next
+	// segment before closing the connection. <= 0 disables the deadline
+	// entirely (no timeout, matching real cardano-node's own behavior on a
+	// trusted local/NtC connection). See defaultSegmentReadTimeout's doc
+	// comment for the full rationale.
+	segmentReadTimeout time.Duration
 }
 
 type segmentChannel struct {
@@ -144,8 +169,23 @@ func (e *ConnectionClosedError) Unwrap() error {
 	return e.Err
 }
 
-// New creates a new Muxer object and starts the read loop
+// New creates a new Muxer object and starts the read loop, using
+// defaultSegmentReadTimeout. Use NewWithSegmentReadTimeout to override or
+// disable that timeout for a connection known to be a trusted NtC channel.
 func New(conn net.Conn) *Muxer {
+	return NewWithSegmentReadTimeout(conn, defaultSegmentReadTimeout)
+}
+
+// NewWithSegmentReadTimeout is like New, but lets the caller override how
+// long the read loop waits for the next segment before closing the
+// connection. segmentReadTimeout <= 0 disables the deadline entirely --
+// see defaultSegmentReadTimeout's doc comment for why a caller might want
+// that (e.g. a local/NtC LocalStateQuery connection, which the Ouroboros
+// Network Specification says must not be timed out at all).
+func NewWithSegmentReadTimeout(
+	conn net.Conn,
+	segmentReadTimeout time.Duration,
+) *Muxer {
 	m := &Muxer{
 		conn:               conn,
 		startChan:          make(chan bool, 1),
@@ -154,6 +194,7 @@ func New(conn net.Conn) *Muxer {
 		protocolSenders:    make(map[uint16]map[ProtocolRole]*segmentSender),
 		protocolReceivers:  make(map[uint16]map[ProtocolRole]*segmentChannel),
 		protocolTombstones: make(map[uint16]map[ProtocolRole]struct{}),
+		segmentReadTimeout: segmentReadTimeout,
 	}
 	// Start read goroutine
 	m.waitGroup.Add(1)
@@ -401,8 +442,15 @@ func (m *Muxer) readLoop() {
 				started = v
 			}
 		}
-		// Set read deadline to prevent slowloris-style DoS attacks
-		_ = m.conn.SetReadDeadline(time.Now().Add(segmentReadTimeout))
+		// Set read deadline to prevent slowloris-style DoS attacks against an
+		// untrusted remote peer. A non-positive segmentReadTimeout disables
+		// this entirely (time.Time{} clears any previously set deadline) --
+		// see its doc comment for why a caller may need that.
+		if m.segmentReadTimeout > 0 {
+			_ = m.conn.SetReadDeadline(time.Now().Add(m.segmentReadTimeout))
+		} else {
+			_ = m.conn.SetReadDeadline(time.Time{})
+		}
 		header := SegmentHeader{}
 		if err := binary.Read(m.conn, binary.BigEndian, &header); err != nil {
 			if errors.Is(err, io.ErrClosedPipe) {

--- a/muxer/segment_read_timeout_test.go
+++ b/muxer/segment_read_timeout_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package muxer_test
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/muxer"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSegmentReadTimeout_CustomShortTimeoutFires proves
+// NewWithSegmentReadTimeout's override actually reaches the read loop's
+// deadline: with nothing sent by the peer, the muxer must report an error
+// once the configured (short, test-friendly) timeout elapses. Uses
+// net.Pipe rather than mockConn, since mockConn's SetReadDeadline is a
+// no-op (it never blocks a real Read call), so it cannot exercise this
+// behavior at all.
+func TestSegmentReadTimeout_CustomShortTimeoutFires(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() { _ = clientConn.Close() })
+
+	m := muxer.NewWithSegmentReadTimeout(serverConn, 50*time.Millisecond)
+	defer m.Stop()
+	m.Start()
+
+	select {
+	case err := <-m.ErrorChan():
+		require.Error(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal(
+			"expected a read-timeout error within the configured 50ms " +
+				"deadline, got none after 2s",
+		)
+	}
+}
+
+// TestSegmentReadTimeout_DisabledNeverFires is the regression test for the
+// actual bug this option exists to fix: a legitimate peer that is still
+// computing a reply (e.g. Dingo resolving a whole-UTxO-set GetUTxOWhole
+// query) must not have its connection killed. segmentReadTimeout <= 0
+// disables the deadline entirely -- not just "a longer" one -- so the
+// muxer must report no error even after outliving the short timeout
+// TestSegmentReadTimeout_CustomShortTimeoutFires proved does fire, and the
+// connection must still be able to deliver a real, late-arriving segment
+// afterward.
+func TestSegmentReadTimeout_DisabledNeverFires(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() { _ = clientConn.Close() })
+
+	m := muxer.NewWithSegmentReadTimeout(serverConn, 0)
+	defer m.Stop()
+
+	_, recvChan, _ := m.RegisterProtocol(0x01, muxer.ProtocolRoleResponder)
+	require.NotNil(t, recvChan)
+	m.Start()
+
+	// Comfortably longer than the 50ms proven to trigger a timeout above,
+	// with nothing sent -- simulating a peer legitimately still computing.
+	select {
+	case err := <-m.ErrorChan():
+		t.Fatalf(
+			"expected no error with segmentReadTimeout disabled, got: %v",
+			err,
+		)
+	case <-time.After(300 * time.Millisecond):
+		// Good -- no premature timeout.
+	}
+
+	// The connection must still be alive and able to deliver a real,
+	// late-arriving segment, proving this is a genuinely unbounded wait,
+	// not just a longer bound.
+	segment := muxer.NewSegment(0x01, []byte("late reply"), false)
+	data := createSegmentData(segment)
+	writeErrChan := make(chan error, 1)
+	go func() {
+		_, err := clientConn.Write(data)
+		writeErrChan <- err
+	}()
+
+	select {
+	case err := <-writeErrChan:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out writing the late segment")
+	}
+
+	select {
+	case seg := <-recvChan:
+		require.Equal(t, []byte("late reply"), seg.Payload)
+	case err := <-m.ErrorChan():
+		t.Fatalf("expected the late segment to be delivered, got error: %v", err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected the late segment to be delivered within 2s")
+	}
+}

--- a/muxer/segment_read_timeout_test.go
+++ b/muxer/segment_read_timeout_test.go
@@ -85,6 +85,7 @@ func TestSegmentReadTimeout_DisabledNeverFires(t *testing.T) {
 	// late-arriving segment, proving this is a genuinely unbounded wait,
 	// not just a longer bound.
 	segment := muxer.NewSegment(0x01, []byte("late reply"), false)
+	require.NotNil(t, segment, "payload is well within NewSegment's size limit")
 	data := createSegmentData(segment)
 	writeErrChan := make(chan error, 1)
 	go func() {

--- a/protocol/localstatequery/client.go
+++ b/protocol/localstatequery/client.go
@@ -104,6 +104,7 @@ func NewClient(protoOptions protocol.ProtocolOptions, cfg *Config) *Client {
 		MessageFromCborFunc: NewMsgFromCbor,
 		StateMap:            stateMap,
 		InitialState:        stateIdle,
+		MaxReadBufferSize:   cfg.MaxReadBufferSize,
 	}
 	// Enable version-dependent features
 	if (protoOptions.Version - protocol.ProtocolVersionNtCOffset) >= 10 {

--- a/protocol/localstatequery/client.go
+++ b/protocol/localstatequery/client.go
@@ -1704,8 +1704,17 @@ func (c *Client) handleAcquired() error {
 	default:
 	}
 	c.acquired = true
-	c.acquireResultChan <- nil
+	// Invalidate the cached era before signaling completion on
+	// acquireResultChan, not after: a caller blocked in acquire() wakes up
+	// on that channel receive and can immediately call a query that reads
+	// currentEra (getCurrentEra, via GetCurrentProtocolParams/GetEpochNo/
+	// etc.). Writing it after the send has no happens-before relationship
+	// to that caller's subsequent read -- a data race under the Go memory
+	// model, confirmed live under -race with a low-latency (fast, local)
+	// server, where the window between the two statements is otherwise
+	// too narrow to hit against normal network latency.
 	c.currentEra = -1
+	c.acquireResultChan <- nil
 	return nil
 }
 

--- a/protocol/localstatequery/localstatequery.go
+++ b/protocol/localstatequery/localstatequery.go
@@ -125,6 +125,13 @@ type Config struct {
 	ReleaseFunc    ReleaseFunc
 	AcquireTimeout time.Duration
 	QueryTimeout   time.Duration
+	// MaxReadBufferSize overrides protocol.Protocol's default 16MB cap on a
+	// reassembling multi-segment message's size. Zero means "use the
+	// default". A whole-UTxO-set reply (GetUTxOWhole) is bounded only by
+	// how much live state the query names, and can exceed 16MB well before
+	// it exceeds anything a trusted peer's caller actually wants rejected
+	// (blinklabs-io/dingo#1900).
+	MaxReadBufferSize int
 }
 
 // Acquire target types
@@ -217,5 +224,13 @@ func WithAcquireTimeout(timeout time.Duration) LocalStateQueryOptionFunc {
 func WithQueryTimeout(timeout time.Duration) LocalStateQueryOptionFunc {
 	return func(c *Config) {
 		c.QueryTimeout = timeout
+	}
+}
+
+// WithMaxReadBufferSize overrides the default 16MB cap on a reassembling
+// multi-segment message's size (protocol.ProtocolConfig.MaxReadBufferSize).
+func WithMaxReadBufferSize(size int) LocalStateQueryOptionFunc {
+	return func(c *Config) {
+		c.MaxReadBufferSize = size
 	}
 }

--- a/protocol/localstatequery/server.go
+++ b/protocol/localstatequery/server.go
@@ -58,6 +58,7 @@ func NewServer(protoOptions protocol.ProtocolOptions, cfg *Config) *Server {
 		MessageFromCborFunc: NewMsgFromCbor,
 		StateMap:            StateMap,
 		InitialState:        stateIdle,
+		MaxReadBufferSize:   cfg.MaxReadBufferSize,
 	}
 	// Enable version-dependent features
 	if (protoOptions.Version - protocol.ProtocolVersionNtCOffset) >= 10 {

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -824,14 +824,36 @@ func (p *Protocol) readLoop() {
 			// bounded fallback -- e.g. a short timeout alongside the drain
 			// select -- rather than an unconditional size gate; left as
 			// future work rather than shipped without full validation.
+			//
+			// This select must watch the same shutdown channels the outer
+			// one above does, and must bound readBuffer's growth itself
+			// (not just rely on the existing post-decode check below): a
+			// peer that keeps the channel non-empty by sending segments as
+			// fast as this loop drains them would otherwise let it spin
+			// unboundedly on both counts -- ignoring shutdown, and growing
+			// readBuffer past p.config.maxReadBufferSize() before ever
+			// returning control to check it (CWE-400, caught in review on
+			// blinklabs-io/gouroboros#2291). Breaking out once the bound is
+			// exceeded (rather than erroring here directly) lets the
+			// existing check just below do the actual rejection, so there
+			// is one place that decides "too big", not two.
 		drainQueued:
 			for {
 				select {
+				case <-p.stopChan:
+					return
+				case <-p.sendDoneChan:
+					return
+				case <-p.muxerDoneChan:
+					return
 				case segment, ok := <-p.muxerRecvChan:
 					if !ok {
 						return
 					}
 					readBuffer.Write(segment.Payload)
+					if readBuffer.Len() > p.config.maxReadBufferSize() {
+						break drainQueued
+					}
 				default:
 					break drainQueued
 				}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -34,10 +34,19 @@ import (
 // This is completely arbitrary, but the line had to be drawn somewhere
 const maxMessagesPerSegment = 20
 
-// maxReadBufferSize is the upper bound on the read buffer in readLoop.
-// This prevents a malicious peer from sending incomplete CBOR indefinitely
-// to cause unbounded memory growth (OOM). 16MB accommodates large legitimate
-// messages such as ledger state query responses.
+// maxReadBufferSize is the default upper bound on the read buffer in
+// readLoop, used whenever a ProtocolConfig doesn't override it via
+// MaxReadBufferSize. This prevents a malicious peer from sending incomplete
+// CBOR indefinitely to cause unbounded memory growth (OOM). 16MB
+// accommodates most legitimate messages, but not every one: a
+// LocalStateQuery reply is bounded only by the size of whatever the query
+// asks for, and a whole-UTxO-set dump against a large enough chain can
+// exceed 16MB by a wide margin (confirmed live against a real ~3.17M-UTxO
+// Preview node, blinklabs-io/dingo#1900's node-parity tool). A caller
+// talking to a peer it trusts with that kind of query (a local socket, or a
+// bridge it controls) should override this via MaxReadBufferSize rather
+// than have a legitimate reply rejected as if it were the DoS this constant
+// guards against.
 const maxReadBufferSize = 16 * 1024 * 1024 // 16MB
 
 // DefaultRecvQueueSize is the default capacity for the recv queue channel
@@ -92,6 +101,22 @@ type ProtocolConfig struct {
 	// after their first state transition.
 	InitialStateTimeout bool
 	RecvQueueSize       int
+	// MaxReadBufferSize overrides maxReadBufferSize's default 16MB cap on
+	// how large an incomplete, still-reassembling multi-segment message may
+	// grow before readLoop gives up and errors out. Zero means "use the
+	// default" -- there is no sensible "unbounded" spelling here (unlike a
+	// timeout, where 0 means "wait forever"), since a literal zero-byte
+	// buffer could never hold even the smallest message.
+	MaxReadBufferSize int
+}
+
+// maxReadBufferSize returns the effective read-buffer cap for this config:
+// its own MaxReadBufferSize when set, otherwise the package default.
+func (c ProtocolConfig) maxReadBufferSize() int {
+	if c.MaxReadBufferSize > 0 {
+		return c.MaxReadBufferSize
+	}
+	return maxReadBufferSize
 }
 
 // ProtocolMode is an enum of the protocol modes
@@ -771,6 +796,46 @@ func (p *Protocol) readLoop() {
 				// Add segment payload to buffer
 				readBuffer.Write(segment.Payload)
 			}
+			// Opportunistically drain any additional segments the muxer
+			// has already queued for us before spending a decode attempt.
+			// cbor.Decode has no way to resume a prior partial parse -- on
+			// an incomplete buffer it walks from byte 0 through every
+			// already-buffered element before rediscovering
+			// io.ErrUnexpectedEOF, so a message spanning many segments
+			// pays that full-buffer cost again on every single one.
+			// Batching whatever the muxer has already queued into one
+			// attempt reduces how many times that happens for a message
+			// arriving as a fast back-to-back segment burst -- confirmed
+			// live against a real ~3.17M-entry LocalStateQuery
+			// GetUTxOWhole reply, which pegged the receiving process at
+			// 100% CPU for 25+ minutes and never finished
+			// (blinklabs-io/dingo#1900) -- without changing behavior for
+			// the common case (nothing to drain when a message completes
+			// in its first segment or two).
+			//
+			// A further, size-growth-gated skip (only re-attempt once the
+			// buffer has grown substantially since the last attempt) was
+			// tried here and reverted: it broke
+			// TestUnpipelinedIdleLimitRejectsMainnetSizedBlock by skipping
+			// forever once a message's growth stopped satisfying the gate
+			// with no further segments ever arriving to satisfy it (the
+			// message was already fully buffered and complete, but never
+			// got decoded). A correct version of that optimization needs a
+			// bounded fallback -- e.g. a short timeout alongside the drain
+			// select -- rather than an unconditional size gate; left as
+			// future work rather than shipped without full validation.
+		drainQueued:
+			for {
+				select {
+				case segment, ok := <-p.muxerRecvChan:
+					if !ok {
+						return
+					}
+					readBuffer.Write(segment.Payload)
+				default:
+					break drainQueued
+				}
+			}
 		}
 		leftoverData = false
 		// Check for zero-byte read before attempting to decode
@@ -798,7 +863,7 @@ func (p *Protocol) readLoop() {
 			if errors.Is(err, io.ErrUnexpectedEOF) && readBuffer.Len() > 0 {
 				// This is probably a multi-part message, so we wait until we get more of the message
 				// before trying to process it
-				if readBuffer.Len() > maxReadBufferSize {
+				if readBuffer.Len() > p.config.maxReadBufferSize() {
 					p.SendError(
 						fmt.Errorf(
 							"%s: read buffer exceeded maximum size (%d bytes)",

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -542,13 +542,16 @@ func TestReadLoopDrainRespectsMaxBufferSize(t *testing.T) {
 	)
 
 	muxerRecvChan := make(chan *muxer.Segment, numSegments)
-	// A byte-string header declaring a ~4GB length, with no chance of ever
-	// supplying that much content: cbor.Decode always reports
-	// io.ErrUnexpectedEOF on this (not the unrelated max-nested-level guard
-	// a repeated indefinite-array-start would trip), so readLoop keeps
-	// draining and never completes a message -- exactly the "peer never
-	// finishes" case the buffer-size guard exists for.
-	header := muxer.NewSegment(0, []byte{0x5A, 0xFF, 0xFF, 0xFF, 0xFF}, false)
+	// A byte-string header declaring a 100MB length -- comfortably more
+	// than this test's ~1MB flood could ever supply, but safely under
+	// math.MaxInt32 so it doesn't itself overflow int on a 32-bit build
+	// (0xFFFFFFFF did, tripping cbor's own integer-overflow guard instead
+	// of the io.ErrUnexpectedEOF this test means to exercise). Either way
+	// cbor.Decode never completes this message (not the unrelated
+	// max-nested-level guard a repeated indefinite-array-start would
+	// trip), so readLoop keeps draining forever -- exactly the "peer
+	// never finishes" case the buffer-size guard exists for.
+	header := muxer.NewSegment(0, []byte{0x5A, 0x05, 0xF5, 0xE1, 0x00}, false)
 	require.NotNil(t, header)
 	muxerRecvChan <- header
 	filler := bytes.Repeat([]byte{0x00}, segmentPayloadSize)

--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -15,10 +15,13 @@
 package protocol
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"net"
+	"regexp"
+	"strconv"
 	"testing"
 	"time"
 
@@ -503,4 +506,98 @@ func TestIsInTerminalOrIdleState(t *testing.T) {
 
 		require.True(t, p.IsInTerminalOrIdleState(), "IsInTerminalOrIdleState() should return true when in initial state (no messages exchanged)")
 	})
+}
+
+// TestReadLoopDrainRespectsMaxBufferSize is the regression test for a real
+// bug caught in review on the gouroboros#2291 pull request: readLoop's
+// opportunistic same-cycle segment drain (added to reduce repeated
+// full-buffer CBOR decode attempts on a fast, multi-segment reply) wrote
+// every drained segment straight into readBuffer with no size check at all,
+// unlike the check that already runs just after cbor.Decode fails. A peer
+// that kept the muxer's receive channel non-empty by sending segments as
+// fast as this loop could drain them would let readBuffer grow past
+// MaxReadBufferSize indefinitely, never returning control to the
+// post-decode check that would otherwise catch it -- an unbounded
+// memory-growth DoS from an untrusted peer (CWE-400).
+//
+// Feeds muxerRecvChan directly (bypassing a real muxer/net.Pipe) with a
+// buffered channel pre-loaded with far more segments than could ever fit
+// under the configured limit, then runs readLoop against it directly.
+// This is deterministic on purpose: driving the same scenario over a real
+// connection depends on which of the muxer's own goroutine and readLoop's
+// happens to win each scheduling quantum, which reproduces the bug often
+// but not reliably (confirmed while writing this test: a net.Pipe-based
+// version caught the bug in roughly a third of runs and passed the rest,
+// entirely by scheduling luck) -- exactly the kind of flakiness a
+// regression test must not have. Pre-loading every segment before readLoop
+// ever starts removes that variable: with the bug, the drain loop finds a
+// full channel and keeps draining it in one pass regardless of scheduling;
+// with the fix, it always stops within one segment of the configured
+// limit, also regardless of scheduling.
+func TestReadLoopDrainRespectsMaxBufferSize(t *testing.T) {
+	const (
+		maxBufferSize      = 256
+		segmentPayloadSize = 200
+		numSegments        = 5000 // 5000 * 200 = 1MB, far more than fits under maxBufferSize
+	)
+
+	muxerRecvChan := make(chan *muxer.Segment, numSegments)
+	// A byte-string header declaring a ~4GB length, with no chance of ever
+	// supplying that much content: cbor.Decode always reports
+	// io.ErrUnexpectedEOF on this (not the unrelated max-nested-level guard
+	// a repeated indefinite-array-start would trip), so readLoop keeps
+	// draining and never completes a message -- exactly the "peer never
+	// finishes" case the buffer-size guard exists for.
+	header := muxer.NewSegment(0, []byte{0x5A, 0xFF, 0xFF, 0xFF, 0xFF}, false)
+	require.NotNil(t, header)
+	muxerRecvChan <- header
+	filler := bytes.Repeat([]byte{0x00}, segmentPayloadSize)
+	for range numSegments - 1 {
+		segment := muxer.NewSegment(0, filler, false)
+		require.NotNil(t, segment)
+		muxerRecvChan <- segment
+	}
+
+	errorChan := make(chan error, 1)
+	p := &Protocol{
+		config: ProtocolConfig{
+			Name:              "test",
+			ErrorChan:         errorChan,
+			MaxReadBufferSize: maxBufferSize,
+		},
+		doneChan:      make(chan struct{}),
+		stopChan:      make(chan struct{}),
+		sendDoneChan:  make(chan struct{}),
+		muxerDoneChan: make(chan bool),
+		muxerRecvChan: muxerRecvChan,
+	}
+	go p.readLoop()
+
+	select {
+	case err := <-errorChan:
+		require.ErrorContains(t, err, "read buffer exceeded maximum size")
+		matches := regexp.MustCompile(`\((\d+) bytes\)`).FindStringSubmatch(err.Error())
+		require.Len(t, matches, 2, "expected the error to report a byte count: %v", err)
+		reportedSize, parseErr := strconv.Atoi(matches[1])
+		require.NoError(t, parseErr)
+		// The fix checks after every single write inside the drain loop,
+		// so growth is always bounded to at most one segment past the
+		// configured limit. The bug checked only after the whole drain
+		// finished, so with every segment pre-loaded it drains the full
+		// channel -- all ~1MB of it -- in one pass before ever checking.
+		require.Less(
+			t, reportedSize, maxBufferSize+segmentPayloadSize,
+			"read buffer grew to %d bytes before being rejected, far more "+
+				"than the %d-byte configured limit -- the drain loop is "+
+				"not bounding growth against a channel already full of "+
+				"queued segments",
+			reportedSize, maxBufferSize,
+		)
+	case <-time.After(5 * time.Second):
+		t.Fatal(
+			"expected the oversized read buffer to be rejected within 5s, " +
+				"got nothing -- the drain loop may be growing readBuffer " +
+				"past MaxReadBufferSize without checking it",
+		)
+	}
 }


### PR DESCRIPTION
## Summary

gouroboros' mux applied a fixed, unconditional 120s segment-read timeout to
every connection, closing it if the next segment did not arrive in time.
This is appropriate as an anti-DoS guard against an untrusted remote NtN
peer, but the Ouroboros Network Specification defines no timeout at the
mux/transport layer at all -- every mini-protocol specifies its own
timeouts, per state, in its own chapter, and LocalStateQuery's own table
(section 3.13.4) reads "No timeouts": a query is expected to be able to
take an arbitrarily long time. Real cardano-node applies no equivalent
bearer-level timeout on local Unix-domain-socket (node-to-client)
connections either.

Applying the fixed deadline unconditionally killed a legitimate,
still-computing LocalStateQuery reply (e.g. a whole-UTxO-set dump against a
large chain) mid-flight, with no way for a caller who trusts the peer (a
local socket, or a bridge it controls) to disable it (blinklabs-io/dingo#4082).

## Changes

- `muxer.NewWithSegmentReadTimeout` / `ouroboros.WithMuxerSegmentReadTimeout`
  let a caller override or disable (`<= 0`) the deadline per connection.
- `protocol.ProtocolConfig.MaxReadBufferSize` and
  `localstatequery.WithMaxReadBufferSize` similarly let a caller raise the
  16MB default cap on a reassembling multi-segment message: a real
  whole-UTxO-set reply against a Preview-scale chain exceeds 16MB by a wide
  margin.
- `protocol.Protocol`'s `readLoop` now opportunistically drains any segments
  the muxer has already queued before each decode attempt, since
  `cbor.Decode` cannot resume a partial parse and otherwise re-walks the
  whole buffer from byte 0 on every single segment of a multi-segment
  reply.

Also includes a separate, unrelated fix found while building test coverage
for the above: `localstatequery.Client.handleAcquired` wrote
`currentEra = -1` after signaling `Acquire`'s completion channel rather
than before, so a caller unblocked by that signal could read `currentEra`
(via `GetCurrentProtocolParams`/`GetEpochNo`) with no happens-before
relationship to the write -- a data race confirmed under `-race` against a
low-latency local server.

## Testing

- `go build ./...`, `go vet ./...` clean.
- `go test -race ./muxer/... ./protocol/...` -- all pass.
- `golangci-lint run ./muxer/... ./protocol/...` -- 0 issues.
- New tests: `muxer/segment_read_timeout_test.go`
  (`TestSegmentReadTimeout_CustomShortTimeoutFires`,
  `TestSegmentReadTimeout_DisabledNeverFires`).
- Live-validated against a real Preview `cardano-node` + Dingo pair via
  blinklabs-io/dingo#1900's node-parity tool: whole-UTxO-set queries
  (7-15 min against ~3.17M live UTxOs) now complete reliably where they
  previously failed at the 120s/180s timeout boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the muxer's segment-read timeout and protocol read-buffer cap configurable so trusted LocalStateQuery connections can wait out arbitrarily long replies, and fixes a data race in `localstatequery`.

- Adds `WithMuxerSegmentReadTimeout` and `NewWithSegmentReadTimeout` to override or disable (`<= 0`) the default 120s timeout, which previously killed legitimate, still-computing LocalStateQuery replies mid-flight.
- Adds `protocol.ProtocolConfig.MaxReadBufferSize` and `localstatequery.WithMaxReadBufferSize` to raise the 16MB cap on multi-segment messages, which whole-UTxO-set replies against large chains exceed.
- Optimizes the read loop to drain already-queued segments before decoding, now bounded to the configured buffer size and shutdown-aware so a flooding peer cannot cause unbounded memory growth.
- Fixes a data race where `currentEra` was written after signaling acquire completion, letting callers read a stale cached era.

<sup>Written for commit 913dce5c16618f1d3d574f5adf7f8ae85ec7b3d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added per-connection control over how long the system waits for the next message segment, including the ability to disable the timeout.
  - Added configurable maximum read-buffer size for large multi-segment Local State Query responses.

- **Bug Fixes**
  - Improved handling of large segmented messages to reduce unnecessary processing.
  - Fixed Local State Query acquisition so callers receive the current era instead of stale cached information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->