### PR TITLE
fix(ledger): correct utxorpc cost-model key indexing, add missing Conway governance fields

### DIFF
--- a/ledger/alonzo/pparams_test.go
+++ b/ledger/alonzo/pparams_test.go
@@ -226,10 +226,12 @@ func TestAlonzoUtxorpc(t *testing.T) {
 			Memory: 5000000,
 			Steps:  1000000,
 		},
+		// Keys follow the real cardano-ledger wire convention: 0-indexed
+		// (0=PlutusV1, 1=PlutusV2, 2=PlutusV3).
 		CostModels: map[uint][]int64{
-			1: {100, 200, 300},
-			2: {400, 500, 600},
-			3: {700, 800, 900},
+			0: {100, 200, 300},
+			1: {400, 500, 600},
+			2: {700, 800, 900},
 		},
 	}
 

--- a/ledger/babbage/pparams_test.go
+++ b/ledger/babbage/pparams_test.go
@@ -505,10 +505,12 @@ func TestBabbageUtxorpc(t *testing.T) {
 					Memory: 5000000,
 					Steps:  1000000,
 				},
+				// Keys follow the real cardano-ledger wire convention:
+				// 0-indexed (0=PlutusV1, 1=PlutusV2, 2=PlutusV3).
 				CostModels: map[uint][]int64{
-					1: {100, 200, 300},
-					2: {400, 500, 600},
-					3: {700, 800, 900},
+					0: {100, 200, 300},
+					1: {400, 500, 600},
+					2: {700, 800, 900},
 				},
 			},
 			expectedUtxorpc: &utxorpc.PParams{

--- a/ledger/common/pparams.go
+++ b/ledger/common/pparams.go
@@ -66,8 +66,19 @@ type ExUnitPrice struct {
 	StepPrice *cbor.Rat
 }
 
-// ConvertToUtxorpcCardanoCostModels converts a map of cost models for Plutus scripts into cardano.CostModels
-// Only PlutusV(keys 1, 2, and 3) are supported.
+// ConvertToUtxorpcCardanoCostModels converts a map of cost models for Plutus
+// scripts into cardano.CostModels.
+//
+// NOTE: the map keys follow the real cardano-ledger wire convention for the
+// protocol-parameter cost-models map (`Map language pv -> CostModel`), which
+// is 0-indexed: PlutusV1=0, PlutusV2=1, PlutusV3=2, PlutusV4=3. This matches
+// the same 0-indexed keys used throughout this repo's own genesis loading
+// (e.g. ledger/alonzo/pparams.go's PlutusV1Key/PlutusV2Key/PlutusV3Key
+// constants) and script-execution cost-model lookups (e.g.
+// ledger/conway/rules.go, ledger/dijkstra/rules.go), and is verified against
+// a real on-chain transaction fixture in
+// ledger/babbage/script_data_hash_used_languages_test.go. Do not shift this
+// back to 1-indexed keys.
 func ConvertToUtxorpcCardanoCostModels(
 	models map[uint][]int64,
 ) *cardano.CostModels {
@@ -75,12 +86,14 @@ func ConvertToUtxorpcCardanoCostModels(
 	for k, v := range models {
 		costModel := &cardano.CostModel{Values: v}
 		switch k {
-		case 1:
+		case 0:
 			costModels.PlutusV1 = costModel
-		case 2:
+		case 1:
 			costModels.PlutusV2 = costModel
-		case 3:
+		case 2:
 			costModels.PlutusV3 = costModel
+		case 3:
+			costModels.PlutusV4 = costModel
 		default:
 			slog.Warn("unsupported cost model version", "version", k)
 		}

--- a/ledger/common/pparams_test.go
+++ b/ledger/common/pparams_test.go
@@ -21,11 +21,20 @@ import (
 	"github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
 
+// TestConvertToUtxorpcCardanoCostModels_Mapping pins the real cardano-ledger
+// wire convention for the cost-models map: 0-indexed language keys
+// (0=PlutusV1, 1=PlutusV2, 2=PlutusV3, 3=PlutusV4). Key 0 is exercised
+// explicitly since it is the most common real-world value (PlutusV1) and was
+// previously dropped by an off-by-one mapping. See the same fixture values
+// used against a real on-chain transaction in
+// ledger/babbage/script_data_hash_used_languages_test.go (cost models keyed
+// 0 and 1 for PlutusV1/PlutusV2).
 func TestConvertToUtxorpcCardanoCostModels_Mapping(t *testing.T) {
 	models := map[uint][]int64{
-		1:  {10, 20},
-		2:  {30},
-		3:  {40, 50, 60},
+		0:  {10, 20},
+		1:  {30},
+		2:  {40, 50, 60},
+		3:  {70, 80},
 		99: {999}, // unsupported, should be ignored
 	}
 
@@ -45,6 +54,33 @@ func TestConvertToUtxorpcCardanoCostModels_Mapping(t *testing.T) {
 		!reflect.DeepEqual(cm.PlutusV3.Values, []int64{40, 50, 60}) {
 		t.Fatalf("PlutusV3 not mapped correctly: %+v", cm.PlutusV3)
 	}
+	if cm.PlutusV4 == nil ||
+		!reflect.DeepEqual(cm.PlutusV4.Values, []int64{70, 80}) {
+		t.Fatalf("PlutusV4 not mapped correctly: %+v", cm.PlutusV4)
+	}
+}
+
+// TestConvertToUtxorpcCardanoCostModels_KeyZeroIsPlutusV1 is a focused
+// regression test for the specific bug found by the node-parity audit: cost
+// model key 0 (real-world PlutusV1) must not be silently dropped. Before the
+// fix, the switch only handled keys 1/2/3 and key 0 fell into the "default"
+// branch, logging "unsupported cost model version" and omitting PlutusV1
+// entirely from every comparison.
+func TestConvertToUtxorpcCardanoCostModels_KeyZeroIsPlutusV1(t *testing.T) {
+	models := map[uint][]int64{
+		0: {197209, 0},
+	}
+	cm := ConvertToUtxorpcCardanoCostModels(models)
+	if cm.PlutusV1 == nil ||
+		!reflect.DeepEqual(cm.PlutusV1.Values, []int64{197209, 0}) {
+		t.Fatalf("key 0 not mapped to PlutusV1: %+v", cm.PlutusV1)
+	}
+	if cm.PlutusV2 != nil || cm.PlutusV3 != nil || cm.PlutusV4 != nil {
+		t.Fatalf(
+			"expected only PlutusV1 to be populated: %+v",
+			cm,
+		)
+	}
 }
 
 func TestConvertToUtxorpcCardanoCostModels_Empty(t *testing.T) {
@@ -52,7 +88,8 @@ func TestConvertToUtxorpcCardanoCostModels_Empty(t *testing.T) {
 	if cm == nil {
 		t.Fatal("expected non-nil CostModels")
 	}
-	if cm.PlutusV1 != nil || cm.PlutusV2 != nil || cm.PlutusV3 != nil {
+	if cm.PlutusV1 != nil || cm.PlutusV2 != nil || cm.PlutusV3 != nil ||
+		cm.PlutusV4 != nil {
 		t.Fatalf("expected all nil cost model fields for empty input: %+v", cm)
 	}
 	// ensure it is a *cardano.CostModels

--- a/ledger/conway/pparams.go
+++ b/ledger/conway/pparams.go
@@ -98,41 +98,42 @@ func (p *ConwayProtocolParameters) DRepDepositAmount() *big.Int {
 	return new(big.Int).SetUint64(p.DRepDeposit)
 }
 
+// ratOutOfRange reports whether r's numerator or denominator cannot be
+// represented in utxorpc.RationalNumber's int32/uint32 fields. Compares the
+// underlying *big.Int values directly against the bounds, not via Int64()
+// first: Int64() is undefined for a value that does not fit in int64 at all
+// (silently wraps rather than erroring, per math/big's own documentation),
+// so a value far outside range (e.g. 2^64+1) could pass an
+// Int64()-based comparison completely undetected -- review-caught on
+// blinklabs-io/gouroboros#2292, in both this file's pre-existing
+// rational-number guards below (A0, Rho, Tau, the execution-cost prices)
+// and the voting-threshold one added alongside them (ratToUtxorpcRationalNumber).
+// r itself must be non-nil; every caller already guards that separately
+// (e.g. "p.A0 == nil ||", short-circuiting before this runs).
+func ratOutOfRange(r *big.Rat) bool {
+	return r.Num().Cmp(big.NewInt(math.MinInt32)) < 0 ||
+		r.Num().Cmp(big.NewInt(math.MaxInt32)) > 0 ||
+		r.Denom().Sign() < 0 ||
+		r.Denom().Cmp(new(big.Int).SetUint64(math.MaxUint32)) > 0
+}
+
 func (p *ConwayProtocolParameters) Utxorpc() (*utxorpc.PParams, error) {
 	// sanity check
-	if p.A0 == nil ||
-		p.A0.Num().Int64() < math.MinInt32 ||
-		p.A0.Num().Int64() > math.MaxInt32 ||
-		p.A0.Denom().Int64() < 0 ||
-		p.A0.Denom().Int64() > math.MaxUint32 {
+	if p.A0 == nil || ratOutOfRange(p.A0.Rat) {
 		return nil, errors.New("invalid A0 rational number values")
 	}
-	if p.Rho == nil ||
-		p.Rho.Num().Int64() < math.MinInt32 ||
-		p.Rho.Num().Int64() > math.MaxInt32 ||
-		p.Rho.Denom().Int64() < 0 ||
-		p.Rho.Denom().Int64() > math.MaxUint32 {
+	if p.Rho == nil || ratOutOfRange(p.Rho.Rat) {
 		return nil, errors.New("invalid Rho rational number values")
 	}
-	if p.Tau == nil ||
-		p.Tau.Num().Int64() < math.MinInt32 ||
-		p.Tau.Num().Int64() > math.MaxInt32 ||
-		p.Tau.Denom().Int64() < 0 ||
-		p.Tau.Denom().Int64() > math.MaxUint32 {
+	if p.Tau == nil || ratOutOfRange(p.Tau.Rat) {
 		return nil, errors.New("invalid Tau rational number values")
 	}
 	if p.ExecutionCosts.MemPrice == nil ||
-		p.ExecutionCosts.MemPrice.Num().Int64() < math.MinInt32 ||
-		p.ExecutionCosts.MemPrice.Num().Int64() > math.MaxInt32 ||
-		p.ExecutionCosts.MemPrice.Denom().Int64() < 0 ||
-		p.ExecutionCosts.MemPrice.Denom().Int64() > math.MaxUint32 {
+		ratOutOfRange(p.ExecutionCosts.MemPrice.Rat) {
 		return nil, errors.New("invalid memory price rational number values")
 	}
 	if p.ExecutionCosts.StepPrice == nil ||
-		p.ExecutionCosts.StepPrice.Num().Int64() < math.MinInt32 ||
-		p.ExecutionCosts.StepPrice.Num().Int64() > math.MaxInt32 ||
-		p.ExecutionCosts.StepPrice.Denom().Int64() < 0 ||
-		p.ExecutionCosts.StepPrice.Denom().Int64() > math.MaxUint32 {
+		ratOutOfRange(p.ExecutionCosts.StepPrice.Rat) {
 		return nil, errors.New("invalid step price rational number values")
 	}
 	if p.MaxTxExUnits.Memory < 0 || p.MaxTxExUnits.Steps < 0 ||
@@ -249,8 +250,7 @@ func ratToUtxorpcRationalNumber(r cbor.Rat) (*utxorpc.RationalNumber, error) {
 	if r.Rat == nil {
 		return nil, nil
 	}
-	if r.Num().Int64() < math.MinInt32 || r.Num().Int64() > math.MaxInt32 ||
-		r.Denom().Int64() < 0 || r.Denom().Int64() > math.MaxUint32 {
+	if ratOutOfRange(r.Rat) {
 		return nil, errors.New("invalid rational number values")
 	}
 	return &utxorpc.RationalNumber{

--- a/ledger/conway/pparams.go
+++ b/ledger/conway/pparams.go
@@ -138,6 +138,16 @@ func (p *ConwayProtocolParameters) Utxorpc() (*utxorpc.PParams, error) {
 		p.MaxBlockExUnits.Memory < 0 || p.MaxBlockExUnits.Steps < 0 {
 		return nil, errors.New("invalid execution unit values")
 	}
+	if p.MinFeeRefScriptCostPerByte != nil {
+		if p.MinFeeRefScriptCostPerByte.Num().Int64() < math.MinInt32 ||
+			p.MinFeeRefScriptCostPerByte.Num().Int64() > math.MaxInt32 ||
+			p.MinFeeRefScriptCostPerByte.Denom().Int64() < 0 ||
+			p.MinFeeRefScriptCostPerByte.Denom().Int64() > math.MaxUint32 {
+			return nil, errors.New(
+				"invalid MinFeeRefScriptCostPerByte rational number values",
+			)
+		}
+	}
 	// #nosec G115
 	return &utxorpc.PParams{
 		CoinsPerUtxoByte:         common.ToUtxorpcBigInt(p.AdaPerUtxoByte),
@@ -191,7 +201,122 @@ func (p *ConwayProtocolParameters) Utxorpc() (*utxorpc.PParams, error) {
 			Memory: uint64(p.MaxBlockExUnits.Memory),
 			Steps:  uint64(p.MaxBlockExUnits.Steps),
 		},
+		MinFeeScriptRefCostPerByte: ratPtrToUtxorpcRationalNumber(
+			p.MinFeeRefScriptCostPerByte,
+		),
+		PoolVotingThresholds: poolVotingThresholdsUtxorpc(
+			p.PoolVotingThresholds,
+		),
+		DrepVotingThresholds: drepVotingThresholdsUtxorpc(
+			p.DRepVotingThresholds,
+		),
+		MinCommitteeSize:               uint32(p.MinCommitteeSize),
+		CommitteeTermLimit:             p.CommitteeTermLimit,
+		GovernanceActionValidityPeriod: p.GovActionValidityPeriod,
+		GovernanceActionDeposit: common.ToUtxorpcBigInt(
+			p.GovActionDeposit,
+		),
+		DrepDeposit:          common.ToUtxorpcBigInt(p.DRepDeposit),
+		DrepInactivityPeriod: p.DRepInactivityPeriod,
 	}, nil
+}
+
+// ratToUtxorpcRationalNumber converts a cbor.Rat to a *utxorpc.RationalNumber.
+// It returns nil when the rational is unset (embedded *big.Rat is nil), which
+// happens for a ConwayProtocolParameters value that was never populated with
+// this particular threshold (e.g. constructed directly rather than decoded
+// from a full on-chain protocol-parameters value or genesis).
+func ratToUtxorpcRationalNumber(r cbor.Rat) *utxorpc.RationalNumber {
+	if r.Rat == nil {
+		return nil
+	}
+	return &utxorpc.RationalNumber{
+		// #nosec G115
+		Numerator: int32(r.Num().Int64()),
+		// #nosec G115
+		Denominator: uint32(r.Denom().Int64()),
+	}
+}
+
+// ratPtrToUtxorpcRationalNumber is the nil-safe pointer variant of
+// ratToUtxorpcRationalNumber, for the optional *cbor.Rat protocol-parameter
+// fields (e.g. MinFeeRefScriptCostPerByte).
+func ratPtrToUtxorpcRationalNumber(r *cbor.Rat) *utxorpc.RationalNumber {
+	if r == nil {
+		return nil
+	}
+	return ratToUtxorpcRationalNumber(*r)
+}
+
+// poolVotingThresholdsUtxorpc converts PoolVotingThresholds into the flat
+// utxorpc.VotingThresholds list. The order matches the field order of this
+// repo's own PoolVotingThresholds struct, which in turn matches the named
+// utxorpc.PoolVotingThresholds genesis message
+// (github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano): MotionNoConfidence,
+// CommitteeNormal, CommitteeNoConfidence, HardForkInitiation,
+// PpSecurityGroup.
+//
+// Returns nil unless every threshold is populated: utxorpc.PParams only
+// supports one flat, position-based list, so a partially populated set of
+// thresholds (not expected for a fully decoded on-chain protocol-parameters
+// value) cannot be represented without corrupting the positions of the
+// thresholds that are present.
+func poolVotingThresholdsUtxorpc(
+	t PoolVotingThresholds,
+) *utxorpc.VotingThresholds {
+	rats := [...]cbor.Rat{
+		t.MotionNoConfidence,
+		t.CommitteeNormal,
+		t.CommitteeNoConfidence,
+		t.HardForkInitiation,
+		t.PpSecurityGroup,
+	}
+	thresholds := make([]*utxorpc.RationalNumber, len(rats))
+	for i, r := range rats {
+		rn := ratToUtxorpcRationalNumber(r)
+		if rn == nil {
+			return nil
+		}
+		thresholds[i] = rn
+	}
+	return &utxorpc.VotingThresholds{Thresholds: thresholds}
+}
+
+// drepVotingThresholdsUtxorpc converts DRepVotingThresholds into the flat
+// utxorpc.VotingThresholds list. The order matches the field order of this
+// repo's own DRepVotingThresholds struct, which in turn matches the named
+// utxorpc.DRepVotingThresholds genesis message
+// (github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano): MotionNoConfidence,
+// CommitteeNormal, CommitteeNoConfidence, UpdateToConstitution,
+// HardForkInitiation, PpNetworkGroup, PpEconomicGroup, PpTechnicalGroup,
+// PpGovGroup, TreasuryWithdrawal.
+//
+// Returns nil unless every threshold is populated; see
+// poolVotingThresholdsUtxorpc for why a partial list cannot be represented.
+func drepVotingThresholdsUtxorpc(
+	t DRepVotingThresholds,
+) *utxorpc.VotingThresholds {
+	rats := [...]cbor.Rat{
+		t.MotionNoConfidence,
+		t.CommitteeNormal,
+		t.CommitteeNoConfidence,
+		t.UpdateToConstitution,
+		t.HardForkInitiation,
+		t.PpNetworkGroup,
+		t.PpEconomicGroup,
+		t.PpTechnicalGroup,
+		t.PpGovGroup,
+		t.TreasuryWithdrawal,
+	}
+	thresholds := make([]*utxorpc.RationalNumber, len(rats))
+	for i, r := range rats {
+		rn := ratToUtxorpcRationalNumber(r)
+		if rn == nil {
+			return nil
+		}
+		thresholds[i] = rn
+	}
+	return &utxorpc.VotingThresholds{Thresholds: thresholds}
 }
 
 func (p *ConwayProtocolParameters) Update(

--- a/ledger/conway/pparams.go
+++ b/ledger/conway/pparams.go
@@ -119,20 +119,33 @@ func ratOutOfRange(r *big.Rat) bool {
 
 func (p *ConwayProtocolParameters) Utxorpc() (*utxorpc.PParams, error) {
 	// sanity check
-	if p.A0 == nil || ratOutOfRange(p.A0.Rat) {
+	//
+	// Checks the embedded *big.Rat for nil separately from the *cbor.Rat
+	// pointer itself: A0/Rho/Tau/the execution-cost prices are mandatory
+	// fields here (unlike the optional MinFeeRefScriptCostPerByte, whose
+	// nil-embedded-Rat case legitimately means "unset" via
+	// ratPtrToUtxorpcRationalNumber), so a non-nil *cbor.Rat with a nil
+	// embedded Rat -- the same shape that panic was found on for
+	// MinFeeRefScriptCostPerByte -- must be rejected as invalid too,
+	// rather than reaching ratOutOfRange's Num()/Denom() calls, which
+	// require their receiver to be non-nil (review-caught on
+	// blinklabs-io/gouroboros#2292).
+	if p.A0 == nil || p.A0.Rat == nil || ratOutOfRange(p.A0.Rat) {
 		return nil, errors.New("invalid A0 rational number values")
 	}
-	if p.Rho == nil || ratOutOfRange(p.Rho.Rat) {
+	if p.Rho == nil || p.Rho.Rat == nil || ratOutOfRange(p.Rho.Rat) {
 		return nil, errors.New("invalid Rho rational number values")
 	}
-	if p.Tau == nil || ratOutOfRange(p.Tau.Rat) {
+	if p.Tau == nil || p.Tau.Rat == nil || ratOutOfRange(p.Tau.Rat) {
 		return nil, errors.New("invalid Tau rational number values")
 	}
 	if p.ExecutionCosts.MemPrice == nil ||
+		p.ExecutionCosts.MemPrice.Rat == nil ||
 		ratOutOfRange(p.ExecutionCosts.MemPrice.Rat) {
 		return nil, errors.New("invalid memory price rational number values")
 	}
 	if p.ExecutionCosts.StepPrice == nil ||
+		p.ExecutionCosts.StepPrice.Rat == nil ||
 		ratOutOfRange(p.ExecutionCosts.StepPrice.Rat) {
 		return nil, errors.New("invalid step price rational number values")
 	}

--- a/ledger/conway/pparams.go
+++ b/ledger/conway/pparams.go
@@ -303,15 +303,20 @@ func poolVotingThresholdsUtxorpc(
 		t.PpSecurityGroup,
 	}
 	thresholds := make([]*utxorpc.RationalNumber, len(rats))
+	allPopulated := true
 	for i, r := range rats {
 		rn, err := ratToUtxorpcRationalNumber(r)
 		if err != nil {
 			return nil, fmt.Errorf("threshold %d: %w", i, err)
 		}
 		if rn == nil {
-			return nil, nil
+			allPopulated = false
+			continue
 		}
 		thresholds[i] = rn
+	}
+	if !allPopulated {
+		return nil, nil
 	}
 	return &utxorpc.VotingThresholds{Thresholds: thresholds}, nil
 }
@@ -344,15 +349,20 @@ func drepVotingThresholdsUtxorpc(
 		t.TreasuryWithdrawal,
 	}
 	thresholds := make([]*utxorpc.RationalNumber, len(rats))
+	allPopulated := true
 	for i, r := range rats {
 		rn, err := ratToUtxorpcRationalNumber(r)
 		if err != nil {
 			return nil, fmt.Errorf("threshold %d: %w", i, err)
 		}
 		if rn == nil {
-			return nil, nil
+			allPopulated = false
+			continue
 		}
 		thresholds[i] = rn
+	}
+	if !allPopulated {
+		return nil, nil
 	}
 	return &utxorpc.VotingThresholds{Thresholds: thresholds}, nil
 }

--- a/ledger/conway/pparams.go
+++ b/ledger/conway/pparams.go
@@ -16,6 +16,7 @@ package conway
 
 import (
 	"errors"
+	"fmt"
 	"maps"
 	"math"
 	"math/big"
@@ -138,15 +139,31 @@ func (p *ConwayProtocolParameters) Utxorpc() (*utxorpc.PParams, error) {
 		p.MaxBlockExUnits.Memory < 0 || p.MaxBlockExUnits.Steps < 0 {
 		return nil, errors.New("invalid execution unit values")
 	}
-	if p.MinFeeRefScriptCostPerByte != nil {
-		if p.MinFeeRefScriptCostPerByte.Num().Int64() < math.MinInt32 ||
-			p.MinFeeRefScriptCostPerByte.Num().Int64() > math.MaxInt32 ||
-			p.MinFeeRefScriptCostPerByte.Denom().Int64() < 0 ||
-			p.MinFeeRefScriptCostPerByte.Denom().Int64() > math.MaxUint32 {
-			return nil, errors.New(
-				"invalid MinFeeRefScriptCostPerByte rational number values",
-			)
-		}
+	// minFeeRefScriptCost, poolVotingThresholds, and drepVotingThresholds are
+	// resolved before constructing the reply below, rather than inline in
+	// the struct literal, so a range violation in any of them (silently
+	// wrapping during the int32/uint32 cast otherwise, review-caught on
+	// blinklabs-io/gouroboros#2292) is rejected the same way every other
+	// rational field above is, instead of only MinFeeRefScriptCostPerByte
+	// getting a dedicated (and, before this fix, embedded-Rat-unsafe) guard
+	// while the voting thresholds got none at all.
+	minFeeRefScriptCost, err := ratPtrToUtxorpcRationalNumber(
+		p.MinFeeRefScriptCostPerByte,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("invalid MinFeeRefScriptCostPerByte: %w", err)
+	}
+	poolVotingThresholds, err := poolVotingThresholdsUtxorpc(
+		p.PoolVotingThresholds,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("invalid pool voting thresholds: %w", err)
+	}
+	drepVotingThresholds, err := drepVotingThresholdsUtxorpc(
+		p.DRepVotingThresholds,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("invalid drep voting thresholds: %w", err)
 	}
 	// #nosec G115
 	return &utxorpc.PParams{
@@ -201,15 +218,9 @@ func (p *ConwayProtocolParameters) Utxorpc() (*utxorpc.PParams, error) {
 			Memory: uint64(p.MaxBlockExUnits.Memory),
 			Steps:  uint64(p.MaxBlockExUnits.Steps),
 		},
-		MinFeeScriptRefCostPerByte: ratPtrToUtxorpcRationalNumber(
-			p.MinFeeRefScriptCostPerByte,
-		),
-		PoolVotingThresholds: poolVotingThresholdsUtxorpc(
-			p.PoolVotingThresholds,
-		),
-		DrepVotingThresholds: drepVotingThresholdsUtxorpc(
-			p.DRepVotingThresholds,
-		),
+		MinFeeScriptRefCostPerByte:     minFeeRefScriptCost,
+		PoolVotingThresholds:           poolVotingThresholds,
+		DrepVotingThresholds:           drepVotingThresholds,
 		MinCommitteeSize:               uint32(p.MinCommitteeSize),
 		CommitteeTermLimit:             p.CommitteeTermLimit,
 		GovernanceActionValidityPeriod: p.GovActionValidityPeriod,
@@ -222,28 +233,46 @@ func (p *ConwayProtocolParameters) Utxorpc() (*utxorpc.PParams, error) {
 }
 
 // ratToUtxorpcRationalNumber converts a cbor.Rat to a *utxorpc.RationalNumber.
-// It returns nil when the rational is unset (embedded *big.Rat is nil), which
-// happens for a ConwayProtocolParameters value that was never populated with
-// this particular threshold (e.g. constructed directly rather than decoded
-// from a full on-chain protocol-parameters value or genesis).
-func ratToUtxorpcRationalNumber(r cbor.Rat) *utxorpc.RationalNumber {
+// It returns (nil, nil) when the rational is unset (embedded *big.Rat is
+// nil), which happens for a ConwayProtocolParameters value that was never
+// populated with this particular threshold (e.g. constructed directly
+// rather than decoded from a full on-chain protocol-parameters value or
+// genesis).
+// It also validates the value fits utxorpc.RationalNumber's int32/uint32
+// fields the same way every other rational conversion in this file does
+// (A0, Rho, Tau, the execution-cost prices): an out-of-range numerator or
+// denominator returns an error instead of silently wrapping during the
+// int32/uint32 cast (review-caught on blinklabs-io/gouroboros#2292 -- this
+// helper originally cast unconditionally, unlike its callers' sibling
+// fields above).
+func ratToUtxorpcRationalNumber(r cbor.Rat) (*utxorpc.RationalNumber, error) {
 	if r.Rat == nil {
-		return nil
+		return nil, nil
+	}
+	if r.Num().Int64() < math.MinInt32 || r.Num().Int64() > math.MaxInt32 ||
+		r.Denom().Int64() < 0 || r.Denom().Int64() > math.MaxUint32 {
+		return nil, errors.New("invalid rational number values")
 	}
 	return &utxorpc.RationalNumber{
 		// #nosec G115
 		Numerator: int32(r.Num().Int64()),
 		// #nosec G115
 		Denominator: uint32(r.Denom().Int64()),
-	}
+	}, nil
 }
 
 // ratPtrToUtxorpcRationalNumber is the nil-safe pointer variant of
 // ratToUtxorpcRationalNumber, for the optional *cbor.Rat protocol-parameter
-// fields (e.g. MinFeeRefScriptCostPerByte).
-func ratPtrToUtxorpcRationalNumber(r *cbor.Rat) *utxorpc.RationalNumber {
+// fields (e.g. MinFeeRefScriptCostPerByte). A non-nil *cbor.Rat whose
+// embedded *big.Rat is itself nil is treated the same as an unset field
+// (returns (nil, nil), not a panic on the nil embedded value): both mean
+// "this ConwayProtocolParameters value was never populated with this
+// threshold."
+func ratPtrToUtxorpcRationalNumber(
+	r *cbor.Rat,
+) (*utxorpc.RationalNumber, error) {
 	if r == nil {
-		return nil
+		return nil, nil
 	}
 	return ratToUtxorpcRationalNumber(*r)
 }
@@ -256,14 +285,16 @@ func ratPtrToUtxorpcRationalNumber(r *cbor.Rat) *utxorpc.RationalNumber {
 // CommitteeNormal, CommitteeNoConfidence, HardForkInitiation,
 // PpSecurityGroup.
 //
-// Returns nil unless every threshold is populated: utxorpc.PParams only
-// supports one flat, position-based list, so a partially populated set of
-// thresholds (not expected for a fully decoded on-chain protocol-parameters
-// value) cannot be represented without corrupting the positions of the
-// thresholds that are present.
+// Returns (nil, nil) unless every threshold is populated: utxorpc.PParams
+// only supports one flat, position-based list, so a partially populated set
+// of thresholds (not expected for a fully decoded on-chain
+// protocol-parameters value) cannot be represented without corrupting the
+// positions of the thresholds that are present. Returns an error instead if
+// any populated threshold is out of utxorpc.RationalNumber's representable
+// range -- see ratToUtxorpcRationalNumber.
 func poolVotingThresholdsUtxorpc(
 	t PoolVotingThresholds,
-) *utxorpc.VotingThresholds {
+) (*utxorpc.VotingThresholds, error) {
 	rats := [...]cbor.Rat{
 		t.MotionNoConfidence,
 		t.CommitteeNormal,
@@ -273,13 +304,16 @@ func poolVotingThresholdsUtxorpc(
 	}
 	thresholds := make([]*utxorpc.RationalNumber, len(rats))
 	for i, r := range rats {
-		rn := ratToUtxorpcRationalNumber(r)
+		rn, err := ratToUtxorpcRationalNumber(r)
+		if err != nil {
+			return nil, fmt.Errorf("threshold %d: %w", i, err)
+		}
 		if rn == nil {
-			return nil
+			return nil, nil
 		}
 		thresholds[i] = rn
 	}
-	return &utxorpc.VotingThresholds{Thresholds: thresholds}
+	return &utxorpc.VotingThresholds{Thresholds: thresholds}, nil
 }
 
 // drepVotingThresholdsUtxorpc converts DRepVotingThresholds into the flat
@@ -291,11 +325,12 @@ func poolVotingThresholdsUtxorpc(
 // HardForkInitiation, PpNetworkGroup, PpEconomicGroup, PpTechnicalGroup,
 // PpGovGroup, TreasuryWithdrawal.
 //
-// Returns nil unless every threshold is populated; see
-// poolVotingThresholdsUtxorpc for why a partial list cannot be represented.
+// Returns (nil, nil) unless every threshold is populated, and an error if
+// any populated threshold is out of range; see poolVotingThresholdsUtxorpc
+// for both.
 func drepVotingThresholdsUtxorpc(
 	t DRepVotingThresholds,
-) *utxorpc.VotingThresholds {
+) (*utxorpc.VotingThresholds, error) {
 	rats := [...]cbor.Rat{
 		t.MotionNoConfidence,
 		t.CommitteeNormal,
@@ -310,13 +345,16 @@ func drepVotingThresholdsUtxorpc(
 	}
 	thresholds := make([]*utxorpc.RationalNumber, len(rats))
 	for i, r := range rats {
-		rn := ratToUtxorpcRationalNumber(r)
+		rn, err := ratToUtxorpcRationalNumber(r)
+		if err != nil {
+			return nil, fmt.Errorf("threshold %d: %w", i, err)
+		}
 		if rn == nil {
-			return nil
+			return nil, nil
 		}
 		thresholds[i] = rn
 	}
-	return &utxorpc.VotingThresholds{Thresholds: thresholds}
+	return &utxorpc.VotingThresholds{Thresholds: thresholds}, nil
 }
 
 func (p *ConwayProtocolParameters) Update(

--- a/ledger/conway/pparams.go
+++ b/ledger/conway/pparams.go
@@ -153,6 +153,17 @@ func (p *ConwayProtocolParameters) Utxorpc() (*utxorpc.PParams, error) {
 		p.MaxBlockExUnits.Memory < 0 || p.MaxBlockExUnits.Steps < 0 {
 		return nil, errors.New("invalid execution unit values")
 	}
+	// p.MinCommitteeSize is a uint (64 bits wide on a 64-bit build) decoded
+	// straight from CBOR key 27 and assigned unchecked in Update(); the
+	// struct literal below narrows it to utxorpc.PParams.MinCommitteeSize's
+	// uint32 with a plain conversion. Without this check, a value like
+	// 1<<32 silently becomes 0 -- a real, materially different governance
+	// parameter turned invisible to any comparison built on this field,
+	// the same failure mode every other guard in this function exists to
+	// reject rather than let through (chrisguiney review).
+	if uint64(p.MinCommitteeSize) > math.MaxUint32 {
+		return nil, errors.New("invalid MinCommitteeSize value")
+	}
 	// minFeeRefScriptCost, poolVotingThresholds, and drepVotingThresholds are
 	// resolved before constructing the reply below, rather than inline in
 	// the struct literal, so a range violation in any of them (silently

--- a/ledger/conway/pparams_test.go
+++ b/ledger/conway/pparams_test.go
@@ -964,6 +964,65 @@ func TestConwayUtxorpc_MinFeeRefScriptCostPerByteNilEmbeddedRatDoesNotPanic(
 	})
 }
 
+// TestConwayUtxorpc_MandatoryRatFieldNilEmbeddedRatRejectedNotPanic is the
+// regression test for a CodeRabbit finding on blinklabs-io/gouroboros#2292:
+// unlike the optional MinFeeRefScriptCostPerByte above (where a nil
+// embedded *big.Rat legitimately means "unset"), A0, Rho, Tau, and the two
+// execution-cost prices are mandatory -- Utxorpc()'s own validation guard
+// for each already rejects a nil *cbor.Rat pointer with an "invalid ...
+// rational number values" error, but only checked that outer pointer, not
+// whether a non-nil *cbor.Rat's embedded *big.Rat was itself nil. That
+// shape reached ratOutOfRange's Num()/Denom() calls, which panic on a nil
+// receiver, instead of being rejected with the same existing error a nil
+// outer pointer already gets.
+func TestConwayUtxorpc_MandatoryRatFieldNilEmbeddedRatRejectedNotPanic(
+	t *testing.T,
+) {
+	validBase := func() conway.ConwayProtocolParameters {
+		return conway.ConwayProtocolParameters{
+			A0:  &cbor.Rat{Rat: big.NewRat(1, 2)},
+			Rho: &cbor.Rat{Rat: big.NewRat(3, 4)},
+			Tau: &cbor.Rat{Rat: big.NewRat(5, 6)},
+			ExecutionCosts: common.ExUnitPrice{
+				MemPrice:  &cbor.Rat{Rat: big.NewRat(1, 2)},
+				StepPrice: &cbor.Rat{Rat: big.NewRat(2, 3)},
+			},
+		}
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*conway.ConwayProtocolParameters)
+	}{
+		{"A0", func(p *conway.ConwayProtocolParameters) {
+			p.A0 = &cbor.Rat{}
+		}},
+		{"Rho", func(p *conway.ConwayProtocolParameters) {
+			p.Rho = &cbor.Rat{}
+		}},
+		{"Tau", func(p *conway.ConwayProtocolParameters) {
+			p.Tau = &cbor.Rat{}
+		}},
+		{"memory price", func(p *conway.ConwayProtocolParameters) {
+			p.ExecutionCosts.MemPrice = &cbor.Rat{}
+		}},
+		{"step price", func(p *conway.ConwayProtocolParameters) {
+			p.ExecutionCosts.StepPrice = &cbor.Rat{}
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := validBase()
+			tt.mutate(&params)
+
+			require.NotPanics(t, func() {
+				_, err := params.Utxorpc()
+				require.Error(t, err)
+			})
+		})
+	}
+}
+
 // TestConwayUtxorpc_VotingThresholdOutOfRangeRejected is the regression
 // test for a review finding on blinklabs-io/gouroboros#2292:
 // ratToUtxorpcRationalNumber cast a threshold's numerator/denominator to

--- a/ledger/conway/pparams_test.go
+++ b/ledger/conway/pparams_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/hex"
 	"math"
 	"math/big"
+	"math/bits"
 	"reflect"
 	"strings"
 	"testing"
@@ -1089,8 +1090,17 @@ func TestConwayUtxorpc_MinCommitteeSizeOutOfRangeRejected(t *testing.T) {
 	})
 
 	t.Run("beyond uint32 range", func(t *testing.T) {
+		if bits.UintSize <= 32 {
+			// uint(1) << 32 as a constant overflows a 32-bit uint at
+			// compile time (breaks the build on 386, not just this
+			// test), and uint itself cannot hold a value beyond
+			// uint32's range on such a build in the first place -- so
+			// there is nothing this subtest can exercise there.
+			t.Skip("uint cannot exceed uint32 range on a 32-bit build")
+		}
 		params := base
-		params.MinCommitteeSize = uint(1) << 32
+		var beyondUint32 uint64 = 1 << 32
+		params.MinCommitteeSize = uint(beyondUint32)
 		_, err := params.Utxorpc()
 		require.Error(t, err)
 	})

--- a/ledger/conway/pparams_test.go
+++ b/ledger/conway/pparams_test.go
@@ -645,10 +645,12 @@ func TestUtxorpc(t *testing.T) {
 					Memory: 5000000,
 					Steps:  1000000,
 				},
+				// Keys follow the real cardano-ledger wire convention:
+				// 0-indexed (0=PlutusV1, 1=PlutusV2, 2=PlutusV3).
 				CostModels: map[uint][]int64{
-					1: {100, 200, 300},
-					2: {400, 500, 600},
-					3: {700, 800, 900},
+					0: {100, 200, 300},
+					1: {400, 500, 600},
+					2: {700, 800, 900},
 				},
 			},
 			expectedUtxorpc: &utxorpc.PParams{
@@ -723,6 +725,16 @@ func TestUtxorpc(t *testing.T) {
 					Memory: 5000000,
 					Steps:  1000000,
 				},
+				// GovActionDeposit/DRepDeposit are plain uint64 fields (not
+				// pointers) on ConwayProtocolParameters, so
+				// common.ToUtxorpcBigInt always returns a non-nil BigInt,
+				// even for the zero value left unset by this test case.
+				GovernanceActionDeposit: &utxorpc.BigInt{
+					BigInt: &utxorpc.BigInt_Int{Int: 0},
+				},
+				DrepDeposit: &utxorpc.BigInt{
+					BigInt: &utxorpc.BigInt_Int{Int: 0},
+				},
 			},
 		},
 	}
@@ -741,6 +753,178 @@ func TestUtxorpc(t *testing.T) {
 			)
 		}
 	}
+}
+
+// TestConwayUtxorpc_GovernanceFields is the regression test for the
+// node-parity audit finding that Utxorpc() silently omitted every Conway
+// governance parameter: GovActionDeposit, DRepDeposit, voting thresholds,
+// committee settings, governance-action validity period, and the
+// reference-script fee rational. Before this fix, changing e.g.
+// GovActionDeposit produced an identical, empty node-parity diff because
+// none of these fields ever reached the returned *utxorpc.PParams. Each
+// field below is given a distinct value (and, for the voting-threshold
+// lists, distinct per-position values) so a mapping mistake -- a dropped
+// field or a misordered threshold list -- makes this test fail rather than
+// passing by coincidence.
+func TestConwayUtxorpc_GovernanceFields(t *testing.T) {
+	rat := func(num, den int64) cbor.Rat {
+		return cbor.Rat{Rat: big.NewRat(num, den)}
+	}
+	params := conway.ConwayProtocolParameters{
+		// Fields required by Utxorpc()'s existing sanity checks.
+		A0:  &cbor.Rat{Rat: big.NewRat(1, 2)},
+		Rho: &cbor.Rat{Rat: big.NewRat(3, 4)},
+		Tau: &cbor.Rat{Rat: big.NewRat(5, 6)},
+		ExecutionCosts: common.ExUnitPrice{
+			MemPrice:  &cbor.Rat{Rat: big.NewRat(1, 2)},
+			StepPrice: &cbor.Rat{Rat: big.NewRat(2, 3)},
+		},
+		// Newly-mapped governance fields under test, each a distinct value.
+		MinFeeRefScriptCostPerByte: &cbor.Rat{Rat: big.NewRat(15, 2)},
+		PoolVotingThresholds: conway.PoolVotingThresholds{
+			MotionNoConfidence:    rat(1, 11),
+			CommitteeNormal:       rat(2, 11),
+			CommitteeNoConfidence: rat(3, 11),
+			HardForkInitiation:    rat(4, 11),
+			PpSecurityGroup:       rat(5, 11),
+		},
+		DRepVotingThresholds: conway.DRepVotingThresholds{
+			MotionNoConfidence:    rat(1, 13),
+			CommitteeNormal:       rat(2, 13),
+			CommitteeNoConfidence: rat(3, 13),
+			UpdateToConstitution:  rat(4, 13),
+			HardForkInitiation:    rat(5, 13),
+			PpNetworkGroup:        rat(6, 13),
+			PpEconomicGroup:       rat(7, 13),
+			PpTechnicalGroup:      rat(8, 13),
+			PpGovGroup:            rat(9, 13),
+			TreasuryWithdrawal:    rat(10, 13),
+		},
+		MinCommitteeSize:        7,
+		CommitteeTermLimit:      365,
+		GovActionValidityPeriod: 30000,
+		// Matches the exact scenario from the node-parity audit: a changed
+		// GovActionDeposit must produce a different Utxorpc() value.
+		GovActionDeposit:     100000000001,
+		DRepDeposit:          500000000,
+		DRepInactivityPeriod: 20,
+	}
+
+	result, err := params.Utxorpc()
+	if err != nil {
+		t.Fatalf("Utxorpc() conversion failed: %v", err)
+	}
+
+	assert.Equal(t,
+		&utxorpc.RationalNumber{Numerator: 15, Denominator: 2},
+		result.MinFeeScriptRefCostPerByte,
+		"MinFeeScriptRefCostPerByte",
+	)
+	assert.Equal(t,
+		&utxorpc.VotingThresholds{
+			Thresholds: []*utxorpc.RationalNumber{
+				{Numerator: 1, Denominator: 11},
+				{Numerator: 2, Denominator: 11},
+				{Numerator: 3, Denominator: 11},
+				{Numerator: 4, Denominator: 11},
+				{Numerator: 5, Denominator: 11},
+			},
+		},
+		result.PoolVotingThresholds,
+		"PoolVotingThresholds",
+	)
+	assert.Equal(t,
+		&utxorpc.VotingThresholds{
+			Thresholds: []*utxorpc.RationalNumber{
+				{Numerator: 1, Denominator: 13},
+				{Numerator: 2, Denominator: 13},
+				{Numerator: 3, Denominator: 13},
+				{Numerator: 4, Denominator: 13},
+				{Numerator: 5, Denominator: 13},
+				{Numerator: 6, Denominator: 13},
+				{Numerator: 7, Denominator: 13},
+				{Numerator: 8, Denominator: 13},
+				{Numerator: 9, Denominator: 13},
+				{Numerator: 10, Denominator: 13},
+			},
+		},
+		result.DrepVotingThresholds,
+		"DrepVotingThresholds",
+	)
+	assert.Equal(t, uint32(7), result.MinCommitteeSize, "MinCommitteeSize")
+	assert.Equal(
+		t,
+		uint64(365),
+		result.CommitteeTermLimit,
+		"CommitteeTermLimit",
+	)
+	assert.Equal(
+		t,
+		uint64(30000),
+		result.GovernanceActionValidityPeriod,
+		"GovernanceActionValidityPeriod",
+	)
+	assert.Equal(t,
+		common.ToUtxorpcBigInt(100000000001),
+		result.GovernanceActionDeposit,
+		"GovernanceActionDeposit",
+	)
+	assert.Equal(t,
+		common.ToUtxorpcBigInt(500000000),
+		result.DrepDeposit,
+		"DrepDeposit",
+	)
+	assert.Equal(
+		t,
+		uint64(20),
+		result.DrepInactivityPeriod,
+		"DrepInactivityPeriod",
+	)
+
+	// Changing GovActionDeposit must change the converted value -- this is
+	// the exact audit scenario (100000000000 -> 100000000001 previously
+	// produced an identical, empty diff).
+	changed := params
+	changed.GovActionDeposit = 100000000000
+	changedResult, err := changed.Utxorpc()
+	if err != nil {
+		t.Fatalf("Utxorpc() conversion failed: %v", err)
+	}
+	assert.NotEqual(
+		t,
+		result.GovernanceActionDeposit,
+		changedResult.GovernanceActionDeposit,
+		"GovActionDeposit change must be visible in Utxorpc() output",
+	)
+}
+
+// TestConwayUtxorpc_GovernanceFields_UnsetVotingThresholdsOmitted verifies
+// that a ConwayProtocolParameters value with unset (zero-value)
+// PoolVotingThresholds/DRepVotingThresholds/MinFeeRefScriptCostPerByte -- as
+// happens when a value is constructed directly rather than decoded from a
+// full on-chain protocol-parameters value or genesis -- leaves the
+// corresponding utxorpc fields nil instead of emitting a spurious all-zero
+// VotingThresholds list, which would misrepresent a real 0/0 rational as a
+// present-but-degenerate threshold.
+func TestConwayUtxorpc_GovernanceFields_UnsetVotingThresholdsOmitted(
+	t *testing.T,
+) {
+	params := conway.ConwayProtocolParameters{
+		A0:  &cbor.Rat{Rat: big.NewRat(1, 2)},
+		Rho: &cbor.Rat{Rat: big.NewRat(3, 4)},
+		Tau: &cbor.Rat{Rat: big.NewRat(5, 6)},
+		ExecutionCosts: common.ExUnitPrice{
+			MemPrice:  &cbor.Rat{Rat: big.NewRat(1, 2)},
+			StepPrice: &cbor.Rat{Rat: big.NewRat(2, 3)},
+		},
+	}
+	result, err := params.Utxorpc()
+	if err != nil {
+		t.Fatalf("Utxorpc() conversion failed: %v", err)
+	}
+	assert.Nil(t, result.MinFeeScriptRefCostPerByte)
+	assert.Nil(t, result.PoolVotingThresholds)
+	assert.Nil(t, result.DrepVotingThresholds)
 }
 
 // Unit test for ConwayTransactionBody.Utxorpc()

--- a/ledger/conway/pparams_test.go
+++ b/ledger/conway/pparams_test.go
@@ -16,6 +16,7 @@ package conway_test
 
 import (
 	"encoding/hex"
+	"math"
 	"math/big"
 	"reflect"
 	"strings"
@@ -29,6 +30,7 @@ import (
 	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/blinklabs-io/plutigo/data"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	utxorpc "github.com/utxorpc/go-codegen/utxorpc/v1alpha/cardano"
 )
 
@@ -925,6 +927,81 @@ func TestConwayUtxorpc_GovernanceFields_UnsetVotingThresholdsOmitted(
 	assert.Nil(t, result.MinFeeScriptRefCostPerByte)
 	assert.Nil(t, result.PoolVotingThresholds)
 	assert.Nil(t, result.DrepVotingThresholds)
+}
+
+// TestConwayUtxorpc_MinFeeRefScriptCostPerByteNilEmbeddedRatDoesNotPanic is
+// the regression test for a review finding on
+// blinklabs-io/gouroboros#2292: MinFeeRefScriptCostPerByte is a *cbor.Rat,
+// and the nil check in Utxorpc()'s original validation guard only covered
+// that outer pointer -- a non-nil *cbor.Rat whose embedded *big.Rat is
+// itself nil (the same "unset" representation
+// TestConwayUtxorpc_GovernanceFields_UnsetVotingThresholdsOmitted's
+// zero-value fields use, just wrapped in a non-nil pointer instead of a
+// nil one) reached a call to Num() on a nil *big.Rat and panicked, before
+// the nil-safe ratPtrToUtxorpcRationalNumber conversion ever got a chance
+// to correctly return nil for it.
+func TestConwayUtxorpc_MinFeeRefScriptCostPerByteNilEmbeddedRatDoesNotPanic(
+	t *testing.T,
+) {
+	params := conway.ConwayProtocolParameters{
+		A0:  &cbor.Rat{Rat: big.NewRat(1, 2)},
+		Rho: &cbor.Rat{Rat: big.NewRat(3, 4)},
+		Tau: &cbor.Rat{Rat: big.NewRat(5, 6)},
+		ExecutionCosts: common.ExUnitPrice{
+			MemPrice:  &cbor.Rat{Rat: big.NewRat(1, 2)},
+			StepPrice: &cbor.Rat{Rat: big.NewRat(2, 3)},
+		},
+		// Non-nil *cbor.Rat, nil embedded *big.Rat -- the panic-inducing
+		// shape, distinct from a nil MinFeeRefScriptCostPerByte pointer
+		// entirely (already covered by the unset-fields test above).
+		MinFeeRefScriptCostPerByte: &cbor.Rat{},
+	}
+
+	require.NotPanics(t, func() {
+		result, err := params.Utxorpc()
+		require.NoError(t, err)
+		assert.Nil(t, result.MinFeeScriptRefCostPerByte)
+	})
+}
+
+// TestConwayUtxorpc_VotingThresholdOutOfRangeRejected is the regression
+// test for a review finding on blinklabs-io/gouroboros#2292:
+// ratToUtxorpcRationalNumber cast a threshold's numerator/denominator to
+// int32/uint32 unconditionally, unlike every sibling rational field in this
+// file (A0, Rho, Tau, the execution-cost prices), which reject an
+// out-of-range value with an error rather than silently wrapping it during
+// the cast. An out-of-range voting threshold must fail the same way.
+func TestConwayUtxorpc_VotingThresholdOutOfRangeRejected(t *testing.T) {
+	base := conway.ConwayProtocolParameters{
+		A0:  &cbor.Rat{Rat: big.NewRat(1, 2)},
+		Rho: &cbor.Rat{Rat: big.NewRat(3, 4)},
+		Tau: &cbor.Rat{Rat: big.NewRat(5, 6)},
+		ExecutionCosts: common.ExUnitPrice{
+			MemPrice:  &cbor.Rat{Rat: big.NewRat(1, 2)},
+			StepPrice: &cbor.Rat{Rat: big.NewRat(2, 3)},
+		},
+	}
+	outOfRange := cbor.Rat{
+		Rat: big.NewRat(int64(math.MaxInt32)+1, 1),
+	}
+
+	t.Run("pool voting threshold", func(t *testing.T) {
+		params := base
+		params.PoolVotingThresholds = conway.PoolVotingThresholds{
+			MotionNoConfidence: outOfRange,
+		}
+		_, err := params.Utxorpc()
+		require.Error(t, err)
+	})
+
+	t.Run("drep voting threshold", func(t *testing.T) {
+		params := base
+		params.DRepVotingThresholds = conway.DRepVotingThresholds{
+			MotionNoConfidence: outOfRange,
+		}
+		_, err := params.Utxorpc()
+		require.Error(t, err)
+	})
 }
 
 // Unit test for ConwayTransactionBody.Utxorpc()

--- a/ledger/conway/pparams_test.go
+++ b/ledger/conway/pparams_test.go
@@ -1049,6 +1049,54 @@ func TestConwayUtxorpc_ValueBeyondInt64RangeRejected(t *testing.T) {
 	})
 }
 
+// TestConwayUtxorpc_VotingThresholdOutOfRangeRejectedAfterUnsetField is the
+// regression test for a review finding on blinklabs-io/gouroboros#2292:
+// poolVotingThresholdsUtxorpc/drepVotingThresholdsUtxorpc returned (nil, nil)
+// as soon as the scan reached the first unset threshold, before ever
+// checking any threshold that came after it in field order. An out-of-range
+// threshold positioned after an earlier unset one was therefore never
+// caught -- the whole set was silently treated as "not fully populated"
+// instead of surfacing the real range error. Leaves MotionNoConfidence
+// (the first field in both structs' order) unset and puts the out-of-range
+// value on CommitteeNormal (the second field) to prove the scan still
+// reaches and validates it.
+func TestConwayUtxorpc_VotingThresholdOutOfRangeRejectedAfterUnsetField(
+	t *testing.T,
+) {
+	base := conway.ConwayProtocolParameters{
+		A0:  &cbor.Rat{Rat: big.NewRat(1, 2)},
+		Rho: &cbor.Rat{Rat: big.NewRat(3, 4)},
+		Tau: &cbor.Rat{Rat: big.NewRat(5, 6)},
+		ExecutionCosts: common.ExUnitPrice{
+			MemPrice:  &cbor.Rat{Rat: big.NewRat(1, 2)},
+			StepPrice: &cbor.Rat{Rat: big.NewRat(2, 3)},
+		},
+	}
+	outOfRange := cbor.Rat{
+		Rat: big.NewRat(int64(math.MaxInt32)+1, 1),
+	}
+
+	t.Run("pool voting threshold", func(t *testing.T) {
+		params := base
+		params.PoolVotingThresholds = conway.PoolVotingThresholds{
+			// MotionNoConfidence left unset (zero-value cbor.Rat).
+			CommitteeNormal: outOfRange,
+		}
+		_, err := params.Utxorpc()
+		require.Error(t, err)
+	})
+
+	t.Run("drep voting threshold", func(t *testing.T) {
+		params := base
+		params.DRepVotingThresholds = conway.DRepVotingThresholds{
+			// MotionNoConfidence left unset (zero-value cbor.Rat).
+			CommitteeNormal: outOfRange,
+		}
+		_, err := params.Utxorpc()
+		require.Error(t, err)
+	})
+}
+
 // Unit test for ConwayTransactionBody.Utxorpc()
 func TestConwayTransactionBody_Utxorpc(t *testing.T) {
 	input := shelley.NewShelleyTransactionInput(

--- a/ledger/conway/pparams_test.go
+++ b/ledger/conway/pparams_test.go
@@ -1063,6 +1063,39 @@ func TestConwayUtxorpc_VotingThresholdOutOfRangeRejected(t *testing.T) {
 	})
 }
 
+// TestConwayUtxorpc_MinCommitteeSizeOutOfRangeRejected is the regression
+// test for a chrisguiney review finding on blinklabs-io/gouroboros#2292:
+// MinCommitteeSize is a uint (64 bits wide on a 64-bit build) narrowed
+// unchecked to utxorpc.PParams.MinCommitteeSize's uint32. A value of
+// 1<<32 silently converted to 0 instead of surfacing an error, unlike
+// every rational field and MaxTxExUnits/MaxBlockExUnits in the same
+// function.
+func TestConwayUtxorpc_MinCommitteeSizeOutOfRangeRejected(t *testing.T) {
+	base := conway.ConwayProtocolParameters{
+		A0:  &cbor.Rat{Rat: big.NewRat(1, 2)},
+		Rho: &cbor.Rat{Rat: big.NewRat(3, 4)},
+		Tau: &cbor.Rat{Rat: big.NewRat(5, 6)},
+		ExecutionCosts: common.ExUnitPrice{
+			MemPrice:  &cbor.Rat{Rat: big.NewRat(1, 2)},
+			StepPrice: &cbor.Rat{Rat: big.NewRat(2, 3)},
+		},
+	}
+
+	t.Run("in range", func(t *testing.T) {
+		params := base
+		params.MinCommitteeSize = 7
+		_, err := params.Utxorpc()
+		require.NoError(t, err)
+	})
+
+	t.Run("beyond uint32 range", func(t *testing.T) {
+		params := base
+		params.MinCommitteeSize = uint(1) << 32
+		_, err := params.Utxorpc()
+		require.Error(t, err)
+	})
+}
+
 // TestConwayUtxorpc_ValueBeyondInt64RangeRejected is the regression test
 // for a review finding on blinklabs-io/gouroboros#2292: the range check
 // (both the voting-threshold one just added, and the pre-existing A0/Rho/

--- a/ledger/conway/pparams_test.go
+++ b/ledger/conway/pparams_test.go
@@ -1004,6 +1004,51 @@ func TestConwayUtxorpc_VotingThresholdOutOfRangeRejected(t *testing.T) {
 	})
 }
 
+// TestConwayUtxorpc_ValueBeyondInt64RangeRejected is the regression test
+// for a review finding on blinklabs-io/gouroboros#2292: the range check
+// (both the voting-threshold one just added, and the pre-existing A0/Rho/
+// Tau/execution-cost-price ones it was modeled on) compared
+// r.Num().Int64() against math.MinInt32/MaxInt32 -- but big.Int.Int64() is
+// undefined (silently wraps, per math/big's own documentation) for a value
+// that does not fit in int64 at all, which is a much lower bar to clear
+// than not fitting in int32. A numerator like 2^64+1 could pass that
+// Int64()-based comparison completely undetected instead of being
+// rejected. Covers both a pre-existing guard (A0) and the new
+// voting-threshold path, since both used the same flawed pattern.
+func TestConwayUtxorpc_ValueBeyondInt64RangeRejected(t *testing.T) {
+	beyondInt64 := new(big.Int).Lsh(big.NewInt(1), 64) // 2^64
+	beyondInt64.Add(beyondInt64, big.NewInt(1))        // 2^64 + 1
+	badRat := new(big.Rat).SetFrac(beyondInt64, big.NewInt(1))
+
+	validBase := func() conway.ConwayProtocolParameters {
+		return conway.ConwayProtocolParameters{
+			A0:  &cbor.Rat{Rat: big.NewRat(1, 2)},
+			Rho: &cbor.Rat{Rat: big.NewRat(3, 4)},
+			Tau: &cbor.Rat{Rat: big.NewRat(5, 6)},
+			ExecutionCosts: common.ExUnitPrice{
+				MemPrice:  &cbor.Rat{Rat: big.NewRat(1, 2)},
+				StepPrice: &cbor.Rat{Rat: big.NewRat(2, 3)},
+			},
+		}
+	}
+
+	t.Run("pre-existing A0 guard", func(t *testing.T) {
+		params := validBase()
+		params.A0 = &cbor.Rat{Rat: badRat}
+		_, err := params.Utxorpc()
+		require.Error(t, err)
+	})
+
+	t.Run("voting threshold", func(t *testing.T) {
+		params := validBase()
+		params.PoolVotingThresholds = conway.PoolVotingThresholds{
+			MotionNoConfidence: cbor.Rat{Rat: badRat},
+		}
+		_, err := params.Utxorpc()
+		require.Error(t, err)
+	})
+}
+
 // Unit test for ConwayTransactionBody.Utxorpc()
 func TestConwayTransactionBody_Utxorpc(t *testing.T) {
 	input := shelley.NewShelleyTransactionInput(


### PR DESCRIPTION
## How this was found

While testing blinklabs-io/dingo#1900's cross-node comparison tool
(node-parity), wrote deliberate mutation tests against the checker: change
one real protocol-parameter value on one side, then assert the comparison
actually reports a difference. Two of those tests failed that assertion:

```
2026/09/10 11:14:31 WARN unsupported cost model version version=0
2026/09/10 11:14:31 WARN unsupported cost model version version=0
=== NAME  TestConwayParameterDifferenceIsOmitted
    regressions_test.go:49: Governance action deposits differ (100000000000 vs 100000000001), but checker reports no difference
--- PASS: TestConwayParameterDifferenceIsOmitted (0.00s)
=== NAME  TestCostModelZeroDifferenceIsOmitted
    regressions_test.go:60: Cost model key 0 differs, but checker reports no difference
--- PASS: TestCostModelZeroDifferenceIsOmitted (0.00s)
```

(The tests are named for the bug they *prove exists*, so "PASS" here means
"successfully demonstrated the checker misses a real difference" -- a
false negative, not a crash.)

The comparison converts both nodes' protocol parameters through
`ConvertToUtxorpcCardanoCostModels` / `ConwayProtocolParameters.Utxorpc()`
before diffing them (`internal/nodeparity/snapshot.go` in Dingo). Tracing
into those two conversion functions in this repo found the actual defects
below.

## Root cause

**Cost-model key indexing (`ledger/common/pparams.go`).**
`ConvertToUtxorpcCardanoCostModels`'s switch mapped map key 1 -> PlutusV1,
2 -> PlutusV2, 3 -> PlutusV3. Real cardano-ledger's cost-models map is
0-indexed: PlutusV1=0, PlutusV2=1, PlutusV3=2, PlutusV4=3. Two independent
sources confirm this:
- This repo's own `ledger/alonzo/pparams.go`: `PlutusV1Key uint = 0`,
  `PlutusV2Key uint = 1`, `PlutusV3Key uint = 2`.
- A real on-chain Preview transaction fixture in
  `ledger/babbage/script_data_hash_used_languages_test.go`
  (`preview1796036TxHex`): its `ScriptDataHash` only reproduces correctly
  when the cost models passed to `UtxoValidateScriptDataHash` are keyed
  `{0: ..., 1: ...}` -- the strongest form of proof available, since it's
  checked against a real cryptographic hash from a real historical
  transaction, not just an internal constant.

Under the old (wrong) mapping, key 0 (a real PlutusV1 cost model) hit the
switch's `default` branch and was silently dropped, logging only
`"unsupported cost model version" version=0`. Worse than a clean drop: key
1 (real PlutusV2) landed in the PlutusV1 slot, and key 2 (real PlutusV3)
landed in the PlutusV2 slot -- everything shifted by one, so nothing ever
populated the real PlutusV3 slot at all under realistic input.

Because *both* sides of a node-parity comparison go through the same buggy
conversion, a real difference in PlutusV1 cost models between two nodes
disappears identically on both sides before the diff ever runs --
explaining exactly the empty-diff false negative the cost-model test above
demonstrated.

**Missing Conway governance fields (`ledger/conway/pparams.go`).**
`ConwayProtocolParameters.Utxorpc()` never mapped 9 real, on-chain
CIP-1694/Conway fields to the output structure at all:
`MinFeeScriptRefCostPerByte`, `PoolVotingThresholds`,
`DrepVotingThresholds`, `MinCommitteeSize`, `CommitteeTermLimit`,
`GovernanceActionValidityPeriod`, `GovernanceActionDeposit`,
`DrepDeposit`, `DrepInactivityPeriod`. Not a wrong mapping -- an absent
one, so no amount of change in any of them could ever surface in a diff.
This is exactly what the governance-deposit test above demonstrated by
mutating `GovernanceActionDeposit`.

## Independently re-validated live, today, against a real network

Before opening this PR, reverted just this fix (`git stash`, keeping the
unrelated mux-timeout fix from #2291 in place) and re-ran a live
node-parity `check` against a real, synced Preview `cardano-node` + Dingo
pair, to confirm the bug is not just a unit-test artifact:

```
{"time":"2026-09-10T18:15:00.077214-05:00","level":"WARN","msg":"unsupported cost model version","version":0}
{"time":"2026-09-10T18:26:13.167129-05:00","level":"WARN","msg":"unsupported cost model version","version":0}
check complete: DIVERGED at slot 122426072 (block 4651291), 143 difference(s)
```

The warning fired live against real, current protocol-parameter data --
confirming PlutusV1 cost models are genuinely present on Preview right now
and genuinely get dropped by the old code. The final diff's 143 differences
were exclusively stake-distribution/UTxO entries; zero were
protocol-parameter differences, in both the reverted and fixed runs --
consistent with Dingo's and cardano-node's real cost models/governance
fields currently agreeing, so this specific comparison didn't change
today. The fix still matters: with the bug in place, a *future* real
divergence in PlutusV1 cost models or any of the 9 missing Conway fields
would be structurally invisible to this comparison, no matter how real it
got.

## Changes

- `ledger/common/pparams.go`: `ConvertToUtxorpcCardanoCostModels`'s switch
  fixed to 0/1/2/3, PlutusV4 added.
- `ledger/conway/pparams.go`: added the 9 missing governance fields to
  `Utxorpc()`, with nil-safe helpers (`ratToUtxorpcRationalNumber`,
  `poolVotingThresholdsUtxorpc`, `drepVotingThresholdsUtxorpc`) that leave
  a field nil rather than fabricate a zero value when unset.
- Existing Alonzo/Babbage/common test fixtures updated from 1/2/3-indexed
  to 0/1/2-indexed inputs to match the corrected convention (expected
  outputs unchanged -- these tests had been unknowingly validating the
  wrong convention, passing only because the bug was symmetric between
  test and implementation).

## Testing

- `go build ./...`, `go vet ./...` clean.
- `go test -race ./ledger/common/... ./ledger/conway/... ./ledger/alonzo/... ./ledger/babbage/...`
  -- all pass.
- `golangci-lint run` (scoped to changed packages) -- 0 issues.
- New tests: `TestConvertToUtxorpcCardanoCostModels_KeyZeroIsPlutusV1`,
  `TestConwayUtxorpc_GovernanceFields`,
  `TestConwayUtxorpc_GovernanceFields_UnsetVotingThresholdsOmitted`.
- Live re-validation described above, against a real Preview `cardano-node`
  + Dingo pair.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Plutus cost model conversion to use zero-based protocol keys, including Plutus V4.
  * Improved Conway protocol parameter conversion for governance fields and rational values.
  * Added validation for out-of-range values and safe handling of unset or malformed parameters.
* **Tests**
  * Expanded coverage for cost model mappings, governance fields, omitted thresholds, nil values, and large numeric inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->