### PR TITLE
fix(consensus)!: honor caller leadership ranges

### DIFF
--- a/consensus/leader.go
+++ b/consensus/leader.go
@@ -336,12 +336,8 @@ func FindNextSlotLeadership(
 	)
 }
 
-// MaxLeadershipSearchSlots bounds one leadership search so callers cannot
-// accidentally turn a scheduling query into an unbounded VRF workload.
-const MaxLeadershipSearchSlots uint64 = 1_000_000
-
 // FindNextSlotLeadershipContext searches for leadership with cancellation and
-// an explicit maximum range. The legacy function delegates here with a
+// an inclusive maximum slot. The legacy function delegates here with a
 // background context.
 func FindNextSlotLeadershipContext(
 	ctx context.Context,
@@ -358,12 +354,6 @@ func FindNextSlotLeadershipContext(
 	}
 	if maxSlot < startSlot {
 		return 0, nil, nil, errors.New("maxSlot must not precede startSlot")
-	}
-	if maxSlot-startSlot >= MaxLeadershipSearchSlots {
-		return 0, nil, nil, fmt.Errorf(
-			"leadership search range exceeds maximum of %d slots",
-			MaxLeadershipSearchSlots,
-		)
 	}
 	for slot := startSlot; ; slot++ {
 		if err := ctx.Err(); err != nil {

--- a/consensus/leader_test.go
+++ b/consensus/leader_test.go
@@ -483,20 +483,25 @@ func TestFindNextSlotLeadershipNoEligibility(t *testing.T) {
 	}
 }
 
-func TestFindNextSlotLeadershipContextRejectsOversizedRange(t *testing.T) {
+func TestFindNextSlotLeadershipContextAllowsLargeRange(t *testing.T) {
 	signer, err := NewSimpleVRFSigner(testVRFSeed)
 	require.NoError(t, err)
-	_, _, _, err = FindNextSlotLeadershipContext(
+	startSlot := uint64(42)
+	maxSlot := startSlot + 1_000_000
+	slot, proof, output, err := FindNextSlotLeadershipContext(
 		context.Background(),
-		0,
-		MaxLeadershipSearchSlots,
+		startSlot,
+		maxSlot,
 		make([]byte, 32),
 		1,
 		1,
-		big.NewRat(1, 2),
+		big.NewRat(1, 1),
 		signer,
 	)
-	require.Error(t, err)
+	require.NoError(t, err)
+	require.Equal(t, startSlot, slot)
+	require.NotNil(t, proof)
+	require.NotNil(t, output)
 }
 
 func TestFindNextSlotLeadershipContextHonorsCancellation(t *testing.T) {
@@ -512,6 +517,27 @@ func TestFindNextSlotLeadershipContextHonorsCancellation(t *testing.T) {
 		1,
 		1,
 		big.NewRat(1, 2),
+		signer,
+	)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestFindNextSlotLeadershipContextHonorsCancellationForLargeRange(
+	t *testing.T,
+) {
+	signer, err := NewSimpleVRFSigner(testVRFSeed)
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	startSlot := uint64(42)
+	_, _, _, err = FindNextSlotLeadershipContext(
+		ctx,
+		startSlot,
+		startSlot+1_000_000,
+		make([]byte, 32),
+		1,
+		1,
+		big.NewRat(1, 1),
 		signer,
 	)
 	require.ErrorIs(t, err, context.Canceled)


### PR DESCRIPTION
Honor the caller's inclusive `maxSlot` instead of rejecting every search spanning more than one million slots. The fixed cap also masked context cancellation and rejected searches whose first slot was already eligible.

Preserve cancellation checks, invalid-range rejection and overflow-safe termination. Add first-slot eligibility and canceled-context regressions for a large requested range.

Breaking API change: remove the exported `MaxLeadershipSearchSlots` constant. Callers choose their own search ranges and context deadlines; the search function signatures are unchanged.

Related to #2027; its separate Byron and VRF checks are unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the fixed 1,000,000-slot cap on leadership searches so callers' requested ranges are honored. The old cap rejected searches whose starting slot was already eligible and masked context cancellation.

**Breaking change**

- Removes the exported `MaxLeadershipSearchSlots` constant; callers now own their search ranges and deadlines.
- Leadership search function signatures are unchanged, and the separate Byron and VRF checks from #2027 are untouched.

<sup>Written for commit cc505034631d2836ac4790194bd04ae71f500020. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/gouroboros/pull/2293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Large leadership-search ranges are now supported without an arbitrary size limit.
  * Search cancellation continues to be honored, including for large ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->